### PR TITLE
make forward_while also work if the while loop is at the end of a block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ PROGS_FILES= \
   verif_nest3.v verif_nest2.v \
   logical_compare.v verif_logical_compare.v field_loadstore.v  verif_field_loadstore.v \
   even.v verif_even.v odd.v verif_odd.v \
-  merge.v verif_merge.v
+  merge.v verif_merge.v while_at_end_of_block.v verif_while_at_end_of_block.v
 # verif_message.v verif_dotprod.v verif_insertion_sort.v 
 
 SHA_FILES= \

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -1219,6 +1219,14 @@ Tactic Notation "forward_while" constr(Inv) :=
           let a := fresh a2 in pose (a := EXP_NAME); 
           rewrite exp_uncurry
       end;
+      lazymatch goal with
+      (* goal already has the desired shape *)
+      | |- semax _ _ (Ssequence (Swhile _ _) _) _ => idtac
+      (* add unnecessary skip so that goal has the desired shape *)
+      | |- semax _ _ (Swhile _ _) _ => rewrite semax_seq_skip
+      (* bad goal *)
+      | |- _ => fail 1 "expected (Swhile _ _) or (Ssequence (Swhile _ _) _)"
+      end;
       eapply semax_seq;
       [match goal with |- semax ?Delta ?Pre (Swhile ?e _) _ =>
         (* the following line was before: eapply semax_while_3g1; *)
@@ -1268,7 +1276,8 @@ Tactic Notation "forward_while" constr(Inv) :=
                | apply typed_false_ptr in HRE
                | idtac ];
          repeat (apply semax_extract_PROP; intro);
-         do_repr_inj HRE; normalize in HRE
+         do_repr_inj HRE; normalize in HRE;
+         try fwd_skip
        ]
     ]; abbreviate_semax; autorewrite with ret_assert.
 

--- a/progs/verif_while_at_end_of_block.v
+++ b/progs/verif_while_at_end_of_block.v
@@ -1,0 +1,35 @@
+Require Import floyd.proofauto.
+Require Import progs.while_at_end_of_block.
+Instance CompSpecs : compspecs. make_compspecs prog. Defined.
+Definition Vprog : varspecs.  mk_varspecs prog. Defined.
+
+Definition identity_spec :=
+ DECLARE _identity
+  WITH v: Z, by_counting: Z
+  PRE  [_v OF tuint, _by_counting OF tbool] 
+        PROP (0 <= v <= Int.max_unsigned)
+        LOCAL(temp _v (Vint (Int.repr v)); temp _by_counting (Vint (Int.repr by_counting)))
+        SEP()
+  POST [ tuint ]
+         PROP() 
+         LOCAL (temp ret_temp (Vint (Int.repr v)))
+         SEP ().
+
+Definition Gprog : funspecs := nil.
+
+Lemma body_identity: semax_body Vprog Gprog f_identity identity_spec.
+Proof.
+  start_function.
+  forward.
+  forward_if (PROP() LOCAL (temp _v (Vint (Int.repr v)); temp _result (Vint (Int.repr v))) SEP ()).
+  * forward_while (EX r: Z, (PROP(0 <= r <= v)
+                             LOCAL (temp _v (Vint (Int.repr v));
+                                    temp _result (Vint (Int.repr r))) SEP ())).
+    - Exists 0. entailer!.
+    - entailer!.
+    - forward. Exists (r + 1). entailer!.
+    - entailer!. f_equal. f_equal. omega.
+  * forward. entailer!.
+  * forward.
+Qed.
+

--- a/progs/while_at_end_of_block.c
+++ b/progs/while_at_end_of_block.c
@@ -1,0 +1,12 @@
+#include<stdbool.h>
+
+unsigned int identity(unsigned int v, bool by_counting) {
+  unsigned int result = 0;
+  if (by_counting) {
+    while (result < v) result++;
+  } else {
+    result = v;
+  }
+  return result;
+}
+

--- a/progs/while_at_end_of_block.v
+++ b/progs/while_at_end_of_block.v
@@ -1,0 +1,312 @@
+Require Import Clightdefs.
+
+Local Open Scope Z_scope.
+
+Definition ___builtin_read32_reversed : ident := 40%positive.
+Definition ___builtin_fsqrt : ident := 32%positive.
+Definition ___i64_stod : ident := 16%positive.
+Definition ___builtin_fnmsub : ident := 38%positive.
+Definition _by_counting : ident := 46%positive.
+Definition ___i64_shl : ident := 24%positive.
+Definition ___i64_smod : ident := 22%positive.
+Definition ___i64_utod : ident := 17%positive.
+Definition ___builtin_va_copy : ident := 8%positive.
+Definition ___builtin_membar : ident := 5%positive.
+Definition ___builtin_nop : ident := 43%positive.
+Definition ___compcert_va_float64 : ident := 12%positive.
+Definition _result : ident := 47%positive.
+Definition ___compcert_va_int32 : ident := 10%positive.
+Definition ___builtin_debug : ident := 44%positive.
+Definition ___builtin_annot : ident := 3%positive.
+Definition ___builtin_memcpy_aligned : ident := 2%positive.
+Definition ___builtin_fabs : ident := 1%positive.
+Definition ___builtin_fmsub : ident := 36%positive.
+Definition ___builtin_ctz : ident := 31%positive.
+Definition ___i64_dtos : ident := 14%positive.
+Definition ___builtin_va_start : ident := 6%positive.
+Definition ___i64_sar : ident := 26%positive.
+Definition ___i64_utof : ident := 19%positive.
+Definition ___builtin_read16_reversed : ident := 39%positive.
+Definition ___compcert_va_int64 : ident := 11%positive.
+Definition _main : ident := 49%positive.
+Definition ___builtin_fnmadd : ident := 37%positive.
+Definition ___builtin_annot_intval : ident := 4%positive.
+Definition ___builtin_bswap32 : ident := 28%positive.
+Definition ___builtin_va_arg : ident := 7%positive.
+Definition ___builtin_write32_reversed : ident := 42%positive.
+Definition ___i64_udiv : ident := 21%positive.
+Definition ___i64_stof : ident := 18%positive.
+Definition ___builtin_va_end : ident := 9%positive.
+Definition _v : ident := 45%positive.
+Definition ___builtin_write16_reversed : ident := 41%positive.
+Definition ___compcert_va_composite : ident := 13%positive.
+Definition ___builtin_bswap : ident := 27%positive.
+Definition ___builtin_fmax : ident := 33%positive.
+Definition ___i64_shr : ident := 25%positive.
+Definition ___i64_dtou : ident := 15%positive.
+Definition ___builtin_fmin : ident := 34%positive.
+Definition ___builtin_bswap16 : ident := 29%positive.
+Definition ___builtin_fmadd : ident := 35%positive.
+Definition ___builtin_clz : ident := 30%positive.
+Definition ___i64_umod : ident := 23%positive.
+Definition _identity : ident := 48%positive.
+Definition ___i64_sdiv : ident := 20%positive.
+
+Definition f_identity := {|
+  fn_return := tuint;
+  fn_callconv := cc_default;
+  fn_params := ((_v, tuint) :: (_by_counting, tbool) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_result, tuint) :: nil);
+  fn_body :=
+(Ssequence
+  (Sset _result (Econst_int (Int.repr 0) tint))
+  (Ssequence
+    (Sifthenelse (Etempvar _by_counting tbool)
+      (Swhile
+        (Ebinop Olt (Etempvar _result tuint) (Etempvar _v tuint) tint)
+        (Sset _result
+          (Ebinop Oadd (Etempvar _result tuint)
+            (Econst_int (Int.repr 1) tint) tuint)))
+      (Sset _result (Etempvar _v tuint)))
+    (Sreturn (Some (Etempvar _result tuint)))))
+|}.
+
+Definition composites : list composite_definition :=
+nil.
+
+Definition prog : Clight.program := {|
+prog_defs :=
+((___builtin_fabs,
+   Gfun(External (EF_builtin "__builtin_fabs"
+                   (mksignature (AST.Tfloat :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_memcpy_aligned,
+   Gfun(External (EF_builtin "__builtin_memcpy_aligned"
+                   (mksignature
+                     (AST.Tint :: AST.Tint :: AST.Tint :: AST.Tint :: nil)
+                     None cc_default))
+     (Tcons (tptr tvoid)
+       (Tcons (tptr tvoid) (Tcons tuint (Tcons tuint Tnil)))) tvoid
+     cc_default)) ::
+ (___builtin_annot,
+   Gfun(External (EF_builtin "__builtin_annot"
+                   (mksignature (AST.Tint :: nil) None
+                     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot_intval,
+   Gfun(External (EF_builtin "__builtin_annot_intval"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) (Some AST.Tint)
+                     cc_default)) (Tcons (tptr tschar) (Tcons tint Tnil))
+     tint cc_default)) ::
+ (___builtin_membar,
+   Gfun(External (EF_builtin "__builtin_membar"
+                   (mksignature nil None cc_default)) Tnil tvoid cc_default)) ::
+ (___builtin_va_start,
+   Gfun(External (EF_builtin "__builtin_va_start"
+                   (mksignature (AST.Tint :: nil) None cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___builtin_va_arg,
+   Gfun(External (EF_builtin "__builtin_va_arg"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) None
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_va_copy,
+   Gfun(External (EF_builtin "__builtin_va_copy"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) None
+                     cc_default))
+     (Tcons (tptr tvoid) (Tcons (tptr tvoid) Tnil)) tvoid cc_default)) ::
+ (___builtin_va_end,
+   Gfun(External (EF_builtin "__builtin_va_end"
+                   (mksignature (AST.Tint :: nil) None cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___compcert_va_int32,
+   Gfun(External (EF_external "__compcert_va_int32"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons (tptr tvoid) Tnil) tuint cc_default)) ::
+ (___compcert_va_int64,
+   Gfun(External (EF_external "__compcert_va_int64"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tlong)
+                     cc_default)) (Tcons (tptr tvoid) Tnil) tulong
+     cc_default)) ::
+ (___compcert_va_float64,
+   Gfun(External (EF_external "__compcert_va_float64"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons (tptr tvoid) Tnil) tdouble
+     cc_default)) ::
+ (___compcert_va_composite,
+   Gfun(External (EF_external "__compcert_va_composite"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) (Some AST.Tint)
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     (tptr tvoid) cc_default)) ::
+ (___i64_dtos,
+   Gfun(External (EF_external "__i64_dtos"
+                   (mksignature (AST.Tfloat :: nil) (Some AST.Tlong)
+                     cc_default)) (Tcons tdouble Tnil) tlong cc_default)) ::
+ (___i64_dtou,
+   Gfun(External (EF_external "__i64_dtou"
+                   (mksignature (AST.Tfloat :: nil) (Some AST.Tlong)
+                     cc_default)) (Tcons tdouble Tnil) tulong cc_default)) ::
+ (___i64_stod,
+   Gfun(External (EF_external "__i64_stod"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons tlong Tnil) tdouble cc_default)) ::
+ (___i64_utod,
+   Gfun(External (EF_external "__i64_utod"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons tulong Tnil) tdouble cc_default)) ::
+ (___i64_stof,
+   Gfun(External (EF_external "__i64_stof"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tsingle)
+                     cc_default)) (Tcons tlong Tnil) tfloat cc_default)) ::
+ (___i64_utof,
+   Gfun(External (EF_external "__i64_utof"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tsingle)
+                     cc_default)) (Tcons tulong Tnil) tfloat cc_default)) ::
+ (___i64_sdiv,
+   Gfun(External (EF_external "__i64_sdiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tlong Tnil)) tlong cc_default)) ::
+ (___i64_udiv,
+   Gfun(External (EF_external "__i64_udiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tulong (Tcons tulong Tnil)) tulong cc_default)) ::
+ (___i64_smod,
+   Gfun(External (EF_external "__i64_smod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tlong Tnil)) tlong cc_default)) ::
+ (___i64_umod,
+   Gfun(External (EF_external "__i64_umod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tulong (Tcons tulong Tnil)) tulong cc_default)) ::
+ (___i64_shl,
+   Gfun(External (EF_external "__i64_shl"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tint Tnil)) tlong cc_default)) ::
+ (___i64_shr,
+   Gfun(External (EF_external "__i64_shr"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tulong (Tcons tint Tnil)) tulong cc_default)) ::
+ (___i64_sar,
+   Gfun(External (EF_external "__i64_sar"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tint Tnil)) tlong cc_default)) ::
+ (___builtin_bswap,
+   Gfun(External (EF_builtin "__builtin_bswap"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap32,
+   Gfun(External (EF_builtin "__builtin_bswap32"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap16,
+   Gfun(External (EF_builtin "__builtin_bswap16"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tushort Tnil) tushort cc_default)) ::
+ (___builtin_clz,
+   Gfun(External (EF_builtin "__builtin_clz"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctz,
+   Gfun(External (EF_builtin "__builtin_ctz"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_fsqrt,
+   Gfun(External (EF_builtin "__builtin_fsqrt"
+                   (mksignature (AST.Tfloat :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_fmax,
+   Gfun(External (EF_builtin "__builtin_fmax"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble Tnil)) tdouble cc_default)) ::
+ (___builtin_fmin,
+   Gfun(External (EF_builtin "__builtin_fmin"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble Tnil)) tdouble cc_default)) ::
+ (___builtin_fmadd,
+   Gfun(External (EF_builtin "__builtin_fmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fmsub,
+   Gfun(External (EF_builtin "__builtin_fmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmadd,
+   Gfun(External (EF_builtin "__builtin_fnmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmsub,
+   Gfun(External (EF_builtin "__builtin_fnmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_read16_reversed,
+   Gfun(External (EF_builtin "__builtin_read16_reversed"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons (tptr tushort) Tnil) tushort cc_default)) ::
+ (___builtin_read32_reversed,
+   Gfun(External (EF_builtin "__builtin_read32_reversed"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons (tptr tuint) Tnil) tuint cc_default)) ::
+ (___builtin_write16_reversed,
+   Gfun(External (EF_builtin "__builtin_write16_reversed"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) None
+                     cc_default)) (Tcons (tptr tushort) (Tcons tushort Tnil))
+     tvoid cc_default)) ::
+ (___builtin_write32_reversed,
+   Gfun(External (EF_builtin "__builtin_write32_reversed"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) None
+                     cc_default)) (Tcons (tptr tuint) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_nop,
+   Gfun(External (EF_builtin "__builtin_nop"
+                   (mksignature nil None cc_default)) Tnil tvoid cc_default)) ::
+ (___builtin_debug,
+   Gfun(External (EF_external "__builtin_debug"
+                   (mksignature (AST.Tint :: nil) None
+                     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tint Tnil) tvoid
+     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
+ (_identity, Gfun(Internal f_identity)) :: nil);
+prog_public :=
+(_identity :: ___builtin_debug :: ___builtin_nop ::
+ ___builtin_write32_reversed :: ___builtin_write16_reversed ::
+ ___builtin_read32_reversed :: ___builtin_read16_reversed ::
+ ___builtin_fnmsub :: ___builtin_fnmadd :: ___builtin_fmsub ::
+ ___builtin_fmadd :: ___builtin_fmin :: ___builtin_fmax ::
+ ___builtin_fsqrt :: ___builtin_ctz :: ___builtin_clz ::
+ ___builtin_bswap16 :: ___builtin_bswap32 :: ___builtin_bswap ::
+ ___i64_sar :: ___i64_shr :: ___i64_shl :: ___i64_umod :: ___i64_smod ::
+ ___i64_udiv :: ___i64_sdiv :: ___i64_utof :: ___i64_stof :: ___i64_utod ::
+ ___i64_stod :: ___i64_dtou :: ___i64_dtos :: ___compcert_va_composite ::
+ ___compcert_va_float64 :: ___compcert_va_int64 :: ___compcert_va_int32 ::
+ ___builtin_va_end :: ___builtin_va_copy :: ___builtin_va_arg ::
+ ___builtin_va_start :: ___builtin_membar :: ___builtin_annot_intval ::
+ ___builtin_annot :: ___builtin_memcpy_aligned :: ___builtin_fabs :: nil);
+prog_main := _main;
+prog_types := composites;
+prog_comp_env := make_composite_env composites;
+prog_comp_env_eq := refl_equal _
+|}.
+


### PR DESCRIPTION
Hi,

when I wanted to prove a specification for a function whose body contains a block ending with a while loop, i.e. something of the form

```
if (...) {
  ...
  while (...) {...}
}
```

I could not apply the `forward_while` tactic (after `forward`ing until just before the while).
See `progs/verif_while_at_end_of_block.v` and `progs/while_at_end_of_block.c` for a small example exhibiting the problem.
In tactic `forward_while` in file `floyd/forward.v`, the line `eapply semax_seq;` fails, because it expects a goal of the form `semax _ _ (Ssequence (Swhile _ _) _) _`, whereas our goal is of the form `semax _ _ (Swhile _ _) _`.

I considered two ways to fix this:
-    Not applying `semax_seq` if we don't have an `Ssequence`. But then, nor `semax_while_3g1` nor `semax_while` can be applied directly, and the two cases (ie whether there is an `Ssequence` around the `Swhile` or not) have to be treated separately (or rather, seem tricky to be handled together ;-) )
-    Making the goal a bit more complex by turning the `(Swhile _ _)` into a `(Ssequence (Swhile _ _) Sskip)`, just to undo this step in the next line. This sounds a bit silly, but allows a uniform treatment of both cases.

The second approach is in this PR, I'd love to hear what you think about it ;-)
