### PR TITLE
Allow overriding of the COMPCERT variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # See the file BUILD_ORGANIZATION for 
 # explanations of why this is the way it is
 
-COMPCERT=compcert
+COMPCERT ?= compcert
 -include CONFIGURE
 #Note:  You can make a CONFIGURE file with the definition
 #   COMPCERT=../compcert

--- a/Makefile-8.4
+++ b/Makefile-8.4
@@ -1,7 +1,7 @@
 # See the file BUILD_ORGANIZATION for 
 # explanations of why this is the way it is
 
-COMPCERT=compcert
+COMPCERT ?= compcert
 -include CONFIGURE
 #Note:  You can make a CONFIGURE file with the definition
 #   COMPCERT=../compcert


### PR DESCRIPTION
Declaring the value of COMPCERT with ?= allows it to be overridden from the
command-line, for example,

    make -C VST COMPCERT=../CompCert

(refer: https://www.gnu.org/software/make/manual/make.html#Setting-Variables)

This is useful, in particular, for including both VST and CompCert as git
submodules of another project without having to modify (and
commit/branch/share/etc.) their contents.