### PR TITLE
Explicitly name parameter in destruct.

### DIFF
--- a/veric/expr_lemmas.v
+++ b/veric/expr_lemmas.v
@@ -1067,7 +1067,7 @@ induction t.
       simpl in *. rewrite PTree.gsspec in *. rewrite peq_true in *.
       auto.
 
-      simpl in *. rewrite PTree.gsspec in *. destruct a0. simpl in *.
+      simpl in *. rewrite PTree.gsspec in *. destruct a0 as (i,t0). simpl in *.
       if_tac. subst. clear - H. specialize (H i i). intuition.  apply IHp.
       unfold list_disjoint in *. intros. apply H; simpl in *; auto.
       intros. apply IHt. unfold list_disjoint in *. intros; simpl in *; apply H;      auto.


### PR DESCRIPTION
This is needed in order for VST to compile with Coq 8.7.

The usual annoyance with automatically generated names, in this case the type changes, and so does the name. This patch thus makes the destruct more robust.

See https://github.com/coq/coq/pull/489 for more context.