### PR TITLE
add _Coqproject into gitignore: generated by the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ coqide
 *#
 .#*
 *.aux
+_CoqProject


### PR DESCRIPTION
The _Coqproject file is generated by the Makefile, thus it should be added into the .gitignore to avoid conflicts.