### PR TITLE
Improve dep

### DIFF
--- a/floyd/efield_lemmas.v
+++ b/floyd/efield_lemmas.v
@@ -566,10 +566,10 @@ Inductive compute_root_type: forall (t_from_e: type) (lr: LLRR) (t_root: type), 
 
 Lemma compute_nested_efield_aux: forall e t,
   match compute_nested_efield e with
-  | (e', gfs, tts) => nested_efield e' gfs tts = e
+  | (e', gfs, tts, lr) => nested_efield e' gfs tts = e
   end /\
   match compute_nested_efield (Ederef e t) with
-  | (e', gfs, tts) => nested_efield e' gfs tts = Ederef e t
+  | (e', gfs, tts, lr) => nested_efield e' gfs tts = Ederef e t
   end.
 Proof.
   intros.
@@ -580,7 +580,7 @@ Proof.
   + clear IHe2.
     destruct (IHe1 t) as [? _]; clear IHe1.
     simpl; destruct b, t; try reflexivity.
-    destruct (compute_nested_efield e1) as ((?, ?), ?); try reflexivity.
+    destruct (compute_nested_efield e1) as (((?, ?), ?), ?); try reflexivity.
     destruct (typeof e1); try reflexivity.
     - destruct (eqb_type t t0) eqn:?H; try reflexivity.
       apply eqb_type_spec in H0.
@@ -596,15 +596,15 @@ Proof.
       reflexivity.
   + destruct (IHe t) as [? _]; clear IHe.
     simpl.
-    destruct (compute_nested_efield e) as ((?, ?), ?); try reflexivity.
+    destruct (compute_nested_efield e) as (((?, ?), ?), ?); try reflexivity.
     destruct (typeof e); try reflexivity.
-    - simpl. rewrite <- H. reflexivity.
-    - simpl. rewrite <- H. reflexivity.
+    - if_tac; auto. simpl. rewrite <- H. reflexivity.
+    - if_tac; auto. simpl. rewrite <- H. reflexivity.
 Qed.
 
 Lemma compute_nested_efield_lemma: forall e,
   match compute_nested_efield e with
-  | (e', gfs, tts) => nested_efield e' gfs tts = e
+  | (e', gfs, tts, lr) => nested_efield e' gfs tts = e
   end.
 Proof.
   intros.

--- a/floyd/efield_lemmas.v
+++ b/floyd/efield_lemmas.v
@@ -29,7 +29,7 @@ Fixpoint nested_efield (e: expr) (efs: list efield) (tts: list type) : expr :=
 Definition compute_lr e (efs: list efield) :=
   match typeof e, length efs with
   | Tpointer _ _, S _ => RRRR
-  | Tarray _ _ _, _ => LLLL (* This line can be either L or R *)
+  | Tarray _ _ _, _ => RRRR (* This line can be either L or R, but R is consistent with LR_of_type *)
   | _, _ => LLLL
   end.
 
@@ -50,22 +50,6 @@ Inductive efield_denote {cs: compspecs}: list efield -> list gfield -> environ -
   | efield_denote_UnionField: forall i efs gfs rho,
       efield_denote efs gfs rho ->
       efield_denote (eUnionField i :: efs) (UnionField i :: gfs) rho.
-
-(* (* TODO: delete this original version *)
-Fixpoint efield_denote {cs: compspecs} (efs: list efield) (gfs: list gfield) : environ -> mpred :=
-  match efs, gfs with
-  | nil, nil => TT
-  | eArraySubsc ei :: efs', ArraySubsc i :: gfs' =>
-    local (`(eq (Vint (Int.repr i))) (eval_expr ei)) &&
-    !! (match typeof ei with | Tint _ _ _ => True | _ => False end) &&
-    efield_denote efs' gfs'
-  | eStructField i :: efs', StructField i0 :: gfs' =>
-    !! (i = i0) && efield_denote efs' gfs'
-  | eUnionField i :: efs', UnionField i0 :: gfs' =>
-    !! (i = i0) && efield_denote efs' gfs'
-  | _, _ => FF
-  end.
-*)
 
 Fixpoint typecheck_efield {cs: compspecs} (Delta: tycontext) (efs: list efield) : tc_assert :=
   match efs with

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -1949,37 +1949,37 @@ Ltac construct_nested_efield e e1 efs tts :=
     clear pp.
 
 Lemma efield_denote_cons_array: forall {cs: compspecs} P efs gfs ei i,
-  P |-- efield_denote efs gfs ->
+  P |-- local (efield_denote efs gfs) ->
   P |-- local (`(eq (Vint (Int.repr i))) (eval_expr ei)) ->
-  match typeof ei with
-  | Tint _ _ _ => True
-  | _ => False
-  end ->
-  P |-- efield_denote (eArraySubsc ei :: efs) (ArraySubsc i :: gfs).
+  is_int_type (typeof ei) = true ->
+  P |-- local (efield_denote (eArraySubsc ei :: efs) (ArraySubsc i :: gfs)).
 Proof.
   intros.
-  simpl efield_denote.
-  intro rho. simpl.
-  repeat apply andp_right; auto.
-  apply prop_right, H1.
+  rewrite (add_andp _ _ H), (add_andp _ _ H0), andp_assoc.
+  apply andp_left2.
+  intros rho; simpl; unfold local, lift1; unfold_lift; normalize.
+  constructor; auto.
+  constructor; auto.
 Qed.
 
 Lemma efield_denote_cons_struct: forall {cs: compspecs} P efs gfs i,
-  P |-- efield_denote efs gfs ->
-  P |-- efield_denote (eStructField i :: efs) (StructField i :: gfs).
+  P |-- local (efield_denote efs gfs) ->
+  P |-- local (efield_denote (eStructField i :: efs) (StructField i :: gfs)).
 Proof.
   intros.
   eapply derives_trans; [exact H |].
-  simpl; intros; normalize.
+  intros rho; simpl; unfold local, lift1; unfold_lift; normalize.
+  constructor; auto.
 Qed.
 
 Lemma efield_denote_cons_union: forall {cs: compspecs} P efs gfs i,
-  P |-- efield_denote efs gfs ->
-  P |-- efield_denote (eUnionField i :: efs) (UnionField i :: gfs).
+  P |-- local (efield_denote efs gfs) ->
+  P |-- local (efield_denote (eUnionField i :: efs) (UnionField i :: gfs)).
 Proof.
   intros.
   eapply derives_trans; [exact H |].
-  simpl; intros; normalize.
+  intros rho; simpl; unfold local, lift1; unfold_lift; normalize.
+  constructor; auto.
 Qed.
 
 Ltac unify_var_or_evar name val :=
@@ -2071,7 +2071,7 @@ Ltac find_load_result Hresult t_root gfs0 v gfs1 :=
 
 Ltac solve_efield_denote Delta P Q R efs gfs H :=
   evar (gfs : list gfield);
-  assert (ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |-- efield_denote efs gfs) as H;
+  assert (ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |-- local (efield_denote efs gfs)) as H;
   [
     unfold efs, gfs;
     match goal with

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -1941,9 +1941,9 @@ Ltac construct_nested_efield e e1 efs tts :=
   let pp := fresh "pp" in
     pose (compute_nested_efield e) as pp;
     simpl in pp;
-    pose (fst (fst pp)) as e1;
-    pose (snd (fst pp)) as efs;
-    pose (snd pp) as tts;
+    pose (fst (fst (fst pp))) as e1;
+    pose (snd (fst (fst pp))) as efs;
+    pose (snd (fst pp)) as tts;
     simpl in e1, efs, tts;
     change e with (nested_efield e1 efs tts);
     clear pp.

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -2077,7 +2077,7 @@ Ltac solve_efield_denote Delta P Q R efs gfs H :=
     match goal with
     | efs := nil |- _ =>
       instantiate (1 := nil);
-      apply prop_right, I
+      intros rho; apply prop_right; constructor
     | efs := ?ef :: ?efs' |- _ =>
       let efs0 := fresh "efs" in
       let gfs0 := fresh "gfs" in
@@ -2119,7 +2119,7 @@ Ltac solve_efield_denote Delta P Q R efs gfs H :=
           end;
 
           let HB := fresh "H" in
-          assert (match typeof ei with | Tint _ _ _ => True | _ => False end) as HB by (simpl; auto);
+          assert (is_int_type (typeof ei) = true) as HB by reflexivity;
 
           apply (efield_denote_cons_array _ _ _ _ _ H0 HA HB)
 

--- a/floyd/loadstore_field_at.v
+++ b/floyd/loadstore_field_at.v
@@ -98,7 +98,7 @@ Lemma semax_max_path_field_load_nth_ram:
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
         (tc_LR Delta e1 lr) &&
         (tc_efield Delta efs) &&
-        efield_denote efs gfs &&
+        local (efield_denote efs gfs) &&
         local `(tc_val (typeof (nested_efield e1 efs tts)) v) ->
       semax Delta (|>PROPx P (LOCALx Q (SEPx R)))
         (Sset id (nested_efield e1 efs tts))
@@ -112,9 +112,9 @@ Proof.
   assert_PROP (typeof (nested_efield e1 efs tts) = nested_field_type t_root gfs).
   Focus 1. {
     eapply derives_trans; [exact H9 |].
-    rewrite (add_andp _ _ (typeof_nested_efield _ _ _ _ _ _ H4)).
-    normalize.
-    apply prop_right; symmetry; auto.
+    intros rho; simpl; unfold local, lift1; unfold_lift; normalize.
+    apply prop_right.
+    symmetry; eapply typeof_nested_efield; eauto.
   } Unfocus.
   rewrite H11 in H10.
   assert_PROP (field_compatible t_root gfs p).
@@ -208,7 +208,7 @@ Lemma semax_max_path_field_load_nth_ram'':
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
         (tc_LR Delta e1 lr) &&
         (tc_efield Delta efs) &&
-        efield_denote efs gfsB &&
+        local (efield_denote efs gfsB) &&
         local `(tc_val (typeof (nested_efield e1 efs tts)) v) ->
       semax Delta (|>PROPx P (LOCALx Q (SEPx R)))
         (Sset id (nested_efield e1 efs tts))
@@ -222,9 +222,9 @@ Proof.
   assert_PROP (typeof (nested_efield e1 efs tts) = nested_field_type t_root (gfsB ++ gfsA)) as EqT. {
     rewrite <- nested_field_type_nested_field_type.
     eapply derives_trans; [exact Tc |].
-    rewrite (add_andp _ _ (typeof_nested_efield _ _ _ _ _ _ Lnf)).
-    normalize.
-    apply prop_right; symmetry; auto.
+    intros rho; simpl; unfold local, lift1; unfold_lift; normalize.
+    apply prop_right.
+    symmetry; eapply typeof_nested_efield; eauto.
   }
   rewrite EqT in ByVal.
   assert_PROP (field_compatible t_root (gfsB ++ gfsA) a) as Fc. {
@@ -322,7 +322,7 @@ Lemma semax_max_path_field_cast_load_nth_ram:
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
         (tc_LR Delta e1 lr) &&
         (tc_efield Delta efs) &&
-        efield_denote efs gfs &&
+        local (efield_denote efs gfs) &&
         local `(tc_val t (eval_cast (typeof (nested_efield e1 efs tts)) t v)) ->
       semax Delta (|> PROPx P (LOCALx Q (SEPx R)))
         (Sset id (Ecast (nested_efield e1 efs tts) t))
@@ -335,9 +335,9 @@ Proof.
   assert_PROP (typeof (nested_efield e1 efs tts) = nested_field_type t_root gfs).
   Focus 1. {
     eapply derives_trans; [exact H9 |].
-    rewrite (add_andp _ _ (typeof_nested_efield _ _ _ _ _ _ H4)).
-    normalize.
-    apply prop_right; symmetry; auto.
+    intros rho; simpl; unfold local, lift1; unfold_lift; normalize.
+    apply prop_right.
+    symmetry; eapply typeof_nested_efield; eauto.
   } Unfocus.
   rewrite H10 in H0.
   assert_PROP (field_compatible t_root gfs p).
@@ -440,7 +440,7 @@ Lemma semax_max_path_field_store_nth_ram:
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
         (tc_LR Delta e1 lr) &&
         (tc_efield Delta efs) &&
-        efield_denote efs gfs &&
+        local (efield_denote efs gfs) &&
         (tc_expr Delta (Ecast e2 (typeof (nested_efield e1 efs tts)))) ->
       semax Delta (|>PROPx P (LOCALx Q (SEPx R)))
         (Sassign (nested_efield e1 efs tts) e2)
@@ -454,9 +454,9 @@ Proof.
   assert_PROP (typeof (nested_efield e1 efs tts) = nested_field_type t_root gfs).
   Focus 1. {
     eapply derives_trans; [exact H9 |].
-    rewrite (add_andp _ _ (typeof_nested_efield _ _ _ _ _ _ H3)).
-    normalize.
-    apply prop_right; symmetry; auto.
+    intros rho; simpl; unfold local, lift1; unfold_lift; normalize.
+    apply prop_right.
+    symmetry; eapply typeof_nested_efield; eauto.
   } Unfocus.
   assert_PROP (field_compatible t_root gfs p).
   Focus 1. {
@@ -505,7 +505,7 @@ Lemma semax_partial_path_field_store_nth_ram:
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
         (tc_LR Delta e1 lr) && 
         (tc_efield Delta efs) &&
-        efield_denote efs gfsB &&
+        local (efield_denote efs gfsB) &&
         (tc_expr Delta (Ecast e2 (typeof (nested_efield e1 efs tts)))) ->
       legal_nested_efield (nested_field_type t_root gfsA) e1 gfsB tts lr = true ->
       semax Delta (|>PROPx P (LOCALx Q (SEPx R))) 
@@ -520,9 +520,9 @@ Proof.
   assert_PROP (typeof (nested_efield e1 efs tts) = nested_field_type t_root (gfsB ++ gfsA)) as EqT. {
     rewrite <- nested_field_type_nested_field_type.
     eapply derives_trans; [exact Tc |].
-    rewrite (add_andp _ _ (typeof_nested_efield _ _ _ _ _ _ Lnef)).
-    normalize.
-    apply prop_right; symmetry; auto.
+    intros rho; simpl; unfold local, lift1; unfold_lift; normalize.
+    apply prop_right.
+    symmetry; eapply typeof_nested_efield; eauto.
   }
   rewrite EqT in ByVal.
   assert_PROP (field_compatible t_root (gfsB ++ gfsA) a) as Fc. {

--- a/floyd/loadstore_field_at.v
+++ b/floyd/loadstore_field_at.v
@@ -240,7 +240,7 @@ Proof.
   + exact EqT.
   + exact TId.
   + exact Cast.
-  + rewrite field_address_app by assumption.
+  + rewrite field_address_app.
     rewrite (add_andp _ _ Evale1), (add_andp _ _ Tc).
     eapply derives_trans; [| apply eval_lvalue_nested_efield; try eassumption].
     - solve_andp.
@@ -537,7 +537,7 @@ Proof.
   }
   eapply semax_store_nth_ram with (p := (field_address t_root (gfsB ++ gfsA) a)).
   + exact EqT.
-  + rewrite field_address_app by assumption.
+  + rewrite field_address_app.
     rewrite (add_andp _ _ Evale1), (add_andp _ _ Tc).
     eapply derives_trans; [| apply eval_lvalue_nested_efield; try eassumption].
     - solve_andp.

--- a/floyd/nested_field_lemmas.v
+++ b/floyd/nested_field_lemmas.v
@@ -591,19 +591,21 @@ Definition field_address0 t gfs p :=
   else Vundef.
 
 Lemma field_address_isptr:
-  forall t path c, isptr c -> field_compatible t path c -> isptr (field_address t path c).
+  forall t path c, field_compatible t path c -> isptr (field_address t path c).
 Proof.
   intros.
   unfold field_address. rewrite if_true by auto.
+  destruct H as [? _].
   normalize.
 Qed.
 
 Lemma field_address0_isptr:
-  forall t path c, isptr c -> field_compatible0 t path c -> isptr (field_address0 t path c).
+  forall t path c, field_compatible0 t path c -> isptr (field_address0 t path c).
 Proof.
- intros.
- unfold field_address0. rewrite if_true by auto.
- normalize.
+  intros.
+  unfold field_address0. rewrite if_true by auto.
+  destruct H as [? _].
+  normalize.
 Qed.
 
 Lemma field_address_clarify:
@@ -611,7 +613,7 @@ Lemma field_address_clarify:
    is_pointer_or_null (field_address t path c) ->
    field_address t path c = offset_val (nested_field_offset t path) c.
 Proof.
- intros. unfold field_address in *.
+  intros. unfold field_address in *.
   if_tac; try contradiction.
   auto.
 Qed.

--- a/floyd/nested_field_lemmas.v
+++ b/floyd/nested_field_lemmas.v
@@ -1535,6 +1535,16 @@ Proof.
     { assumption. }
 Qed.
 
+Lemma field_address_app_rewrite: forall t_root t' gfsA gfsB a,
+  nested_field_type t_root gfsA = t' ->
+  field_address t_root (gfsB ++ gfsA) a =
+  field_address t' gfsB (field_address t_root gfsA a).
+Proof.
+  intros.
+  subst.
+  apply field_address_app.
+Qed.
+
 End COMPOSITE_ENV.
 (*
 Arguments nested_field_offset2 {cs} t gfs /.

--- a/floyd/nested_loadstore.v
+++ b/floyd/nested_loadstore.v
@@ -379,6 +379,60 @@ Proof.
   tauto.
 Qed.
 
+Lemma nested_field_ramif_load: forall sh t gfs0 gfs1 (v_reptype: reptype (nested_field_type t gfs0)) (v_val: val) p,
+  field_compatible t (gfs1 ++ gfs0) p ->
+  JMeq (proj_reptype (nested_field_type t gfs0) gfs1 v_reptype) v_val ->
+  exists v_reptype',
+    JMeq v_reptype' v_val /\
+    field_at sh t gfs0 v_reptype p |--
+      field_at sh t (gfs1 ++ gfs0) v_reptype' p * TT.
+Proof.
+  intros.
+  generalize (JMeq_refl (proj_reptype (nested_field_type t gfs0) gfs1 v_reptype)).
+  set (v0 := proj_reptype (nested_field_type t gfs0) gfs1 v_reptype) at 2.
+  clearbody v0.
+  revert v0.
+  pattern (reptype (nested_field_type (nested_field_type t gfs0) gfs1)) at 1 3.
+  rewrite nested_field_type_nested_field_type at 1.
+  intros; exists v0.
+  split.
+  1: eapply JMeq_trans; [apply @JMeq_sym |]; eassumption.
+  eapply derives_trans; [apply nested_field_ramif; eassumption |].
+  apply sepcon_derives; auto.
+Qed.
+
+Lemma nested_field_ramif_store: forall sh t gfs0 gfs1 (v_reptype: reptype (nested_field_type t gfs0)) (v0_reptype: reptype (nested_field_type (nested_field_type t gfs0) gfs1)) (v_val: val) p,
+  field_compatible t (gfs1 ++ gfs0) p ->
+  JMeq v0_reptype v_val ->
+  exists v0_reptype',
+    JMeq v0_reptype' v_val /\
+    field_at sh t gfs0 v_reptype p |--
+      field_at_ sh t (gfs1 ++ gfs0) p *
+       (field_at sh t (gfs1 ++ gfs0) v0_reptype' p -*
+          field_at sh t gfs0 (upd_reptype (nested_field_type t gfs0) gfs1 v_reptype v0_reptype) p).
+Proof.
+  intros.
+  generalize (JMeq_refl (proj_reptype (nested_field_type t gfs0) gfs1 v_reptype)).
+  set (v0 := proj_reptype (nested_field_type t gfs0) gfs1 v_reptype) at 2.
+  clearbody v0.
+  generalize (JMeq_refl v0_reptype).
+  set (v0_reptype' := v0_reptype) at 2.
+  clearbody v0_reptype'.
+  revert v0 v0_reptype'.
+  pattern (reptype (nested_field_type (nested_field_type t gfs0) gfs1)) at 1 2 4 6.
+  rewrite nested_field_type_nested_field_type at 1.
+  intros; exists v0_reptype'.
+  split.
+  1: eapply JMeq_trans; [apply @JMeq_sym |]; eassumption.
+  eapply derives_trans; [apply nested_field_ramif; eassumption |].
+  apply sepcon_derives.
+  1: apply field_at_field_at_.
+  eapply allp_left.
+  eapply allp_left.
+  rewrite prop_imp; [apply derives_refl |].
+  auto.
+Qed.
+
 End NESTED_RAMIF.
 
 Lemma semax_extract_later_prop' {cs: compspecs}:

--- a/floyd/nested_loadstore.v
+++ b/floyd/nested_loadstore.v
@@ -455,28 +455,6 @@ Proof.
     auto.
 Qed.
 
-Lemma corable_efield_denote {cs: compspecs}: forall efs gfs rho, corable (efield_denote efs gfs rho).
-Proof.
-  intros.
-  revert gfs; induction efs; destruct gfs; simpl; intros.
-  + apply corable_prop.
-  + apply corable_prop.
-  + destruct a; apply corable_prop.
-  + destruct a, g; try apply corable_prop.
-    - unfold local, lift1.
-      unfold_lift.
-      repeat apply corable_andp.
-      apply corable_prop.
-      apply corable_prop.
-      apply IHefs.
-    - apply corable_andp.
-      apply corable_prop.
-      apply IHefs.
-    - apply corable_andp.
-      apply corable_prop.
-      apply IHefs.
-Qed.
-
 Lemma insert_corable_sep: forall R1 P Q R,
   corable R1 ->
   `R1 && PROPx P (LOCALx Q (SEPx R)) = PROPx P (LOCALx Q (SEPx (R1 && emp :: R))).

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -637,34 +637,34 @@ The set, load, cast-load and store rules will be used in the future.
 
 ************************************************)
 
-(* TODO: This was broken because semax_SC_field_load's specification is changed. *)
-(*
 Lemma semax_PTree_set:
   forall {Espec: OracleKind},
-    forall Delta id P T1 T2 R (e2: Clight.expr) t v,
+    forall Delta id P Q R T1 T2 (e2: expr) t v,
+      local2ptree Q = (T1, T2, nil, nil) ->
       typeof_temp Delta id = Some t ->
       is_neutral_cast (implicit_deref (typeof e2)) t = true ->
       msubst_eval_expr T1 T2 e2 = Some v ->
-      (local (tc_environ Delta)) && (assertD P (localD T1 T2) R) |--
+      ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
          (tc_expr Delta e2) ->
-      semax Delta (|> (assertD P (localD T1 T2) R))
+      semax Delta (|>PROPx P (LOCALx Q (SEPx R)))
         (Sset id e2)
           (normal_ret_assert
-            (assertD P (localD (PTree.set id v T1) T2) R)).
+            (PROPx P
+              (LOCALx (temp id v :: remove_localdef_temp id Q)
+                (SEPx R)))).
 Proof.
   intros.
-  unfold assertD, localD in *.
-  eapply semax_post'.
-  Focus 2. {
-    eapply semax_SC_set; eauto.
-    instantiate (1 := v).
-    apply andp_left2.
-    apply msubst_eval_expr_eq, H1.
-  } Unfocus.
-  normalize.
-  apply SC_remove_subst.
+  eapply semax_SC_set.
+  1: eassumption.
+  1: eassumption.
+  2: eassumption.
+  apply andp_left2.
+  erewrite local2ptree_soundness by eassumption.
+  apply msubst_eval_expr_eq; auto.
 Qed.
 
+(* TODO: This was broken because semax_SC_field_load's specification is changed. *)
+(*
 Lemma semax_PTree_load:
   forall {Espec: OracleKind},
     forall Delta sh n id P T1 T2 R Rn (e1: expr)

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -714,6 +714,7 @@ Proof.
   apply msubst_eval_expr_eq; auto.
 Qed.
 
+(*
 Lemma semax_PTree_field_load:
   forall {Espec: OracleKind},
     forall Delta sh id P Q R (e1: expr)
@@ -721,7 +722,7 @@ Lemma semax_PTree_field_load:
       (t t_root: type) (gfs0 gfs1 gfs: list gfield) 
       (p: val) (v : val) (v' : reptype (nested_field_type t_root gfs0)) lr,
       local2ptree Q = (T1, T2, nil, nil) ->
-      compute_nested_efield e = (e_root, efs, tts) ->
+      compute_nested_efield e = (e_root, efs, tts, lr) ->
       typeof_temp Delta id = Some t ->
       is_neutral_cast (typeof e) t = true ->
       msubst_eval_LR T1 T2 e1 lr = Some p_from_e ->
@@ -750,6 +751,7 @@ Lemma semax_PTree_field_load:
             (PROPx P
               (LOCALx (temp id v :: remove_localdef_temp id Q)
                 (SEPx R)))).
+ *)
 
 (* TODO: This was broken because semax_SC_field_load's specification is changed. *)
 (*

--- a/floyd/seplog_tactics.v
+++ b/floyd/seplog_tactics.v
@@ -15,6 +15,44 @@ Proof. intros. rewrite andp_assoc. rewrite andp_comm.  rewrite <- prop_and; auto
 Qed.
 Hint Rewrite gather_prop_left gather_prop_right : gather_prop.
 
+Lemma andp_in_order1 {A}{NA: NatDed A}:
+  forall P Q, P && Q = P && (P --> Q).
+Proof.
+  intros.
+  apply pred_ext.
+  + apply andp_derives; auto.
+    apply imp_andp_adjoint.
+    apply andp_left1; auto.
+  + apply andp_right.
+    - apply andp_left1; auto.
+    - apply modus_ponens.
+Qed.
+
+Lemma andp_in_order2 {A}{NA: NatDed A}:
+  forall P Q, P && Q = Q && (Q --> P).
+Proof.
+  intros.
+  rewrite (andp_comm P Q).
+  apply andp_in_order1.
+Qed.
+
+Lemma andp_right1{A}{NA: NatDed A}:
+  forall P Q R, P |-- Q -> P && Q |-- R -> P |-- Q && R.
+Proof.
+  intros.
+  rewrite andp_in_order1.
+  apply andp_right; auto.
+  apply imp_andp_adjoint; auto.
+Qed.
+
+Lemma andp_right2{A}{NA: NatDed A}:
+  forall P Q R, P |-- R -> P && R |-- Q -> P |-- Q && R.
+Proof.
+  intros.
+  rewrite andp_comm.
+  apply andp_right1; auto.
+Qed.
+
 Definition not_a_prop {A} (P: A) := True.
 
 Ltac not_a_prop := match goal with

--- a/floyd/stronger.v
+++ b/floyd/stronger.v
@@ -1,3 +1,4 @@
+(* TODO: remove this file *)
 Require Import floyd.base2.
 Require Import floyd.client_lemmas.
 Require Import floyd.nested_field_lemmas.


### PR DESCRIPTION
Improve some lemmas like field_address_app and field_address_isptr: some unnecessary assumptions are removed.

Redefine denote_efield. Now we use "local (denote_efield efs gfs)" instead of "denote_efield efs gfs". So, it is a pure fact by shape.