### PR TITLE
Fix bug in tc_environ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 branches:
   only:
   - master
-  - canon-semax-return
+  - fix_bug_tc_environ
 notifications:
   email:
     recipients:

--- a/floyd/assert_lemmas.v
+++ b/floyd/assert_lemmas.v
@@ -156,7 +156,7 @@ Proof.
   unfold same_env in *.
   destruct (H3 _ _ H1).
   unfold Map.get; rewrite H4.
-  destruct (H2 _ _ H1) as [b [? ?]].
+  destruct (H2 _ _ H1) as [b ?].
    rewrite H5. simpl.
   eauto.
   destruct H4; congruence.
@@ -447,7 +447,7 @@ intros.
 unfold tc_environ, typecheck_environ in H.
 destruct H as [Ha [Hb [Hc Hd]]].
 hnf in Hc.
-specialize (Hc _ _ H1). destruct Hc as [b [Hc Hc']].
+specialize (Hc _ _ H1). destruct Hc as [b Hc].
 exists b.
 unfold eval_var; simpl.
 apply Hd in H1.
@@ -486,11 +486,11 @@ Proof.
   rewrite eqb_type_refl.
   simpl. auto.
   destruct H0.
-  destruct (H1 _ _ H3) as [b [? ?]].
+  destruct (H1 _ _ H3) as [b ?].
   rewrite H4. simpl.
  destruct (H2 _ _ H3).
- unfold Map.get; rewrite H6.
+ unfold Map.get; rewrite H5.
  auto.
- destruct H6. congruence.
+ destruct H5. congruence.
 Qed.
 

--- a/floyd/globals_lemmas.v
+++ b/floyd/globals_lemmas.v
@@ -61,7 +61,7 @@ unfold globvar2pred.
 simpl.
 destruct H6 as [? [? [? ?]]].
 destruct (H9 i _ H0); [ | destruct H10; congruence].
-destruct (H8 _ _ H0) as [b [? ?]].
+destruct (H8 _ _ H0) as [b ?].
 rewrite H11. rewrite H1.
 rewrite H3; simpl.
 unfold eval_var.
@@ -86,7 +86,7 @@ unfold globvar2pred.
 simpl.
 destruct H6 as [? [? [? ?]]].
 destruct (H9 i _ H0); [ | destruct H10; congruence].
-destruct (H8 _ _ H0) as [b [? ?]].
+destruct (H8 _ _ H0) as [b ?].
 rewrite H11. rewrite H1.
 rewrite H3; simpl.
 apply exp_right with (Vptr b Int.zero).
@@ -239,7 +239,7 @@ intros H1 HH H1' H6' H6 H7 H8 H1'' RS.
 *  destruct ((var_types Delta) ! i) eqn:Hv;
    destruct ((glob_types Delta) ! i) eqn:Hg;
     try destruct g; try solve [simpl; apply TT_right].
- +   destruct (proj1 (proj2 (proj2 H7)) _ _ Hg) as [b' [H15 H16]]; rewrite H15.
+ +   destruct (proj1 (proj2 (proj2 H7)) _ _ Hg) as [b' H15]; rewrite H15.
      simpl.
      rewrite H8.
      eapply derives_trans.
@@ -251,7 +251,7 @@ intros H1 HH H1' H6' H6 H7 H8 H1'' RS.
     auto.
     auto.
  +
-   destruct (proj1 (proj2 (proj2 H7)) _ _ Hg) as [b' [H15 H16]]; rewrite H15.
+   destruct (proj1 (proj2 (proj2 H7)) _ _ Hg) as [b' H15]; rewrite H15.
    assert (Hv' :=proj1 (expr_lemmas2.typecheck_var_environ_None _ _ (proj1 (proj2 H7)) i) Hv).
    assert (locald_denote (gvar i (Vptr b' Int.zero)) rho)
      by (hnf; rewrite Hv'; rewrite H15; auto).

--- a/progs/conclib.v
+++ b/progs/conclib.v
@@ -3081,7 +3081,7 @@ apply andp_right.
   unfold gvar_denote, eval_var, Map.get.
   destruct H as (_ & _ & DG & DS).
   destruct (DS id _ GS) as [-> | (t & E)]; [ | congruence].
-  destruct (DG id _ GS) as (? & -> & ?); auto.
+  destruct (DG id _ GS) as [? ?]; rewrite H; auto.
 - (* about func_ptr/func_ptr' *)
   unfold func_ptr'.
   rewrite <- andp_left_corable, andp_comm; auto.

--- a/veric/expr.v
+++ b/veric/expr.v
@@ -943,8 +943,7 @@ forall id ty, tc ! id = Some (ty) <-> exists v, Map.get ve id = Some(v,ty).
 Definition typecheck_glob_environ
 (ge: genviron) (tc: PTree.t type) :=
 forall id  t,  tc ! id = Some t ->
-((exists b,
-(ge id = Some b /\ tc_val t (Vptr b Int.zero)))).
+(exists b, ge id = Some b).
 
 Definition same_env (rho:environ) (Delta:tycontext)  :=
 forall id t, (glob_types Delta) ! id = Some t ->

--- a/veric/expr_lemmas.v
+++ b/veric/expr_lemmas.v
@@ -777,7 +777,7 @@ revert H1; case_eq ((var_types Delta) ! i); intros; try contradiction.
 specialize (Hve i t0). destruct Hve as [Hve _].
 destruct (Hve H0). simpl in *; congruence.
 revert H1; case_eq ((glob_types Delta) ! i); intros; try contradiction.
-destruct (Hge _ _ H1) as [b [? ?]].
+destruct (Hge _ _ H1) as [b ?].
 simpl. simpl in H3.
 rewrite H3.
 
@@ -805,7 +805,7 @@ apply Clight.eval_Evar_global; auto.
  rewrite eqb_type_refl. reflexivity.
  +
  destruct ((glob_types Delta)!i) eqn:?; inv H3.
- destruct (H1 _ _ Heqo) as [b [? ?]];
+ destruct (H1 _ _ Heqo) as [b ?];
  exists b; exists Int.zero; split; auto.
  specialize (H2 _ _ Heqo).
  simpl in H2.
@@ -1155,10 +1155,10 @@ typecheck_glob_environ (ge_of rho) (glob_types Delta).
 Proof.
 intros. destruct c; simpl in *; try apply H;
 try destruct o; try rewrite set_temp_ge in *; try apply H;
-unfold typecheck_glob_environ in *; intros; apply H; try rewrite glob_types_update_dist;
+unfold typecheck_glob_environ in *; intros; eapply H; try rewrite glob_types_update_dist;
 try apply join_ge_eqv;
 repeat rewrite update_tycon_same_ge in *; try rewrite update_le_same_ge;
-auto.
+eauto.
 Qed.
 
 Lemma typecheck_environ_update:

--- a/veric/expr_lemmas2.v
+++ b/veric/expr_lemmas2.v
@@ -52,7 +52,7 @@ destruct ((var_types Delta) ! i) eqn:?H;
 + apply tc_bool_e in H2.
   apply (typecheck_var_environ_None _ _ H0) in H.
   apply H1 in H3.
-  destruct H3 as [b [? ?]].
+  destruct H3 as [b ?].
   exists b, Int.zero.
   rewrite H, H3.
   auto.
@@ -131,7 +131,7 @@ subst.
 unfold same_env in *.
 symmetry in Heqo0.  specialize (H5 _ _ Heqo0).
 destruct H5. simpl in *. unfold Map.get. rewrite H4.
-unfold typecheck_glob_environ in *. destruct (H3 i _ Heqo0). destruct H5.
+unfold typecheck_glob_environ in *. destruct (H3 i _ Heqo0).
 rewrite H5.
 destruct pt; inv H1; reflexivity.
 destruct H4; congruence. inv H0.
@@ -229,8 +229,8 @@ unfold get_var_type in *.
 
 remember ((var_types Delta) ! i).
 destruct o; try rewrite eqb_type_eq in *; simpl in *; intuition.
-remember (type_eq t t0). destruct s; intuition.
-- subst. simpl in H0.
+- remember (type_eq t t0). destruct s; intuition.
+ subst. simpl in H0.
 clear H0.
 symmetry in Heqo.
 specialize (H i t0).
@@ -238,19 +238,19 @@ destruct H as [H _]; specialize (H Heqo).
 destruct H. unfold eval_var. simpl.
 rewrite H in *. rewrite eqb_type_refl in *.
 simpl. destruct t0; try destruct i0; try destruct s; try destruct f; inv MODE; simpl; auto.
-- remember ((glob_types Delta) ! i). destruct o; try congruence.
+- remember ((glob_types Delta) ! i). destruct o; [| inv H0].
 simpl in *.
 unfold eval_var in *.
- super_unfold_lift. remember (eqb_type t t0).
-symmetry in Heqb. destruct b; simpl in *; try congruence. apply eqb_type_true in Heqb.
+super_unfold_lift. remember (eqb_type t t0).
+symmetry in Heqb. destruct b; simpl in *; [| inv H0].
+apply eqb_type_true in Heqb.
 subst.
 symmetry in Heqo0.  specialize (SM _ _ Heqo0).
-destruct SM.
+destruct SM as [| [? ?]]; [| congruence].
 unfold Map.get. rewrite H3.
 unfold typecheck_glob_environ in *.
-destruct (H2 _ _ Heqo0). destruct H4.
-rewrite H4. auto. destruct H3; congruence.
-inv H0. inv H0.
+destruct (H2 _ _ Heqo0).
+rewrite H4. destruct t0 as [| [| | |] [|] | | [|] | | | | |]; inv MODE; simpl; auto.
 Qed.
 
 Definition unOp_result_type op t :=

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -221,7 +221,7 @@ Proof.
   specialize (H0 _ _ H).
   specialize (SAME _ _ H).
   destruct SAME as [SAME | [t SAME]]; [ | congruence].
-  destruct H0 as [b [? ?]].
+  destruct H0 as [b ?].
   specialize (H7 (Vptr b Int.zero) fsig0 cc A P' Q' _ (necR_refl _)).
   spec H7.
   Focus 1. {
@@ -239,7 +239,7 @@ Proof.
     specialize (H5 _ _ _ (necR_refl _) H').
     destruct H5 as [b' [? ?]].
     do 3 red in H5. inversion2 H0 H5.
-    apply H10.
+    apply H9.
 Qed.
 
 Import JuicyMemOps.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -155,8 +155,8 @@ split; [ | split; [ | split]].
  intros id ty. specialize (H4 id ty). rewrite <- H4.
  rewrite H0. clear; intuition.
 * clear - H2 H5.
- hnf; intros. apply H5.
- specialize (H2 id). hnf in H2. rewrite H in H2. auto.
+ hnf; intros. eapply H5.
+ specialize (H2 id). hnf in H2. rewrite H in H2. eauto.
 * clear - H6 H1 H2 H0.
  hnf; intros. specialize (H6 id t).
  specialize (H2 id); hnf in H2. rewrite H in H2.

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -948,11 +948,7 @@ clear - H2. induction l; simpl; auto.
 destruct a. destruct g; simpl in *. destruct H2; auto. right; auto.
 apply IHl; auto.
 destruct (find_funct_ptr_exists prog id fd) as [b [? ?]]; auto.
-exists b.
-unfold globalenv; simpl Genv.find_symbol.
-split; auto.
-unfold type_of_global.
-destruct f; simpl; auto.
+exists b; auto.
 *
  unfold filter_genv.
  destruct (match_globvars_in' _ _ _ _ H0 H2) as [g [? [? TC]]].
@@ -960,9 +956,7 @@ destruct f; simpl; auto.
  pose proof (prog_defmap_norepet _ _ _ H H3).
 destruct (proj1 (Genv.find_def_symbol _ _ _) H5)
   as [b [? ?]].
- exists b.
- split; auto.
- destruct t; inv TC; simpl; auto.
+ exists b; auto.
 Qed.
 
 Lemma semax_prog_typecheck_aux:


### PR DESCRIPTION
Fixing a bug in the definition of typecheck_environ. But more importantly, we should check why this is not revealed by the end-to-end guarantee of veric.