### PR TITLE
Simplify *Make clean* using wildcards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,26 +368,6 @@ FILES = \
  $(HMACDRBG_Files:%=hmacdrbg/%)
 # $(DRBG_FILES:%=verifiedDrbg/spec/%)
 
-CLEANFILES = \
- $(MSL_FILES:%=msl/.%o.aux) \
- $(SEPCOMP_FILES:%=sepcomp/.%o.aux) \
- $(VERIC_FILES:%=veric/.%o.aux) \
- $(FLOYD_FILES:%=floyd/.%o.aux) \
- $(PROGS_FILES:%=progs/.%o.aux) \
- $(WAND_DEMO_FILES:%=wand_demo/.%o.aux) \
- $(SHA_FILES:%=sha/.%o.aux) \
- $(HMAC_FILES:%=sha/.%o.aux) \
- $(FCF_FILES:%=fcf/.%o.aux) \
- $(HMACFCF_FILES:%=hmacfcf/.%o.aux) \
- $(HMACEQUIV_FILES:%=sha/.%o.aux) \
- $(CCC26x86_FILES:%=ccc26x86/.%o.aux) \
- $(TWEETNACL_FILES:%=tweetnacl20140427/.%o.aux) \
- $(CONCUR_FILES:%=concurrency/.%o.aux) \
- $(HMACDRBG_Files:%=hmacdrbg/.%o.aux)
-# $(DRBG_FILES:%=verifiedDrbg/spec/%)
-
-
-
 %_stripped.v: %.v
 # e.g., 'make progs/verif_reverse_stripped.v will remove the tutorial comments
 # from progs/verif_reverse.v
@@ -566,7 +546,8 @@ depend-paco:
 	$(COQDEP) > .depend-paco $(PACO_FILES:%.v=concurrency/paco/src/%.v)
 
 clean:
-	rm -f $(FILES:%.v=%.vo) $(FILES:%.v=%.glob) $(CLEANFILES) version.vo .version.vo.aux version.glob .lia.cache .nia.cache floyd/floyd.coq .loadpath .depend _CoqProject
+	rm -f version.vo .version.vo.aux version.glob .lia.cache .nia.cache floyd/floyd.coq .loadpath .depend _CoqProject $(wildcard */.*.aux)  $(wildcard */*.glob) $(wildcard */*.vo)
+
 
 clean-concur:
 	rm -f $(CONCUR_FILES:%.v=%.vo) $(CONCUR_FILES:%.v=%.glob)


### PR DESCRIPTION
This should get rid of the usual generated files in a more aggressive way.  
This is more interesting that previous version because it was only removing .vo files existing in FILES.  
If a path changed for a file, the respective .vo file was not deleted but still accessible through CoqIDE.  
This could lead to some inconsistencies.

Remark the clean now get rid of all the files of type:
```
*/*.vo
*/.*.aux
*/*.glob
```

This aims to unify the clean between version 8.6 and 8.6.1 of Coq:  
Coq 8.6 used `.xxx.vo.aux`  
Coq 8.6.1 uses `.xxx.aux`  