### PR TITLE
[coq] Update for Coq 8.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - NJOBS=4
   # system is == 4.02.3
   - COMPILER="system"
+  - COQ_VERSION="8.7.0"
 branches:
   only:
   - master
@@ -42,7 +43,7 @@ install:
 - "[ -e .opam ] || opam init -j ${NJOBS} --compiler=${COMPILER} -n -y"
 - eval $(opam config env)
 - opam config var root
-- opam install -j ${NJOBS} -y coq=8.6.1 ${EXTRA_OPAM}
+- opam install -j ${NJOBS} -y coq=${COQ_VERSION} ${EXTRA_OPAM}
 - opam list
 
 jobs:

--- a/BUILD_ORGANIZATION.md
+++ b/BUILD_ORGANIZATION.md
@@ -7,8 +7,7 @@
    will tell you which versions are compatible.
 
 2. Make sure you have the right version of CompCert.
-   VST 1.9 uses CompCert 2.7.2 for Coq 8.6.1 or Coq 8.6 or Coq 8.7.
-   More recent versions use only Coq 8.6.1 or 8.7.
+   VST 1.9 uses CompCert 2.7.2 for Coq 8.6.1 or Coq 8.7.
 
    However, [AbsInt.com](https://www.absint.com) (the official distributor of
    CompCert) does not support CompCert 2.7 for Coq 8.6 (only for 8.4 and 8.5).

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ else
 endif
 
 # you can also write, COQVERSION= 8.6 or-else 8.6pl2 or-else 8.6pl3   (etc.)
-COQVERSION= 8.6 or-else 8.6.1 or-else 8.7.0
+COQVERSION= 8.6.1 or-else 8.7.0
 COQV=$(shell $(COQC) -v)
 ifeq ($(IGNORECOQVERSION),true)
 else

--- a/compcert/lib/Coqlib.v
+++ b/compcert/lib/Coqlib.v
@@ -21,6 +21,7 @@ Require Export ZArith.
 Require Export Znumtheory.
 Require Export List.
 Require Export Bool.
+Require Export FunInd.
 
 Global Set Asymmetric Patterns.
 


### PR DESCRIPTION
VST can't currently compile out-of-the-box with Coq 8.7.0 due to a
missing include. This affects Coq's CI system as they are testing a
branch instead the main VST repository.

The solution is to add the missing include, this however restricts the
out-of-the-box VST to 8.6.1 and 8.7.0+ , removing support for 8.6.0.

IMO this OOTB configuration makes more sense than the current one
requiring a manual compcert update.

We also switch the main Travis testing to 8.7.0 which is slightly
faster and should provide a better testing base.