### PR TITLE
Remove uses of deprecated appcontext.

### DIFF
--- a/concurrency/paco/src/pacotacuser.v
+++ b/concurrency/paco/src/pacotacuser.v
@@ -81,7 +81,7 @@ Tactic Notation "pcofix" ident(CIH) := pcofix CIH with r.
 Ltac pclearbot :=
   let X := fresh "_X" in
   repeat match goal with
-  | [H: appcontext[pacoid] |- _] => red in H; destruct H as [H|X]; [|contradiction X]
+  | [H: context[pacoid] |- _] => red in H; destruct H as [H|X]; [|contradiction X]
   end.
 
 (** ** [pdestruct H] and [pinversion H]

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -2755,7 +2755,7 @@ Ltac clear_Delta_specs_if_leaf_function :=
  match goal with DS := @abbreviate (PTree.t funspec) _  |- semax _ _ ?S _ =>
    let S' := eval compute in S in
     match S' with 
-    | appcontext [Scall] => idtac
+    | context [Scall] => idtac
     | _ => clearbody DS
     end
  end.


### PR DESCRIPTION
`appcontext` is likely to be removed in Coq 8.8 and is semantically equivalent to `context`