### PR TITLE
add some 64 bit equivalence

### DIFF
--- a/floyd/coqlib3.v
+++ b/floyd/coqlib3.v
@@ -318,6 +318,64 @@ Proof.
   reflexivity.
 Qed.
 
+Lemma add64_repr: forall i j, Int64.add (Int64.repr i) (Int64.repr j) = Int64.repr (i+j).
+Proof. intros.
+  rewrite Int64.add_unsigned.
+ apply Int64.eqm_samerepr.
+ unfold Int64.eqm.
+ apply Int64.eqm_add; apply Int64.eqm_sym; apply Int64.eqm_unsigned_repr.
+Qed.
+
+Lemma mul64_repr:
+ forall x y, Int64.mul (Int64.repr x) (Int64.repr y) = Int64.repr (x * y).
+Proof.
+intros. unfold Int64.mul.
+apply Int64.eqm_samerepr.
+repeat rewrite Int64.unsigned_repr_eq.
+apply Int64.eqm_mult; unfold Int64.eqm; apply Int64.eqmod_sym;
+apply Int64.eqmod_mod; compute; congruence.
+Qed.
+
+Lemma sub64_repr: forall i j,
+  Int64.sub (Int64.repr i) (Int64.repr j) = Int64.repr (i-j).
+Proof.
+ intros. unfold Int64.sub.
+ apply Int64.eqm_samerepr.
+ unfold Int64.eqm.
+ apply Int64.eqm_sub; apply Int64.eqm_sym; apply Int64.eqm_unsigned_repr.
+Qed.
+
+Lemma and64_repr
+     : forall i j : Z, Int64.and (Int64.repr i) (Int64.repr j) = Int64.repr (Z.land i j).
+Proof.
+  intros.
+  unfold Int64.and.
+  rewrite <- (Int64.repr_unsigned (Int64.repr (Z.land i j))).
+  rewrite !Int64.unsigned_repr_eq.
+  change Int64.modulus with (2 ^ 64).
+  rewrite <- !Zland_two_p by omega.
+  f_equal.
+  rewrite <- !Z.land_assoc.
+  f_equal.
+  rewrite (Z.land_comm (Z.ones 64)).
+  rewrite <- !Z.land_assoc.
+  f_equal.
+Qed.
+
+Lemma or64_repr
+     : forall i j : Z, Int64.or (Int64.repr i) (Int64.repr j) = Int64.repr (Z.lor i j).
+Proof.
+  intros.
+  unfold Int64.or.
+  rewrite <- (Int64.repr_unsigned (Int64.repr (Z.lor i j))).
+  rewrite !Int64.unsigned_repr_eq.
+  change Int64.modulus with (2 ^ 64).
+  rewrite <- !Zland_two_p by omega.
+  f_equal.
+  rewrite <- Z.land_lor_distr_l.
+  reflexivity.
+Qed.
+
 Arguments Int.unsigned n : simpl never.
 Arguments Pos.to_nat !x / .
 
@@ -385,7 +443,7 @@ Proof.
     apply Permutation_app_tail.
     apply Permutation_app_comm.
   + eapply Permutation_trans; eauto.
-Qed.    
+Qed.
 
 Lemma proj_sumbool_is_false:
   forall (P: Prop) (a: {P}+{~P}), ~P -> proj_sumbool a = false.


### PR DESCRIPTION
We have this lemmas in their 32-bits version (Int.repr), why not in their 64-bits too (Int64.repr).