### PR TITLE
Added initial step to after_forward_call tactic, and corresponding le…

### DIFF
--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -805,21 +805,38 @@ Ltac cleanup_no_post_exists :=
  end
  || unfold eq_no_post.
 
-Ltac after_forward_call :=
+Lemma remove_localdef_temp_remove_localdef i: forall l,
+remove_localdef_temp i l = remove_localdef (temp i Vundef) l.
+Proof. induction l; trivial. simpl. rewrite IHl.
+  destruct a; trivial.
+  destruct (ident_eq i i0). subst; rewrite Pos.eqb_refl; trivial.
+  apply Pos.eqb_neq in n; rewrite n; trivial.
+Qed.
+
+Lemma remove_localdef_cons j i (N: Pos.eqb i j = false) v l:
+remove_localdef (temp i Vundef) (temp j v::l) = temp j v:: remove_localdef (temp i Vundef) l.
+Proof. simpl. rewrite N; trivial. Qed.
+
+Lemma remove_localdef_temp_cons j i (N: Pos.eqb i j = false) v l:
+remove_localdef_temp i (temp j v::l) = temp j v:: remove_localdef_temp i l.
+Proof. simpl. apply Pos.eqb_neq in N. rewrite if_false; trivial. Qed.
+
+Ltac after_forward_call := 
+    repeat (rewrite remove_localdef_temp_cons by reflexivity);
     cbv beta iota delta [remove_localdef_temp];
     simpl ident_eq; cbv beta iota zeta;
     repeat match goal with |- context [eq_rec_r ?A ?B ?C] =>
               change (eq_rec_r A B C) with B; cbv beta iota zeta
-            end;
-    unfold_app;
-    try (apply extract_exists_pre; intros _);
+            end; 
+    unfold_app; 
+    try (apply extract_exists_pre; intros _); 
     match goal with
         | |- semax _ _ _ _ => idtac
         | |- unit -> semax _ _ _ _ => intros _
-    end;
-    repeat (apply semax_extract_PROP; intro);
-    cleanup_no_post_exists;
-    abbreviate_semax;
+    end; 
+    repeat (apply semax_extract_PROP; intro); 
+    cleanup_no_post_exists; 
+    abbreviate_semax; 
     try fwd_skip.
 
 Ltac clear_MORE_POST :=

--- a/tweetnacl20140427/tweetNaclBase.v
+++ b/tweetnacl20140427/tweetNaclBase.v
@@ -4,7 +4,7 @@ Local Open Scope logic.
 Require Import List. Import ListNotations.
 Require Import sha.general_lemmas.
 
-Require Import tweetnacl20140427.split_array_lemmas.
+(*Require Import tweetnacl20140427.split_array_lemmas.*)
 Require Import ZArith.
 
 Lemma Zlength_list_repeat' {A} n (v:A): Zlength (list_repeat n v) = Z.of_nat n.


### PR DESCRIPTION
The fix appears to solve the exponential explosion of forward call in situations where there's a large number of temps. My example prog has 30 temps, and the following timings for the first 12 forward_calls (in seconds):
OLD:  5.2, 6.8, 15, 28, 7.8, 7.5, 57, out-of-memory-crash
NEW: 1.4 1.8 2.6 1.6 1.9 3.2 3.3 3.5 3.7 3.9 5.4 4.1