### PR TITLE
Don't depend on the judgmental behavior of Bool.eqb (version 2)

### DIFF
--- a/compcert/flocq/Appli/Fappli_rnd_odd.v
+++ b/compcert/flocq/Appli/Fappli_rnd_odd.v
@@ -199,7 +199,7 @@ case (Zeven (Zfloor r));  simpl; ring.
 apply trans_eq with (Zeven (Zceil r)).
 rewrite Zceil_floor_neq.
 rewrite Zeven_plus.
-simpl; reflexivity.
+destruct (Zeven (Zfloor r)); reflexivity.
 now apply sym_not_eq.
 rewrite <- (Zeven_opp (Zfloor (- r))).
 reflexivity.


### PR DESCRIPTION
This change is backwards compatible, and makes flocq compatible with https://github.com/coq/coq/pull/6596.

This has now been merged into both flocq and CompCert at https://gitlab.inria.fr/flocq/flocq/commit/db356aa5ea0fd0234e3872f70e8972086055cd57 and https://github.com/AbsInt/CompCert/pull/217.