### PR TITLE
Improve loadstore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 branches:
   only:
   - master
-  - align
+  - improve_loadstore
 notifications:
   email:
     recipients:

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -1101,17 +1101,14 @@ Definition upd_val t_root gfs v v0 :=
 
 End SEMAX_PTREE.
 
-Ltac unify_var_or_evar name val :=
-  let E := fresh "E" in assert (name = val) as E by (try subst name; reflexivity); clear E.
-
 Ltac SEP_field_at_unify' gfs :=
   match goal with
   | |- field_at ?shl ?tl ?gfsl ?vl ?pl = field_at ?shr ?tr ?gfsr ?vr ?pr =>
       unify tl tr;
       unify (skipn (length gfs - length gfsl) gfs) gfsl;
-      unify_var_or_evar gfsl gfsr;
-      unify_var_or_evar shl shr;
-      unify_var_or_evar vl vr;
+      unify gfsl gfsr;
+      unify shl shr;
+      unify vl vr;
       generalize vl; intro;
       rewrite <- ?field_at_offset_zero; reflexivity
   end.
@@ -1133,23 +1130,23 @@ Ltac SEP_field_at_strong_unify' gfs :=
   | |- @field_at ?cs ?shl ?tl ?gfsl ?vl ?pl = ?Rv ?vr /\ (_ = fun v => field_at ?shr ?tr ?gfsr v ?pr) =>
       unify tl tr;
       unify (skipn (length gfs - length gfsl) gfs) gfsl;
-      unify_var_or_evar gfsl gfsr;
-      unify_var_or_evar shl shr;
-      unify_var_or_evar vl vr;
+      unify gfsl gfsr;
+      unify shl shr;
+      unify vl vr;
       split;
       [ match type of vl with
-        | ?tv1 => unify_var_or_evar Rv (fun v: tv1 => @field_at cs shl tl gfsl v pl)
+        | ?tv1 => unify Rv (fun v: tv1 => @field_at cs shl tl gfsl v pl)
         end; reflexivity
       | extensionality;
         rewrite <- ?field_at_offset_zero; reflexivity]
   | |- @data_at ?cs ?shl ?tl ?vl ?pl = ?Rv ?vr /\ (_ = fun v => field_at ?shr ?tr ?gfsr v ?pr) =>
       unify tl tr;
-      unify_var_or_evar gfsr (@nil gfield);
-      unify_var_or_evar shl shr;
-      unify_var_or_evar vl vr;
+      unify gfsr (@nil gfield);
+      unify shl shr;
+      unify vl vr;
       split;
       [ match type of vl with
-        | ?tv1 => unify_var_or_evar Rv (fun v: tv1 => @data_at cs shl tl v pl)
+        | ?tv1 => unify Rv (fun v: tv1 => @data_at cs shl tl v pl)
         end; reflexivity
       | extensionality;
         unfold data_at;
@@ -1178,7 +1175,7 @@ Ltac prove_gfs_suffix gfs :=
   | |- _ = ?gfs1 ++ ?gfs0 =>
        let len := fresh "len" in
        let gfs1' := eval_list (firstn ((length gfs - length gfs0)%nat) gfs) in
-       unify_var_or_evar gfs1 gfs1';
+       unify gfs1 gfs1';
        reflexivity
   end.
 

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -595,7 +595,7 @@ Qed.
 
 Lemma semax_PTree_field_load_no_hint:
   forall {Espec: OracleKind},
-    forall n Delta sh id P Q R (e: expr) t
+    forall n Rn Delta sh id P Q R (e: expr) t
       T1 T2 e_root (efs: list efield) (tts: list type) lr
       t_root_from_e gfs_from_e p_from_e
       (t_root: type) (gfs0 gfs1 gfs: list gfield) (p: val)
@@ -609,8 +609,7 @@ Lemma semax_PTree_field_load_no_hint:
       msubst_efield_denote T1 T2 efs gfs_from_e ->
       compute_root_type (typeof e_root) lr t_root_from_e ->
       field_address_gen (t_root_from_e, gfs_from_e, p_from_e) (t_root, gfs, p) ->
-      nth_error R n = Some (field_at sh t_root gfs0 v' p) /\
-      gfs = gfs1 ++ gfs0 ->
+      find_nth_SEP_preds (fun Rn => Rn = field_at sh t_root gfs0 v' p /\ gfs = gfs1 ++ gfs0) R (Some (n, Rn)) ->
       readable_share sh ->
       JMeq (proj_reptype (nested_field_type t_root gfs0) gfs1 v') v ->
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
@@ -626,13 +625,13 @@ Lemma semax_PTree_field_load_no_hint:
               (LOCALx (temp id v :: remove_localdef_temp id Q)
                 (SEPx R)))).
 Proof.
-  intros ? ? ? ? ? ? ? ? ? ?
+  intros ? ? ? ? ? ? ? ? ? ? ?
          ? ? ? ? ? ?
          ? ? ?
          ? ? ? ? ?
          ? ?
          LOCAL2PTREE COMPUTE_NESTED_EFIELD ? ? ? EVAL_ROOT EVAL_EFIELD ROOT_TYPE
-         FIELD_ADD_GEN [NTH GFS] SH JMEQ LEGAL_NESTED_FIELD TC.
+         FIELD_ADD_GEN NTH SH JMEQ LEGAL_NESTED_FIELD TC.
   pose proof is_neutral_cast_by_value _ _ H0 as BY_VALUE.
   assert_PROP (nested_efield e_root efs tts = e /\
                LR_of_type t_root_from_e = lr /\
@@ -648,6 +647,8 @@ Proof.
     pose proof compute_nested_efield_lemma _ rho BY_VALUE.
     rewrite COMPUTE_NESTED_EFIELD in H3; apply H3; auto.
   } Unfocus.
+  apply find_nth_SEP_preds_Some in NTH.
+  destruct NTH as [NTH [? GFS]]; subst Rn.
   destruct H2 as [NESTED_EFIELD [LR [LEGAL_NESTED_EFIELD TYPEOF]]].
   rewrite <- TYPEOF in BY_VALUE.
   assert_PROP (field_compatible t_root gfs0 p).
@@ -706,7 +707,7 @@ Qed.
 
 Lemma semax_PTree_field_load_with_hint:
   forall {Espec: OracleKind},
-    forall n Delta sh id P Q R (e: expr) t
+    forall n Rn Delta sh id P Q R (e: expr) t
       T1 T2 p_from_e
       (t_root: type) (gfs0 gfs1 gfs: list gfield) (p: val)
       (v_val : val) (v_reptype : reptype (nested_field_type t_root gfs0)),
@@ -717,8 +718,7 @@ Lemma semax_PTree_field_load_with_hint:
       msubst_eval_lvalue T1 T2 e = Some p_from_e ->
       p_from_e = field_address t_root gfs p ->
       typeof e = nested_field_type t_root gfs ->
-      nth_error R n = Some (field_at sh t_root gfs0 v_reptype p) /\
-      gfs = gfs1 ++ gfs0 ->
+      find_nth_SEP_preds (fun Rn => Rn = field_at sh t_root gfs0 v_reptype p /\ gfs = gfs1 ++ gfs0) R (Some (n, Rn)) ->
       readable_share sh ->
       JMeq (proj_reptype (nested_field_type t_root gfs0) gfs1 v_reptype) v_val ->
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
@@ -730,11 +730,13 @@ Lemma semax_PTree_field_load_with_hint:
             (LOCALx (temp id v_val :: remove_localdef_temp id Q)
               (SEPx R)))).
 Proof.
-  intros ? ? ? ? ? ? ? ? ?
+  intros ? ? ? ? ? ? ? ? ? ?
          ? ? ? ?
          ? ? ? ? ?
          ? ?
-         LOCAL2PTREE ? ? ? EVAL_L FIELD_ADD TYPE_EQ [NTH GFS] SH JMEQ TC.
+         LOCAL2PTREE ? ? ? EVAL_L FIELD_ADD TYPE_EQ NTH SH JMEQ TC.
+  apply find_nth_SEP_preds_Some in NTH.
+  destruct NTH as [NTH [? GFS]]; subst Rn.
   eapply semax_SC_field_load.
   1: eassumption.
   1: eassumption.
@@ -753,7 +755,7 @@ Qed.
 
 Lemma semax_PTree_field_cast_load_no_hint:
   forall {Espec: OracleKind},
-    forall n Delta sh id P Q R (e: expr) t
+    forall n Rn Delta sh id P Q R (e: expr) t
       T1 T2 e_root (efs: list efield) (tts: list type) lr
       t_root_from_e gfs_from_e p_from_e
       (t_root: type) (gfs0 gfs1 gfs: list gfield) (p: val)
@@ -768,8 +770,7 @@ Lemma semax_PTree_field_cast_load_no_hint:
       msubst_efield_denote T1 T2 efs gfs_from_e ->
       compute_root_type (typeof e_root) lr t_root_from_e ->
       field_address_gen (t_root_from_e, gfs_from_e, p_from_e) (t_root, gfs, p) ->
-      nth_error R n = Some (field_at sh t_root gfs0 v' p) /\
-      gfs = gfs1 ++ gfs0 ->
+      find_nth_SEP_preds (fun Rn => Rn = field_at sh t_root gfs0 v' p /\ gfs = gfs1 ++ gfs0) R (Some (n, Rn)) ->
       readable_share sh ->
       JMeq (proj_reptype (nested_field_type t_root gfs0) gfs1 v') v ->
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
@@ -785,13 +786,13 @@ Lemma semax_PTree_field_cast_load_no_hint:
               (LOCALx (temp id (eval_cast (typeof e) t v) :: remove_localdef_temp id Q)
                 (SEPx R)))).
 Proof.
-  intros ? ? ? ? ? ? ? ? ? ?
+  intros ? ? ? ? ? ? ? ? ? ? ?
          ? ? ? ? ? ?
          ? ? ?
          ? ? ? ? ?
          ? ?
          LOCAL2PTREE COMPUTE_NESTED_EFIELD ? BY_VALUE ? ? EVAL_ROOT EVAL_EFIELD ROOT_TYPE
-         FIELD_ADD_GEN [NTH GFS] SH JMEQ LEGAL_NESTED_FIELD TC.
+         FIELD_ADD_GEN NTH SH JMEQ LEGAL_NESTED_FIELD TC.
   assert_PROP (nested_efield e_root efs tts = e /\
                LR_of_type t_root_from_e = lr /\
                legal_nested_efield t_root_from_e e_root gfs_from_e tts lr = true /\
@@ -806,6 +807,8 @@ Proof.
     pose proof compute_nested_efield_lemma _ rho BY_VALUE.
     rewrite COMPUTE_NESTED_EFIELD in H3; apply H3; auto.
   } Unfocus.
+  apply find_nth_SEP_preds_Some in NTH.
+  destruct NTH as [NTH [? GFS]]; subst Rn.
   destruct H2 as [NESTED_EFIELD [LR [LEGAL_NESTED_EFIELD TYPEOF]]].
   rewrite <- TYPEOF in BY_VALUE.
   assert_PROP (field_compatible t_root gfs0 p).
@@ -866,7 +869,7 @@ Qed.
 
 Lemma semax_PTree_field_cast_load_with_hint:
   forall {Espec: OracleKind},
-    forall n Delta sh id P Q R (e: expr) t
+    forall n Rn Delta sh id P Q R (e: expr) t
       T1 T2 p_from_e
       (t_root: type) (gfs0 gfs1 gfs: list gfield) (p: val)
       (v_val : val) (v_reptype : reptype (nested_field_type t_root gfs0)),
@@ -878,8 +881,7 @@ Lemma semax_PTree_field_cast_load_with_hint:
       msubst_eval_lvalue T1 T2 e = Some p_from_e ->
       p_from_e = field_address t_root gfs p ->
       typeof e = nested_field_type t_root gfs ->
-      nth_error R n = Some (field_at sh t_root gfs0 v_reptype p) /\
-      gfs = gfs1 ++ gfs0 ->
+      find_nth_SEP_preds (fun Rn => Rn = field_at sh t_root gfs0 v_reptype p /\ gfs = gfs1 ++ gfs0) R (Some (n, Rn)) ->
       readable_share sh ->
       JMeq (proj_reptype (nested_field_type t_root gfs0) gfs1 v_reptype) v_val ->
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
@@ -891,11 +893,13 @@ Lemma semax_PTree_field_cast_load_with_hint:
             (LOCALx (temp id (eval_cast (typeof e) t v_val) :: remove_localdef_temp id Q)
               (SEPx R)))).
 Proof.
-  intros ? ? ? ? ? ? ? ? ?
+  intros ? ? ? ? ? ? ? ? ? ?
          ? ? ? ?
          ? ? ? ? ?
          ? ?
-         LOCAL2PTREE ? ? ? ? EVAL_L FIELD_ADD TYPE_EQ [NTH GFS] SH JMEQ TC.
+         LOCAL2PTREE ? ? ? ? EVAL_L FIELD_ADD TYPE_EQ NTH SH JMEQ TC.
+  apply find_nth_SEP_preds_Some in NTH.
+  destruct NTH as [NTH [? GFS]]; subst Rn.
   rewrite TYPE_EQ.
   eapply semax_SC_field_cast_load.
   1: eassumption.
@@ -916,7 +920,7 @@ Qed.
 
 Lemma semax_PTree_field_store_no_hint:
   forall {Espec: OracleKind},
-    forall n Delta sh P Q R (e1 e2 : expr)
+    forall n Rn Delta sh P Q R (e1 e2 : expr)
       T1 T2 e_root (efs: list efield) (tts: list type) lr
       t_root_from_e gfs_from_e p_from_e
       (t_root: type) (gfs0 gfs1 gfs: list gfield) (p: val) 
@@ -931,8 +935,7 @@ Lemma semax_PTree_field_store_no_hint:
       msubst_efield_denote T1 T2 efs gfs_from_e ->
       compute_root_type (typeof e_root) lr t_root_from_e ->
       field_address_gen (t_root_from_e, gfs_from_e, p_from_e) (t_root, gfs, p) ->
-      nth_error R n = Some (field_at sh t_root gfs0 v p) /\
-      gfs = gfs1 ++ gfs0 ->
+      find_nth_SEP_preds (fun Rn => Rn = field_at sh t_root gfs0 v p /\ gfs = gfs1 ++ gfs0) R (Some (n, Rn)) ->
       writable_share sh ->
       JMeq v0_val v0 ->
       data_equal (upd_reptype (nested_field_type t_root gfs0) gfs1 v v0) v_new ->
@@ -951,13 +954,13 @@ Lemma semax_PTree_field_store_no_hint:
                   (replace_nth n R
                     (field_at sh t_root gfs0 v_new p)))))).
 Proof.
-  intros ? ? ? ? ? ? ? ? ?
+  intros ? ? ? ? ? ? ? ? ? ?
          ? ? ? ? ? ?
          ? ? ?
          ? ? ? ? ?
          ? ? ? ?
          LOCAL2PTREE COMPUTE_NESTED_EFIELD BY_VALUE ? EVAL_R EVAL_ROOT EVAL_EFIELD ROOT_TYPE
-         FIELD_ADD_GEN [NTH GFS] SH JMEQ DATA_EQ LEGAL_NESTED_FIELD TC.
+         FIELD_ADD_GEN NTH SH JMEQ DATA_EQ LEGAL_NESTED_FIELD TC.
   assert_PROP (nested_efield e_root efs tts = e1 /\
                LR_of_type t_root_from_e = lr /\
                legal_nested_efield t_root_from_e e_root gfs_from_e tts lr = true /\
@@ -972,6 +975,8 @@ Proof.
     pose proof compute_nested_efield_lemma _ rho BY_VALUE.
     rewrite COMPUTE_NESTED_EFIELD in H1; apply H1; auto.
   } Unfocus.
+  apply find_nth_SEP_preds_Some in NTH.
+  destruct NTH as [NTH [? GFS]]; subst Rn.
   destruct H0 as [NESTED_EFIELD [LR [LEGAL_NESTED_EFIELD TYPEOF]]].
   rewrite <- TYPEOF in BY_VALUE.
   assert_PROP (field_compatible t_root gfs0 p).
@@ -1034,7 +1039,7 @@ Qed.
 
 Lemma semax_PTree_field_store_with_hint:
   forall {Espec: OracleKind},
-    forall n Delta sh P Q R (e1 e2 : expr)
+    forall n Rn Delta sh P Q R (e1 e2 : expr)
       T1 T2 p_from_e
       (t_root: type) (gfs0 gfs1 gfs: list gfield) (p: val) 
       (v0: reptype (nested_field_type (nested_field_type t_root gfs0) gfs1))
@@ -1046,8 +1051,7 @@ Lemma semax_PTree_field_store_with_hint:
       msubst_eval_lvalue T1 T2 e1 = Some p_from_e ->
       p_from_e = field_address t_root gfs p ->
       typeof e1 = nested_field_type t_root gfs ->
-      nth_error R n = Some (field_at sh t_root gfs0 v p) /\
-      gfs = gfs1 ++ gfs0 ->
+      find_nth_SEP_preds (fun Rn => Rn = field_at sh t_root gfs0 v p /\ gfs = gfs1 ++ gfs0) R (Some (n, Rn)) ->
       writable_share sh ->
       JMeq v0_val v0 ->
       data_equal (upd_reptype (nested_field_type t_root gfs0) gfs1 v v0) v_new ->
@@ -1063,11 +1067,13 @@ Lemma semax_PTree_field_store_with_hint:
                   (replace_nth n R
                     (field_at sh t_root gfs0 v_new p)))))).
 Proof.
-  intros ? ? ? ? ? ? ? ? ?
+  intros ? ? ? ? ? ? ? ? ? ?
          ? ? ? ?
          ? ? ? ? ?
          ? ? ?
-         LOCAL2PTREE ? ? EVAL_R EVAL_L FIELD_ADD TYPE_EQ [NTH GFS] SH JMEQ DATA_EQ TC.
+         LOCAL2PTREE ? ? EVAL_R EVAL_L FIELD_ADD TYPE_EQ NTH SH JMEQ DATA_EQ TC.
+  apply find_nth_SEP_preds_Some in NTH.
+  destruct NTH as [NTH [? GFS]]; subst Rn.
   eapply semax_SC_field_store.
   1: eassumption.
   1: rewrite <- TYPE_EQ; eassumption.

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -1146,17 +1146,15 @@ Ltac quick_typecheck3 :=
  apply quick_derives_right; clear; go_lowerx; intros;
  clear; repeat apply andp_right; auto; fail.
 
-Ltac default_entailer_for_load_tac :=
+Ltac default_entailer_for_load_store :=
   repeat match goal with H := _ |- _ => clear H end;
   try quick_typecheck3;
   unfold tc_efield, tc_LR, tc_LR_strong; simpl typeof;
   try solve [entailer!].
 
-Ltac entailer_for_load_tac := default_entailer_for_load_tac.
+Ltac entailer_for_load_tac := default_entailer_for_load_store.
 
-Ltac default_entailer_for_store_tac := try solve [entailer!]. (* TODO: maybe use the same one for load? *)
-
-Ltac entailer_for_store_tac := default_entailer_for_store_tac.
+Ltac entailer_for_store_tac := default_entailer_for_load_store.
 
 Ltac load_tac_with_hint LOCAL2PTREE :=
   eapply semax_PTree_field_load_with_hint;
@@ -1269,8 +1267,7 @@ Ltac cast_load_tac :=
     first [ cast_load_tac_with_hint LOCAL2PTREE | cast_load_tac_no_hint LOCAL2PTREE | SEP_type_contradict LOCAL2PTREE e R | hint_msg LOCAL2PTREE e];
     clear T1 T2 LOCAL2PTREE
   end.
-Check semax_PTree_field_store_with_hint.
-Locate solve_load_rule_evaluation.
+
 Lemma data_equal_congr {cs: compspecs}:
     forall T (v1 v2: reptype T),
    v1 = v2 ->
@@ -1296,7 +1293,7 @@ Ltac store_tac_with_hint LOCAL2PTREE :=
                                                          "unexpected failure in converting stored value")
   | first [apply data_equal_congr; solve_store_rule_evaluation
                                              | fail 1000 "unexpected failure in store_tac_with_hint."
-                                                         "unexpected failure in generating loaded value"]
+                                                         "unexpected failure in computing stored result"]
   | first [entailer_for_store_tac            | fail 1000 "unexpected failure in store_tac_with_hint."
                                                          "unexpected failure in entailer_for_store_tac"]
   ].
@@ -1315,11 +1312,11 @@ Ltac store_tac_no_hint LOCAL2PTREE :=
   | search_field_at_in_SEP (* This line can fail. If it does not, the following should not fail. *)
   | (auto                                   || fail 1000 "unexpected failure in store_tac_no_hint."
                                                          "Cannot prove writable_share")
-  | (apply JMeq_refl                        || fail 1000 "unexpected failure in store_tac_with_hint."
+  | (apply JMeq_refl                        || fail 1000 "unexpected failure in store_tac_no_hint."
                                                          "unexpected failure in converting stored value")
   | first [apply data_equal_congr; solve_store_rule_evaluation
-                                             | fail 1000 "unexpected failure in store_tac_with_hint."
-                                                         "unexpected failure in generating loaded value"]
+                                             | fail 1000 "unexpected failure in store_tac_no_hint."
+                                                         "unexpected failure in computing stored result"]
   | first [solve_legal_nested_field_in_entailment
                                              | fail 1000 "unexpected failure in store_tac_no_hint."
                                                          "unexpected failure in solve_legal_nested_field_in_entailment"]

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -940,11 +940,11 @@ Lemma semax_PTree_field_store_no_hint:
       JMeq v0_val v0 ->
       data_equal (upd_reptype (nested_field_type t_root gfs0) gfs1 v v0) v_new ->
       ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
-        !! (legal_nested_field (nested_field_type t_root gfs0) gfs1) ->
-      ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
          (tc_LR Delta e_root lr) &&
          (tc_expr Delta (Ecast e2 (typeof e1))) &&
          (tc_efield Delta efs) ->
+      ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
+        !! (legal_nested_field (nested_field_type t_root gfs0) gfs1) ->
       semax Delta (|>PROPx P (LOCALx Q (SEPx R)))
         (Sassign e1 e2)
           (normal_ret_assert
@@ -959,7 +959,7 @@ Proof.
          ? ? ? ? ?
          ? ? ? ?
          LOCAL2PTREE COMPUTE_NESTED_EFIELD BY_VALUE ? EVAL_R EVAL_ROOT EVAL_EFIELD ROOT_TYPE
-         FIELD_ADD_GEN NTH SH JMEQ DATA_EQ LEGAL_NESTED_FIELD TC.
+         FIELD_ADD_GEN NTH SH JMEQ DATA_EQ TC LEGAL_NESTED_FIELD.
   assert_PROP (nested_efield e_root efs tts = e1 /\
                LR_of_type t_root_from_e = lr /\
                legal_nested_efield t_root_from_e e_root gfs_from_e tts lr = true /\
@@ -1379,11 +1379,11 @@ Ltac store_tac_no_hint LOCAL2PTREE :=
   | first [apply data_equal_congr; solve_store_rule_evaluation
                                              | fail 1000 "unexpected failure in store_tac_no_hint."
                                                          "unexpected failure in computing stored result"]
+  | first [entailer_for_store_tac            | fail 1000 "unexpected failure in store_tac_no_hint."
+                                                         "unexpected failure in entailer_for_store_tac"]
   | first [solve_legal_nested_field_in_entailment
                                              | fail 1000 "unexpected failure in store_tac_no_hint."
                                                          "unexpected failure in solve_legal_nested_field_in_entailment"]
-  | first [entailer_for_store_tac            | fail 1000 "unexpected failure in store_tac_no_hint."
-                                                         "unexpected failure in entailer_for_store_tac"]
   ].
 
 Ltac store_tac :=

--- a/floyd/simpl_reptype.v
+++ b/floyd/simpl_reptype.v
@@ -182,3 +182,48 @@ Ltac solve_load_rule_evaluation :=
         subst opaque_v; subst; apply JMeq_refl
     end
   | canon_load_result; apply JMeq_refl ].
+
+Ltac simplify_casts := 
+  cbv beta iota delta [ Cop.cast_int_int  Cop.cast_int_float Cop.cast_float_int  Cop.cast_int_single Cop.cast_single_int
+                  Cop.cast_int_long Cop.cast_long_float Cop.cast_long_single Cop.cast_float_long Cop.cast_single_long ];
+ rewrite ?sign_ext_inrange 
+  by (let z := fresh "z" in set (z := two_p (Zpos _ - 1)); compute in z; subst z;
+          rewrite Int.signed_repr by rep_omega;  rep_omega).
+
+Lemma cons_congr: forall {A} (a a': A) bl bl',
+  a=a' -> bl=bl' -> a::bl = a'::bl'.
+Proof.
+intros; f_equal; auto.
+Qed.
+
+Ltac subst_indexes gfs :=
+  match gfs with
+  | ArraySubsc ?i :: ?g' => 
+     match goal with H: ?x = ?i |- _ => is_var x; subst x; subst_indexes g' end
+  | _ :: ?g' => subst_indexes g'
+  | nil => idtac
+  end.
+
+Ltac solve_store_rule_evaluation :=
+(*  we comment these out, because "simplify_casts" can make use of these user hypotheses 
+  repeat match goal with
+  | A : _ |- _ => clear A
+  | A := _ |- _ => clear A
+  end;
+*)
+(*  apply data_equal_congr;*)
+  match goal with A := ?gfs : list gfield |- upd_reptype _ _ ?v0 (valinject _ ?v1) = ?B =>
+   let rhs := fresh "rhs" in set (rhs := B);
+   lazy beta zeta iota delta [reptype reptype_gen] in rhs;
+   simpl in rhs;
+   let h0 := fresh "h0" in let h1 := fresh "h1" in
+   set (h0:=v0); set (h1:=v1);
+   remember_indexes gfs;
+   let j := fresh "j" in match type of h0 with ?J => set (j := J) in h0 end;
+   lazy beta zeta iota delta in j; subst j;
+   lazy beta zeta iota delta - [rhs h0 h1 upd_Znth Zlength];
+   unfold v1 in h1;
+   revert h1; simplify_casts; cbv zeta;
+   subst rhs h0; subst_indexes gfs;
+  apply eq_refl
+  end.

--- a/floyd/simpl_reptype.v
+++ b/floyd/simpl_reptype.v
@@ -196,10 +196,10 @@ Proof.
 intros; f_equal; auto.
 Qed.
 
-Ltac subst_indexes gfs :=
+Ltac subst_indexes gfs ::=
   match gfs with
   | ArraySubsc ?i :: ?g' => 
-     match goal with H: ?x = ?i |- _ => is_var x; subst x; subst_indexes g' end
+     match goal with H: ?x = i |- _ => is_var x; subst x; subst_indexes g' end
   | _ :: ?g' => subst_indexes g'
   | nil => idtac
   end.

--- a/floyd/simpl_reptype.v
+++ b/floyd/simpl_reptype.v
@@ -205,24 +205,17 @@ Ltac subst_indexes gfs :=
   end.
 
 Ltac solve_store_rule_evaluation :=
-(*  we comment these out, because "simplify_casts" can make use of these user hypotheses 
-  repeat match goal with
-  | A : _ |- _ => clear A
-  | A := _ |- _ => clear A
-  end;
-*)
-(*  apply data_equal_congr;*)
-  match goal with A := ?gfs : list gfield |- upd_reptype _ _ ?v0 (valinject _ ?v1) = ?B =>
+  match goal with |- upd_reptype ?t ?gfs ?v0 ?v1 = ?B =>
    let rhs := fresh "rhs" in set (rhs := B);
    lazy beta zeta iota delta [reptype reptype_gen] in rhs;
    simpl in rhs;
    let h0 := fresh "h0" in let h1 := fresh "h1" in
-   set (h0:=v0); set (h1:=v1);
+   set (h0:=v0); set (h1:=v1); change (upd_reptype t gfs h0 h1 = rhs);
    remember_indexes gfs;
    let j := fresh "j" in match type of h0 with ?J => set (j := J) in h0 end;
    lazy beta zeta iota delta in j; subst j;
    lazy beta zeta iota delta - [rhs h0 h1 upd_Znth Zlength];
-   unfold v1 in h1;
+   try unfold v1 in h1;
    revert h1; simplify_casts; cbv zeta;
    subst rhs h0; subst_indexes gfs;
   apply eq_refl

--- a/floyd/simpl_reptype.v
+++ b/floyd/simpl_reptype.v
@@ -196,7 +196,7 @@ Proof.
 intros; f_equal; auto.
 Qed.
 
-Ltac subst_indexes gfs ::=
+Ltac subst_indexes gfs :=
   match gfs with
   | ArraySubsc ?i :: ?g' => 
      match goal with H: ?x = i |- _ => is_var x; subst x; subst_indexes g' end

--- a/mailbox/verif_mailbox_write.v
+++ b/mailbox/verif_mailbox_write.v
@@ -57,7 +57,7 @@ Proof.
   forward_for_simple_bound N (EX i : Z, PROP ( )
    LOCAL (temp _i (vint B); lvar _available (tarray tint B) v_available;
    gvar _writing writing; gvar _last_given last_given; gvar _last_taken last_taken)
-   SEP (field_at Tsh (tarray tint B) [] (map (fun x => vint (if eq_dec x b0 then 0
+   SEP (data_at Tsh (tarray tint B) (map (fun x => vint (if eq_dec x b0 then 0
      else if in_dec eq_dec x (sublist 0 i lasts) then 0 else 1)) (upto (Z.to_nat B))) v_available;
    data_at_ Ews tint writing; data_at Ews tint (vint b0) last_given;
    data_at Ews (tarray tint N) (map (fun x : Z => vint x) lasts) last_taken)).

--- a/progs/verif_bst_oo.v
+++ b/progs/verif_bst_oo.v
@@ -412,7 +412,7 @@ Proof.
         by (unfold field_address; simpl;
             rewrite if_true by auto with field_compatible; auto).
       simpl_compb. simpl_compb.
-      unfold_field_at 1%nat.
+      unfold_data_at 1%nat.
       rewrite (field_at_data_at _ t_struct_tree [StructField _value]).
       rewrite (field_at_data_at _ t_struct_tree [StructField _left]).
       rewrite (field_at_data_at _ t_struct_tree [StructField _right]).

--- a/progs/verif_cond.v
+++ b/progs/verif_cond.v
@@ -73,7 +73,6 @@ Proof.
   Intro i.
   forward.
   forward_call (cond, sh).
-  rewrite field_at_isptr; Intros.
   forward_call (lock, sh, dlock_inv data).
   { lock_props.
     unfold dlock_inv; Exists 1; cancel. }
@@ -108,7 +107,6 @@ Proof.
   forward.
   forward_call (cond, Ews).
   { unfold tcond; entailer!. }
-  rewrite field_at_isptr; Intros.
   destruct split_Ews as (sh1 & sh2 & ? & ? & Hsh).
   forward_call (lock, Ews, dlock_inv data).
   { rewrite (sepcon_comm _ (fold_right_sepcon _)); apply sepcon_derives; [cancel | apply lock_struct]. }

--- a/progs/verif_incr.v
+++ b/progs/verif_incr.v
@@ -87,7 +87,6 @@ Proof.
   Intro z.
   forward.
   forward.
-  rewrite field_at_isptr; Intros.
   forward_call (lock, sh, cptr_lock_inv ctr).
   { lock_props.
     unfold cptr_lock_inv; Exists (z + 1); entailer!. }
@@ -101,7 +100,6 @@ Proof.
   unfold cptr_lock_inv at 2; simpl.
   Intro z.
   forward.
-  rewrite data_at_isptr; Intros.
   forward_call (lock, sh, cptr_lock_inv ctr).
   { lock_props.
     unfold cptr_lock_inv; Exists z; entailer!. }
@@ -140,7 +138,6 @@ Proof.
   forward.
   forward_call (lock, Ews, cptr_lock_inv ctr).
   { rewrite (sepcon_comm _ (fold_right_sepcon _)); apply sepcon_derives; [cancel | apply lock_struct]. }
-  rewrite field_at_isptr; Intros.
   forward_call (lock, Ews, cptr_lock_inv ctr).
   { lock_props.
     unfold cptr_lock_inv; Exists 0; cancel. }

--- a/progs/verif_merge.v
+++ b/progs/verif_merge.v
@@ -269,7 +269,7 @@ rewrite (lseg_unfold LS _ _ b_).
 Time entailer!. (* 24.7 sec -> 10.16 sec*)
 Exists b_'.
 rewrite list_cell_field_at.
-unfold_data_at 2%nat.
+unfold_data_at 3%nat.
 Time entailer!.  (* 12.6 -> 3.2 sec *)
 }
 
@@ -293,7 +293,7 @@ rewrite butlast_snoc. rewrite last_snoc.
 rewrite (snoc merged) at 3 by auto.
 rewrite map_app. simpl map.
 unfold_data_at 1%nat.
-unfold_field_at 5%nat.
+unfold_data_at 1%nat.
 match goal with |- ?B * ?C * ?D * ?E * ?F * ?G * (?H * ?A) |-- _ =>
  apply derives_trans with ((H * A * G * C) * (B * D * E * F));
   [cancel | ]
@@ -362,7 +362,7 @@ simpl map. rewrite @lseg_cons_eq.
 Exists a_'.
 rewrite list_cell_field_at.
 entailer!.
-unfold_data_at 2%nat.
+unfold_data_at 3%nat.
 entailer!.
 
 (* we have now finished the case merged=nil, proceeding to the other case *)
@@ -392,7 +392,7 @@ rewrite map_app. simpl map.
 assert (LCR := lseg_cons_right_neq LS sh (map Vint (butlast merged)) begin (Vint (last merged)) c_ b_' b_).
 simpl in LCR. rewrite emp_sepcon, list_cell_field_at in LCR.
 unfold_data_at 1%nat.
-unfold_field_at 4%nat.
+unfold_data_at 1%nat.
 match goal with |- ?B * ?C * ?D * ?E * (?F * ?A) |-- _ =>
  apply derives_trans with ((F * A * E * D) * (B * C)); [cancel | ]
 end.

--- a/progs/verif_nest3.v
+++ b/progs/verif_nest3.v
@@ -83,12 +83,10 @@ Qed. (* 77 sec *)
 
 Lemma body_set:  semax_body Vprog Gprog f_set set_spec.
 Proof.
-Time start_function. (* 0.22 sec *)
-(* Time unfold_repinj. (* 0.25 sec *)*)
-
-Time forward.  (* 137 sec -> 15.8 sec *)
-Time match goal with |- context [field_at _ _ _ ?X _] =>
+Time start_function.
+Time forward.
+Time match goal with |- context [data_at _ _ ?X _] =>
   set (v1 := X) (* do this so the forward doesn't blow up *)
-end. (* 8.3 sec *)
+end.
 Time forward. (* 125 sec -> 33 sec *)
 Time Qed. (* 2.74 sec *)

--- a/progs/verif_queue.v
+++ b/progs/verif_queue.v
@@ -128,14 +128,14 @@ Qed.
 
 Lemma make_unmake:
  forall a b p,
- field_at Tsh t_struct_elem [] (Vint a, (Vint b, Vundef)) p =
+ data_at Tsh t_struct_elem (Vint a, (Vint b, Vundef)) p =
  field_at Qsh' t_struct_elem [StructField _a] (Vint a) p *
  field_at Qsh' t_struct_elem [StructField _b] (Vint b) p *
  list_cell QS Qsh (Vundef, Vundef) p *
  field_at_ Tsh t_struct_elem [StructField _next] p.
 Proof.
 intros.
-unfold_field_at 1%nat.
+unfold_data_at 1%nat.
 rewrite <- !sepcon_assoc.
 match goal with |- ?A = _ => set (J := A) end.
 unfold field_at_.
@@ -512,7 +512,7 @@ forward_call (*  free(p, sizeof( *p)); *)
    field_at Qsh' list_struct [StructField _b] (Vint (Int.repr 20)) p2 *
    malloc_token Tsh (sizeof t_struct_elem) p2).
  apply derives_trans with work_around_coq_bug; subst work_around_coq_bug.
- unfold data_at; rewrite make_unmake; cancel.
+ rewrite make_unmake; cancel.
  apply derives_trans with
    (data_at_ Tsh t_struct_elem p' * fold_right_sepcon Frame).
  cancel.

--- a/progs/verif_queue2.v
+++ b/progs/verif_queue2.v
@@ -262,11 +262,9 @@ forward_if
      rewrite if_false by (clear; destruct prefix; simpl; congruence).
      Exists  (prefix ++ last0 :: nil) last.
      entailer.
-     change (@field_at CompSpecs Tsh (Tstruct _elem noattr) [] (last0, p) tl)
-      with (@data_at CompSpecs Tsh t_struct_elem (last0,p) tl).
      rewrite (field_at_list_cell Tsh last0 p).
+     unfold_data_at 4%nat.
      unfold_data_at 2%nat.
-     unfold_field_at 3%nat.
      simpl sizeof.
      match goal with
      | |- _ |-- _ * _ * (_ * ?AA) => remember AA as A

--- a/progs/verif_queue2.v
+++ b/progs/verif_queue2.v
@@ -262,7 +262,8 @@ forward_if
      rewrite if_false by (clear; destruct prefix; simpl; congruence).
      Exists  (prefix ++ last0 :: nil) last.
      entailer.
-     fold (data_at Tsh t_struct_elem (last0,p) tl).
+     change (@field_at CompSpecs Tsh (Tstruct _elem noattr) [] (last0, p) tl)
+      with (@data_at CompSpecs Tsh t_struct_elem (last0,p) tl).
      rewrite (field_at_list_cell Tsh last0 p).
      unfold_data_at 2%nat.
      unfold_field_at 3%nat.

--- a/progs/verif_union.v
+++ b/progs/verif_union.v
@@ -219,7 +219,7 @@ Proof.
 start_function.
 forward.
 destruct (fabs_float32_lemma x) as [y [H3 H4]].
-unfold_field_at 1%nat.
+unfold_data_at 1%nat.
 rewrite field_at_data_at.
 erewrite data_at_single_int with (v2:= Vint y);
  [ | apply I | apply I | exact H3 | auto | apply (union_field_address _ (eq_refl _))].

--- a/sha/verif_hmac_init_part2.v
+++ b/sha/verif_hmac_init_part2.v
@@ -493,9 +493,6 @@ eapply semax_post_flipped'.
            with a residual subgoal thats more complex to discharge*)
         Time forward. (*5.8 versus 4.8*) (*FIXME NOW: 19 secs*)
         Time entailer!. (*4.2 versus 5.6*)
-        rewrite field_at_data_at.
-        rewrite field_address_offset by auto with field_compatible.
-        simpl; rewrite Ptrofs.add_zero.
         apply derives_refl'. f_equal. apply UPD_OPAD; eassumption.
       }
 *

--- a/sha/verif_sha_final.v
+++ b/sha/verif_sha_final.v
@@ -67,7 +67,6 @@ assert_PROP (field_address t_struct_SHA256state_st [StructField _data] c = offse
  entailer!.
 rewrite <- H0; clear H0.
 forward. (* n = c->num; *)
-rewrite field_at_data_at with (gfs := [StructField _data]) by reflexivity.
 assert (Hddlen: 0 <= Zlength (s256a_data a) < 64) by Omega1.
 forward. (* p[n] = 0x80; *)
 change (Int.zero_ext 8 (Int.repr 128)) with (Int.repr 128).

--- a/sha/verif_sha_final2.v
+++ b/sha/verif_sha_final2.v
@@ -130,10 +130,8 @@ semax Delta_final_if1
    field_at Tsh t_struct_SHA256state_st [StructField _h] (map Vint (s256a_regs a)) c;
    field_at Tsh t_struct_SHA256state_st [StructField _Nl] (Vint (lo_part (s256a_len a))) c;
    field_at Tsh t_struct_SHA256state_st [StructField _Nh] (Vint (hi_part (s256a_len a))) c;
-   field_at Tsh (tarray tuchar 64) []
-     ((map Vint (map Int.repr (s256a_data a)) ++ [Vint (Int.repr 128)]) ++
-      sublist (Zlength (s256a_data a) + 1) CBLOCKz r_data)
-     (field_address t_struct_SHA256state_st [StructField _data] c);
+   field_at Tsh t_struct_SHA256state_st [StructField _data]
+     ((map Vint (map Int.repr (s256a_data a)) ++ [Vint (Int.repr 128)]) ++ sublist (Zlength (s256a_data a) + 1) CBLOCKz r_data) c;
    field_at Tsh t_struct_SHA256state_st [StructField _num]
      (Vint (Int.repr (Zlength (s256a_data a)))) c; memory_block shmd 32 md))
   (Sifthenelse
@@ -198,6 +196,7 @@ replace_SEP 0  (data_at Tsh t_struct_SHA256state_st
  change (cons (Vint (Int.repr 128))) with (app [Vint (Int.repr 128)]).
  rewrite <- !(app_ass _ [_]).
  rewrite <- app_nil_end.
+ rewrite field_at_data_at with (gfs := [StructField _data]) by reflexivity.
  eapply cancel_field_at_array_partial_undef; try reflexivity; try apply JMeq_refl.
  autorewrite with sublist. omega.
  autorewrite with sublist; apply JMeq_refl.
@@ -341,7 +340,7 @@ split.
 autorewrite with sublist. omega.
 apply s256a_hashed_divides.
 autorewrite with sublist; auto.
-rewrite (field_at_data_at _ _ [_]).
+rewrite !(field_at_data_at _ _ [_]).
 eapply cancel_field_at_array_partial_undef; try reflexivity; try apply JMeq_refl.
 autorewrite with sublist; Omega1.
 autorewrite with sublist.

--- a/sha/verif_sha_update.v
+++ b/sha/verif_sha_update.v
@@ -206,7 +206,7 @@ forward_if (   PROP  ()
     assert_PROP (field_compatible0 (tarray tuchar (Zlength data)) [ArraySubsc b4d] d)
       by (entailer!; auto with field_compatible).
  evar (Frame: list mpred).
-  unfold_field_at 1%nat.
+  unfold_data_at 1%nat.
   eapply(call_memcpy_tuchar
    (*dst*) Tsh t_struct_SHA256state_st [StructField _data] 0
                    (list_repeat (Z.to_nat CBLOCKz) Vundef) c
@@ -264,7 +264,7 @@ hnf.  unfold s256_h, s256_data, s256_num, s256_Nh, s256_Nl, s256a_regs, fst, snd
  forward. (* skip; *)
  unfold sha256state_.
  unfold data_block.
- match goal with |- context [field_at _ _ _ ?r _] => Exists r end.
+ match goal with |- context [data_at _ t_struct_SHA256state_st ?r _] => Exists r end.
  entailer!.
  rewrite <- UAE.
  autorewrite with sublist.

--- a/tweetnacl20140427/verif_crypto_stream_salsa20_xor.v
+++ b/tweetnacl20140427/verif_crypto_stream_salsa20_xor.v
@@ -600,10 +600,9 @@ forward_for_simple_bound 16 (i_8_16_inv F x z c b m nonce k SV zbytes).
   f_equal. assert (W:Z.of_nat (Z.to_nat (i - 8)) + 8 = i).
      rewrite Z2Nat.id; omega.
      rewrite W. f_equal.
-     unfold Int.add. rewrite Int_unsigned_repr_byte. trivial. 
+     unfold Int.add. rewrite Int_unsigned_repr_byte. trivial.
 
-  rewrite field_at_data_at. apply derives_refl'. f_equal.
-  2: rewrite field_address_offset by auto with field_compatible; apply isptr_offset_val_zero; trivial.
+  apply derives_refl'. f_equal.
   clear H2. unfold Bl2VL.
   rewrite Q; simpl; rewrite <- HeqX. 
   rewrite upd_Znth_map. f_equal. simpl.
@@ -616,13 +615,13 @@ forward_for_simple_bound 16 (i_8_16_inv F x z c b m nonce k SV zbytes).
     rewrite Int.Zzero_ext_spec; trivial. rewrite (Byte.Ztestbit_mod_two_p 8); trivial.
     rewrite Int.unsigned_repr; trivial.
     symmetry in HeqX. apply ZZ_is_byte in HeqX. destruct (Byte.unsigned_range_2 (Znth i Zi Byte.zero)).
-    rewrite byte_unsigned_max_eq in H3; rewrite int_max_unsigned_eq; omega.
+    rewrite byte_unsigned_max_eq in H4; rewrite int_max_unsigned_eq; omega.
   + destruct (Z_mod_lt (Int.unsigned ui + Byte.unsigned (Znth i Zi Byte.zero)) 256). 
     omega. rewrite byte_unsigned_max_eq; omega.
 }
 Opaque ZZ.
 entailer!.
-Qed. 
+Qed.
 
 Definition null_or_offset x q y :=
 match x with 
@@ -817,7 +816,7 @@ rename H into I.
     autorewrite with sublist in LL.
     rewrite upd_Znth_app2.  
     Focus 2. rewrite Zlength_Bl2VL. autorewrite with sublist. omega.
-    rewrite field_at_data_at, Zlength_Bl2VL, LL, Zminus_diag, upd_Znth0, sublist_list_repeat; try omega.
+    rewrite Zlength_Bl2VL, LL, Zminus_diag, upd_Znth0, sublist_list_repeat; try omega.
     2: autorewrite with sublist; omega.
     simpl. thaw FR3.
     rewrite Znth_map with (d':=Int.zero) in Xi. inv Xi. 2: repeat rewrite Zlength_map; omega.
@@ -830,8 +829,6 @@ rename H into I.
     + apply prop_right. 
       eapply (bxorlist_snoc mInit q m mybyte l); trivial; omega.
     + autorewrite with sublist.
-      rewrite field_address_offset by auto with field_compatible.
-      simpl. rewrite isptr_offset_val_zero; trivial.
       apply derives_refl'. f_equal. unfold Bl2VL. subst mybyte. clear.
       repeat rewrite map_app. rewrite <- app_assoc. f_equal. simpl.
       f_equal.
@@ -841,7 +838,7 @@ rename H into I.
       assert (X:cLen - Zlength l - 1 = cLen - (Zlength l + 1)) by omega.
       rewrite X; trivial.
   }
-apply andp_left2. apply derives_refl. 
+apply andp_left2. apply derives_refl.
 Qed.
 
 Definition loop2Inv F x z c mInit m b nonce k SV q xbytes mbytes cLen: environ -> mpred:=
@@ -1018,7 +1015,7 @@ Focus 2.
     autorewrite with sublist in LL.
     rewrite upd_Znth_app2.  
     Focus 2. rewrite Zlength_Bl2VL. autorewrite with sublist. omega.
-    rewrite field_at_data_at, Zlength_Bl2VL, LL, Zminus_diag, upd_Znth0, sublist_list_repeat; try omega.
+    rewrite Zlength_Bl2VL, LL, Zminus_diag, upd_Znth0, sublist_list_repeat; try omega.
     2: autorewrite with sublist; omega.
     simpl. thaw FR3. 
     rewrite Znth_map with (d':=Int.zero) in Xi. inv Xi. 2: repeat rewrite Zlength_map; omega.
@@ -1031,8 +1028,6 @@ Focus 2.
     - apply prop_right. 
       eapply (bxorlist_snoc mInit q m mybyte l); trivial; omega.
     - autorewrite with sublist.
-      rewrite field_address_offset by auto with field_compatible.
-      simpl. rewrite isptr_offset_val_zero; trivial.
       apply derives_refl'. f_equal. unfold Bl2VL. subst mybyte. clear.
       repeat rewrite map_app. rewrite <- app_assoc. f_equal. simpl.
       f_equal.
@@ -1105,14 +1100,14 @@ forward_if
   specialize (Int64.eq_spec b Int64.zero). intros.
   destruct (Int64.eq b Int64.zero); [ | inv H].
   clear H.
-  forward. entailer!. 
+  forward. entailer!.
   unfold crypto_stream_xor_postsep. 
   rewrite Int64.eq_true. cancel. }
 { unfold typed_false, strict_bool_val in H. simpl in H.
   unfold eval_unop in H. simpl in H.
   specialize (Int64.eq_spec b Int64.zero). intros.
   destruct (Int64.eq b Int64.zero); simpl in *. inv H.
-  clear H.  
+  clear H.
   forward. Time entailer!. }
 Intros. rename H into B.
 assert_PROP (field_compatible (Tarray tuchar (Int64.unsigned b) noattr) [] c) as FC by entailer!.
@@ -1127,8 +1122,6 @@ forward_for_simple_bound 16 (EX i:Z,
 { rename H into I. Intros l. rename H into LI16.
   forward. Exists (sublist 1 (Zlength l) l). entailer!.
     rewrite Zlength_sublist; omega.
-  rewrite field_at_data_at. rewrite field_address_offset by auto with field_compatible. 
-  simpl. rewrite isptr_offset_val_zero; trivial.
   apply derives_refl'. f_equal. 
   rewrite Z2Nat.inj_add, <- list_repeat_app, <- app_assoc; try omega. 
   rewrite upd_Znth_app2.
@@ -1175,8 +1168,6 @@ forward_for_simple_bound 8 (EX i:Z,
   forward.
   rewrite NB.
   entailer!.
-  rewrite field_at_data_at. rewrite field_address_offset by auto with field_compatible. 
-  simpl. rewrite isptr_offset_val_zero; trivial.
   apply derives_refl'. f_equal.
   rewrite upd_Znth_app2; try autorewrite with sublist. 2: omega.
   rewrite upd_Znth0, <- (@sublist_rejoin val 0 i (i+1)), <- app_assoc. f_equal.

--- a/tweetnacl20140427/verif_fcore_epilogue_htrue.v
+++ b/tweetnacl20140427/verif_fcore_epilogue_htrue.v
@@ -332,17 +332,13 @@ Proof. intros. abbreviate_semax.
        rewrite <- SSS, <- C16. cbv; trivial.
        rewrite <- NNN, <- N16; trivial.
        rewrite <- NNN, <- N16. cbv; trivial.
-     + rewrite field_at_isptr. Time normalize. apply isptrD in Px. destruct Px as [xb [xoff XP]]; subst x.
-       rewrite field_at_data_at.
-       rewrite field_address_offset by auto with field_compatible.
-       simpl. rewrite Ptrofs.add_zero.
-(*       rewrite isptr_offset_val_zero by trivial. *)
+     + Time normalize. apply isptrD in Px. destruct Px as [xb [xoff XP]]; subst x.
        apply data_at_ext.
-clear H1.
+       clear H1.
        remember (Zlength Front) as i.
        rewrite (Zplus_comm i 1), Z2Nat.inj_add; simpl; try omega.
        replace (length Front) with (Z.to_nat i).
-       rewrite Z2Nat.id by omega.    
+       rewrite Z2Nat.id by omega.
        rewrite upd_Znth_ints.
        autorewrite with sublist.
        f_equal.
@@ -391,7 +387,7 @@ clear H1.
         rewrite !VJeq, !EQ.
         simpl force_val.
         autorewrite with sublist.
-        rewrite !sublist_map. 
+        rewrite !sublist_map.
         rewrite map_app. reflexivity.
         subst i. rewrite Zlength_correct. rewrite Nat2Z.id. auto.
    }
@@ -541,7 +537,7 @@ Proof. intros. abbreviate_semax.
     freeze [0;1;3] FR3.
     rewrite Znth_map with (d':= Int.zero) in Xi; try omega. 
     inversion Xi; clear Xi; subst xi.
-    Time forward_call (offset_val (4 * i) (Vptr ob ooff), (Znth (5 * i) xs Int.zero)). 
+    Time forward_call (offset_val (4 * i) (Vptr ob ooff), (Znth (5 * i) xs Int.zero)).
     1: solve [autorewrite with sublist; entailer!]. 
     simpl.
     assert (Upd_ll_Zlength: Zlength (UpdateOut ll (4 * i) (Znth (5 * i) xs Int.zero)) = 32).
@@ -562,7 +558,7 @@ deadvars!.
       thaw FR3. thaw FR2. cancel.
       unfold QByte.
       rewrite <- Upd_ll_Zlength. unfold tarray. 
-      erewrite (split3_data_at_Tarray_tuchar Tsh _ (4 * i) (4+4 * i) (UpdateOut ll (4 * i) (Znth (5 * i) xs Int.zero))); 
+      erewrite (split3_data_at_Tarray_tuchar Tsh _ (4 * i) (4+4 * i) (UpdateOut ll (4 * i) (Znth (5 * i) xs Int.zero)));
        try rewrite UpdateOut_Zlength, P3_Zlength; try omega.
       rewrite field_address0_offset by auto with field_compatible.
       rewrite field_address0_offset by auto with field_compatible.

--- a/tweetnacl20140427/verif_ld_st.v
+++ b/tweetnacl20140427/verif_ld_st.v
@@ -319,10 +319,7 @@ Time forward_for_simple_bound 4 (EX i:Z,
   Time entailer!. (*1.5*)
   unfold upd_Znth.
   autorewrite with sublist.
-  rewrite field_at_data_at. simpl. unfold field_address. simpl.
-  rewrite if_true; trivial.
-  replace (4 - (1 + i)) with (4-i-1) by omega.
-  rewrite isptr_offset_val_zero; trivial. clear H.
+  simpl.
   apply data_at_ext. rewrite Zplus_comm.
         assert (ZW: Int.zwordsize = 32) by reflexivity.
         assert (EIGHT: Int.unsigned (Int.repr 8) = 8). apply Int.unsigned_repr.

--- a/wand/wand_demo/verif_bst.v
+++ b/wand/wand_demo/verif_bst.v
@@ -74,6 +74,7 @@ Lemma body_insert: semax_body Vprog Gprog f_insert insert_spec.
 Proof.
   start_function.
   apply insert_concrete_to_abstract; intros.
+  abbreviate_semax.
   forward_loop (EX p: val, EX t: tree val, EX P: tree val -> tree val,
        PROP(P (insert x v t) = (insert x v t0))
        LOCAL(temp _p p; temp _x (Vint (Int.repr (Z.of_nat x)));   temp _value v)
@@ -148,6 +149,7 @@ Lemma body_insert: semax_body Vprog Gprog f_insert insert_spec.
 Proof.
   start_function.
   apply insert_concrete_to_abstract; intros.
+  abbreviate_semax.
   forward_loop (EX p: val, EX t: tree val,
       PROP()
       LOCAL(temp _p p; temp _x (Vint (Int.repr (Z.of_nat x)));   temp _value v)
@@ -222,6 +224,7 @@ Lemma body_insert: semax_body Vprog Gprog f_insert insert_spec.
 Proof.
   start_function.
   apply insert_concrete_to_abstract; intros.
+  abbreviate_semax.
   forward_loop (EX p: val, EX t: tree val, EX pt: partial_tree val,
       PROP(partial_tree_tree pt (insert x v t) = (insert x v t0))
       LOCAL(temp _p p; temp _x (Vint (Int.repr (Z.of_nat x)));   temp _value v)
@@ -305,6 +308,7 @@ Lemma body_insert: semax_body Vprog Gprog f_insert insert_spec.
 Proof.
   start_function.
   apply insert_concrete_to_abstract; intros.
+  abbreviate_semax.
   forward_loop (EX p: val, EX t: tree val, EX pt: partial_tree val,
       PROP(partial_tree_tree pt (insert x v t) = (insert x v t0))
       LOCAL(temp _p p; temp _x (Vint (Int.repr (Z.of_nat x)));   temp _value v)


### PR DESCRIPTION
Add a new general tactic for finding nth element in SEP clauses satisfying condition. This replaces original find_type_conflict and sc_new_instantiate.

This enables some finer grained manipulation. Now, a forward for a store command will not turn a data_at into field_at nil.

