### PR TITLE
Do not disable Coq warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 COQFLAGS=$(foreach d, $(VSTDIRS), $(if $(wildcard $(d)), -Q $(d) VST.$(d))) $(foreach d, $(OTHERDIRS), $(if $(wildcard $(d)), -Q $(d) $(d))) $(EXTFLAGS)
 DEPFLAGS:=$(COQFLAGS)
 
-COQC=$(COQBIN)coqc -w none
+COQC=$(COQBIN)coqc
 COQTOP=$(COQBIN)coqtop
 COQDEP=$(COQBIN)coqdep $(DEPFLAGS)
 COQDOC=$(COQBIN)coqdoc -d doc/html -g  $(DEPFLAGS)


### PR DESCRIPTION
Warnings that are on by default require user action. They should be addressed, not ignored. For example, deprecation warnings make it easier to port developments smoothly to new versions of Coq.