### PR TITLE
Connected ghost state to external state (oracle).

### DIFF
--- a/veric/SeparationLogicSoundness.v
+++ b/veric/SeparationLogicSoundness.v
@@ -50,6 +50,25 @@ Axiom semax_prog_rule :
        app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)
      } } }%type.
 
+(* This version lets the user choose the external state instead of quantifying over it. *)
+Axiom semax_prog_rule' :
+  forall {Espec: OracleKind}{CS: compspecs},
+  forall V G prog m h,
+     @semax_prog Espec CS prog V G ->
+     Genv.init_mem prog = Some m ->
+     { b : block & { q : corestate &
+       (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
+       (semantics.initial_core (juicy_core_sem cl_core_sem) h
+                    (globalenv prog) (Vptr b Ptrofs.zero) nil = Some q) *
+       forall n z, { jm |
+       m_dry jm = m /\ level jm = n /\
+       nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
+       jsafeN (@OK_spec Espec) (globalenv prog) n z q jm /\
+       no_locks (m_phi jm) /\
+       matchfunspecs (globalenv prog) G (m_phi jm) /\
+       app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)
+     } } }%type.
+
 End SEPARATION_LOGIC_SOUNDNESS.
 
 Module SoundSeparationLogic : SEPARATION_LOGIC_SOUNDNESS.
@@ -142,5 +161,6 @@ Qed.
 End CSL.
 
 Definition semax_prog_rule := @semax_prog_rule.
+Definition semax_prog_rule' := @semax_prog_rule'.
 
 End SoundSeparationLogic.

--- a/veric/initial_world.v
+++ b/veric/initial_world.v
@@ -435,9 +435,47 @@ Definition initial_core' (ge: Genv.t fundef type) (G: funspecs) (n: nat) (loc: a
           end
    else NO Share.bot bot_unreadable.
 
-(* What should the ghost state be in an initial core? *)
+(* This version starts with an empty ghost. *)
 Program Definition initial_core (ge: Genv.t fundef type) (G: funspecs) (n: nat): rmap :=
   proj1_sig (make_rmap (initial_core' ge G n) nil _ n _ eq_refl).
+Next Obligation.
+intros.
+intros ? ?.
+unfold compose.
+unfold initial_core'.
+if_tac; simpl; auto.
+destruct (Genv.invert_symbol ge b); simpl; auto.
+destruct (find_id i G); simpl; auto.
+destruct f; simpl; auto.
+Qed.
+Next Obligation.
+intros.
+extensionality loc; unfold compose, initial_core'.
+if_tac; [ | simpl; auto].
+destruct (Genv.invert_symbol ge (fst loc)); [ | simpl; auto].
+destruct (find_id i G); [ | simpl; auto].
+destruct f.
+unfold resource_fmap.
+f_equal.
+simpl.
+f_equal.
+change R.approx with approx.
+extensionality i0 ts b rho.
+rewrite fmap_app.
+pattern (approx n) at 7 8 9.
+rewrite <- approx_oo_approx.
+auto.
+Qed.
+
+(* We can also start with knowledge of the external state. *)
+Instance ext_PCM Z : ghost.Ghost := { valid a := True; Join_G := Join_equiv Z }.
+Proof. auto. Defined.
+
+Definition ext_ghost {Z} (ora : Z) : {g : ghost.Ghost & {a : ghost.G | ghost.valid a}} :=
+  existT _ (ext_PCM _) (exist _ ora I).
+
+Program Definition initial_core_ext {Z} (ora : Z) (ge: Genv.t fundef type) (G: funspecs) (n: nat): rmap :=
+  proj1_sig (make_rmap (initial_core' ge G n) (Some (ext_ghost ora, NoneP) :: nil) _ n _ eq_refl).
 Next Obligation.
 intros.
 intros ? ?.
@@ -1381,6 +1419,181 @@ rewrite Hg1, Hg2.
 unfold initial_core; rewrite !ghost_of_make_rmap; auto.
 Qed.
 
+Lemma initial_core_ext_ok: forall {Z} (ora : Z) (prog: program) G n m,
+      list_norepet (prog_defs_names prog) ->
+      match_fdecs (prog_funct prog) G ->
+      Genv.init_mem prog = Some m ->
+     initial_rmap_ok m (initial_core_ext ora (Genv.globalenv prog) G n).
+Proof.
+intros.
+rename H1 into Hm.
+intros [b z]. simpl.
+unfold initial_core_ext; simpl.
+rewrite <- core_resource_at.
+rewrite resource_at_make_rmap.
+unfold initial_core'.
+simpl in *.
+if_tac; [ | rewrite core_NO; auto].
+case_eq (@Genv.invert_symbol fundef _ (Genv.globalenv prog) b);
+   intros;  try now (rewrite core_NO; auto).
+case_eq (find_id i G); intros; [ | rewrite core_NO; auto].
+apply Genv.invert_find_symbol in H2.
+pose proof (Genv.find_symbol_not_fresh _ _ Hm H2).
+unfold valid_block in H4.
+split; intros.
+contradiction.
+destruct (match_fdecs_exists_Gfun _ _ _ _ H3 H0) as [fd [? _]].
+destruct f.
+split; auto.
+subst z.
+destruct (find_symbol_globalenv _ _ _ H H2) as [RANGE [d ?]].
+assert (d = Gfun fd).
+clear - H H5 H1.
+unfold prog_defs_names in H.
+change (AST.prog_defs prog) with (prog_defs prog) in H.
+forget (prog_defs prog) as dl. forget (nat_of_Z (Z.pos b-1)) as n.
+revert dl H H5 H1; induction n; simpl; intros.
+destruct dl; inv H1.
+inv H. simpl in H5.
+destruct H5. inv H; auto.
+apply (in_map (@fst ident (globdef fundef type))) in H. simpl in H;  contradiction.
+destruct dl; inv H1. inv H.
+simpl in H5. destruct H5. subst.
+clear - H2 H3. apply nth_error_in in H2.
+apply (in_map (@fst ident (globdef fundef type))) in H2. simpl in *;  contradiction.
+apply (IHn dl); auto.
+(* end assert d = Gfun fd *)
+subst d.
+clear H5.
+clear - RANGE H2 H1 H Hm.
+unfold Genv.init_mem in Hm.
+forget (Genv.globalenv prog) as ge.
+change (AST.prog_defs prog) with (prog_defs prog) in Hm.
+forget (prog_defs prog) as dl.
+rewrite <- (rev_involutive dl) in H1,Hm.
+rewrite nth_error_rev in H1.
+Focus 2.
+rewrite rev_length. clear - RANGE.
+destruct RANGE.
+apply inj_lt_iff. rewrite Coqlib.nat_of_Z_eq by omega. omega.
+rename H1 into H5.
+replace (length (rev dl) - nat_of_Z (Z.pos b - 1) - 1)%nat
+ with (length (rev dl) - nat_of_Z (Z.pos b))%nat in H5.
+Focus 2. rewrite rev_length.
+clear - RANGE.
+replace (nat_of_Z (Z.pos b-1)) with (nat_of_Z (Z.pos b) - 1)%nat.
+assert (nat_of_Z (Z.pos b) <= length dl)%nat.
+destruct RANGE.
+apply inj_le_iff. rewrite Coqlib.nat_of_Z_eq by omega. auto.
+assert (nat_of_Z (Z.pos b) > 0)%nat. apply inj_gt_iff.
+rewrite Coqlib.nat_of_Z_eq by omega.  simpl. omega.
+omega. destruct RANGE as [? _].
+apply nat_of_Z_lem1.
+assert (nat_of_Z (Z.pos b) > 0)%nat. apply inj_gt_iff. simpl.
+pose proof (Pos2Nat.is_pos b); omega.
+omega.
+assert (0 < nat_of_Z (Z.pos b) <= length dl)%nat.
+clear - RANGE.
+destruct RANGE; split.
+apply inj_lt_iff. rewrite Coqlib.nat_of_Z_eq; try omega. simpl. auto.
+apply inj_le_iff. rewrite Coqlib.nat_of_Z_eq; try omega.
+clear RANGE; rename H0 into RANGE.
+unfold nat_of_Z in *. rewrite Z2Nat.inj_pos in *.
+rewrite <- rev_length in RANGE.
+forget (rev dl) as dl'; clear dl; rename dl' into dl.
+destruct RANGE.
+rewrite alloc_globals_rev_eq in Hm.
+revert m Hm H1 H5; induction dl; intros.
+inv H5.
+simpl in H1,Hm.
+invSome.
+specialize (IHdl _ Hm).
+destruct (eq_dec (Pos.to_nat b) (S (length dl))).
+rewrite e, minus_diag in H5. simpl in H5.
+inversion H5; clear H5; subst a.
+apply alloc_globals_rev_nextblock in Hm.
+rewrite Zlength_correct in Hm.
+rewrite <- inj_S in Hm. rewrite <- e in Hm.
+ rewrite positive_nat_Z in Hm.  rewrite Pos2Z.id in Hm.
+ subst b.
+clear IHdl H1 H0. clear dl e.
+unfold Genv.alloc_global in H6.
+revert H6; case_eq (alloc m0 0 1); intros.
+unfold drop_perm in H6.
+destruct (range_perm_dec m1 b 0 1 Cur Freeable).
+unfold max_access_at, access_at; inv H6.
+simpl. apply alloc_result in H0. subst b.
+rewrite PMap.gss.
+simpl. auto.
+inv H6.
+destruct IHdl.
+omega.
+replace (length (a::dl) - Pos.to_nat b)%nat with (S (length dl - Pos.to_nat b))%nat in H5.
+apply H5.
+simpl. destruct (Pos.to_nat b); omega.
+assert (b < nextblock m0)%positive.
+apply alloc_globals_rev_nextblock in Hm.
+rewrite Zlength_correct in Hm. clear - Hm n H1.
+rewrite Hm.
+apply Pos2Nat.inj_lt.
+pattern Pos.to_nat at 1; rewrite <- Z2Nat.inj_pos.
+rewrite Z2Pos.id by omega.
+rewrite Z2Nat.inj_succ by omega.
+rewrite Nat2Z.id. omega.
+destruct (alloc_global_old _ _ _ _ H6 (b,0)) as [? ?]; auto.
+unfold max_access_at.
+rewrite <- H8.
+split; auto.
+Qed.
+
+Definition initial_jm_ext {Z} (ora : Z) (prog: program) m (G: funspecs) (n: nat)
+        (H: Genv.init_mem prog = Some m)
+        (H1: list_norepet (prog_defs_names prog))
+        (H2: match_fdecs (prog_funct prog) G) : juicy_mem :=
+  initial_mem m (initial_core_ext ora (Genv.globalenv prog) G n)
+           (initial_core_ext_ok _ _ _ _ m H1 H2 H).
+
+Program Definition set_ghost (m : rmap) (g : ghost) (Hg : _) :=
+  proj1_sig (make_rmap _ g (rmap_valid m) (level m) _ Hg).
+Next Obligation.
+Proof.
+  intros.
+  extensionality; apply resource_at_approx.
+Qed.
+
+Lemma initial_jm_ext_eq : forall {Z} (ora : Z) (prog: program) m (G: funspecs) (n: nat)
+        (H: Genv.init_mem prog = Some m)
+        (H1: list_norepet (prog_defs_names prog))
+        (H2: match_fdecs (prog_funct prog) G),
+  join (m_phi (initial_jm prog m G n H H1 H2))
+       (set_ghost (core (m_phi (initial_jm prog m G n H H1 H2))) (Some (ext_ghost ora, NoneP) :: nil) eq_refl)
+       (m_phi (initial_jm_ext ora prog m G n H H1 H2)).
+Proof.
+  intros.
+  apply resource_at_join2.
+  - simpl.
+    rewrite !inflate_initial_mem_level.
+    unfold initial_core, initial_core_ext; rewrite !level_make_rmap; auto.
+  - unfold set_ghost; rewrite level_make_rmap.
+    rewrite level_core.
+    simpl.
+    rewrite !inflate_initial_mem_level.
+    unfold initial_core, initial_core_ext; rewrite !level_make_rmap; auto.
+  - intros.
+    unfold set_ghost; rewrite resource_at_make_rmap, <- core_resource_at.
+    simpl.
+    unfold initial_core, initial_core_ext, inflate_initial_mem.
+    rewrite !resource_at_make_rmap.
+    unfold inflate_initial_mem'.
+    rewrite !resource_at_make_rmap.
+    apply join_comm, core_unit.
+  - unfold set_ghost; rewrite ghost_of_make_rmap.
+    simpl.
+    unfold initial_core, initial_core_ext, inflate_initial_mem.
+    rewrite !ghost_of_make_rmap.
+    constructor.
+Qed.
+
 Fixpoint prog_vars' {F V} (l: list (ident * globdef F V)) : list (ident * globvar V) :=
  match l with nil => nil | (i,Gvar v)::r => (i,v):: prog_vars' r | _::r => prog_vars' r
  end.
@@ -1405,6 +1618,22 @@ Proof.
   destruct (access_at m addr); try (split; congruence).
   destruct p; try (split; congruence).
   destruct (fst (proj1_sig (snd (unsquash (initial_core (Genv.globalenv prog) G n)))) addr);
+    split; try congruence.
+Qed.
+
+Lemma initial_jm_ext_without_locks {Z} (ora : Z) prog m G n H H1 H2:
+  no_locks (m_phi (initial_jm_ext ora prog m G n H H1 H2)).
+Proof.
+  simpl.
+  unfold inflate_initial_mem; simpl.
+  match goal with |- context [ proj1_sig ?a ] => destruct a as (phi & lev & E & ?) end; simpl.
+  unfold inflate_initial_mem' in E.
+  unfold resource_at in E.
+  unfold no_locks, "@"; intros.
+  rewrite E.
+  destruct (access_at m addr); try (split; congruence).
+  destruct p; try (split; congruence).
+  destruct (fst (proj1_sig (snd (unsquash (initial_core_ext ora (Genv.globalenv prog) G n)))) addr);
     split; try congruence.
 Qed.
 
@@ -1512,6 +1741,76 @@ Proof.
   clear -Pi lev.
 
   unfold initial_core in *.
+  rewrite resource_at_make_rmap in Pi.
+  unfold initial_core' in *.
+  if_tac in Pi. 2:tauto.
+  simpl fst in Pi.
+  unfold fundef in *.
+  destruct (Genv.invert_symbol (Genv.globalenv prog) b) as [i|] eqn:Eb. 2: congruence.
+  destruct (find_id i G) as [f0 |] eqn:Ei. 2:congruence.
+  destruct f0 as [f1 c0 A0 P0 Q0 P_ne0 Q_ne0].
+
+  subst pp.
+  injection Pi as <- -> -> EE.
+  apply inj_pair2 in EE.
+  apply Genv.invert_find_symbol in Eb.
+  unfold filter_genv in *.
+  exists i, P0, Q0, P_ne0, Q_ne0.
+  split. assumption.
+  split. assumption.
+  subst n.
+
+  constructor.
+  all: intros ts.
+  all: apply equal_f_dep with (x := ts) in EE.
+  all: extensionality a.
+  all: apply equal_f_dep with (x := a) in EE.
+
+  1: apply equal_f_dep with (x := true) in EE.
+  2: apply equal_f_dep with (x := false) in EE.
+
+  all: extensionality ge.
+  all: apply equal_f_dep with (x := ge) in EE.
+  all: simpl in *.
+  all: symmetry; rewrite (* Epp',  *)<-EE.
+  all: reflexivity.
+Qed.
+
+Lemma initial_jm_ext_matchfunspecs {Z} (ora : Z) prog m G n H H1 H2:
+  matchfunspecs (globalenv prog) G (m_phi (initial_jm_ext ora prog m G n H H1 H2)).
+Proof.
+  simpl.
+  unfold inflate_initial_mem; simpl.
+  match goal with |- context [ proj1_sig ?a ] => destruct a as (phi & lev & E & ?) end; simpl.
+  unfold inflate_initial_mem' in E.
+  unfold resource_at in E.
+  intros b fsig cc A P Q FAT.
+  unfold func_at'' in *.
+  unfold initial_core_ext in lev; rewrite level_make_rmap in lev.
+
+  set (pp := SomeP _ _) in FAT.
+  assert (Pi :
+            initial_core_ext ora (Genv.globalenv prog) G n @ (b, 0)
+            = PURE (FUN fsig cc) (preds_fmap (approx n) (approx n) pp)).
+  {
+    simpl in FAT.
+    pose proof FAT as E2.
+    unfold "@" in *.
+    rewrite E in FAT.
+    destruct (access_at m (b, 0)) as [[]|]; simpl in E2; try congruence.
+    set (r := fst (proj1_sig _) _) in FAT at 2.
+    destruct (fst (proj1_sig (snd (unsquash (initial_core_ext ora (Genv.globalenv prog) G n)))) (b, 0))
+      as [t | t p k p0 | k p] eqn:E'''; simpl in E2; try congruence.
+    subst r.
+    injection FAT as -> ->; f_equal. subst pp. f_equal.
+    simpl. f_equal.
+    repeat extensionality.
+    repeat (f_equal; auto).
+  }
+
+  clear -Pi lev.
+
+  unfold initial_core_ext in *.
   rewrite resource_at_make_rmap in Pi.
   unfold initial_core' in *.
   if_tac in Pi. 2:tauto.

--- a/veric/juicy_extspec.v
+++ b/veric/juicy_extspec.v
@@ -239,11 +239,7 @@ Proof.
     rewrite <- !level_juice_level_phi; congruence.
 Qed.
 
-Instance ext_PCM Z : ghost.Ghost := { valid a := True; Join_G := Join_equiv Z }.
-Proof. auto. Defined.
-
-Definition ext_ghost {Z} (ora : Z) : {g : ghost.Ghost & {a : ghost.G | ghost.valid a}} :=
-  existT _ (ext_PCM _) (exist _ ora I).
+Definition has_ext {Z} (ora : Z) : pred rmap := @own (ext_PCM _) 0 ora NoneP.
 
 (* use the external state to restrict the ghost moves *)
 Definition jm_bupd {Z} (ora : Z) P m := forall C : ghost,

--- a/veric/own.v
+++ b/veric/own.v
@@ -53,28 +53,49 @@ Proof.
       rewrite Hl1, Hl2; apply ghost_fmap_join; auto.
 Qed.
 
+Fixpoint make_join (a c : ghost) : ghost :=
+  match a, c with
+  | nil, _ => c
+  | _, nil => nil
+  | None :: a', x :: c' => x :: make_join a' c'
+  | _ :: a', None :: c' => None :: make_join a' c'
+  | Some (ga, pa) :: a', Some (gc, _) :: c' => Some (gc, pa) :: make_join a' c'
+  end.
+
+Lemma make_join_nil : forall a, make_join a nil = nil.
+Proof.
+  destruct a; auto.
+  destruct o as [[]|]; auto.
+Qed.
+
+Lemma make_join_nil_cons : forall o a c, make_join (o :: a) (None :: c) = None :: make_join a c.
+Proof.
+  destruct o as [[]|]; auto.
+Qed.
+
 Lemma ghost_joins_approx: forall n a c,
   joins (ghost_fmap (approx n) (approx n) a) (ghost_fmap (approx n) (approx n) c) ->
-  exists c', joins (ghost_fmap (approx (S n)) (approx (S n)) a) (ghost_fmap (approx (S n)) (approx (S n)) c') /\
+  let c' := make_join a c in
+  joins (ghost_fmap (approx (S n)) (approx (S n)) a) (ghost_fmap (approx (S n)) (approx (S n)) c') /\
     forall b, joins b (ghost_fmap (approx (S n)) (approx (S n)) c') ->
       joins (ghost_fmap (approx n) (approx n) b) (ghost_fmap (approx n) (approx n) c).
 Proof.
-  intros ???; revert a; induction c; intros.
-  - exists nil; split.
+  intros ???; revert a; induction c; intros; subst c'; simpl.
+  - rewrite make_join_nil; split.
     + eexists; constructor.
     + eexists; constructor.
   - destruct H; inv H.
     + destruct a0; inv H1.
-      exists (a :: c); split.
+      split.
       { eexists; constructor. }
       intros ? []; eexists.
       apply ghost_fmap_join with (f := approx n)(g := approx n) in H.
       rewrite ghost_fmap_fmap, approx_oo_approx', approx'_oo_approx in H by auto; eauto.
     + destruct a0; inv H0.
-      destruct (IHc a0) as (c' & ? & Hc'); eauto.
+      destruct (IHc a0) as (H & Hc'); eauto.
       inv H3.
       * destruct o; inv H1.
-        exists (a :: c'); split.
+        split.
         { destruct H; eexists; constructor; eauto; constructor. }
         intros ? [? J]; inv J; [eexists; constructor|].
         destruct (Hc' m1); eauto.
@@ -89,18 +110,19 @@ Proof.
            inv H2.
            rewrite preds_fmap_fmap, approx_oo_approx', approx'_oo_approx by auto; constructor; auto.
       * destruct a; inv H2.
-        exists (None :: c'); split.
+        rewrite make_join_nil_cons.
+        split.
         { destruct H; eexists; constructor; eauto; constructor. }
         intros ? [? J]; inv J; [eexists; constructor|].
         destruct (Hc' m1); eauto.
         eexists; constructor; eauto; constructor.
       * destruct o as [[]|], a as [[]|]; inv H0; inv H1.
-        eexists (Some (s0, _) :: c'); split.
+        split.
         { destruct H.
           destruct a4; inv H2; simpl in *.
-          inv H.
+          inv H1.
           eexists (Some (_, _) :: _); constructor; eauto; constructor.
-          constructor; [constructor; eauto | simpl; constructor; eauto]. }
+          constructor; simpl; eauto; constructor; eauto. }
         intros ? [? J]; inv J; [eexists; constructor|].
         destruct (Hc' m1); eauto.
         eexists; constructor; eauto.
@@ -113,8 +135,6 @@ Proof.
            destruct a2, a4, a6; inv H2; inv H6; constructor; auto; simpl in *.
            inv H3; inv H4.
            rewrite <- H6, preds_fmap_fmap, approx_oo_approx', approx'_oo_approx by auto; constructor; auto.
-  Unshelve.
-  auto.
 Qed.
 
 Program Definition bupd (P: pred rmap): pred rmap :=
@@ -126,7 +146,7 @@ Proof.
   repeat intro.
   rewrite (age1_ghost_of _ _ H) in H1.
   rewrite <- ghost_of_approx in H0.
-  destruct (ghost_joins_approx _ _ _ H1) as (c0 & J0 & Hc0).
+  destruct (ghost_joins_approx _ _ _ H1) as (J0 & Hc0).
   rewrite <- (age_level _ _ H) in *.
   specialize (H0 _ J0); destruct H0 as (b & J & Hrb).
   pose proof (age_level _ _ H).

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -1380,7 +1380,7 @@ forall (Delta : tycontext) (A : TypeTree)
         (level (m_phi jm))),
  exists (c' : corestate) (m' : juicy_mem),
   jstep cl_core_sem psi (State vx tx (Kseq (Scall ret a bl) :: k)) jm c' m' /\
-  jm_bupd (jsafeN OK_spec psi n ora c') m'.
+  jm_bupd ora (jsafeN OK_spec psi n ora c') m'.
 Proof.
 intros.
 destruct TC3 as [TC3 TC3'].

--- a/veric/semax_congruence.v
+++ b/veric/semax_congruence.v
@@ -40,7 +40,7 @@ Lemma safeN_step_jsem_spec: forall gx vx tx n k ora jm,
   resource_decay (nextblock (m_dry jm)) (m_phi jm) (m_phi m') /\
   level jm = S (level m') /\
   ghost_of (m_phi m') = ghost_approx m' (ghost_of (m_phi jm)) /\
-  jm_bupd (@jsafeN_ _ _ _ (fun x => Genv.genv_symb (genv_genv x)) (cl_core_sem) OK_spec gx n ora c') m').
+  jm_bupd ora (@jsafeN_ _ _ _ (fun x => Genv.genv_symb (genv_genv x)) (cl_core_sem) OK_spec gx n ora c') m').
 Proof.
   intros.
   split; intros.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -1155,7 +1155,7 @@ Lemma safe_step_forward:
    j_halted cl_core_sem st  = None ->
    jsafeN (@OK_spec Espec) psi (S n) ora st m ->
  exists st', exists m',
-   jstep cl_core_sem psi st m st' m' /\ jm_bupd (jsafeN (@OK_spec Espec) psi n ora  st') m'.
+   jstep cl_core_sem psi st m st' m' /\ jm_bupd ora (jsafeN (@OK_spec Espec) psi n ora  st') m'.
 Proof.
  intros.
  inv H1.
@@ -1336,8 +1336,8 @@ Qed.
 Lemma control_as_safe_bupd: forall ge n ctl1 ctl2, control_as_safe ge n ctl1 ctl2 ->
  forall (ora : OK_ty) (ve : env) (te : temp_env) (m : juicy_mem) (n' : nat),
      n' <= n ->
-     jm_bupd (jsafeN (@OK_spec Espec) ge n' ora (State ve te ctl1)) m ->
-     jm_bupd (jsafeN (@OK_spec Espec) ge n' ora (State ve te ctl2)) m.
+     jm_bupd ora (jsafeN (@OK_spec Espec) ge n' ora (State ve te ctl1)) m ->
+     jm_bupd ora (jsafeN (@OK_spec Espec) ge n' ora (State ve te ctl2)) m.
 Proof.
   repeat intro.
   destruct (H1 _ H2) as (? & ? & ? & ?); eauto.
@@ -1349,11 +1349,11 @@ Lemma corestep_preservation_lemma:
       (forall k : list cont', control_as_safe ge n (k ++ ctl1) (k ++ ctl2)) ->
       control_as_safe ge (S n) ctl1 ctl2 ->
       jstep cl_core_sem ge (State ve te (c :: l ++ ctl1)) m c' m' ->
-      jm_bupd (jsafeN (@OK_spec Espec) ge n ora c') m' ->
+      jm_bupd ora (jsafeN (@OK_spec Espec) ge n ora c') m' ->
    exists c2 : corestate,
      exists m2 : juicy_mem,
        jstep cl_core_sem ge (State ve te (c :: l ++ ctl2)) m c2 m2 /\
-       jm_bupd (jsafeN (@OK_spec Espec) ge n ora c2) m2.
+       jm_bupd ora (jsafeN (@OK_spec Espec) ge n ora c2) m2.
 Proof. intros until m'. intros H0 H4 CS0 H H1.
   remember (State ve te (c :: l ++ ctl1)) as q. rename c' into q'.
   destruct H as [H [Hb [Hc Hg]]].
@@ -2069,7 +2069,7 @@ Qed.
 
 Lemma assert_safe_jsafe: forall Espec ge ve te ctl ora jm,
   assert_safe Espec ge ve te ctl (construct_rho (filter_genv ge) ve te) (m_phi jm) ->
-  jm_bupd (jsafeN OK_spec ge (level jm) ora (State ve te ctl)) jm.
+  jm_bupd ora (jsafeN OK_spec ge (level jm) ora (State ve te ctl)) jm.
 Proof.
   repeat intro.
   destruct (H _ H0) as (? & ? & ? & Hl & Hr & ? & Hsafe); subst.

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -698,6 +698,144 @@ Proof.
   right; auto.  right; auto.
 Qed.
 
+Lemma funassert_initial_core_ext:
+  forall {Z} (ora : Z) (prog: program) ve te V G n,
+      list_norepet (prog_defs_names prog) ->
+      match_fdecs (prog_funct prog) G ->
+      app_pred (funassert (nofunc_tycontext V G) (mkEnviron (filter_genv (globalenv prog)) ve te))
+                      (initial_core_ext ora (Genv.globalenv prog) G n).
+Proof.
+ intros; split.
+*
+ intros id fs.
+ apply prop_imp_i; intros.
+ simpl ge_of; simpl fst; simpl snd.
+ unfold filter_genv.
+ assert (exists f, In (id, f) (prog_funct prog)). {
+ simpl in H1.
+ forget (prog_funct prog) as g.
+clear - H1 H0.
+revert G H1 H0; induction g; destruct G; intros; simpl in *.
+elimtype False.
+rewrite PTree.gempty in H1; inv H1.
+inv H0.
+destruct a; simpl in *; subst.
+destruct (eq_dec i id). subst; eauto.
+ specialize (IHg nil H1). inv H0.
+(*destruct (IHg). destruct g; simpl; auto.
+constructor. apply match_fdecs_nil.
+eauto. *)
+destruct a. destruct p.
+ inv H0.
+ simpl in H1.
+ destruct (ident_eq i0 id). subst. eauto.
+ destruct (IHg G); auto. rewrite PTree.gso in H1; auto.
+ eauto.
+(* simpl in H1.
+ destruct (IHg ((i0,f0)::G)); auto. eauto.
+*)
+ }
+ destruct H2 as [f ?].
+ destruct (find_funct_ptr_exists prog id f) as [b [? ?]]; auto.
+ apply in_prog_funct_in_prog_defs; auto.
+ exists b. unfold fundef.
+ unfold globalenv. simpl. rewrite H3.
+ split; auto.
+ unfold func_at. destruct fs as [f0 cc0 A a a0].
+ unfold initial_core_ext.
+ hnf. rewrite resource_at_make_rmap.
+ rewrite level_make_rmap.
+ unfold initial_core'.
+ simpl.
+ rewrite (Genv.find_invert_symbol (Genv.globalenv prog) id); auto.
+ assert (H9: In (id, mk_funspec f0 cc0 A a a0 P_ne Q_ne) G). {
+   clear - H1.
+    simpl in H1. unfold make_tycontext_g in H1; simpl in H1.
+    induction G; simpl in *.
+    rewrite PTree.gempty in H1; inv H1.
+    destruct (ident_eq (fst a1) id); subst.
+    change (@ptree_set) with (@PTree.set) in *. destruct a1; simpl in *.
+    rewrite PTree.gss in H1; inv H1. left; auto.
+    change (@ptree_set) with (@PTree.set) in *. destruct a1; simpl in *. 
+    rewrite PTree.gso in H1; auto.
+ }
+ rewrite (find_id_i _ _ _ H9); auto.
+ clear - H0 H. unfold prog_defs_names, prog_funct in *.
+ eapply match_fdecs_norepet; eauto.
+ apply list_norepet_prog_funct'; auto.
+*
+ intros loc'  [fsig' cc' A' P' Q' NEP' NEQ'].
+ unfold func_at.
+ intros w ? ?.
+ destruct H2 as [pp ?].
+ hnf in H2.
+ assert (exists pp, initial_core_ext ora (Genv.globalenv prog) G n @ (loc',0) = PURE (FUN fsig' cc') pp).
+case_eq (initial_core_ext ora (Genv.globalenv prog) G n @ (loc',0)); intros.
+destruct (necR_NO _ _ (loc',0) sh n0 H1) as [? _].
+rewrite H4 in H2 by auto.
+inv H2.
+eapply necR_YES in H1; try apply H3.
+rewrite H1 in H2; inv H2.
+eapply necR_PURE in H1; try apply H3.
+rewrite H1 in H2; inv H2; eauto.
+destruct H3 as [pp' ?].
+unfold initial_core_ext in H3.
+rewrite resource_at_make_rmap in H3.
+unfold initial_core' in H3.
+if_tac in H3; [ | inv H3].
+simpl.
+simpl @fst in *.
+revert H3; case_eq (@Genv.invert_symbol fundef type
+         (@Genv.globalenv (Ctypes.fundef function) type
+            prog) loc'); intros;
+  [ | congruence].
+revert H5; case_eq (find_id i G); intros; [| congruence].
+destruct f as [?f ?A ?a ?a]; inv H6.
+apply Genv.invert_find_symbol in H3.
+exists i.
+simpl ge_of. unfold filter_genv.
+unfold globalenv; simpl.
+ rewrite H3.
+ split; auto.
+ assert (exists f, In (i,f) (prog_funct prog)
+              /\ type_of_fundef f = Tfunction (type_of_params (fst fsig')) (snd fsig') cc'). {
+ clear - H0 H5.
+ forget (prog_funct prog) as g.
+ revert G H0 H5; induction g; intros.
+ inv H0. inv H5.
+ inv H0.
+ simpl in H5.
+ if_tac in H5. subst i0. inv H5. exists fd; split; auto. left; auto.
+ destruct (IHg G0) as [f3 [? ?]]; auto. exists f3; split; auto.
+ right; auto.
+(*
+ destruct (IHg _ H3 H5) as [f [H4 H4']].
+ exists f; split; auto. right; auto.
+*)
+ }
+ clear H4.
+ destruct H6 as [f [H4 H4']].
+ destruct (find_funct_ptr_exists prog i f) as [b [? ?]]; auto.
+ apply in_prog_funct_in_prog_defs; auto.
+ unfold fundef in *.
+ inversion2 H3 H6.
+ case_eq (Genv.find_var_info (Genv.globalenv prog) loc'); intros.
+ elimtype False; clear - H7 H6.
+ unfold Genv.find_funct_ptr in H7.
+ unfold Genv.find_var_info in H6.
+ destruct (Genv.find_def (Genv.globalenv prog) loc'); try destruct g0; congruence.
+ apply find_id_e in H5. apply in_map_fst in H5.
+ clear - H5.
+ revert H5; induction G; simpl; intro. contradiction.
+ destruct H5. subst.
+ change (@ptree_set) with (@PTree.set) in *. destruct a; simpl in *.
+ econstructor; rewrite PTree.gss; reflexivity.
+ destruct (IHG H) as [fs ?].
+ change (@ptree_set) with (@PTree.set) in *. destruct a; simpl in *.
+ destruct (eq_dec i0 i). econstructor; subst; rewrite PTree.gss; eauto.
+ econstructor; rewrite PTree.gso by auto; eauto.
+Qed.
+
 (* there's a place this lemma should be applied, perhaps in proof of semax_call *)
 Lemma funassert_rho:
   forall G rho rho', ge_of rho = ge_of rho' -> funassert G rho |-- funassert G rho'.
@@ -744,6 +882,59 @@ inversion2 H1 H4.
 if_tac.
  destruct (IOK l) as [_ ?].
  unfold initial_core in H6. rewrite resource_at_make_rmap in H6.
+  unfold initial_core' in H6. rewrite if_true in H6 by auto.
+  apply Genv.find_invert_symbol in H1.
+  unfold fundef in *; rewrite H1 in *.
+  rewrite H2 in *. destruct fs.
+  destruct H6 as [? [? ?]]. rewrite H7.
+  rewrite core_PURE; auto.
+  destruct (access_at m l); try destruct p; try rewrite core_YES; try rewrite core_NO; auto.
+  unfold fundef in *; rewrite H1,H2 in *.
+  if_tac;  destruct (access_at m l); try destruct p; try rewrite core_YES; try rewrite core_NO; auto.
+  unfold fundef in *; rewrite H1 in *.
+ if_tac;   destruct (access_at m l); try destruct p; try rewrite core_YES; try rewrite core_NO; auto.
+ rewrite ghost_of_core.
+ unfold inflate_initial_mem, initial_core; rewrite !ghost_of_make_rmap, ghost_core; auto.
+Qed.
+
+Lemma core_inflate_initial_mem':
+  forall {Z} (ora : Z) (m: mem) (prog: program) (G: funspecs) (n: nat)
+     (INIT: Genv.init_mem prog = Some m),
+    match_fdecs (prog_funct prog) G ->
+      list_norepet (prog_defs_names prog) ->
+   core (inflate_initial_mem m (initial_core_ext ora (Genv.globalenv prog) G n)) =
+         initial_core (Genv.globalenv prog) G n.
+Proof.
+intros.
+assert (IOK := initial_core_ext_ok ora _ _ n _ H0 H INIT).
+apply rmap_ext.
+  unfold inflate_initial_mem, initial_core, initial_core_ext; simpl.
+  rewrite level_core. rewrite !level_make_rmap; auto.
+intro l.
+unfold inflate_initial_mem, initial_core, initial_core_ext; simpl.
+rewrite <- core_resource_at.
+repeat rewrite resource_at_make_rmap.
+unfold inflate_initial_mem'.
+repeat rewrite resource_at_make_rmap.
+unfold initial_core'.
+case_eq (Genv.invert_symbol (Genv.globalenv prog) (fst l)); intros; auto.
+rename i into id.
+case_eq (find_id id G); intros; auto.
+rename f into fs.
+assert (exists f, In (id,f) (prog_funct prog)).
+apply find_id_e in H2.
+apply in_map_fst in H2.
+eapply match_fdecs_in in H2; eauto.
+apply in_map_iff in H2.
+destruct H2 as [[i' f] [? ?]]. subst id; exists f; auto.
+destruct H3 as [f ?].
+apply Genv.invert_find_symbol in H1.
+destruct (find_funct_ptr_exists prog id f) as [b [? ?]]; auto.
+apply in_prog_funct_in_prog_defs; auto.
+inversion2 H1 H4.
+if_tac.
+ destruct (IOK l) as [_ ?].
+ unfold initial_core_ext in H6. rewrite resource_at_make_rmap in H6.
   unfold initial_core' in H6. rewrite if_true in H6 by auto.
   apply Genv.find_invert_symbol in H1.
   unfold fundef in *; rewrite H1 in *.
@@ -1068,6 +1259,229 @@ Proof.
   unfold juicy_mem_core in *. erewrite E; try reflexivity.
 Qed.
 
+Lemma initial_jm_ext_funassert {Z} (ora : Z) V (prog : Clight.program) m G n H H1 H2 :
+  (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog)))
+    (m_phi (initial_jm_ext ora prog m G n H H1 H2)).
+Proof.
+  unfold initial_jm_ext.
+  assert (FA: app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog)))
+    (initial_world.initial_core_ext ora (Genv.globalenv prog) G n)
+         ).
+  apply funassert_initial_core_ext; auto.
+  revert FA.
+  pose proof assert_lemmas.corable_funassert (nofunc_tycontext V G) (empty_environ (globalenv prog)) as CO.
+  rewrite corable_spec in CO. apply CO.
+  pose proof initial_mem_core as E.
+  unfold juicy_mem_core in *. erewrite E; try reflexivity.
+Qed.
+
+Lemma semax_prog_rule' {CS: compspecs} :
+  forall V G prog m h,
+     @semax_prog CS prog V G ->
+     Genv.init_mem prog = Some m ->
+     { b : block & { q : corestate &
+       (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
+       (semantics.initial_core (juicy_core_sem cl_core_sem) h
+                    (globalenv prog) (Vptr b Ptrofs.zero) nil = Some q) *
+       forall n z,
+         { jm |
+           m_dry jm = m /\ level jm = n /\
+           nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
+           jsafeN (@OK_spec Espec) (globalenv prog) n z q jm /\
+           no_locks (m_phi jm) /\
+           matchfunspecs (globalenv prog) G (m_phi jm) /\
+           (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)
+     } } }%type.
+Proof.
+  intros until m.
+  pose proof I; intros.
+  destruct H0 as [? [AL [HGG [[? ?] [GV ?]]]]].
+  assert (H4': exists post, In (prog_main prog, main_spec' prog post) G). {
+    destruct (find_id (prog_main prog) G) eqn:?.
+    apply find_id_e in Heqo. destruct H4 as [post ?]. exists post.
+    subst. auto. contradiction.
+  } clear H4. rename H4' into H4.
+  assert ({ f | In (prog_main prog, f) (prog_funct prog)}).
+  forget (prog_main prog) as id.
+  assert (H4': In id (map fst G)). {
+    destruct H4 as [? H4].
+  apply in_map_fst in H4. auto.
+  }
+  pose proof (match_fdecs_in _ _ _ H4' H2).
+  apply in_map_sig in H5. 2:decide equality.
+  destruct H5 as [[? ?] [? ?]]; subst.
+  eauto.
+  destruct H5 as [f ?].
+  apply compute_list_norepet_e in H0.
+  assert (indefs: In (prog_main prog, Gfun f) (AST.prog_defs prog))
+    by (apply in_prog_funct_in_prog_defs; auto).
+  pose proof (find_funct_ptr_exists prog (prog_main prog) f) as EXx.
+  (* Genv.find_funct_ptr_exists is a Prop existential, we use constructive epsilon and
+     decidability on a countable set to transform it to a Type existential *)
+  apply find_symbol_funct_ptr_ex_sig in EXx; auto.
+
+  pose proof I.
+  destruct EXx as [b [? ?]]; auto.
+  exists b.
+  unfold semantics.initial_core. simpl (_ = Some _).
+  unfold fundef in *; rewrite H7.
+  rewrite if_true by auto.
+  (* unfold is_Internal in HInt. *)
+  (* rewrite H6 in HInt. *)
+  (* rewrite H7 in HInt. *)
+  (* destruct f as [func | ]; [ | exfalso; discriminate ]. *)
+  (* set (func' := func) at 1; destruct func' eqn:Ef. *)
+  econstructor.
+  repeat split; auto.
+  intros n z.
+  exists (initial_jm_ext z _ _ _ n H1 H0 H2).
+  repeat split.
+  - simpl.
+    rewrite inflate_initial_mem_level.
+    unfold initial_core_ext. rewrite level_make_rmap; auto.
+
+  - unfold initial_jm_ext; simpl.
+    unfold inflate_initial_mem; rewrite ghost_of_make_rmap.
+    unfold initial_core_ext; rewrite ghost_of_make_rmap.
+    reflexivity.
+
+  - specialize (H3 (globalenv prog) (prog_contains_prog_funct _ H0)).
+    destruct H4 as [post H4].
+    assert (E: type_of_fundef f = Tfunction Tnil tint cc_default). {
+      destruct (match_fdecs_exists_Gfun
+                  prog G (prog_main prog)
+                  (main_spec' prog post))
+        as (fd, (Ifd, sametypes)); auto.
+      {
+        apply find_id_i; auto.
+        eapply match_fdecs_norepet; eauto.
+        clear -H0; revert H0.
+        apply sublist_norepet.
+        unfold prog_funct, prog_funct', prog_defs_names.
+        replace (AST.prog_defs prog) with (prog_defs prog) by reflexivity.
+        generalize (prog_defs prog); intros l; induction l as [|(i,[g|]) l];
+          constructor; auto.
+      }
+      assert (fd = f).
+      cut (Gfun fd = @Gfun _ type f); [ intros E; injection E; auto | ].
+      apply (list_norepet_In_In (prog_main prog) _ _ (prog_defs prog)); auto.
+      subst fd.
+      auto.
+    }
+
+    rewrite E in *.
+    unfold temp_bindings. simpl length. simpl typed_params. simpl type_of_params.
+    pattern n at 1; replace n with (level (m_phi (initial_jm_ext z prog m G n H1 H0 H2))).
+    pose (rho1 := mkEnviron (filter_genv (globalenv prog)) (Map.empty (block * type))
+                           (Map.set 1 (Vptr b Ptrofs.zero) (Map.empty val))).
+    pose (post' := fun rho => TT * EX rv:val, post nil (globals_of_env rho1) (env_set (globals_only rho) ret_temp rv)).
+    eapply (semax_call_aux Espec (Delta1 V G) (ConstType (ident->val))
+              _ post _ (const_super_non_expansive _ _) (const_super_non_expansive _ _)
+              nil (globals_of_env rho1) (fun _ => TT) (fun _ => TT)
+              None (nil, tint) cc_default _ _ (normal_ret_assert post') _ _ _ _
+              (construct_rho (filter_genv (globalenv prog)) empty_env
+                 (PTree.set 1 (Vptr b Ptrofs.zero) (PTree.empty val)))
+              _ _ b (prog_main prog));
+      try apply H3; try eassumption; auto.
+    + simpl snd.
+      replace (params_of_fundef f) with (@nil type). auto. clear -E.
+      destruct f as [[? ? [ | [] ]] | e [|] ? c] ; compute in *; congruence.
+    + clear - GV H2 H0.
+      split.
+      eapply semax_prog_typecheck_aux; eauto.
+      simpl.
+      auto.
+    + hnf; intros; intuition.
+    + hnf; intros; intuition.
+      unfold normal_ret_assert; simpl.
+      extensionality rho'.
+      normalize.
+(*      unfold main_post. rewrite TT_sepcon_TT. *)
+      unfold post'.
+      apply pred_ext.
+         normalize. intro rv. do 2 apply exp_right with rv; auto.
+         normalize. intro rv. apply exp_right with rv; auto. 
+    + rewrite (corable_funassert _ _).
+      simpl m_phi.
+      rewrite core_inflate_initial_mem'; auto.
+      do 3 (pose proof I).
+      replace (funassert (Delta1 V G)) with
+      (funassert (@nofunc_tycontext V G)).
+      unfold rho1; apply funassert_initial_core; auto.
+      apply same_glob_funassert.
+      reflexivity.
+    + intros ek vl tx' vx'.
+      cbv zeta. rewrite proj_frame_ret_assert. simpl seplog.sepcon.
+      subst post'. cbv beta.
+      destruct ek; simpl proj_ret_assert; normalize.
+      apply derives_subp.
+      normalize. intro rv.
+      simpl.
+      eapply derives_trans, own.bupd_intro.
+      intros ? ? ? ? _ ?.
+      destruct H8 as [[? [H10 [H11 ?]]] ?].
+      hnf in H10, H11.
+      destruct H8.
+      subst a.
+      change Clight_new.true_expr with true_expr.
+      change (level (m_phi jm)) with (level jm).
+      apply safe_loop_skip.
+    + unfold glob_types, Delta1. simpl @snd.
+      forget (prog_main prog) as main.
+      instantiate (1:= post).
+      instantiate (1:= main_pre prog).
+      assert (H8: list_norepet (map (@fst _ _) (prog_funct prog))). {
+      clear - H0.
+      unfold prog_defs_names in H0. unfold prog_funct.
+      change (AST.prog_defs prog) with (prog_defs prog) in H0.
+      induction (prog_defs prog); auto. inv H0.
+      destruct a; destruct g; simpl; auto. constructor; auto.
+      clear - H2; simpl in H2; contradict H2; induction l; simpl in *; auto.
+      destruct a; destruct g; simpl in *; auto. destruct H2; auto.
+      }
+      forget (prog_funct prog) as fs.
+      clear - H4 H8 H2.
+      fold (main_spec prog).
+      forget (main_spec prog) as fd.
+      revert G H2 H4 H8; induction fs; intros; inv H2.
+      inv H4.
+      simpl in *.
+      destruct (ident_eq i main). subst. rewrite PTree.gss.
+      destruct H4. inv H; auto.
+      inv H8.
+      contradiction H3.
+      eapply match_fdecs_in; eauto.
+      apply in_map_fst in H; auto.
+      rewrite PTree.gso by auto.
+      destruct H4; try congruence.
+      inv H8.
+      eapply IHfs; eauto.
+(*      inv H8; eauto. *)
+    + intros.
+      intros ? ?.
+      split; apply derives_imp; auto.
+    + unfold main_pre.
+      apply now_later.
+      rewrite TT_sepcon_TT.
+      rewrite sepcon_comm.
+      eexists; eexists; split; [apply initial_jm_ext_eq|].
+      split; auto.
+     match goal with |- app_pred (globvars2pred (globals_of_env ?A) _ ?B) _ => 
+       change (globals_of_env A) with (globals_of_env B)
+      end.
+      apply global_initializers; auto.
+    + simpl.
+      rewrite inflate_initial_mem_level.
+      unfold initial_core.
+      apply level_make_rmap.
+  - apply initial_jm_ext_without_locks.
+  - apply initial_jm_ext_without_locks.
+  - apply initial_jm_ext_matchfunspecs.
+  -  destruct (initial_jm_ext_funassert z V prog m G n H1 H0 H2). auto.
+  -  destruct (initial_jm_ext_funassert z V prog m G n H1 H0 H2). auto.
+Qed.
+
+(* This version works if we don't need to know anything about the external state. *)
 Lemma semax_prog_rule {CS: compspecs} :
   forall V G prog m h,
      @semax_prog CS prog V G ->


### PR DESCRIPTION
The definition of juicy safety now reserves a specific ghost location for modeling the external state. This allows programs to include assertions on the external state, and leads to a variant of semax_prog_rule in which the program is correct for a specific oracle rather than for all oracles. This should allow us to do I/O reasoning in VST.