### PR TITLE
Call now strips off a later from the precondition.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ travis: default_target progs sha hmac mailbox
 
 files: .loadpath version.vo $(FILES:.v=.vo)
 
-all: default_target files travis hmacdrbg tweetnacl aes atomics
+all: default_target files travis hmacdrbg tweetnacl aes
 
 
 # ifeq ($(COMPCERT), compcert)

--- a/concurrency/lksize.v
+++ b/concurrency/lksize.v
@@ -3,5 +3,19 @@ Require Import compcert.common.Memdata.
 Require Import Coq.ZArith.ZArith.
 
 (* LKSIZE should match sizeof(semax_conc.tlock).  *)
-Definition LKSIZE:= 8%Z.
+Definition LKSIZE:= (2 * size_chunk Mptr)%Z.
 Definition LKSIZE_nat:= Z.to_nat LKSIZE.
+
+Lemma LKSIZE_pos : (0 < LKSIZE)%Z.
+Proof.
+  unfold LKSIZE.
+  pose proof (size_chunk_pos Mptr); omega.
+Qed.
+
+Lemma LKSIZE_int : (size_chunk Mint32 < LKSIZE)%Z.
+Proof.
+  unfold LKSIZE; simpl.
+  rewrite size_chunk_Mptr; destruct Archi.ptr64; omega.
+Qed.
+
+Ltac lkomega := pose proof LKSIZE_pos; pose proof LKSIZE_int; simpl in *; try omega.

--- a/concurrency/semax_conc.v
+++ b/concurrency/semax_conc.v
@@ -45,7 +45,7 @@ Goal forall (cenv: composite_env), @sizeof cenv tlock = LKSIZE.
 Proof. reflexivity. Qed.
 
 Definition selflock_fun Q sh p : (unit -> mpred) -> (unit -> mpred) :=
-  fun R _ => (Q * lock_inv sh p (|> R tt))%logic.
+  fun R _ => (Q * |>lock_inv sh p (R tt))%logic.
 
 Definition selflock' Q sh p : unit -> mpred := HORec (selflock_fun Q sh p).
 Definition selflock Q sh p : mpred := selflock' Q sh p tt.
@@ -72,21 +72,33 @@ Proof.
     auto.
 Qed.
 
-Lemma lock_inv_later sh p R : lock_inv sh p R |-- lock_inv sh p (|> R)%logic.
-Admitted. (* lock_inv_later *)
-
 Lemma selflock'_eq Q sh p : selflock' Q sh p =
   selflock_fun Q sh p (selflock' Q sh p).
 Proof.
   apply HORec_fold_unfold, prove_HOcontractive.
   intros P1 P2 u.
   apply subp_sepcon; [ apply subp_refl | ].
-  eapply derives_trans.
-  + apply HOnonexpansive_nonexpansive; apply (nonexpansive_lock_inv sh p).
-  + apply allp_left with tt, fash_derives, andp_left1, derives_refl.
+  rewrite <- subp_later.
+  repeat intro.
+  match goal with |- app_pred (?P >=> ?Q)%logic ?a => change (subtypes.fash (P --> Q) a) end.
+  unfold lock_inv; repeat intro.
+  destruct H3 as (b & ofs & ? & Hl & ?); exists b, ofs; split; auto; split; auto.
+  intro l; specialize (Hl l); simpl in *.
+  if_tac; auto.
+  if_tac; auto.
+  destruct Hl as [rsh Hl]; exists rsh; rewrite Hl; repeat f_equal.
+  extensionality.
+  specialize (H tt); rewrite <- eqp_later in H.
+  specialize (H _ H0).
+  apply necR_level in H2.
+  apply predicates_hered.pred_ext; intros ? []; split; auto.
+  - destruct (H a0) as [X _]; [omega|].
+    specialize (X _ (necR_refl _)); auto.
+  - destruct (H a0) as [_ X]; [omega|].
+    specialize (X _ (necR_refl _)); auto.
 Qed.
 
-Lemma selflock_eq Q sh p : selflock Q sh p = (Q * lock_inv sh p (|> selflock Q sh p))%logic.
+Lemma selflock_eq Q sh p : selflock Q sh p = (Q * |>lock_inv sh p (selflock Q sh p))%logic.
 Proof.
   unfold selflock at 1.
   rewrite selflock'_eq.
@@ -310,7 +322,7 @@ Definition release_pre: val * share * mpred -> environ -> mpred :=
   | (v, sh, R) =>
      PROP (readable_share sh)
      LOCAL (temp _lock v)
-     SEP (weak_precise_mpred R && weak_positive_mpred R && emp; lock_inv sh v R; R)
+     SEP (weak_exclusive_mpred R && emp; lock_inv sh v R; R)
   end.
 
 Notation release_post :=
@@ -328,16 +340,15 @@ Proof.
   intros.
   destruct x as [[v sh] R]; simpl in *.
   apply (nonexpansive_super_non_expansive
-   (fun R => (PROP (readable_share sh)  LOCAL (temp _lock v)  SEP (weak_precise_mpred R && weak_positive_mpred R && emp; lock_inv sh v R; R)) rho)).
+   (fun R => (PROP (readable_share sh)  LOCAL (temp _lock v)  SEP (weak_exclusive_mpred R && emp; lock_inv sh v R; R)) rho)).
   apply (PROP_LOCAL_SEP_nonexpansive
           ((fun _ => readable_share sh) :: nil)
           ((temp _lock v) :: nil)
-          ((fun R => weak_precise_mpred R && weak_positive_mpred R && emp)%logic :: (fun R => lock_inv sh v R) :: (fun R => R) :: nil));
+          ((fun R => weak_exclusive_mpred R && emp)%logic :: (fun R => lock_inv sh v R) :: (fun R => R) :: nil));
   repeat apply Forall_cons; try apply Forall_nil.
   + apply const_nonexpansive.
-  + apply (conj_nonexpansive (fun R => weak_precise_mpred R && weak_positive_mpred R)%logic); [apply (conj_nonexpansive weak_precise_mpred) |].
-    - apply precise_mpred_nonexpansive.
-    - apply positive_mpred_nonexpansive.
+  + apply (conj_nonexpansive (fun R => weak_exclusive_mpred R)%logic).
+    - apply exclusive_mpred_nonexpansive.
     - apply const_nonexpansive.
   + apply nonexpansive_lock_inv.
   + apply identity_nonexpansive.
@@ -418,7 +429,7 @@ Program Definition freelock_spec cs: funspec := mk_funspec
    | (v, sh, R) =>
      PROP (writable_share sh)
      LOCAL (temp _lock v)
-     SEP (weak_precise_mpred R && weak_positive_mpred R && emp; lock_inv sh v R; R)
+     SEP (weak_exclusive_mpred R && emp; lock_inv sh v R; R)
    end)
   (fun _ x =>
    match x with
@@ -435,7 +446,6 @@ Next Obligation.
   intros.
   destruct x as [[v sh] R]; simpl in *.
 Admitted. (* super_non_expansive obligation of freelock_spec' *)
-(* I added "weak_precise_mpred &&" to freelock's precondition *)
 (*
   apply (nonexpansive_super_non_expansive
    (fun R => (PROP (writable_share sh)
@@ -477,17 +487,6 @@ Proof.
   apply selflock_eq.
 Qed.
 
-Lemma lock_inv_later_eq : forall sh v R, (|> lock_inv sh v R = lock_inv sh v (|> R))%logic.
-Proof.
-Admitted.
-
-Lemma later_rec_lock : forall sh v (Q R: mpred), rec_inv sh v Q R -> rec_inv sh v (later Q) (later R).
-Proof.
-  unfold rec_inv; intros.
-  rewrite H at 1.
-  rewrite later_sepcon, lock_inv_later_eq; auto.
-Qed.
-
 Program Definition freelock2_spec cs: funspec := mk_funspec
   ((_lock OF tptr Tvoid)%formals :: nil, tvoid)
   cc_default
@@ -497,7 +496,7 @@ Program Definition freelock2_spec cs: funspec := mk_funspec
    | (v, sh, sh', Q, R) =>
      PROP (writable_share sh)
      LOCAL (temp _lock v)
-     SEP (weak_positive_mpred R && weak_rec_inv sh' v Q R && emp; lock_inv sh v R)
+     SEP (weak_exclusive_mpred R && weak_rec_inv sh' v Q R && emp; lock_inv sh v R)
    end)
   (fun _ x =>
    match x with
@@ -516,26 +515,26 @@ Next Obligation.
   apply (nonexpansive2_super_non_expansive
    (fun Q R => (PROP (writable_share sh)
      LOCAL (temp _lock v)
-     SEP (weak_positive_mpred R && weak_rec_inv sh' v Q R && emp; lock_inv sh v R)) rho));
+     SEP (weak_exclusive_mpred R && weak_rec_inv sh' v Q R && emp; lock_inv sh v R)) rho));
   [ clear Q R; intros Q;
     apply (PROP_LOCAL_SEP_nonexpansive
             ((fun _ => writable_share sh) :: nil)
             (temp _lock v :: nil)
-            ((fun R => weak_positive_mpred R && weak_rec_inv sh' v Q R && emp)%logic :: (fun R => lock_inv sh v R) :: nil))
+            ((fun R => weak_exclusive_mpred R && weak_rec_inv sh' v Q R && emp)%logic :: (fun R => lock_inv sh v R) :: nil))
   | clear Q R; intros R;
     apply (PROP_LOCAL_SEP_nonexpansive
             ((fun _ => writable_share sh) :: nil)
             (temp _lock v :: nil)
-            ((fun Q => weak_positive_mpred R && weak_rec_inv sh' v Q R && emp)%logic :: (fun _ => lock_inv sh v R) :: nil))];
+            ((fun Q => weak_exclusive_mpred R && weak_rec_inv sh' v Q R && emp)%logic :: (fun _ => lock_inv sh v R) :: nil))];
   repeat apply Forall_cons; try apply Forall_nil.
   + apply const_nonexpansive.
-  + apply (conj_nonexpansive (fun R => weak_positive_mpred R && weak_rec_inv sh' v Q R)%logic); [apply (conj_nonexpansive weak_positive_mpred) |].
-    - apply positive_mpred_nonexpansive.
+  + apply (conj_nonexpansive (fun R => weak_exclusive_mpred R && weak_rec_inv sh' v Q R)%logic); [apply (conj_nonexpansive weak_exclusive_mpred) |].
+    - apply exclusive_mpred_nonexpansive.
     - apply rec_inv1_nonexpansive.
     - apply const_nonexpansive.
   + apply nonexpansive_lock_inv.
   + apply const_nonexpansive.
-  + apply (conj_nonexpansive (fun Q => weak_positive_mpred R && weak_rec_inv sh' v Q R)%logic); [apply (conj_nonexpansive (fun _ => weak_positive_mpred R)) |].
+  + apply (conj_nonexpansive (fun Q => weak_exclusive_mpred R && weak_rec_inv sh' v Q R)%logic); [apply (conj_nonexpansive (fun _ => weak_exclusive_mpred R)) |].
     - apply const_nonexpansive.
     - apply rec_inv2_nonexpansive.
     - apply const_nonexpansive.
@@ -557,7 +556,7 @@ Program Definition release2_spec: funspec := mk_funspec
    | (v, sh, Q, R) =>
      PROP (readable_share sh)
      LOCAL (temp _lock v)
-     SEP (weak_precise_mpred R && weak_positive_mpred R && weak_rec_inv sh v Q R && emp; R)
+     SEP (weak_exclusive_mpred R && weak_rec_inv sh v Q R && emp; R)
    end)
   (fun _ x =>
    match x with
@@ -576,27 +575,26 @@ Next Obligation.
   apply (nonexpansive2_super_non_expansive
    (fun Q R => (PROP (readable_share sh)
      LOCAL (temp _lock v)
-     SEP (weak_precise_mpred R && weak_positive_mpred R && weak_rec_inv sh v Q R && emp; R)) rho));
+     SEP (weak_exclusive_mpred R && weak_rec_inv sh v Q R && emp; R)) rho));
   [ clear Q R; intros Q;
     apply (PROP_LOCAL_SEP_nonexpansive
             ((fun _ => readable_share sh) :: nil)
             (temp _lock v :: nil)
-            ((fun R => weak_precise_mpred R && weak_positive_mpred R && weak_rec_inv sh v Q R && emp)%logic :: (fun R => R) :: nil))
+            ((fun R => weak_exclusive_mpred R && weak_rec_inv sh v Q R && emp)%logic :: (fun R => R) :: nil))
   | clear Q R; intros R;
     apply (PROP_LOCAL_SEP_nonexpansive
             ((fun _ => readable_share sh) :: nil)
             (temp _lock v :: nil)
-            ((fun Q => weak_precise_mpred R && weak_positive_mpred R && weak_rec_inv sh v Q R && emp)%logic :: (fun _ => R) :: nil))];
+            ((fun Q => weak_exclusive_mpred R && weak_rec_inv sh v Q R && emp)%logic :: (fun _ => R) :: nil))];
   repeat apply Forall_cons; try apply Forall_nil.
   + apply const_nonexpansive.
-  + apply (conj_nonexpansive (fun R => weak_precise_mpred R && weak_positive_mpred R && weak_rec_inv sh v Q R)%logic); [apply (conj_nonexpansive (fun R => weak_precise_mpred R && weak_positive_mpred R)%logic); [apply (conj_nonexpansive weak_precise_mpred) |] |].
-    - apply precise_mpred_nonexpansive.
-    - apply positive_mpred_nonexpansive.
+  + apply (conj_nonexpansive (fun R => weak_exclusive_mpred R && weak_rec_inv sh v Q R)%logic); [apply (conj_nonexpansive (fun R => weak_exclusive_mpred R)%logic) |].
+    - apply exclusive_mpred_nonexpansive.
     - apply rec_inv1_nonexpansive.
     - apply const_nonexpansive.
   + apply identity_nonexpansive.
   + apply const_nonexpansive.
-  + apply (conj_nonexpansive (fun Q => weak_precise_mpred R && weak_positive_mpred R && weak_rec_inv sh v Q R)%logic); [apply (conj_nonexpansive (fun Q => weak_precise_mpred R && weak_positive_mpred R)%logic) |].
+  + apply (conj_nonexpansive (fun Q => weak_exclusive_mpred R && weak_rec_inv sh v Q R)%logic); [apply (conj_nonexpansive (fun Q => weak_exclusive_mpred R)%logic) |].
     - apply const_nonexpansive.
     - apply rec_inv2_nonexpansive.
     - apply const_nonexpansive.
@@ -761,19 +759,12 @@ Definition signal_spec cs :=
 
 (* Notes about spawn_thread:
 
-As in makelock/acquire/... we get a universe inconsistency when we add
-"WITH P" to the specification.  This universe inconsistency will
-eventually disappear in a different model for rmaps tracking
-covariance and contravariance.  In the meantime, we use a the deep
-embedding [Pred] and an embedding [PrePost] of the pre- and
-post-condition depending on Type term [ty].
-
 The spawned function has for argument name [_y], which is
 existentially quantified.  The function also can use a list of global
 variables [globals].
 
 For now, the specification of the spawned function has to be exactly
-of the form that you can see below (inside the "match PrePost ...").
+of the form that you can see below (inside the "match ...").
 Cao Qinxiang is working on a notion of sub-specification that might
 enable us to have smoother specifications.
 
@@ -785,7 +776,7 @@ To enable joinable threads, the postcondition would be [tptr tthread]
 with a type [tthread] related to the postcondition through a [thread]
 predicate in the logic.  The [join] would then also be implemented
 using the oracle, as [acquire] is.  The postcondition would be [match
-PrePost with existT ty (w, pre, post) => thread th (Interp (post w b))
+PrePost with existT ty (w, pre, post) => thread th (post w b)
 end] *)
 
 Definition gvars := map (fun x => gvar (fst x) (snd x)).
@@ -911,12 +902,6 @@ Proof.
 Qed.
 
 Set Printing Implicit.
-
-Lemma at_external_not_halted (G C M : Type) (csem : semantics.CoreSemantics G C M) (q : C) :
-  semantics.at_external csem q <> None -> semantics.halted csem q = None.
-Proof.
-  destruct (@semantics.at_external_halted_excl G C _ csem q); tauto.
-Qed.
 
 Definition concurrent_specs (cs : compspecs) (ext_link : string -> ident) :=
   (ext_link "acquire"%string, acquire_spec) ::

--- a/concurrency/semax_conc_pred.v
+++ b/concurrency/semax_conc_pred.v
@@ -25,7 +25,7 @@ Require Import VST.floyd.client_lemmas.
 Require Import VST.floyd.jmeq_lemmas.
 Require Import VST.concurrency.lksize.
 
-Definition positive_mpred (R : mpred) :=
+(*Definition positive_mpred (R : mpred) :=
   forall phi, app_pred R phi -> exists l sh rsh k p, phi @ l = YES sh rsh k p.
 
 Program Definition weak_positive_mpred (P: mpred): mpred :=
@@ -127,6 +127,69 @@ Proof.
     - destruct H4; split; auto.
       apply H0; auto.
       apply necR_level in H1; omega.
+Qed.*)
+
+Lemma approx_derives_ge : forall n m P, (n <= m)%nat -> approx n P |-- approx m P.
+Proof.
+  intros; change (predicates_hered.derives (approx n P) (approx m P)).
+  intros ? []; split; auto; omega.
+Qed.
+
+Lemma approx_derives : forall P n, approx n P |-- P.
+Proof.
+  exact approx_p.
+Qed.
+
+Definition exclusive_mpred (R : mpred) :=
+  (R * R |-- FF)%logic.
+
+Program Definition weak_exclusive_mpred (P: mpred): mpred :=
+  fun w => exclusive_mpred (approx (S (level w)) P).
+Next Obligation.
+  intros; hnf; intros.
+  unfold exclusive_mpred in *.
+  apply age_level in H.
+  eapply derives_trans, H0.
+  apply sepcon_derives; apply approx_derives_ge; omega.
+Defined.
+
+Lemma corable_weak_exclusive R : seplog.corable (weak_exclusive_mpred R).
+Proof.
+  change (corable.corable (weak_exclusive_mpred R)).
+  intro; simpl.
+  rewrite level_core; auto.
+Qed.
+
+Lemma exclusive_mpred_nonexpansive:
+  nonexpansive weak_exclusive_mpred.
+Proof.
+  hnf; intros.
+  intros n ?.
+  simpl in H |- *.
+  assert (forall y, (n >= level y)%nat -> (P y <-> Q y)).
+  Focus 1. {
+    intros; specialize (H y H0).
+    destruct H.
+    specialize (H y). spec H; [auto |].
+    specialize (H1 y). spec H1; [auto |].
+    tauto.
+  } Unfocus.
+  clear H.
+  intros; split; intros.
+  + unfold exclusive_mpred in *.
+    eapply derives_trans, H2.
+    match goal with |- ?P |-- ?Q => change (predicates_hered.derives P Q) end.
+    intros ? (? & ? & J & [] & []).
+    pose proof (join_level _ _ _ J) as [].
+    apply necR_level in H1.
+    do 3 eexists; eauto; split; split; try omega; apply H0; auto; omega.
+  + unfold exclusive_mpred in *.
+    eapply derives_trans, H2.
+    match goal with |- ?P |-- ?Q => change (predicates_hered.derives P Q) end.
+    intros ? (? & ? & J & [] & []).
+    pose proof (join_level _ _ _ J) as [].
+    apply necR_level in H1.
+    do 3 eexists; eauto; split; split; try omega; apply H0; auto; omega.
 Qed.
 
 Definition lock_inv : share -> val -> mpred -> mpred :=
@@ -137,10 +200,10 @@ Definition lock_inv : share -> val -> mpred -> mpred :=
         R sh (b, Ptrofs.unsigned ofs))%logic.
 
 Definition rec_inv sh v (Q R: mpred): Prop :=
-  (R = Q * lock_inv sh v (|> R))%logic.
+  (R = Q * |>lock_inv sh v R)%logic.
 
 Definition weak_rec_inv sh v (Q R: mpred): mpred :=
-  (! (R <=> Q * lock_inv sh v (|> R)))%pred.
+  (! (R <=> Q * |>lock_inv sh v R))%pred.
 
 Lemma lockinv_isptr sh v R : lock_inv sh v R = (!! isptr v && lock_inv sh v R)%logic.
 Proof.
@@ -357,8 +420,9 @@ Proof.
     intros n ?.
     split; intros; hnf; intros; auto.
   } Unfocus.
-  eapply predicates_hered.derives_trans; [| apply nonexpansive_lock_inv].
-  apply later_equiv.
+  rewrite <- subtypes.eqp_later.
+  eapply predicates_hered.derives_trans, predicates_hered.now_later.
+  apply nonexpansive_lock_inv.
 Qed.
 
 Lemma rec_inv2_nonexpansive: forall sh v R,
@@ -381,29 +445,16 @@ Proof.
   split; intros; hnf; intros; auto.
 Qed.
 
-Lemma positive_weak_positive: forall R,
-  positive_mpred R ->
-  TT |-- weak_positive_mpred R.
+Lemma exclusive_weak_exclusive: forall R,
+  exclusive_mpred R ->
+  TT |-- weak_exclusive_mpred R.
 Proof.
   intros.
-  change (predicates_hered.derives TT (weak_positive_mpred R)).
+  change (predicates_hered.derives TT (weak_exclusive_mpred R)).
   intros w _.
-  hnf in H |- *.
-  intros; apply H.
-  eapply approx_p; eauto.
-Qed.
-
-Lemma precise_weak_precise: forall R,
-  precise R ->
-  TT |-- weak_precise_mpred R.
-Proof.
-  intros.
-  change (predicates_hered.derives TT (weak_precise_mpred R)).
-  intros w _.
-  hnf in H |- *.
-  intros; apply (H w0); auto.
-  + eapply approx_p; eauto.
-  + eapply approx_p; eauto.
+  simpl.
+  eapply derives_trans, H.
+  apply sepcon_derives; apply approx_derives.
 Qed.
 
 Lemma rec_inv_weak_rec_inv: forall sh v Q R,
@@ -418,5 +469,3 @@ Proof.
   rewrite H at 1 4.
   split; intros; hnf; intros; auto.
 Qed.
-
-

--- a/floyd/call_lemmas.v
+++ b/floyd/call_lemmas.v
@@ -543,7 +543,7 @@ Lemma check_specs_lemma:
    Forall (check_one_temp_spec (pTree_from_elements (combine fl vl)))
           (PTree.elements Qpre_temp) ->
    fold_right `(and) `(True) (map locald_denote (LocalD Qtemp Qvar (map gvars G))) rho ->
-  fold_right ` and ` True (map locald_denote (map gvars G)) rho ->
+  fold_right `(and) `(True) (map locald_denote (map gvars G)) rho ->
   fold_right `(and) `(True) (map locald_denote (LocalD Qpre_temp Qpre_var (map gvars G))) (make_args fl vl rho).
 Proof.
  intros. rename H2 into H8.
@@ -857,8 +857,8 @@ Qed.
 
 Lemma in_gvars_sub:
   forall rho G G', Forall (fun x : globals => In x G) G' ->
-  fold_right ` and ` True (map locald_denote (map gvars G)) rho ->
-  fold_right ` and ` True (map locald_denote (map gvars G')) rho.
+  fold_right `(and) `(True) (map locald_denote (map gvars G)) rho ->
+  fold_right `(and) `(True) (map locald_denote (map gvars G')) rho.
 Proof.
 intros.
 pose proof (proj1 (Forall_forall _ G') H).

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -1613,6 +1613,21 @@ apply semax_extract_prop.
 auto.
 Qed.
 
+Lemma semax_later_SEP:
+  forall {cs: compspecs} {Espec: OracleKind} Delta P Q R c Post,
+           semax Delta (PROPx P (LOCALx Q (|>SEPx R))) c Post ->
+           semax Delta (|> PROPx P (LOCALx Q (SEPx R))) c Post.
+Proof.
+  intros.
+  unfold PROPx, LOCALx; rewrite !later_andp.
+  apply semax_extract_later_prop; intro; simpl.
+  apply semax_remove_later_prop.
+  eapply semax_pre, H.
+  apply andp_right; [apply prop_right; auto|].
+  unfold SEPx.
+  apply andp_left2, derives_refl.
+Qed.
+
 Lemma semax_extract_later_prop1:
   forall {cs: compspecs} {Espec: OracleKind} Delta (PP: Prop) P c Q,
            (PP -> semax Delta (|> P) c Q) ->

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -1620,7 +1620,7 @@ Lemma semax_later_SEP:
 Proof.
   intros.
   unfold PROPx, LOCALx; rewrite !later_andp.
-  apply semax_extract_later_prop; intro; simpl.
+  apply semax_extract_later_prop; intro.
   apply semax_remove_later_prop.
   eapply semax_pre, H.
   apply andp_right; [apply prop_right; auto|].

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -1613,21 +1613,6 @@ apply semax_extract_prop.
 auto.
 Qed.
 
-Lemma semax_later_SEP:
-  forall {cs: compspecs} {Espec: OracleKind} Delta P Q R c Post,
-           semax Delta (PROPx P (LOCALx Q (|>SEPx R))) c Post ->
-           semax Delta (|> PROPx P (LOCALx Q (SEPx R))) c Post.
-Proof.
-  intros.
-  unfold PROPx, LOCALx; rewrite !later_andp.
-  apply semax_extract_later_prop; intro.
-  apply semax_remove_later_prop.
-  eapply semax_pre, H.
-  apply andp_right; [apply prop_right; auto|].
-  unfold SEPx.
-  apply andp_left2, derives_refl.
-Qed.
-
 Lemma semax_extract_later_prop1:
   forall {cs: compspecs} {Espec: OracleKind} Delta (PP: Prop) P c Q,
            (PP -> semax Delta (|> P) c Q) ->

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -996,7 +996,7 @@ lazymatch goal with
   eapply semax_seq';
     [prove_call_setup witness;
      clear_Delta_specs; clear_MORE_POST;
-     [ .. | 
+     [ .. | hoist_later_in_pre;
       lazymatch goal with
       | |- _ -> semax _ _ (Scall (Some _) _ _) _ =>
          forward_call_id1_wow
@@ -1013,7 +1013,7 @@ lazymatch goal with
        eapply semax_seq';
          [prove_call_setup witness;
           clear_Delta_specs; clear_MORE_POST;
-             [ .. | forward_call_id1_x_wow ]
+             [ .. | hoist_later_in_pre; forward_call_id1_x_wow ]
          |  after_forward_call ]
 | |- semax _ _ (Ssequence (Ssequence (Scall (Some ?ret') _ _)
                                        (Sset _ (Etempvar ?ret'2 _))) _) _ =>
@@ -1021,7 +1021,7 @@ lazymatch goal with
        eapply semax_seq';
          [prove_call_setup witness;
           clear_Delta_specs; clear_MORE_POST;
-             [ .. | forward_call_id1_y_wow ]
+             [ .. | hoist_later_in_pre; forward_call_id1_y_wow ]
          |  after_forward_call ]
 | |- _ => rewrite <- seq_assoc; fwd_call' witness
 end.

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -708,7 +708,7 @@ cbv beta iota zeta; unfold_post; extensionality rho;
 *)
 Ltac  forward_call_id1_wow := 
 let H := fresh in intro H;
-eapply (semax_call_id1_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
+eapply (semax_call_id1_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
  clear H; 
  lazymatch goal with Frame := _ : list mpred |- _ => try clear Frame end;
  [check_result_type
@@ -721,7 +721,7 @@ eapply (semax_call_id1_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
 Ltac forward_call_id1_x_wow :=
 let H := fresh in intro H;
-eapply (semax_call_id1_x_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
+eapply (semax_call_id1_x_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
  clear H;
  lazymatch goal with Frame := _ : list mpred |- _ => try clear Frame end;
  [ check_result_type | check_result_type
@@ -737,7 +737,7 @@ eapply (semax_call_id1_x_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
 Ltac forward_call_id1_y_wow :=
 let H := fresh in intro H;
-eapply (semax_call_id1_y_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
+eapply (semax_call_id1_y_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
  clear H;
  lazymatch goal with Frame := _ : list mpred |- _ => try clear Frame end;
  [ check_result_type | check_result_type
@@ -752,7 +752,7 @@ eapply (semax_call_id1_y_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 
 Ltac forward_call_id01_wow :=
 let H := fresh in intro H;
-eapply (semax_call_id01_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
+eapply (semax_call_id01_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
  clear H;
  lazymatch goal with Frame := _ : list mpred |- _ => try clear Frame end;
  [ apply Coq.Init.Logic.I 
@@ -763,7 +763,7 @@ eapply (semax_call_id01_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
 Ltac forward_call_id00_wow  :=
 let H := fresh in intro H;
-eapply (semax_call_id00_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
+eapply (semax_call_id00_wow _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H); 
  clear H;
  lazymatch goal with Frame := _ : list mpred |- _ => try clear Frame end;
  [ check_result_type 
@@ -940,7 +940,8 @@ Ltac prove_call_setup1 :=
 match goal with |- @semax ?CS _ ?Delta (PROPx ?P (LOCALx ?Q (SEPx ?R))) ?c _ =>
  lazymatch c with
  | context [Scall _ (Evar ?id ?ty) ?bl] =>
-    exploit (call_setup1_i2 CS Delta P Q R id ty bl);
+    let R' := strip1_later R in
+    exploit (call_setup1_i2 CS Delta P Q R' R id ty bl);
     [check_prove_local2ptree
     | apply can_assume_funcptr2;
       [ check_function_name
@@ -948,6 +949,7 @@ match goal with |- @semax ?CS _ ?Delta (PROPx ?P (LOCALx ?Q (SEPx ?R))) ?c _ =>
       | find_spec_in_globals'
       | simpl; reflexivity  (* function-id type in AST matches type in funspec *)
       ]
+    | auto 50 with derives
     | simpl; reflexivity  (* function-id type in AST matches type in funspec *)
     |check_typecheck
     |check_typecheck
@@ -956,10 +958,12 @@ match goal with |- @semax ?CS _ ?Delta (PROPx ?P (LOCALx ?Q (SEPx ?R))) ?c _ =>
     | ..
     ]
  | context [Scall _ ?a ?bl] =>
- exploit (call_setup1_i CS Delta P Q R a bl);
+    let R' := strip1_later R in
+ exploit (call_setup1_i CS Delta P Q R R' a bl);
  [check_prove_local2ptree
  |reflexivity
  |prove_func_ptr
+ |auto 50 with derives
  |check_parameter_types
  |check_typecheck
  |check_typecheck
@@ -972,14 +976,14 @@ end.
 Ltac prove_call_setup witness :=
  prove_call_setup1;
  [ .. | 
- match goal with |- call_setup1 _ _ _ _ _ _ _ _ _ _ _ _ ?A _ _ _ _ _ _ _ -> _ =>
+ match goal with |- call_setup1 _ _ _ _ _ _ _ _ _ _ _ _ _ ?A _ _ _ _ _ _ _ -> _ =>
       check_witness_type A witness
  end;
  let H := fresh in
  intro H;
  match goal with | |- @semax ?CS _ _ _ _ _ =>
  let Frame := fresh "Frame" in evar (Frame: list mpred);
- exploit (call_setup2_i _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H witness Frame); clear H;
+ exploit (call_setup2_i _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H witness Frame); clear H;
  [ reflexivity
  | check_prove_local2ptree
  | Forall_pTree_from_elements
@@ -996,11 +1000,11 @@ lazymatch goal with
   eapply semax_seq';
     [prove_call_setup witness;
      clear_Delta_specs; clear_MORE_POST;
-     [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H;
+     [ .. |
       lazymatch goal with
       | |- _ -> semax _ _ (Scall (Some _) _ _) _ =>
          forward_call_id1_wow
-      | |- call_setup2 _ _ _ _ _ _ _ _ _ _ ?retty _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ -> 
+      | |- call_setup2 _ _ _ _ _ _ _ _ _ _ _ ?retty _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ -> 
                 semax _ _ (Scall None _ _) _ =>
         tryif (unify retty Tvoid)
         then forward_call_id00_wow
@@ -1013,7 +1017,7 @@ lazymatch goal with
        eapply semax_seq';
          [prove_call_setup witness;
           clear_Delta_specs; clear_MORE_POST;
-             [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H; forward_call_id1_x_wow ]
+             [ .. | forward_call_id1_x_wow ]
          |  after_forward_call ]
 | |- semax _ _ (Ssequence (Ssequence (Scall (Some ?ret') _ _)
                                        (Sset _ (Etempvar ?ret'2 _))) _) _ =>
@@ -1021,7 +1025,7 @@ lazymatch goal with
        eapply semax_seq';
          [prove_call_setup witness;
           clear_Delta_specs; clear_MORE_POST;
-             [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H; forward_call_id1_y_wow ]
+             [ .. | forward_call_id1_y_wow ]
          |  after_forward_call ]
 | |- _ => rewrite <- seq_assoc; fwd_call' witness
 end.

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -996,7 +996,7 @@ lazymatch goal with
   eapply semax_seq';
     [prove_call_setup witness;
      clear_Delta_specs; clear_MORE_POST;
-     [ .. | hoist_later_in_pre;
+     [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H;
       lazymatch goal with
       | |- _ -> semax _ _ (Scall (Some _) _ _) _ =>
          forward_call_id1_wow
@@ -1013,7 +1013,7 @@ lazymatch goal with
        eapply semax_seq';
          [prove_call_setup witness;
           clear_Delta_specs; clear_MORE_POST;
-             [ .. | hoist_later_in_pre; forward_call_id1_x_wow ]
+             [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H; forward_call_id1_x_wow ]
          |  after_forward_call ]
 | |- semax _ _ (Ssequence (Ssequence (Scall (Some ?ret') _ _)
                                        (Sset _ (Etempvar ?ret'2 _))) _) _ =>
@@ -1021,7 +1021,7 @@ lazymatch goal with
        eapply semax_seq';
          [prove_call_setup witness;
           clear_Delta_specs; clear_MORE_POST;
-             [ .. | hoist_later_in_pre; forward_call_id1_y_wow ]
+             [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H; forward_call_id1_y_wow ]
          |  after_forward_call ]
 | |- _ => rewrite <- seq_assoc; fwd_call' witness
 end.

--- a/mailbox/verif_atomic_exchange.v
+++ b/mailbox/verif_atomic_exchange.v
@@ -43,49 +43,17 @@ Notation hist := (nat -> option AE_hist_el).
 (* the lock invariant used to encode an atomic invariant *)
 Definition AE_inv x g i R := EX h : list AE_hist_el, EX v : val,
   !!(apply_hist i h = Some v /\ tc_val tint v) &&
-  (data_at Tsh tint v x * ghost_ref h g * R h v * (weak_precise_mpred (R h v) && emp)).
+  (data_at Tsh tint v x * ghost_ref h g * R h v).
 
-Lemma AE_inv_positive : forall x g i R, positive_mpred (AE_inv x g i R).
+Lemma AE_inv_exclusive : forall x g i R, exclusive_mpred (AE_inv x g i R).
 Proof.
   unfold AE_inv; intros.
-  do 2 (apply ex_positive; intro).
-  apply positive_andp2, positive_sepcon1, positive_sepcon1, positive_sepcon1; auto.
+  eapply derives_exclusive, exclusive_sepcon1 with (Q := EX h : list AE_hist_el, EX v : val, _),
+    data_at__exclusive with (sh := Tsh)(t := tint); auto; simpl; try omega.
+  Intros h v; rewrite sepcon_assoc; apply sepcon_derives; [cancel|].
+  Exists h v; apply derives_refl.
 Qed.
-Hint Resolve AE_inv_positive.
-
-Lemma AE_inv_precise : forall x g i R,
-  predicates_hered.derives TT (weak_precise_mpred (AE_inv x g i R)).
-Proof.
-  intros ???? rho _ ???
-    (? & h1 & v1 & (Hh1 & ?) & ? & ? & Hj1 & (? & r1 & Hj'1 & (? & ? & ? & (? & Hv1) & ? & Hr1 & Hg1) & HR1) & (HR & Hemp1))
-    (? & h2 & v2 & (Hh2 & ?) & ? & ? & Hj2 & (? & r2 & Hj'2 & (? & ? & ? & (? & Hv2) & ? & Hr2 & Hg2) & HR2) & (_ & Hemp2))
-    Hw1 Hw2.
-  unfold at_offset in *; simpl in *; rewrite data_at_rec_eq in Hv1, Hv2; simpl in *.
-  assert (readable_share Tsh) as Hsh by auto.
-  exploit (mapsto_inj _ _ _ _ _ _ _ w Hsh Hv1 Hv2); auto; try join_sub; unfold unfold_reptype; simpl.
-  { intro; subst; contradiction. }
-  { intro; subst; contradiction. }
-  intros (? & Hv); subst.
-(*  exploit (ghost_inj _ _ _ _ _ w Hg1 Hg2); try join_sub.
-  intros (? & Heq); inv Heq.
-  pose proof (hist_list_inj _ _ _ Hr1 Hr2); subst.
-  destruct (age_sepalg.join_level _ _ _ Hj1), (age_sepalg.join_level _ _ _ Hj2),
-    (age_sepalg.join_level _ _ _ Hj'1), (age_sepalg.join_level _ _ _ Hj'2).
-  pose proof (juicy_mem.rmap_join_sub_eq_level _ _ Hw1);
-    pose proof (juicy_mem.rmap_join_sub_eq_level _ _ Hw2).
-  exploit (HR w r1 r2); try (split; auto; omega); try join_sub.
-  intro; subst; join_inj.
-  apply sepalg.join_comm in Hj1; apply sepalg.join_comm in Hj2.
-  match goal with H1 : predicates_hered.app_pred emp ?a,
-    H2 : predicates_hered.app_pred emp ?b |- _ => assert (a = b);
-      [eapply sepalg.same_identity; auto;
-        [match goal with H : sepalg.join a ?x ?y |- _ =>
-           specialize (Hemp1 _ _ H); instantiate (1 := x); subst; auto end |
-         match goal with H : sepalg.join b ?x ?y |- _ =>
-           specialize (Hemp2 _ _ H); subst; auto end] | subst] end.
-  join_inj.
-Qed.*)
-Admitted.
+Hint Resolve AE_inv_exclusive.
 
 Definition AE_loc sh l p g i R (h : hist) := lock_inv sh l (AE_inv p g i R) * ghost_hist sh h g.
 
@@ -96,10 +64,8 @@ Proof.
   intros; unfold AE_inv.
   rewrite !approx_exp; apply f_equal; extensionality h.
   rewrite !approx_exp; apply f_equal; extensionality v.
-  rewrite !approx_andp, !approx_sepcon, !approx_andp.
-  rewrite approx_idem.
-  rewrite (nonexpansive_super_non_expansive (fun R => weak_precise_mpred R))
-    by (apply precise_mpred_nonexpansive); auto.
+  rewrite !approx_andp, !approx_sepcon.
+  rewrite approx_idem; auto.
 Qed.
 
 Lemma AE_loc_super_non_expansive : forall n sh l p g i R h,
@@ -117,7 +83,7 @@ Qed.
 (* This predicate describes the valid pre- and postconditions for a given atomic invariant R. *)
 Definition AE_spec i P R Q := ALL hc : _, ALL hx : _, ALL vc : _, ALL vx : _,
   !!(apply_hist i hx = Some vx /\ hist_incl hc hx) -->
-  weak_view_shift (R hx vx * P hc vc) (R (hx ++ [AE vx vc]) vc * (weak_precise_mpred (R (hx ++ [AE vx vc]) vc) && emp) *
+  weak_view_shift (R hx vx * P hc vc) (R (hx ++ [AE vx vc]) vc *
     Q (map_upd hc (length hx) (AE vx vc)) vx) && emp.
 
 Definition AE_type := ProdType (ProdType (ProdType
@@ -153,10 +119,7 @@ Proof.
   rewrite !(approx_allp _ _ _ Vundef); apply f_equal; extensionality vx.
   setoid_rewrite approx_imp; f_equal; f_equal.
   rewrite !approx_andp; f_equal.
-  rewrite view_shift_nonexpansive.
-  setoid_rewrite view_shift_nonexpansive at 2.
-  rewrite !approx_sepcon, !approx_andp, !approx_idem.
-  rewrite (nonexpansive_super_non_expansive weak_precise_mpred) by (apply precise_mpred_nonexpansive); auto.
+  rewrite view_shift_nonexpansive, !approx_sepcon; auto.
 Qed.
 Next Obligation.
 Proof.
@@ -186,7 +149,7 @@ Proof.
   { rewrite apply_hist_app.
     replace (apply_hist i h') with (Some v'); simpl.
     apply eq_dec_refl. }
-  gather_SEP 5 2; assert_PROP (hist_incl h h') as Hincl.
+  gather_SEP 4 2; assert_PROP (hist_incl h h') as Hincl.
   { go_lower; apply sepcon_derives_prop.
     rewrite hist_ref_join by auto.
     Intros hr.
@@ -194,9 +157,8 @@ Proof.
   viewshift_SEP 0
     (ghost_hist lsh (map_upd h (length h') (AE v' v)) g * ghost_ref (h' ++ [AE v' v]) g)
     by (go_lower; apply hist_add').
-  gather_SEP 6 3 5; simpl.
-  viewshift_SEP 0 (R (h' ++ [AE v' v]) v * (weak_precise_mpred (R (h' ++ [AE v' v]) v) && emp) *
-    Q (map_upd h (length h') (AE v' v)) v').
+  gather_SEP 5 3 4; simpl.
+  viewshift_SEP 0 (R (h' ++ [AE v' v]) v * Q (map_upd h (length h') (AE v' v)) v').
   { go_lower; unfold AE_spec.
     eapply derives_trans; [apply allp_sepcon1 | apply allp_left with h].
     eapply derives_trans; [apply allp_sepcon1 | apply allp_left with h'].
@@ -205,16 +167,13 @@ Proof.
     rewrite prop_imp by auto.
     apply apply_view_shift. }
   forward_call (l, lsh, AE_inv tgt g i R).
-  { rewrite ?sepcon_assoc; rewrite <- sepcon_emp at 1; rewrite sepcon_comm; apply sepcon_derives;
-      [repeat apply andp_right; auto; eapply derives_trans; try apply positive_weak_positive; auto|].
-    { apply AE_inv_precise; auto. }
+  { lock_props.
     unfold AE_inv.
     Exists (h' ++ [AE v' v]) v; entailer!.
     cancel. }
   forward.
   Exists (length h') (Vint v'). unfold AE_loc; entailer!.
-  - apply hist_incl_lt; auto.
-  - apply andp_left2; auto.
+  apply hist_incl_lt; auto.
 Qed.
 
 Lemma AE_loc_join : forall sh1 sh2 sh l p g i R h1 h2 (Hjoin : sepalg.join sh1 sh2 sh)

--- a/mailbox/verif_mailbox_init.v
+++ b/mailbox/verif_mailbox_init.v
@@ -213,9 +213,7 @@ Proof.
 (*    { entailer!. }
     { entailer!. }
 *)
-    { rewrite ?sepcon_assoc; rewrite <- sepcon_emp at 1; rewrite sepcon_comm; apply sepcon_derives;
-        [repeat apply andp_right; auto; eapply derives_trans; try apply positive_weak_positive; auto|].
-      { apply AE_inv_precise; auto. }
+    { lock_props.
       fast_cancel.
       unfold AE_inv.
       Exists (@nil AE_hist_el) (vint 0).
@@ -225,10 +223,7 @@ Proof.
         [apply prop_right; auto|].
       apply andp_right; [apply prop_right; repeat (split; auto); computable|].
       change_compspecs CompSpecs.
-      Exists 0; fast_cancel.
-      rewrite <- emp_sepcon at 1; apply sepcon_derives.
-      { apply andp_right; auto; eapply derives_trans; [|apply comm_R_precise]; auto. }
-      cancel_frame. }
+      Exists 0; fast_cancel. }
     Exists (locks ++ [l]) (comms ++ [c]) (g ++ [g']) (g0 ++ [g0']) (g1 ++ [g1']) (g2 ++ [g2'])
       (reads ++ [rr]) (lasts ++ [ll]) sh'; rewrite !upd_init; try omega.
     rewrite !Zlength_app, !Zlength_cons, !Zlength_nil; rewrite <- !app_assoc.

--- a/mailbox/verif_mailbox_main.v
+++ b/mailbox/verif_mailbox_main.v
@@ -93,7 +93,9 @@ Proof.
         fold_right sepcon emp (map (fun i => EX sh : share,
           !!(if eq_dec i 0 then sh = sh0 else if eq_dec i 1 then sh = sh0 else sh = Tsh) &&
           EX v : Z, data_at sh tbuffer (vint v) (Znth i bufs)) (upto (Z.to_nat B)))]).
-  { apply andp_right.
+  { eapply derives_trans; [apply andp_derives, derives_refl; apply now_later|].
+    rewrite <- later_andp; apply later_derives.
+    apply andp_right.
     { entailer!. }
     unfold spawn_pre, PROPx, LOCALx, SEPx.
     go_lowerx.
@@ -213,7 +215,9 @@ Proof.
           comm_loc sh2 (Znth r locks) (Znth r comms) g g0 g1 g2 bufs sh gsh2 empty_map;
           EX v : Z, data_at sh tbuffer (vint v) (Znth 1 bufs);
           ghost_var gsh1 (vint 1) g0]).
-    - apply andp_right.
+    - eapply derives_trans; [apply andp_derives, derives_refl; apply now_later|].
+      rewrite <- later_andp; apply later_derives.
+      apply andp_right.
       { entailer!. }
       unfold spawn_pre. simpl fst in *. simpl snd in *.
       assert_PROP (isptr d) by (entailer!; eauto).

--- a/mailbox/verif_mailbox_read.v
+++ b/mailbox/verif_mailbox_read.v
@@ -86,13 +86,9 @@ Proof.
     - assert (b = -1) by (apply Empty_inj; auto; apply repable_buf; auto).
       subst; rewrite eq_dec_refl; entailer!.
       rewrite latest_read_Empty; auto.
-      { apply andp_right; auto.
-        eapply derives_trans; eauto. }
     - destruct (eq_dec b (-1)); [subst; contradiction n; auto|].
       entailer!.
-      apply latest_read_new; auto.
-      { apply andp_right; auto.
-        eapply derives_trans; eauto. } }
+      apply latest_read_new; auto. }
   { repeat (split; auto); computable. }
   Intros x b'; destruct x as (t, v). simpl fst in *; simpl snd in *.
   assert (exists b, v = vint b /\ -1 <= b < B /\ if eq_dec b (-1) then b' = b0 else b' = b) as (b & ? & ? & ?).

--- a/mailbox/verif_mailbox_specs.v
+++ b/mailbox/verif_mailbox_specs.v
@@ -377,33 +377,6 @@ Proof.
   split; [transitivity (-1) | transitivity B]; unfold B, N in *; try computable; auto; omega.
 Qed.
 
-Lemma comm_R_precise : forall bufs sh gsh g0 g1 g2 h v,
-  TT |-- weak_precise_mpred (comm_R bufs sh gsh g0 g1 g2 h v).
-Proof.
-  unfold comm_R; intros; apply precise_weak_precise.
-  apply derives_precise' with (Q := EX b : Z, EX b2 : Z, !!(repable_signed b /\ repable_signed b2 /\
-    v = vint b /\ snd (last_two_reads (rev h)) = vint b2) &&
-    ((EX v : val, ghost_var gsh v g0) * (EX v : val, ghost_var gsh v g1) * (EX v : val, ghost_var gsh v g2) *
-     data_at_ sh tbuffer (Znth (if eq_dec v Empty then b2 else b) bufs))).
-  { Intros b b1 b2.
-    assert (repable_signed b) by (apply repable_buf; auto).
-    Exists b b2 (vint b1) (prev_taken (rev h)) (last_write (rev h)); entailer!.
-    { replace (last_two_reads (rev h)) with (vint b1, vint b2); auto. }
-    destruct (eq_dec (vint b) Empty).
-    - apply Empty_inj in e; auto.
-      subst; rewrite eq_dec_refl; entailer!.
-    - destruct (eq_dec b (-1)); [subst; contradiction n; auto | entailer!]. }
-  intros ??? (b & b2 & (? & ? & ? & ?) & ?) (b' & b2' & (? & ? & ? & ?) & ?); subst.
-  assert (b = b' /\ b2 = b2') as (? & ?) by (split; apply repr_inj_signed; auto; congruence).
-  subst.
-  assert (precise ((EX v : val, ghost_var gsh v g0) * (EX v : val, ghost_var gsh v g1) *
-        (EX v : val, ghost_var gsh v g2) *
-        data_at_ sh tbuffer (Znth (if eq_dec (vint b') Empty then b2' else b') bufs))) as Hp;
-    [|apply Hp; auto].
-  repeat apply precise_sepcon; auto.
-Admitted.
-Hint Resolve comm_R_precise.
-
 Lemma last_two_reads_cons : forall r w h, last_two_reads (AE r w :: h) =
   if eq_dec w Empty then if eq_dec r Empty then last_two_reads h else (r, fst (last_two_reads h))
   else last_two_reads h.

--- a/mailbox/verif_mailbox_write.v
+++ b/mailbox/verif_mailbox_write.v
@@ -849,9 +849,6 @@ Proof.
       rewrite <- !sepcon_assoc, sepcon_comm, <- !sepcon_assoc, 2sepcon_assoc.
       eapply derives_trans; [apply sepcon_derives, derives_refl; apply bupd_sepcon|].
       eapply derives_trans; [apply bupd_frame_r | apply bupd_mono].
-      rewrite (sepcon_comm _ (weak_precise_mpred _ && _)).
-      rewrite <- emp_sepcon at 1; rewrite !sepcon_assoc; apply sepcon_derives.
-      { apply andp_right; auto; eapply derives_trans; [|apply comm_R_precise]; auto. }
       erewrite <- !(ghost_var_share_join _ _ Tsh) by eauto.
       Exists b b1 b2; entailer!.
       { rewrite Forall_app; repeat constructor; auto.

--- a/progs/conclib.v
+++ b/progs/conclib.v
@@ -1,12 +1,8 @@
-Require Import VST.msl.predicates_sl.
 Require Export VST.concurrency.semax_conc_pred.
 Require Export VST.concurrency.semax_conc.
 Require Export VST.floyd.proofauto.
 Require Import VST.floyd.library.
 Require Export VST.floyd.sublist.
-
-Notation precise := precise.
-Notation derives_precise := predicates_sl.derives_precise.
 
 (* general list lemmas *)
 Notation vint z := (Vint (Int.repr z)).
@@ -1883,293 +1879,138 @@ Qed.
 
 (* We could also consider an alpha-renaming axiom, although this may be unnecessary. *)
 
-(* precise and positive *)
-Lemma weak_precise_positive_conflict : forall P,
-  predicates_hered.derives ((weak_precise_mpred P && emp) * (weak_positive_mpred P && emp) * P * P) FF.
+(* exclusive *)
+Lemma weak_exclusive_conflict : forall P,
+  predicates_hered.derives ((weak_exclusive_mpred P && emp) * P * P) FF.
 Proof.
-  repeat intro.
-  destruct H as (r1 & r2 & ? & (? & ? & Hj1 & (? & ? & Hj2 & (Hprecise & Hemp1) & (Hpositive & Hemp2)) & ?) & ?).
-  specialize (Hemp1 _ _ Hj2); subst.
-  specialize (Hemp2 _ _ Hj1); subst.
-  destruct (age_sepalg.join_level _ _ _ Hj1), (age_sepalg.join_level _ _ _ Hj2),
-    (age_sepalg.join_level _ _ _ H).
-  exploit (Hprecise a r1 r2); simpl; try (split; auto; omega).
-  { exists r2; auto. }
-  { exists r1; apply sepalg.join_comm; auto. }
-  intro; subst.
-  destruct (Hpositive r2) as (l & ? & ? & ? & ? & HYES).
-  { split; auto; omega. }
-  apply (compcert_rmaps.RML.resource_at_join _ _ _ l) in H.
-  rewrite HYES in H; inv H.
+  intros ?? (r1 & r2 & ? & (? & ? & Hj & [Hexclusive Hemp] & ?) & ?).
+  destruct (age_sepalg.join_level _ _ _ H), (age_sepalg.join_level _ _ _ Hj).
+  apply Hemp in Hj; subst.
+  simpl in Hexclusive.
+  match goal with H : exclusive_mpred ?P |- _ => change (predicates_hered.derives (P * P) FF) in H end.
+  apply Hexclusive.
+  do 3 eexists; eauto; repeat split; auto; omega.
+Qed.
+
+Lemma exclusive_sepcon1 : forall (P Q : mpred) (HP : exclusive_mpred P), exclusive_mpred (P * Q).
+Proof.
+  unfold exclusive_mpred; intros.
+  eapply derives_trans, sepcon_FF_derives' with (P := Q * Q), HP; cancel.
+Qed.
+
+Lemma exclusive_sepcon2 : forall (P Q : mpred) (HP : exclusive_mpred Q), exclusive_mpred (P * Q).
+Proof.
+  intros; rewrite sepcon_comm; apply exclusive_sepcon1; auto.
+Qed.
+
+Lemma exclusive_andp1 : forall P Q (HP : exclusive_mpred P), exclusive_mpred (P && Q).
+Proof.
+  unfold exclusive_mpred; intros.
+  eapply derives_trans, HP.
+  apply sepcon_derives; apply andp_left1; auto.
+Qed.
+
+Lemma exclusive_andp2 : forall P Q (HQ : exclusive_mpred Q), exclusive_mpred (P && Q).
+Proof.
+  intros; rewrite andp_comm; apply exclusive_andp1; auto.
+Qed.
+
+Lemma lock_inv_exclusive : forall v sh R, exclusive_mpred (lock_inv sh v R).
+Proof.
+  intros; unfold exclusive_mpred, lock_inv.
+  Intros b1 ofs1 b2 ofs2; subst.
+  inv H0.
+  match goal with |- ?P |-- ?Q => change (predicates_hered.derives P Q) end.
+  intros ? (? & ? & ? & Hlock1 & Hlock2).
+  exploit (res_predicates.LKspec_precise _ _ _ _ a _ _ Hlock1 Hlock2); try (eexists; eauto).
+  intros; subst.
+  destruct Hlock1 as [Hlock1 _]; simpl in Hlock1.
+  specialize (Hlock1 (b2, Ptrofs.unsigned ofs2)).
+  rewrite if_true in Hlock1 by (split; auto; pose proof lksize.LKSIZE_pos; omega).
+  rewrite if_true in Hlock1 by auto.
+  destruct Hlock1 as [? Hl1].
+  apply compcert_rmaps.RML.resource_at_join with (loc := (b2, Ptrofs.unsigned ofs2)) in H.
+  rewrite Hl1 in H; inv H.
   apply sepalg.join_self in RJ.
   eapply readable_not_identity; eauto.
 Qed.
 
-Lemma precise_positive_conflict : forall P (Hprecise : precise P) (Hpositive : positive_mpred P), P * P |-- FF.
-Proof.
-  intros.
-  apply derives_trans with (Q := (weak_precise_mpred P && emp) * (weak_positive_mpred P && emp) * P * P);
-    [|apply weak_precise_positive_conflict].
-  Transparent mpred. cancel. Opaque mpred.
-  rewrite <- sepcon_emp at 1.
-  apply sepcon_derives; apply andp_right; auto; try apply derives_refl;
-  apply derives_trans with (Q := TT);
-    auto; [apply precise_weak_precise | apply positive_weak_positive]; auto.
-Qed.
-
-Lemma precise_sepcon : forall (P Q : mpred) (HP : precise P) (HQ : precise Q), precise (P * Q).
-Proof.
-  unfold precise; intros ??????? (l1 & r1 & Hjoin1 & HP1 & HQ1) (l2 & r2 & Hjoin2 & HP2 & HQ2)
-    Hsub1 Hsub2.
-  specialize (HP w _ _ HP1 HP2); specialize (HQ w _ _ HQ1 HQ2).
-  rewrite HP, HQ in Hjoin1.
-  eapply sepalg.join_eq; eauto.
-  - apply sepalg.join_sub_trans with (b := w1); auto.
-    eapply sepalg.join_join_sub'; eauto.
-  - apply sepalg.join_sub_trans with (b := w2); auto.
-    eapply sepalg.join_join_sub'; eauto.
-  - apply sepalg.join_sub_trans with (b := w1); auto.
-    eapply sepalg.join_join_sub; eauto.
-  - apply sepalg.join_sub_trans with (b := w2); auto.
-    eapply sepalg.join_join_sub; eauto.
-Qed.
-
-Lemma precise_andp1 : forall P Q (HP : precise P), precise (P && Q).
-Proof.
-  intros ?????? (? & ?) (? & ?) ??; eauto.
-Qed.
-
-Lemma precise_andp2 : forall P Q (HQ : precise Q), precise (P && Q).
-Proof.
-  intros ?????? (? & ?) (? & ?) ??; eauto.
-Qed.
-
-Lemma ex_address_mapsto_precise: forall ch sh l,
-  precise (EX v : val, res_predicates.address_mapsto ch v sh l).
-Proof.
-  intros.
-  eapply derives_precise, res_predicates.VALspec_range_precise.
-  repeat intro.
-  destruct H.
-  eapply res_predicates.address_mapsto_VALspec_range; eauto.
-Qed.
-
-Lemma lock_inv_precise : forall v sh R, precise (lock_inv sh v R).
-Proof.
-  intros ?????? (b1 & o1 & Hv1 & Hlock1) (b2 & o2 & Hv2 & Hlock2) ??.
-  rewrite Hv2 in Hv1; inv Hv1.
-  eapply res_predicates.LKspec_precise; eauto.
-Qed.
-
-Lemma lock_inv_positive : forall sh v R,
-  positive_mpred (lock_inv sh v R).
-Proof.
-  repeat intro.
-  destruct H as (b & o & Hv & Hlock & Hg).
-  simpl in Hlock.
-  specialize (Hlock (b, Ptrofs.unsigned o)).
-  if_tac [r|nr] in Hlock.
-  - if_tac [e|ne] in Hlock.
-    + destruct Hlock; eauto 6.
-    + contradiction ne; auto.
-  - contradiction nr; unfold adr_range; split; auto.
-    unfold lksize.LKSIZE in *.
-    omega.
-Qed.
-
-Lemma selflock_precise : forall R sh v, precise R -> precise (selflock R v sh).
+Lemma selflock_exclusive : forall R sh v, exclusive_mpred R -> exclusive_mpred (selflock R v sh).
 Proof.
   intros.
   rewrite selflock_eq.
-  apply precise_sepcon; auto.
-  apply lock_inv_precise.
+  apply exclusive_sepcon1; auto.
 Qed.
 
-Lemma positive_sepcon1 : forall P Q (HP : positive_mpred P),
-  positive_mpred (P * Q).
+Lemma exclusive_FF : exclusive_mpred FF.
 Proof.
-  repeat intro.
-  destruct H as (? & ? & ? & HP1 & ?).
-  specialize (HP _ HP1).
-  destruct HP as (l & sh & rsh & k & p & HP).
-  apply compcert_rmaps.RML.resource_at_join with (loc := l) in H.
-  rewrite HP in H; inversion H; eauto 6.
+  unfold exclusive_mpred.
+  rewrite FF_sepcon; auto.
 Qed.
 
-Lemma positive_sepcon2 : forall P Q (HQ : positive_mpred Q),
-  positive_mpred (P * Q).
+Lemma derives_exclusive : forall P Q (Hderives : P |-- Q) (HQ : exclusive_mpred Q),
+  exclusive_mpred P.
 Proof.
-  repeat intro.
-  destruct H as (? & ? & ? & ? & HQ1).
-  specialize (HQ _ HQ1).
-  destruct HQ as (l & sh & rsh & k & p & HQ).
-  apply compcert_rmaps.RML.resource_at_join with (loc := l) in H.
-  rewrite HQ in H; inversion H; eauto 6.
+  unfold exclusive_mpred; intros.
+  eapply derives_trans, HQ.
+  apply sepcon_derives; auto.
 Qed.
 
-Lemma positive_andp1 : forall P Q (HP : positive_mpred P),
-  positive_mpred (P && Q).
+Lemma mapsto_exclusive : forall (sh : Share.t) (t : type) (v : val),
+  sepalg.nonunit sh -> exclusive_mpred (EX v2 : _, mapsto sh t v v2).
 Proof.
-  intros ???? (? & ?); auto.
+  intros; unfold exclusive_mpred.
+  Intros v1 v2; apply mapsto_conflict; auto.
 Qed.
 
-Lemma positive_andp2 : forall P Q (HQ : positive_mpred Q),
-  positive_mpred (P && Q).
+Lemma field_at__exclusive : forall (cs : compspecs) (sh : Share.t) (t : type) (fld : list gfield) (p : val),
+  sepalg.nonidentity sh ->
+  0 < sizeof (nested_field_type t fld) -> exclusive_mpred (field_at_ sh t fld p).
 Proof.
-  intros ???? (? & ?); auto.
+  intros; apply field_at__conflict; auto.
 Qed.
 
-Lemma selflock_positive : forall R sh v, positive_mpred (selflock R v sh).
+Lemma ex_field_at_exclusive : forall (cs : compspecs) (sh : Share.t) (t : type) (fld : list gfield) (p : val),
+  sepalg.nonidentity sh ->
+  0 < sizeof (nested_field_type t fld) -> exclusive_mpred (EX v : _, field_at sh t fld v p).
 Proof.
-  intros.
-  rewrite selflock_eq.
-  apply positive_sepcon2, lock_inv_positive.
+  intros; unfold exclusive_mpred.
+  Intros v v'; apply field_at_conflict; auto.
 Qed.
 
-(* This need not hold; specifically, when an rmap is at level 0, |> P holds vacuously for all P. *)
-Lemma later_positive : forall P, positive_mpred P -> positive_mpred (|> P)%logic.
-Admitted. (* still needed in verif_incr.v and verif_cond.v *)
-(* The solution to this is probably to introduce the Timeless modality. *)
-
-Lemma positive_FF : positive_mpred FF.
+Corollary field_at_exclusive : forall (cs : compspecs) (sh : Share.t) (t : type) (fld : list gfield) v (p : val),
+  sepalg.nonidentity sh -> 0 < sizeof (nested_field_type t fld) -> exclusive_mpred (field_at sh t fld v p).
 Proof.
-  repeat intro; contradiction.
+  intros; eapply derives_exclusive, ex_field_at_exclusive; eauto.
+  Exists v; apply derives_refl.
 Qed.
 
-Lemma derives_positive : forall P Q (Hderives : P |-- Q) (HQ : positive_mpred Q), positive_mpred P.
+Lemma ex_data_at_exclusive : forall (cs : compspecs) (sh : Share.t) (t : type) (p : val),
+  sepalg.nonidentity sh -> 0 < sizeof t -> exclusive_mpred (EX v : _, data_at sh t v p).
 Proof.
-  repeat intro.
-  specialize (Hderives _ H); auto.
+  intros; unfold exclusive_mpred.
+  Intros v v'; apply data_at_conflict; auto.
 Qed.
 
-Lemma ex_address_mapsto_positive: forall ch sh l,
-  positive_mpred (EX v : val, res_predicates.address_mapsto ch v sh l).
+Corollary data_at_exclusive : forall (cs : compspecs) (sh : Share.t) (t : type) v (p : val),
+  sepalg.nonidentity sh -> 0 < sizeof t -> exclusive_mpred (data_at sh t v p).
 Proof.
-  intros ???? (? & ? & [? Hp] & ?); simpl in Hp.
-  specialize (Hp l); destruct (adr_range_dec _ _ _).
-  destruct Hp; eauto 6.
-  { contradiction n; unfold adr_range.
-    destruct l; repeat split; auto; try omega.
-    destruct ch; simpl; omega. }
+  intros; eapply derives_exclusive, ex_data_at_exclusive; eauto.
+  Exists v; apply derives_refl.
 Qed.
 
-Corollary mapsto_positive : forall sh t p v, readable_share sh -> positive_mpred (mapsto sh t p v).
+Corollary data_at__exclusive : forall (cs : compspecs) (sh : Share.t) (t : type) (p : val),
+  sepalg.nonidentity sh -> 0 < sizeof t -> exclusive_mpred (data_at_ sh t p).
 Proof.
-  intros; unfold mapsto.
-  destruct (access_mode t); try apply positive_FF.
-  destruct (type_is_volatile t); try apply positive_FF.
-  destruct p; try apply positive_FF.
-  destruct (readable_share_dec sh); [|contradiction n; auto].
-  eapply derives_positive, ex_address_mapsto_positive.
-  Transparent mpred. apply orp_left; entailer.
-  - Exists v; eauto. apply derives_refl.
-  - Exists v2'; auto.
-Opaque mpred.
+  intros; eapply derives_exclusive, data_at_exclusive; eauto.
+  apply data_at__data_at; eauto.
 Qed.
 
-Corollary data_at__positive : forall {cs} sh t p (Hsh : readable_share sh)
-  (Hval : type_is_by_value t = true) (Hvol : type_is_volatile t = false),
-  positive_mpred (@data_at_ cs sh t p).
+Lemma cond_var_exclusive : forall {cs} sh p, sepalg.nonidentity sh ->
+  exclusive_mpred (@cond_var cs sh p).
 Proof.
-  intros; unfold data_at_, field_at_, field_at, at_offset; rewrite by_value_data_at_rec_nonvolatile; auto;
-    simpl.
-  rewrite repinject_default_val.
-  apply positive_andp2, mapsto_positive; auto.
-Qed.
-
-Corollary data_at_positive : forall {cs} sh t v p (Hsh : readable_share sh)
-  (Hval : type_is_by_value t = true) (Hvol : type_is_volatile t = false),
-  positive_mpred (@data_at cs sh t v p).
-Proof.
-  intros; eapply derives_positive, data_at__positive; eauto.
-  apply data_at_data_at_.
-Qed.
-
-Lemma ex_positive : forall t P, (forall x, positive_mpred (P x)) -> positive_mpred (EX x : t, P x).
-Proof.
-  intros ???? (? & ?).
-  eapply H; eauto.
-Qed.
-
-Lemma precise_emp : precise emp.
-Proof.
-  apply precise_emp.
-Qed.
-
-Lemma derives_precise' : forall (P Q : mpred), P |-- Q -> precise Q -> precise P.
-Proof.
-  intros; eapply derives_precise; [|eassumption]; auto.
-Qed.
-
-Lemma precise_FF : precise FF.
-Proof.
-  repeat intro; contradiction.
-Qed.
-
-Hint Resolve precise_emp precise_FF.
-
-Lemma mapsto_precise : forall sh t p v, precise (mapsto sh t p v).
-Proof.
-  intros; unfold mapsto.
-  destruct (access_mode t); auto.
-  destruct (type_is_volatile t); auto.
-  destruct p; auto.
-  destruct (readable_share_dec sh).
-  - eapply derives_precise, ex_address_mapsto_precise; intros ? [(? & ?) | (? & ? & ?)]; eexists; eauto.
-  - apply precise_andp2, res_predicates.nonlock_permission_bytes_precise.
-Qed.
-Hint Resolve mapsto_precise.
-
-Corollary memory_block_precise : forall sh n v, precise (memory_block sh n v).
-Proof.
-  destruct v; auto; apply precise_andp2.
-  forget (Ptrofs.unsigned i) as o; forget (nat_of_Z n) as z; revert o; induction z; intro; simpl.
-  - apply precise_emp.
-  - apply precise_sepcon; auto.
-    apply mapsto_precise.
-Qed.
-Hint Resolve memory_block_precise.
-
-Corollary field_at__precise : forall {cs : compspecs} sh t gfs p,
-  precise (field_at_ sh t gfs p).
-Proof.
-  intros; rewrite field_at__memory_block; auto.
-Qed.
-Hint Resolve field_at__precise.
-
-Corollary data_at__precise : forall {cs : compspecs} sh t p, precise (data_at_ sh t p).
-Proof.
-  intros; unfold data_at_; auto.
-Qed.
-Hint Resolve data_at__precise.
-
-Corollary field_at_precise : forall {cs : compspecs} sh t gfs v p,
-  precise (field_at sh t gfs v p).
-Proof.
-  intros; eapply derives_precise, field_at__precise; apply field_at_field_at_.
-Qed.
-Hint Resolve field_at_precise.
-
-Corollary data_at_precise : forall {cs : compspecs} sh t v p, precise (data_at sh t v p).
-Proof.
-  intros; unfold data_at; auto.
-Qed.
-Hint Resolve data_at_precise.
-
-Lemma cond_var_precise : forall {cs} sh p, readable_share sh ->
-  precise (@cond_var cs sh p).
-Proof.
-  intros; apply data_at__precise; auto.
-Qed.
-
-Lemma cond_var_positive : forall {cs} sh p, readable_share sh ->
-  positive_mpred (@cond_var cs sh p).
-Proof.
-  intros; unfold cond_var, data_at_, field_at_, field_at, at_offset; simpl.
-  destruct p; try (rewrite prop_false_andp; [|intros (? & ?); contradiction]; apply positive_FF).
-  apply positive_andp2.
-  rewrite data_at_rec_eq; simpl.
-  apply mapsto_positive; auto.
+  intros; apply data_at__exclusive; auto.
+  unfold tcond; simpl; omega.
 Qed.
 
 Lemma lock_inv_isptr : forall sh v R, lock_inv sh v R = !!isptr v && lock_inv sh v R.
@@ -2194,19 +2035,8 @@ Proof.
   intros; unfold cond_var; apply data_at__share_join; auto.
 Qed.
 
-Lemma precise_fold_right : forall l, Forall precise l -> precise (fold_right sepcon emp l).
-Proof.
-  induction l; simpl; auto; intros.
-  inv H; apply precise_sepcon; auto.
-Qed.
-
-Lemma precise_False : precise (!!False).
-Proof.
-  repeat intro.
-  inversion H.
-Qed.
-
 (* Sometimes, in order to prove precise, we actually need to know that the data is the same as well. *)
+(* Do we still need this? Probably not.
 Lemma mapsto_inj : forall sh t v1 v2 p r1 r2 r
   (Hsh : readable_share sh)
   (Hp1 : predicates_hered.app_pred (mapsto sh t p v1) r1)
@@ -2380,11 +2210,10 @@ Proof.
     { eapply sepalg.join_sub_trans; [eexists; eauto | eauto]. }
     intros (? & ?); subst.
     split; [eapply sepalg.join_eq|]; auto.
-Qed.
+Qed. *)
 
-Hint Resolve lock_inv_precise lock_inv_positive selflock_precise selflock_positive
-  cond_var_precise cond_var_positive positive_FF mapsto_precise mapsto_positive
-  data_at_precise data_at_positive data_at__precise data_at__positive selflock_rec.
+Hint Resolve lock_inv_exclusive selflock_exclusive cond_var_exclusive data_at_exclusive
+  data_at__exclusive field_at_exclusive field_at__exclusive selflock_rec.
 
 Lemma eq_dec_refl : forall {A B} {A_eq : EqDec A} (a : A) (b c : B), (if eq_dec a a then b else c) = b.
 Proof.
@@ -3126,7 +2955,7 @@ Qed.
 
 Ltac lock_props := rewrite ?sepcon_assoc; rewrite <- sepcon_emp at 1; rewrite sepcon_comm; apply sepcon_derives;
   [repeat apply andp_right; auto; eapply derives_trans;
-   try (apply precise_weak_precise || apply positive_weak_positive || apply rec_inv_weak_rec_inv); auto |
+   try (apply exclusive_weak_exclusive || (apply rec_inv_weak_rec_inv; try apply selflock_rec)); auto |
    try timeout 20 cancel].
 
 Ltac join_sub := repeat (eapply sepalg.join_sub_trans;
@@ -3147,10 +2976,11 @@ Ltac fast_cancel := rewrite ?sepcon_emp, ?emp_sepcon; rewrite ?sepcon_assoc;
   rewrite memory_block_data_at_ by auto].
 *)
 
+(* This should probably be replaced with a use of forward_call_dep from below. *)
 Ltac forward_spawn sig wit := let Frame := fresh "Frame" in evar (Frame : list mpred);
   try match goal with |- semax _ _ (Scall _ _ _) _ => rewrite -> semax_seq_skip end;
   rewrite <- ?seq_assoc; eapply semax_seq';
-  [match goal with |- semax _ (PROP () (LOCALx ?locals _)) _ _ => eapply semax_pre, semax_call_id0 with
+  [match goal with |- semax _ (PROP () (LOCALx ?locals _)) _ _ => hoist_later_in_pre; eapply semax_pre, semax_call_id0 with
       (argsig := [(_f, tptr voidstar_funtype); (_args, tptr tvoid)])(P := [])
       (Q := locals)(R := Frame)(ts := [sig])
       (A := spawn_arg_type)(x := wit); try reflexivity end |
@@ -3495,44 +3325,39 @@ Lemma semax_call_aux55:
  (PTREE'' : pTree_from_elements (combine (var_names argsig) vl) = Qactuals)
  (PRE1 : Pre ts witness = PROPx Ppre (LOCALx Qpre (SEPx Rpre)))
  (PTREE' : local2ptree Qpre = (Qpre_temp, Qpre_var, nil, map gvars G')) 
- (CHECKTEMP : ENTAIL Delta, PROPx P (LOCALx Q (SEPx R))
-            |-- !! Forall (check_one_temp_spec Qactuals)
-                     (PTree.elements Qpre_temp))
- (CHECKVAR : ENTAIL Delta, PROPx P (LOCALx Q (SEPx R))
-           |-- !! Forall (check_one_var_spec Qvar) (PTree.elements Qpre_var))
+ (CHECKTEMP : Forall (check_one_temp_spec Qactuals) (PTree.elements Qpre_temp))
+ (CHECKVAR : Forall (check_one_var_spec Qvar) (PTree.elements Qpre_var))
  (CHECKG: Forall (fun x => In x G) G')
  (FRAME : fold_right_sepcon R
            |-- fold_right_sepcon Rpre * fold_right_sepcon Frame)
- (PPRE : fold_right_and True Ppre),
+ (PPRE : fold_right_and True Ppre)
+ (LEN : length (argtypes argsig) = length bl),
 ENTAIL Delta,
 (EX v : val,
  lift0 (func_ptr (mk_funspec (argsig, retty) cc A Pre Post NEPre NEPost) v) &&
- local (` (eq v) (eval_expr a))) && PROPx P (LOCALx Q (SEPx R))
-|-- tc_expr Delta a && tc_exprlist Delta (argtypes argsig) bl &&
-    (` (Pre ts witness)
+ local (` (eq v) (eval_expr a))) && PROPx P (LOCALx Q (|>SEPx R))
+|-- |> (tc_expr Delta a && tc_exprlist Delta (argtypes argsig) bl) &&
+    (|> ` (Pre ts witness)
        (make_args' (argsig, retty) (eval_exprlist (argtypes argsig) bl)) *
      ` (func_ptr' (mk_funspec (argsig, retty) cc A Pre Post NEPre NEPost))
-       (eval_expr a) * PROPx P (LOCALx Q (SEPx Frame))).
+       (eval_expr a) * PROPx P (LOCALx Q (|>SEPx Frame))).
 Proof.
 intros.
 rewrite !exp_andp1. Intros v.
-repeat apply andp_right; auto.
-eapply derives_trans; [apply andp_derives; [apply derives_refl | apply andp_left2; apply derives_refl ] | auto].
-eapply derives_trans; [apply andp_derives; [apply derives_refl | apply andp_left2; apply derives_refl ] | auto].
-(*
-normalize.
-assert (H0 := @msubst_eval_expr_eq cs P Qtemp Qvar nil R a v).
-assert (H1 := local2ptree_soundness P Q R Qtemp Qvar nil nil PTREE).
-simpl app in H1. rewrite <- H1 in H0. apply H0 in EVAL. 
-clear H0 H1.
-*)
+rewrite later_andp; repeat apply andp_right; auto.
+{ eapply derives_trans, later_derives, TC0.
+  rewrite later_andp; apply andp_derives; [apply now_later|].
+  apply andp_left2, PROP_later. }
+{ eapply derives_trans, later_derives, TC1.
+  rewrite later_andp; apply andp_derives; [apply now_later|].
+  apply andp_left2, PROP_later. }
 rewrite PRE1.
 match goal with |- _ |-- ?A * ?B * ?C => pull_right B end.
 rewrite sepcon_comm.
 rewrite func_ptr'_func_ptr_lifted.
 apply ENTAIL_trans with
  (`(func_ptr (mk_funspec (argsig, retty) cc A Pre Post NEPre NEPost)) (eval_expr a) &&
-      PROPx P (LOCALx Q (SEPx R))).
+      PROPx P (LOCALx Q (|>SEPx R))).
 apply andp_left2.
 apply andp_right; [  | apply andp_left2; auto].
 apply andp_left1.
@@ -3540,31 +3365,13 @@ intro rho; unfold_lift; unfold local, lift0, lift1; simpl. normalize.
 apply andp_right.
 apply andp_left2; apply andp_left1; auto.
 eapply derives_trans;[ apply andp_derives; [apply derives_refl | apply andp_left2; apply derives_refl] |].
- match goal with |- ?D && PROPx ?A ?B |-- ?C =>
-  apply derives_trans with (D && PROPx ((length (argtypes argsig) = length bl) :: A) B);
-    [ rewrite <- insert_prop | ]
- end.
- apply andp_right; [apply andp_left1; auto | ].
- apply andp_right; [| apply andp_left2; auto].
- eapply derives_trans; [apply TC1 | ].
- clear. go_lowerx.
- unfold tc_exprlist.
- revert bl; induction (argtypes argsig); destruct bl;
-   simpl; try apply @FF_left.
-   
- apply prop_right; auto.
- repeat rewrite denote_tc_assert_andp; simpl. apply andp_left2.
- eapply derives_trans; [ apply IHl | ]. normalize.
-apply derives_extract_PROP; intro LEN.
-subst Qactuals. 
+subst Qactuals.
 clear - PTREE LEN PTREE' MSUBST CHECKVAR FRAME PPRE CHECKTEMP CHECKG.
- progress (autorewrite with norm1 norm2); normalize.
- eapply derives_trans.
- apply andp_right. apply andp_right. apply CHECKVAR. apply CHECKTEMP. apply derives_refl.
- rewrite andp_assoc. apply derives_extract_prop; intro CVAR.
- apply derives_extract_prop; intro CTEMP.
- clear CHECKTEMP CHECKVAR.
-rewrite PROP_combine.
+apply derives_trans with (`(PROPx Ppre (LOCALx Qpre (|> SEPx Rpre)))
+    (make_args' (argsig, retty) (eval_exprlist (argtypes argsig) bl)) *
+  PROPx P (LOCALx Q (|> SEPx Frame))).
+ progress (autorewrite with norm1 norm2).
+rewrite PROP_combine_later.
 rewrite (andp_comm (local (fold_right _ _ _))).
 apply andp_right.
 +
@@ -3579,14 +3386,16 @@ apply andp_left2.
 apply andp_left2.
 apply andp_derives.
 apply derives_refl.
+apply later_derives.
 intro rho; unfold SEPx.
  rewrite fold_right_sepcon_app.
  assumption.
 +
- apply (local2ptree_soundness P _ R) in PTREE.
+ eapply local2ptree_soundness' in PTREE.
  simpl app in PTREE.
- apply msubst_eval_exprlist_eq with (P:=P)(R:=R)(Q:=map gvars G) in MSUBST.
- rewrite PTREE.
+ apply msubst_eval_exprlist_eq' with (P0:=P)(R0:=R)(Q0:=map gvars G) in MSUBST.
+ rewrite <- PTREE, app_nil_r in MSUBST.
+ rewrite app_nil_r in PTREE; rewrite PTREE in *.
  intro rho.
  unfold local, lift1. unfold_lift. simpl.
  apply andp_left2.
@@ -3617,17 +3426,23 @@ apply andp_left2. apply andp_left1.
  apply prop_derives; intro. forget (var_names argsig) as fl.
  forget (eval_exprlist tys bl rho) as vl.
  eapply check_specs_lemma; try eassumption.
- clear - H.
+ instantiate (1:=Qtemp).
+ clear - CHECKG H.
  apply fold_right_and_LocalD_e in H.
-  destruct H as [? [? ?]]. auto.
+ destruct H as [? [? ?]].
+ apply fold_right_and_LocalD_i; auto.
  clear - CHECKG H1.
- admit.  (* easy *)
+ eapply in_gvars_sub; eauto.
  clear - CHECKG H.
  apply fold_right_and_LocalD_e in H.
   destruct H as [? [? ?]].
   clear - H1 CHECKG.
- admit. (* easy *)
-Admitted.
+ eapply in_gvars_sub; eauto.
++
+ apply sepcon_derives, derives_refl.
+ unfold_lift; intro.
+ apply PROP_later.
+Qed.
 
 Lemma semax_call_id00_wow:
  forall  
@@ -3651,13 +3466,18 @@ Lemma semax_call_id00_wow:
    (POST2: Post2 = EX vret:B, PROPx (P++ Ppost vret ) (LOCALx Q
              (SEPx (Rpost vret ++ Frame))))
    (PPRE: fold_right_and True Ppre),
-   @semax cs Espec Delta (PROPx P (LOCALx Q (SEPx R)))
+   @semax cs Espec Delta (|>PROPx P (LOCALx Q (SEPx R)))
     (Scall None a bl)
     (normal_ret_assert Post2).
 Proof.
 intros.
 destruct SETUP as [[PTREE [SPEC [ATY [TC0 [TC1 [MSUBST PTREE'']]]]]] 
                             [PRE1 [PTREE' [CHECKTEMP [CHECKVAR [CHECKG FRAME]]]]]].
+eapply assert_later_PROP; intros.
+{ eapply derives_trans; [apply TC1 | apply tc_exprlist_len]. }
+eapply assert_later_PROP; [apply CHECKTEMP | intro].
+eapply assert_later_PROP; [apply CHECKVAR | intro].
+apply semax_later_SEP.
 apply SPEC. clear SPEC.
 eapply semax_pre_post'; [ | |
    apply (@semax_call0 Espec cs Delta A Pre Post NEPre NEPost 
@@ -3705,13 +3525,18 @@ Lemma semax_call_id1_wow:
    (H0: Post2 = EX vret:B, PROPx (P++ Ppost vret) (LOCALx (temp ret (F vret) :: Qnew)
              (SEPx (Rpost vret ++ Frame))))
    (PPRE: fold_right_and True Ppre),
-   @semax cs Espec Delta (PROPx P (LOCALx Q (SEPx R)))
+   @semax cs Espec Delta (|>PROPx P (LOCALx Q (SEPx R)))
     (Scall (Some ret) a bl)
     (normal_ret_assert Post2).
 Proof.
-intros. 
+intros.
 destruct SETUP as [[PTREE [SPEC [ATY [TC0 [TC1 [MSUBST PTREE'']]]]]] 
                             [PRE1 [PTREE' [CHECKTEMP [CHECKVAR [CHECKG FRAME]]]]]].
+eapply assert_later_PROP; intros.
+{ eapply derives_trans; [apply TC1 | apply tc_exprlist_len]. }
+eapply assert_later_PROP; [apply CHECKTEMP | intro].
+eapply assert_later_PROP; [apply CHECKVAR | intro].
+apply semax_later_SEP.
 apply SPEC. clear SPEC.
 eapply semax_pre_post'; [ | |
    apply (@semax_call1 Espec cs Delta A Pre Post NEPre NEPost 
@@ -3723,7 +3548,8 @@ eapply semax_pre_post'; [ | |
       destruct ((temp_types Delta) ! ret) as [[? ?] | ]; inv TYret; auto
  ].
 *
-eapply semax_call_aux55; eauto.
+eapply derives_trans; [eapply semax_call_aux55; eauto|].
+apply andp_derives, sepcon_derives, PROP_later; auto.
 *
  subst.
  clear CHECKVAR CHECKTEMP TC1 PRE1 PPRE.
@@ -3745,7 +3571,7 @@ eapply semax_call_aux55; eauto.
  go_lowerx.
  repeat apply andp_right; try apply prop_right; auto.
  rewrite !fold_right_and_app_low.
- rewrite !fold_right_and_app_low in H2. destruct H2; split; auto.
+ rewrite !fold_right_and_app_low in H5. destruct H5; split; auto.
 Qed.
 
 Lemma semax_call_id1_x_wow:
@@ -3781,7 +3607,7 @@ Lemma semax_call_id1_x_wow:
                    (LOCALx (temp ret (F vret) :: Qnew)
                     (SEPx (Rpost vret ++ Frame))))
    (PPRE: fold_right_and True Ppre),
-   @semax cs Espec Delta (PROPx P (LOCALx Q (SEPx R)))
+   @semax cs Espec Delta (|>PROPx P (LOCALx Q (SEPx R)))
    (Ssequence (Scall (Some ret') a bl)
       (Sset ret (Ecast (Etempvar ret' retty') retty)))
     (normal_ret_assert Post2).
@@ -3902,7 +3728,7 @@ Lemma semax_call_id1_y_wow:
                    (LOCALx (temp ret (F vret) :: Qnew)
                     (SEPx (Rpost vret ++ Frame))))
    (PPRE: fold_right_and True Ppre),
-   @semax cs Espec Delta (PROPx P (LOCALx Q (SEPx R)))
+   @semax cs Espec Delta (|>PROPx P (LOCALx Q (SEPx R)))
    (Ssequence (Scall (Some ret') a bl)
       (Sset ret (Etempvar ret' retty')))
     (normal_ret_assert Post2).
@@ -4006,13 +3832,18 @@ Lemma semax_call_id01_wow:
    (POST2: Post2 = EX vret:B, PROPx (P++ Ppost vret) (LOCALx Q
              (SEPx (Rpost vret ++ Frame))))
    (PPRE: fold_right_and True Ppre),
-   @semax cs Espec Delta (PROPx P (LOCALx Q (SEPx R)))
+   @semax cs Espec Delta (|>PROPx P (LOCALx Q (SEPx R)))
     (Scall None a bl)
     (normal_ret_assert Post2).
 Proof.
 intros.
 destruct SETUP as [[PTREE [SPEC [ATY [TC0 [TC1 [MSUBST PTREE'']]]]]] 
                             [PRE1 [PTREE' [CHECKTEMP [CHECKVAR [CHECKG FRAME]]]]]].
+eapply assert_later_PROP; intros.
+{ eapply derives_trans; [apply TC1 | apply tc_exprlist_len]. }
+eapply assert_later_PROP; [apply CHECKTEMP | intro].
+eapply assert_later_PROP; [apply CHECKVAR | intro].
+apply semax_later_SEP.
 apply SPEC. clear SPEC.
 eapply semax_pre_post';
    [ |
@@ -4135,7 +3966,7 @@ lazymatch goal with
   eapply semax_seq';
     [prove_call_setup' ts witness;
      clear_Delta_specs; clear_MORE_POST;
-     [ .. | 
+     [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H;
       lazymatch goal with
       | |- _ -> semax _ _ (Scall (Some _) _ _) _ =>
          forward_call_id1_wow'
@@ -4152,7 +3983,7 @@ lazymatch goal with
        eapply semax_seq';
          [prove_call_setup' ts witness;
           clear_Delta_specs; clear_MORE_POST;
-             [ .. | forward_call_id1_x_wow' ]
+             [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H; forward_call_id1_x_wow' ]
          |  after_forward_call ]
 | |- semax _ _ (Ssequence (Ssequence (Scall (Some ?ret') _ _)
                                        (Sset _ (Etempvar ?ret'2 _))) _) _ =>
@@ -4160,7 +3991,7 @@ lazymatch goal with
        eapply semax_seq';
          [prove_call_setup' ts witness;
           clear_Delta_specs; clear_MORE_POST;
-             [ .. | forward_call_id1_y_wow' ]
+             [ .. | let H := fresh in intro H; hoist_later_in_pre; revert H; forward_call_id1_y_wow' ]
          |  after_forward_call ]
 | |- _ => rewrite <- seq_assoc; fwd_call'_dep ts witness
 end.
@@ -4180,3 +4011,14 @@ lazymatch goal with |- @semax ?CS _ ?Delta _ (Ssequence ?C _) _ =>
 end.
 
 Tactic Notation "forward_call_dep" constr(ts) constr(witness) := fwd_call_dep ts witness.
+
+Ltac forward_spawn sig wit ::= forward_call_dep [sig] wit.
+
+let Frame := fresh "Frame" in evar (Frame : list mpred);
+  try match goal with |- semax _ _ (Scall _ _ _) _ => rewrite -> semax_seq_skip end;
+  rewrite <- ?seq_assoc; eapply semax_seq';
+  [match goal with |- semax _ (PROP () (LOCALx ?locals _)) _ _ => hoist_later_in_pre; eapply semax_pre, semax_call_id0 with
+      (argsig := [(_f, tptr voidstar_funtype); (_args, tptr tvoid)])(P := [])
+      (Q := locals)(R := Frame)(ts := [sig])
+      (A := spawn_arg_type)(x := wit); try reflexivity end |
+   after_forward_call; unfold spawn_post; rewrite void_ret; subst Frame; normalize].

--- a/progs/incr.v
+++ b/progs/incr.v
@@ -2,90 +2,88 @@ From Coq Require Import String List ZArith.
 From compcert Require Import Coqlib Integers Floats AST Ctypes Cop Clight Clightdefs.
 Local Open Scope Z_scope.
 
-Definition ___builtin_annot : ident := 9%positive.
-Definition ___builtin_annot_intval : ident := 10%positive.
-Definition ___builtin_bswap : ident := 3%positive.
-Definition ___builtin_bswap16 : ident := 5%positive.
-Definition ___builtin_bswap32 : ident := 4%positive.
-Definition ___builtin_bswap64 : ident := 35%positive.
-Definition ___builtin_clz : ident := 36%positive.
-Definition ___builtin_clzl : ident := 37%positive.
-Definition ___builtin_clzll : ident := 38%positive.
-Definition ___builtin_ctz : ident := 39%positive.
-Definition ___builtin_ctzl : ident := 40%positive.
-Definition ___builtin_ctzll : ident := 41%positive.
-Definition ___builtin_debug : ident := 53%positive.
-Definition ___builtin_fabs : ident := 6%positive.
-Definition ___builtin_fmadd : ident := 44%positive.
-Definition ___builtin_fmax : ident := 42%positive.
-Definition ___builtin_fmin : ident := 43%positive.
-Definition ___builtin_fmsub : ident := 45%positive.
-Definition ___builtin_fnmadd : ident := 46%positive.
-Definition ___builtin_fnmsub : ident := 47%positive.
-Definition ___builtin_fsqrt : ident := 7%positive.
-Definition ___builtin_membar : ident := 11%positive.
-Definition ___builtin_memcpy_aligned : ident := 8%positive.
-Definition ___builtin_nop : ident := 52%positive.
-Definition ___builtin_read16_reversed : ident := 48%positive.
-Definition ___builtin_read32_reversed : ident := 49%positive.
-Definition ___builtin_va_arg : ident := 13%positive.
-Definition ___builtin_va_copy : ident := 14%positive.
-Definition ___builtin_va_end : ident := 15%positive.
-Definition ___builtin_va_start : ident := 12%positive.
-Definition ___builtin_write16_reversed : ident := 50%positive.
-Definition ___builtin_write32_reversed : ident := 51%positive.
-Definition ___compcert_i64_dtos : ident := 20%positive.
-Definition ___compcert_i64_dtou : ident := 21%positive.
-Definition ___compcert_i64_sar : ident := 32%positive.
-Definition ___compcert_i64_sdiv : ident := 26%positive.
-Definition ___compcert_i64_shl : ident := 30%positive.
-Definition ___compcert_i64_shr : ident := 31%positive.
-Definition ___compcert_i64_smod : ident := 28%positive.
-Definition ___compcert_i64_smulh : ident := 33%positive.
-Definition ___compcert_i64_stod : ident := 22%positive.
-Definition ___compcert_i64_stof : ident := 24%positive.
-Definition ___compcert_i64_udiv : ident := 27%positive.
-Definition ___compcert_i64_umod : ident := 29%positive.
-Definition ___compcert_i64_umulh : ident := 34%positive.
-Definition ___compcert_i64_utod : ident := 23%positive.
-Definition ___compcert_i64_utof : ident := 25%positive.
-Definition ___compcert_va_composite : ident := 19%positive.
-Definition ___compcert_va_float64 : ident := 18%positive.
-Definition ___compcert_va_int32 : ident := 16%positive.
-Definition ___compcert_va_int64 : ident := 17%positive.
-Definition _a : ident := 1%positive.
-Definition _acquire : ident := 56%positive.
-Definition _args : ident := 68%positive.
-Definition _ctr : ident := 63%positive.
-Definition _ctr_lock : ident := 61%positive.
-Definition _freelock : ident := 55%positive.
-Definition _freelock2 : ident := 58%positive.
-Definition _incr : ident := 66%positive.
-Definition _l : ident := 64%positive.
-Definition _lock_t : ident := 2%positive.
-Definition _lockc : ident := 70%positive.
-Definition _lockt : ident := 71%positive.
-Definition _main : ident := 72%positive.
-Definition _makelock : ident := 54%positive.
-Definition _read : ident := 67%positive.
-Definition _release : ident := 57%positive.
-Definition _release2 : ident := 59%positive.
-Definition _spawn : ident := 60%positive.
-Definition _t : ident := 65%positive.
-Definition _thread_func : ident := 69%positive.
-Definition _thread_lock : ident := 62%positive.
-Definition _t'1 : ident := 73%positive.
+Definition ___builtin_annot : ident := 7%positive.
+Definition ___builtin_annot_intval : ident := 8%positive.
+Definition ___builtin_bswap : ident := 1%positive.
+Definition ___builtin_bswap16 : ident := 3%positive.
+Definition ___builtin_bswap32 : ident := 2%positive.
+Definition ___builtin_bswap64 : ident := 33%positive.
+Definition ___builtin_clz : ident := 34%positive.
+Definition ___builtin_clzl : ident := 35%positive.
+Definition ___builtin_clzll : ident := 36%positive.
+Definition ___builtin_ctz : ident := 37%positive.
+Definition ___builtin_ctzl : ident := 38%positive.
+Definition ___builtin_ctzll : ident := 39%positive.
+Definition ___builtin_debug : ident := 51%positive.
+Definition ___builtin_fabs : ident := 4%positive.
+Definition ___builtin_fmadd : ident := 42%positive.
+Definition ___builtin_fmax : ident := 40%positive.
+Definition ___builtin_fmin : ident := 41%positive.
+Definition ___builtin_fmsub : ident := 43%positive.
+Definition ___builtin_fnmadd : ident := 44%positive.
+Definition ___builtin_fnmsub : ident := 45%positive.
+Definition ___builtin_fsqrt : ident := 5%positive.
+Definition ___builtin_membar : ident := 9%positive.
+Definition ___builtin_memcpy_aligned : ident := 6%positive.
+Definition ___builtin_nop : ident := 50%positive.
+Definition ___builtin_read16_reversed : ident := 46%positive.
+Definition ___builtin_read32_reversed : ident := 47%positive.
+Definition ___builtin_va_arg : ident := 11%positive.
+Definition ___builtin_va_copy : ident := 12%positive.
+Definition ___builtin_va_end : ident := 13%positive.
+Definition ___builtin_va_start : ident := 10%positive.
+Definition ___builtin_write16_reversed : ident := 48%positive.
+Definition ___builtin_write32_reversed : ident := 49%positive.
+Definition ___compcert_i64_dtos : ident := 18%positive.
+Definition ___compcert_i64_dtou : ident := 19%positive.
+Definition ___compcert_i64_sar : ident := 30%positive.
+Definition ___compcert_i64_sdiv : ident := 24%positive.
+Definition ___compcert_i64_shl : ident := 28%positive.
+Definition ___compcert_i64_shr : ident := 29%positive.
+Definition ___compcert_i64_smod : ident := 26%positive.
+Definition ___compcert_i64_smulh : ident := 31%positive.
+Definition ___compcert_i64_stod : ident := 20%positive.
+Definition ___compcert_i64_stof : ident := 22%positive.
+Definition ___compcert_i64_udiv : ident := 25%positive.
+Definition ___compcert_i64_umod : ident := 27%positive.
+Definition ___compcert_i64_umulh : ident := 32%positive.
+Definition ___compcert_i64_utod : ident := 21%positive.
+Definition ___compcert_i64_utof : ident := 23%positive.
+Definition ___compcert_va_composite : ident := 17%positive.
+Definition ___compcert_va_float64 : ident := 16%positive.
+Definition ___compcert_va_int32 : ident := 14%positive.
+Definition ___compcert_va_int64 : ident := 15%positive.
+Definition _acquire : ident := 54%positive.
+Definition _args : ident := 66%positive.
+Definition _ctr : ident := 61%positive.
+Definition _ctr_lock : ident := 59%positive.
+Definition _freelock : ident := 53%positive.
+Definition _freelock2 : ident := 56%positive.
+Definition _incr : ident := 64%positive.
+Definition _l : ident := 62%positive.
+Definition _lockc : ident := 68%positive.
+Definition _lockt : ident := 69%positive.
+Definition _main : ident := 70%positive.
+Definition _makelock : ident := 52%positive.
+Definition _read : ident := 65%positive.
+Definition _release : ident := 55%positive.
+Definition _release2 : ident := 57%positive.
+Definition _spawn : ident := 58%positive.
+Definition _t : ident := 63%positive.
+Definition _thread_func : ident := 67%positive.
+Definition _thread_lock : ident := 60%positive.
+Definition _t'1 : ident := 71%positive.
 
 Definition v_ctr_lock := {|
-  gvar_info := (Tstruct _lock_t noattr);
-  gvar_init := (Init_space 16 :: nil);
+  gvar_info := (tarray (tptr tvoid) 2);
+  gvar_init := (Init_space 8 :: nil);
   gvar_readonly := false;
   gvar_volatile := false
 |}.
 
 Definition v_thread_lock := {|
-  gvar_info := (Tstruct _lock_t noattr);
-  gvar_init := (Init_space 16 :: nil);
+  gvar_info := (tarray (tptr tvoid) 2);
+  gvar_init := (Init_space 8 :: nil);
   gvar_readonly := false;
   gvar_volatile := false
 |}.
@@ -102,16 +100,16 @@ Definition f_incr := {|
   fn_callconv := cc_default;
   fn_params := nil;
   fn_vars := nil;
-  fn_temps := ((_l, (tptr (Tstruct _lock_t noattr))) :: (_t, tuint) :: nil);
+  fn_temps := ((_l, (tptr (tarray (tptr tvoid) 2))) :: (_t, tuint) :: nil);
   fn_body :=
 (Ssequence
   (Sset _l
-    (Eaddrof (Evar _ctr_lock (Tstruct _lock_t noattr))
-      (tptr (Tstruct _lock_t noattr))))
+    (Eaddrof (Evar _ctr_lock (tarray (tptr tvoid) 2))
+      (tptr (tarray (tptr tvoid) 2))))
   (Ssequence
     (Scall None
       (Evar _acquire (Tfunction (Tcons (tptr tvoid) Tnil) tvoid cc_default))
-      ((Ecast (Etempvar _l (tptr (Tstruct _lock_t noattr))) (tptr tvoid)) ::
+      ((Ecast (Etempvar _l (tptr (tarray (tptr tvoid) 2))) (tptr tvoid)) ::
        nil))
     (Ssequence
       (Sset _t (Evar _ctr tuint))
@@ -122,7 +120,7 @@ Definition f_incr := {|
         (Scall None
           (Evar _release (Tfunction (Tcons (tptr tvoid) Tnil) tvoid
                            cc_default))
-          ((Ecast (Etempvar _l (tptr (Tstruct _lock_t noattr))) (tptr tvoid)) ::
+          ((Ecast (Etempvar _l (tptr (tarray (tptr tvoid) 2))) (tptr tvoid)) ::
            nil))))))
 |}.
 
@@ -137,16 +135,16 @@ Definition f_read := {|
   (Scall None
     (Evar _acquire (Tfunction (Tcons (tptr tvoid) Tnil) tvoid cc_default))
     ((Ecast
-       (Eaddrof (Evar _ctr_lock (Tstruct _lock_t noattr))
-         (tptr (Tstruct _lock_t noattr))) (tptr tvoid)) :: nil))
+       (Eaddrof (Evar _ctr_lock (tarray (tptr tvoid) 2))
+         (tptr (tarray (tptr tvoid) 2))) (tptr tvoid)) :: nil))
   (Ssequence
     (Sset _t (Evar _ctr tuint))
     (Ssequence
       (Scall None
         (Evar _release (Tfunction (Tcons (tptr tvoid) Tnil) tvoid cc_default))
         ((Ecast
-           (Eaddrof (Evar _ctr_lock (Tstruct _lock_t noattr))
-             (tptr (Tstruct _lock_t noattr))) (tptr tvoid)) :: nil))
+           (Eaddrof (Evar _ctr_lock (tarray (tptr tvoid) 2))
+             (tptr (tarray (tptr tvoid) 2))) (tptr tvoid)) :: nil))
       (Sreturn (Some (Etempvar _t tuint))))))
 |}.
 
@@ -155,19 +153,19 @@ Definition f_thread_func := {|
   fn_callconv := cc_default;
   fn_params := ((_args, (tptr tvoid)) :: nil);
   fn_vars := nil;
-  fn_temps := ((_l, (tptr (Tstruct _lock_t noattr))) :: nil);
+  fn_temps := ((_l, (tptr (tarray (tptr tvoid) 2))) :: nil);
   fn_body :=
 (Ssequence
   (Sset _l
-    (Eaddrof (Evar _thread_lock (Tstruct _lock_t noattr))
-      (tptr (Tstruct _lock_t noattr))))
+    (Eaddrof (Evar _thread_lock (tarray (tptr tvoid) 2))
+      (tptr (tarray (tptr tvoid) 2))))
   (Ssequence
     (Scall None (Evar _incr (Tfunction Tnil tvoid cc_default)) nil)
     (Ssequence
       (Scall None
         (Evar _release2 (Tfunction (Tcons (tptr tvoid) Tnil) tvoid
                           cc_default))
-        ((Ecast (Etempvar _l (tptr (Tstruct _lock_t noattr))) (tptr tvoid)) ::
+        ((Ecast (Etempvar _l (tptr (tarray (tptr tvoid) 2))) (tptr tvoid)) ::
          nil))
       (Sreturn (Some (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)))))))
 |}.
@@ -177,8 +175,8 @@ Definition f_main := {|
   fn_callconv := cc_default;
   fn_params := nil;
   fn_vars := nil;
-  fn_temps := ((_lockc, (tptr (Tstruct _lock_t noattr))) ::
-               (_lockt, (tptr (Tstruct _lock_t noattr))) :: (_t, tuint) ::
+  fn_temps := ((_lockc, (tptr (tarray (tptr tvoid) 2))) ::
+               (_lockt, (tptr (tarray (tptr tvoid) 2))) :: (_t, tuint) ::
                (_t'1, tuint) :: nil);
   fn_body :=
 (Ssequence
@@ -186,29 +184,29 @@ Definition f_main := {|
     (Sassign (Evar _ctr tuint) (Econst_int (Int.repr 0) tint))
     (Ssequence
       (Sset _lockc
-        (Eaddrof (Evar _ctr_lock (Tstruct _lock_t noattr))
-          (tptr (Tstruct _lock_t noattr))))
+        (Eaddrof (Evar _ctr_lock (tarray (tptr tvoid) 2))
+          (tptr (tarray (tptr tvoid) 2))))
       (Ssequence
         (Sset _lockt
-          (Eaddrof (Evar _thread_lock (Tstruct _lock_t noattr))
-            (tptr (Tstruct _lock_t noattr))))
+          (Eaddrof (Evar _thread_lock (tarray (tptr tvoid) 2))
+            (tptr (tarray (tptr tvoid) 2))))
         (Ssequence
           (Scall None
             (Evar _makelock (Tfunction (Tcons (tptr tvoid) Tnil) tvoid
                               cc_default))
-            ((Ecast (Etempvar _lockc (tptr (Tstruct _lock_t noattr)))
+            ((Ecast (Etempvar _lockc (tptr (tarray (tptr tvoid) 2)))
                (tptr tvoid)) :: nil))
           (Ssequence
             (Scall None
               (Evar _release (Tfunction (Tcons (tptr tvoid) Tnil) tvoid
                                cc_default))
-              ((Ecast (Etempvar _lockc (tptr (Tstruct _lock_t noattr)))
+              ((Ecast (Etempvar _lockc (tptr (tarray (tptr tvoid) 2)))
                  (tptr tvoid)) :: nil))
             (Ssequence
               (Scall None
                 (Evar _makelock (Tfunction (Tcons (tptr tvoid) Tnil) tvoid
                                   cc_default))
-                ((Ecast (Etempvar _lockt (tptr (Tstruct _lock_t noattr)))
+                ((Ecast (Etempvar _lockt (tptr (tarray (tptr tvoid) 2)))
                    (tptr tvoid)) :: nil))
               (Ssequence
                 (Scall None
@@ -235,7 +233,7 @@ Definition f_main := {|
                       (Evar _acquire (Tfunction (Tcons (tptr tvoid) Tnil)
                                        tvoid cc_default))
                       ((Ecast
-                         (Etempvar _lockt (tptr (Tstruct _lock_t noattr)))
+                         (Etempvar _lockt (tptr (tarray (tptr tvoid) 2)))
                          (tptr tvoid)) :: nil))
                     (Ssequence
                       (Ssequence
@@ -247,7 +245,7 @@ Definition f_main := {|
                           (Evar _acquire (Tfunction (Tcons (tptr tvoid) Tnil)
                                            tvoid cc_default))
                           ((Ecast
-                             (Etempvar _lockc (tptr (Tstruct _lock_t noattr)))
+                             (Etempvar _lockc (tptr (tarray (tptr tvoid) 2)))
                              (tptr tvoid)) :: nil))
                         (Ssequence
                           (Scall None
@@ -255,7 +253,7 @@ Definition f_main := {|
                                                (Tcons (tptr tvoid) Tnil)
                                                tvoid cc_default))
                             ((Ecast
-                               (Etempvar _lockt (tptr (Tstruct _lock_t noattr)))
+                               (Etempvar _lockt (tptr (tarray (tptr tvoid) 2)))
                                (tptr tvoid)) :: nil))
                           (Ssequence
                             (Scall None
@@ -263,15 +261,14 @@ Definition f_main := {|
                                                 (Tcons (tptr tvoid) Tnil)
                                                 tvoid cc_default))
                               ((Ecast
-                                 (Etempvar _lockc (tptr (Tstruct _lock_t noattr)))
+                                 (Etempvar _lockc (tptr (tarray (tptr tvoid) 2)))
                                  (tptr tvoid)) :: nil))
                             (Sreturn (Some (Etempvar _t tuint))))))))))))))))
   (Sreturn (Some (Econst_int (Int.repr 0) tint))))
 |}.
 
 Definition composites : list composite_definition :=
-(Composite _lock_t Struct ((_a, (tarray (tptr tvoid) 4)) :: nil) noattr ::
- nil).
+nil.
 
 Definition global_definitions : list (ident * globdef fundef type) :=
 ((___builtin_bswap,

--- a/progs/threads.h
+++ b/progs/threads.h
@@ -3,7 +3,7 @@
 /* typedef struct {char a[8]; void* b[4];} lock_t; */
 /* typedef struct lock_t {char a[8]; void* b[4];} lock_t; //for mutex */
 /* typedef struct lock_t {void* b[6];} lock_t; //for semaphore */
-typedef struct lock_t {void* a[4];} lock_t; //for semaphore
+typedef void* lock_t[2]; //for semaphore
 typedef unsigned long int thread_t; // like pthread_t
 typedef int cond_t;
 

--- a/progs/verif_cond.v
+++ b/progs/verif_cond.v
@@ -74,8 +74,9 @@ Proof.
   forward_call (lockt, sh, cond_var sh cond * lock_inv sh lock (dlock_inv data),
                 tlock_inv sh lockt lock cond data).
   { unfold tlock_inv; lock_props.
+    { apply selflock_exclusive, exclusive_sepcon2, lock_inv_exclusive. }
     rewrite selflock_eq at 2; cancel.
-    eapply derives_trans; [apply lock_inv_later | cancel]. }
+    eapply derives_trans; [apply now_later | cancel]. }
   forward.
 Qed.
 
@@ -122,7 +123,9 @@ Proof.
     fun (x : (val * share * val * val * val)) (_ : val) => let '(data, sh, lock, lockt, cond) := x in
          !!readable_share sh && emp * cond_var sh cond * lock_inv sh lock (dlock_inv data) *
          lock_inv sh lockt (tlock_inv sh lockt lock cond data)).
-  { simpl spawn_pre; entailer!.
+  { eapply derives_trans; [apply andp_derives, derives_refl; apply now_later|].
+    rewrite <- later_andp; apply later_derives.
+    simpl spawn_pre; entailer!.
     { rewrite (gvar_eval_var _thread_func _ (gv _thread_func)) by auto.
       erewrite !(force_val_sem_cast_neutral_gvar' _ (gv _thread_func)) by eauto.
     rewrite ?gvar_denote_env_set.
@@ -153,17 +156,14 @@ Proof.
     unfold dlock_inv; Exists i'; entailer!.
     Exists i'; entailer!.
   - forward_call (lockt, sh2, tlock_inv sh1 lockt lock cond data).
-    forward_call (lockt, Ews, sh1, |>(cond_var sh1 cond * lock_inv sh1 lock (dlock_inv data)),
-                  |>tlock_inv sh1 lockt lock cond data).
+    unfold tlock_inv at 2.
+    rewrite selflock_eq.
+    Intros.
+    forward_call (lockt, Ews, sh1, cond_var sh1 cond * lock_inv sh1 lock (dlock_inv data),
+                  tlock_inv sh1 lockt lock cond data).
     { unfold tlock_inv; lock_props.
-      + apply later_exclusive; auto.
-      + unfold rec_inv.
-        rewrite selflock_eq at 1.
-        rewrite later_sepcon; f_equal.
-        apply lock_inv_later_eq.
-      + rewrite selflock_eq at 2.
-        erewrite <- (lock_inv_share_join _ _ Ews); try apply Hsh; auto; cancel.
-        rewrite !sepcon_assoc; eapply sepcon_derives; [apply lock_inv_later | cancel]. }
+      { apply selflock_exclusive, exclusive_sepcon2, lock_inv_exclusive. }
+      erewrite <- (lock_inv_share_join _ _ Ews); try apply Hsh; auto; cancel. }
     forward_call (lock, Ews, dlock_inv data).
     { lock_props.
       erewrite <- (lock_inv_share_join _ _ Ews); try apply Hsh; auto; cancel. }

--- a/progs/verif_incr.v
+++ b/progs/verif_incr.v
@@ -208,10 +208,11 @@ Proof.
   forward_call (ctr, sh2, lock, g1, g2, 1, 1).
   (* We've proved that t is 2! *)
   forward_call (lock, sh2, cptr_lock_inv g1 g2 ctr).
-  replace_SEP 6 (lock_inv sh1 lockt (thread_lock_inv sh1 g1 g2 ctr lock lockt)) by admit.
   forward_call (lockt, Ews, sh1, thread_lock_R sh1 g1 g2 ctr lock, thread_lock_inv sh1 g1 g2 ctr lock lockt).
   { lock_props.
-    erewrite <- (lock_inv_share_join _ _ Ews); try apply Hsh; auto; cancel. }
+    unfold thread_lock_inv, thread_lock_R.
+    erewrite <- (lock_inv_share_join _ _ Ews); try apply Hsh; auto; cancel.
+    cancel. }
   forward_call (lock, Ews, cptr_lock_inv g1 g2 ctr).
   { lock_props.
     erewrite <- (lock_inv_share_join _ _ Ews); try apply Hsh; auto; cancel. }

--- a/sha/call_memcpy.v
+++ b/sha/call_memcpy.v
@@ -213,9 +213,9 @@ Lemma semax_call_id0_alt:
        (glob_specs Delta) ! id = Some (NDmk_funspec (argsig, retty) cc A Pre Post) ->
        (glob_types Delta) ! id = Some (type_of_funspec (NDmk_funspec (argsig, retty) cc A Pre Post)) ->
    tfun = type_of_params argsig ->
-  @semax cs Espec Delta (tc_exprlist Delta (argtypes argsig) bl
+  @semax cs Espec Delta (|> (tc_exprlist Delta (argtypes argsig) bl
                   && (`(Pre x) (make_args' (argsig,retty) (eval_exprlist (argtypes argsig) bl))
-                         * PROPx P (LOCALx Q (SEPx R))))
+                         * PROPx P (LOCALx Q (SEPx R)))))
     (Scall None (Evar id (Tfunction tfun retty cc)) bl)
     (normal_ret_assert
        ((ifvoid retty (`(Post x) (make_args nil nil))
@@ -375,6 +375,7 @@ eapply semax_pre_post';
        try eassumption;
        try (rewrite ?Hspec, ?Hglob; reflexivity)].
 *
+ eapply derives_trans, now_later.
  eapply derives_trans; [ apply Hpre | ].
  rewrite !andp_assoc.
  apply andp_derives; auto.  apply derives_refl.
@@ -608,6 +609,7 @@ eapply semax_pre_post';
        try eassumption;
        try (rewrite ?Hspec, ?Hglob; reflexivity)].
 *
+ eapply derives_trans, now_later.
  eapply derives_trans; [ apply Hpre | ].
  rewrite !andp_assoc.
  apply andp_derives; auto.  apply derives_refl.

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -1447,8 +1447,8 @@ Axiom semax_extract_prop:
 Axiom semax_remove_later_prop:
   forall {Espec: OracleKind}{CS: compspecs},
   forall Delta PP P c Q,
-           @semax CS Espec Delta (fun rho => !!(PP rho) && P rho) c Q ->
-           @semax CS Espec Delta (fun rho => (|> !!PP rho) && P rho) c Q.
+           @semax CS Espec Delta ((fun rho => !!(PP rho)) && P) c Q ->
+           @semax CS Espec Delta ((fun rho => |> !!PP rho) && P) c Q.
 
 Axiom semax_extract_later_prop:
   forall {Espec: OracleKind}{CS: compspecs},

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -1268,9 +1268,9 @@ Axiom semax_call :
            (retsig = Tvoid -> ret = None) ->
           tc_fn_return Delta ret retsig ->
   @semax CS Espec Delta
-          ((tc_expr Delta a) && (tc_exprlist Delta (snd (split argsig)) bl)  &&
+          ((|>((tc_expr Delta a) && (tc_exprlist Delta (snd (split argsig)) bl)))  &&
          (`(func_ptr (mk_funspec  (argsig,retsig) cc A P Q NEP NEQ)) (eval_expr a) &&
-          (F * `(P ts x: environ -> mpred) (make_args' (argsig,retsig) (eval_exprlist (snd (split argsig)) bl)))))
+          |>(F * `(P ts x: environ -> mpred) (make_args' (argsig,retsig) (eval_exprlist (snd (split argsig)) bl)))))
          (Scall ret a bl)
          (normal_ret_assert
           (EX old:val, substopt ret (`old) F * maybe_retval (Q ts x) retsig ret)).
@@ -1443,6 +1443,12 @@ Axiom semax_extract_prop:
   forall Delta (PP: Prop) P c Q,
            (PP -> @semax CS Espec Delta P c Q) ->
            @semax CS Espec Delta (!!PP && P) c Q.
+
+Axiom semax_remove_later_prop:
+  forall {Espec: OracleKind}{CS: compspecs},
+  forall Delta PP P c Q,
+           @semax CS Espec Delta (fun rho => !!(PP rho) && P rho) c Q ->
+           @semax CS Espec Delta (fun rho => (|> !!PP rho) && P rho) c Q.
 
 Axiom semax_extract_later_prop:
   forall {Espec: OracleKind}{CS: compspecs},

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -1444,12 +1444,6 @@ Axiom semax_extract_prop:
            (PP -> @semax CS Espec Delta P c Q) ->
            @semax CS Espec Delta (!!PP && P) c Q.
 
-Axiom semax_remove_later_prop:
-  forall {Espec: OracleKind}{CS: compspecs},
-  forall Delta PP P c Q,
-           @semax CS Espec Delta ((fun rho => !!(PP rho)) && P) c Q ->
-           @semax CS Espec Delta ((fun rho => |> !!PP rho) && P) c Q.
-
 Axiom semax_extract_later_prop:
   forall {Espec: OracleKind}{CS: compspecs},
   forall Delta (PP: Prop) P c Q,

--- a/veric/SeparationLogicSoundness.v
+++ b/veric/SeparationLogicSoundness.v
@@ -137,6 +137,7 @@ Definition semax_frame := @semax_frame.
 Definition semax_pre_post_bupd := @semax_pre_post_bupd.
 Definition semax_extensionality_Delta := @semax_extensionality_Delta.
 Definition semax_extract_prop := @semax_extract_prop.
+Definition semax_remove_later_prop := @semax_remove_later_prop.
 Definition semax_extract_later_prop := @semax_extract_later_prop.
 Definition semax_ptr_compare := @semax_ptr_compare.
 Definition semax_unfold_Ssequence := @semax_unfold_Ssequence.

--- a/veric/SeparationLogicSoundness.v
+++ b/veric/SeparationLogicSoundness.v
@@ -137,7 +137,6 @@ Definition semax_frame := @semax_frame.
 Definition semax_pre_post_bupd := @semax_pre_post_bupd.
 Definition semax_extensionality_Delta := @semax_extensionality_Delta.
 Definition semax_extract_prop := @semax_extract_prop.
-Definition semax_remove_later_prop := @semax_remove_later_prop.
 Definition semax_extract_later_prop := @semax_extract_later_prop.
 Definition semax_ptr_compare := @semax_ptr_compare.
 Definition semax_unfold_Ssequence := @semax_unfold_Ssequence.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -431,10 +431,10 @@ split; auto.
 split; auto.
 Qed.
 
-Lemma semax_extract_later_prop:
-  forall {CS: compspecs} Delta (PP: Prop) P c Q,
-           (PP -> semax Espec Delta (fun rho => (P rho)) c Q) ->
-           semax Espec Delta (fun rho => (|> !!PP) && P rho) c Q.
+Lemma semax_remove_later_prop:
+  forall {CS: compspecs} Delta PP P c Q,
+           semax Espec Delta (fun rho => (!!(PP rho) && P rho)) c Q ->
+           semax Espec Delta (fun rho => (|> !!(PP rho)) && P rho) c Q.
 Proof.
 intros.
 intro w.
@@ -442,39 +442,46 @@ rewrite semax_fold_unfold.
 intros gx Delta'.
 apply prop_imp_i; intros [TS HGG].
 intros w' ? ? k F w'' ? ?.
-intros te ve w''' ? w4 ? [[[? ?] ?] ?].
+intros te ve w''' ? w4 ? [[? ?] ?].
 
 replace ((F (construct_rho (filter_genv gx) ve te) *
-        (|>(!!PP) && (P (construct_rho (filter_genv gx) ve te))))%pred) with
-        (|>!!PP && (F (construct_rho (filter_genv gx) ve te) *
-         (P (construct_rho (filter_genv gx) ve te)))%pred) in H8.
+        (|>(!!PP (construct_rho (filter_genv gx) ve te)) && (P (construct_rho (filter_genv gx) ve te))))%pred) with
+        (|>!!(PP (construct_rho (filter_genv gx) ve te)) && (F (construct_rho (filter_genv gx) ve te) *
+         (P (construct_rho (filter_genv gx) ve te)))%pred) in H7.
 Focus 2. {
   rewrite (sepcon_comm (F (construct_rho (filter_genv gx) ve te))
-    (|>!!PP && P (construct_rho (filter_genv gx) ve te))).
+    (|>!!(PP (construct_rho (filter_genv gx) ve te)) && P (construct_rho (filter_genv gx) ve te))).
 
  rewrite corable_andp_sepcon1 by (apply corable_later; apply corable_prop).
 
  rewrite sepcon_comm.
  reflexivity.
 } Unfocus.
-destruct H8.
-simpl in H8.
+destruct H7.
+simpl in H7.
 destruct (age1 w4) eqn:?H.
 + assert (age w4 r) by auto.
-  apply age_laterR in H12.
-  specialize (H8 r H12).
-  specialize (H H8); clear PP H8.
+  apply age_laterR in H11.
+  specialize (H7 r H11).
   hnf in H. rewrite semax_fold_unfold in H.
   eapply H. apply necR_refl. split; eassumption.
   apply necR_refl. eassumption. eassumption. eassumption.
   eassumption. eassumption.
   split; auto.
   split; auto.
-  split; auto.
+  rewrite sepcon_andp_prop2; split; auto.
 + apply bupd_intro; repeat intro.
-  eapply af_level1 in H11; [| apply compcert_rmaps.R.ag_rmap].
-  rewrite H11.
+  eapply af_level1 in H10; [| apply compcert_rmaps.R.ag_rmap].
+  rewrite H10.
   constructor.
+Qed.
+
+Lemma semax_extract_later_prop:
+  forall {CS: compspecs} Delta (PP: Prop) P c Q,
+           (PP -> semax Espec Delta (fun rho => (P rho)) c Q) ->
+           semax Espec Delta (fun rho => (|> !!PP) && P rho) c Q.
+Proof.
+  intros; apply semax_remove_later_prop, semax_extract_prop; auto.
 Qed.
 
 Lemma semax_unfold {CS: compspecs}:

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -1383,8 +1383,9 @@ Proof.
                  (PTree.set 1 (Vptr b Ptrofs.zero) (PTree.empty val)))
               _ _ b (prog_main prog));
       try apply H3; try eassumption; auto.
+    + simpl; auto.
     + simpl snd.
-      replace (params_of_fundef f) with (@nil type). auto. clear -E.
+      replace (params_of_fundef f) with (@nil type). simpl; auto. clear -E.
       destruct f as [[? ? [ | [] ]] | e [|] ? c] ; compute in *; congruence.
     + clear - GV H2 H0.
       split.
@@ -1585,8 +1586,9 @@ Proof.
                  (PTree.set 1 (Vptr b Ptrofs.zero) (PTree.empty val)))
               _ _ b (prog_main prog));
       try apply H3; try eassumption; auto.
+    + simpl; auto.
     + simpl snd.
-      replace (params_of_fundef f) with (@nil type). auto. clear -E.
+      replace (params_of_fundef f) with (@nil type). simpl; auto. clear -E.
       destruct f as [[? ? [ | [] ]] | e [|] ? c] ; compute in *; congruence.
     + clear - GV H2 H0.
       split.
@@ -1877,6 +1879,7 @@ Proof.
   rewrite Ef. reflexivity.
 
   (* tc_expr *)
+  simpl.
   rewrite Ef. reflexivity.
 
   (* tc_exprlist *)


### PR DESCRIPTION
Also included:

lock invariants no longer need to be precise and positive, but only exclusive

fixed definition of rec_inv and removed admitted lemmas about lock_inv and later