### PR TITLE
Allow process_one_globvar to succeed on non-int32 arrays.

### DIFF
--- a/floyd/globals_lemmas.v
+++ b/floyd/globals_lemmas.v
@@ -978,7 +978,7 @@ Ltac process_one_globvar :=
   ];
   change (Share.lub extern_retainer _) with Ews;
   change (Share.lub extern_retainer _) with Ers;
-  change (Vint oo _) with (Vint oo id);
+  try change (Vint oo _) with (Vint oo id);
   fold_types;
   rewrite ?Combinators.compose_id_right.
 


### PR DESCRIPTION
This is useful for string literals.