### PR TITLE
Fix tactic level mistake about (assert_PROP + by) etc.

### DIFF
--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -1166,7 +1166,7 @@ Tactic Notation "replace_SEP" constr(n) constr(R) :=
   unfold my_nth,replace_nth; simpl nat_of_Z;
    repeat simpl_nat_of_P; cbv beta iota; cbv beta iota.
 
-Tactic Notation "replace_SEP" constr(n) constr(R) "by" tactic(t):=
+Tactic Notation "replace_SEP" constr(n) constr(R) "by" tactic1(t):=
   first [apply (replace_SEP' (nat_of_Z n) R) | apply (replace_SEP'' (nat_of_Z n) R)];
   unfold my_nth,replace_nth; simpl nat_of_Z;
    repeat simpl_nat_of_P; cbv beta iota; cbv beta iota; [ now t | ].
@@ -1219,7 +1219,7 @@ Tactic Notation "viewshift_SEP" constr(n) constr(R) :=
   unfold my_nth,replace_nth; simpl nat_of_Z;
    repeat simpl_nat_of_P; cbv beta iota; cbv beta iota.
 
-Tactic Notation "viewshift_SEP" constr(n) constr(R) "by" tactic(t):=
+Tactic Notation "viewshift_SEP" constr(n) constr(R) "by" tactic1(t):=
   first [apply (replace_SEP'_bupd (nat_of_Z n) R) | apply (replace_SEP''_bupd (nat_of_Z n) R)];
   unfold my_nth,replace_nth; simpl nat_of_Z;
    repeat simpl_nat_of_P; cbv beta iota; cbv beta iota; [ now t | ].
@@ -1654,13 +1654,13 @@ Qed.
 Tactic Notation "assert_PROP" constr(A) :=
   first [apply (assert_later_PROP A) | apply (assert_PROP A) | apply (assert_PROP' A)]; [ | intro ].
 
-Tactic Notation "assert_PROP" constr(A) "by" tactic(t) :=
+Tactic Notation "assert_PROP" constr(A) "by" tactic1(t) :=
   first [apply (assert_later_PROP A) | apply (assert_PROP A) | apply (assert_PROP' A) ]; [ now t | intro ].
 
 Tactic Notation "assert_PROP" constr(A) "as" simple_intropattern(H)  :=
   first [apply (assert_later_PROP A) | apply (assert_PROP A) | apply (assert_PROP' A)]; [ | intro H ].
 
-Tactic Notation "assert_PROP" constr(A) "as" simple_intropattern(H) "by" tactic(t) :=
+Tactic Notation "assert_PROP" constr(A) "as" simple_intropattern(H) "by" tactic1(t) :=
   first [apply (assert_later_PROP A) | apply (assert_PROP A) | apply (assert_PROP' A)]; [ now t | intro H ].
 
 Lemma assert_LOCAL:
@@ -1678,7 +1678,7 @@ Qed.
 Tactic Notation "assert_LOCAL" constr(A) :=
   apply (assert_LOCAL A).
 
-Tactic Notation "assert_LOCAL" constr(A) "by" tactic(t) :=
+Tactic Notation "assert_LOCAL" constr(A) "by" tactic1(t) :=
   apply (assert_LOCAL A); [ now t | ].
 
 Lemma drop_LOCAL'':

--- a/veric/coqlib4.v
+++ b/veric/coqlib4.v
@@ -264,7 +264,7 @@ Tactic Notation "assert_specialize" hyp(H) :=
     assert P as Htemp; [ | specialize (H Htemp); try clear Htemp ]
   end.
 
-Tactic Notation "assert_specialize" hyp(H) "by" tactic(tac) :=
+Tactic Notation "assert_specialize" hyp(H) "by" tactic1(tac) :=
   match type of H with
     forall x : ?P, _ =>
     let Htemp := fresh "Htemp" in
@@ -277,7 +277,7 @@ Tactic Notation "assert_specialize" hyp(H) "as" simple_intropattern(Hnew) :=
     assert P as Hnew; [ | specialize (H Hnew) ]
   end.
 
-Tactic Notation "assert_specialize" hyp(H) "as" simple_intropattern(Hnew) "by" tactic(tac) :=
+Tactic Notation "assert_specialize" hyp(H) "as" simple_intropattern(Hnew) "by" tactic1(tac) :=
   match type of H with
     forall x : ?P, _ =>
     assert P as Hnew by tac;

--- a/veristar/LibTactics.v
+++ b/veristar/LibTactics.v
@@ -744,13 +744,13 @@ Tactic Notation "tryfalse" :=
     It is equivalent to [try solve \[ false; tac \]].
     Example: [tryfalse by congruence/] *)
 
-Tactic Notation "tryfalse" "by" tactic(tac) "/" :=
+Tactic Notation "tryfalse" "by" tactic1(tac) "/" :=
   try solve [ false; instantiate; tac ].
 
 (** [false T] tries [false; apply T], or otherwise adds [T] as
     an assumption and calls [false]. *)
 
-Tactic Notation "false" constr(T) "by" tactic(tac) "/" :=
+Tactic Notation "false" constr(T) "by" tactic1(tac) "/" :=
   false_goal; first
     [ first [ apply T | eapply T | rapply T]; instantiate; tac  (* todo: sapply?*)
     | let H := fresh in lets_base H T;


### PR DESCRIPTION
Luke Chen find that "assert_PROP (P) by tac1; tac2" was interpreted as "assert_PROP (P) by (tac1; tac2)".