### PR TITLE
Remove (force_val (sem_cast_pointer _)) from evaluation

### DIFF
--- a/floyd/for_lemmas.v
+++ b/floyd/for_lemmas.v
@@ -134,7 +134,6 @@ repeat apply andp_right; try apply prop_right; auto.
  destruct Archi.ptr64 eqn:Hp; simpl in H3.
   unfold Int.lt in H3. if_tac in H3; inv H3.
   rewrite Int.signed_repr in H; auto.
-  rewrite Hp in H3. simpl in H3.
   unfold Int.lt in H3. if_tac in H3; inv H3.
   rewrite Int.signed_repr in H; auto.
  -
@@ -156,7 +155,6 @@ destruct (eval_expr hi rho); simpl in H; try solve [inv H].
 destruct Archi.ptr64 eqn:Hp; simpl in H.
   unfold Int.lt in H. if_tac in H; inv H.
   rewrite Int.signed_repr in H8; auto.
-  rewrite Hp in H. simpl in H.
   unfold Int.lt in H. if_tac in H; inv H.
   rewrite Int.signed_repr in H8; auto.
 auto.
@@ -382,7 +380,6 @@ repeat apply andp_right; try apply prop_right; auto.
  destruct Archi.ptr64 eqn:Hp; simpl in H5.
   unfold Int.ltu in H5; if_tac in H5; inv H5;
   rewrite Int.unsigned_repr in H3; auto.
-  rewrite Hp in H5. simpl in H5.
   unfold Int.ltu in H5; if_tac in H5; inv H5;
   rewrite Int.unsigned_repr in H3; auto.
  -
@@ -408,7 +405,6 @@ hnf in H4. red.
  destruct Archi.ptr64 eqn:Hp; simpl in H4.
   unfold Int.ltu in H4; if_tac in H4; inv H4;
   rewrite Int.unsigned_repr in H; auto.
-  rewrite Hp in H4. simpl in H4.
   unfold Int.ltu in H4; if_tac in H4; inv H4;
   rewrite Int.unsigned_repr in H; auto.
 *
@@ -468,7 +464,7 @@ unfold locald_denote; simpl.
  unfold Cop2.sem_cast, Cop2.classify_cast. simpl.
  destruct Archi.ptr64 eqn:Hp; simpl.
  normalize.
- rewrite Hp; simpl; normalize.
+ simpl; normalize.
 normalize;
  autorewrite with norm1 norm2; normalize.
 apply andp_right; auto.

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -349,33 +349,6 @@ intros.
  destruct v; try contradiction; reflexivity.
 Qed.
 
-Lemma force_val_sem_cast_neutral_lvar :
-  forall i t v rho,
-  locald_denote (lvar i t v) rho ->
-  Some (force_val (sem_cast_pointer v)) = Some v.
-Proof.
-intros.
- apply lvar_isptr in H; destruct v; try contradiction; reflexivity.
-Qed.
-
-Lemma force_val_sem_cast_neutral_gvar:
-  forall i v rho,
-  locald_denote (gvar i v) rho ->
-  Some (force_val (sem_cast_pointer v)) = Some v.
-Proof.
-intros.
- apply gvar_isptr in H; destruct v; try contradiction; reflexivity.
-Qed.
-
-Lemma force_val_sem_cast_neutral_sgvar:
-  forall i v rho,
-  locald_denote (sgvar i v) rho ->
-  Some (force_val (sem_cast_pointer v)) = Some v.
-Proof.
-intros.
- apply sgvar_isptr in H; destruct v; try contradiction; reflexivity.
-Qed.
-
 Lemma prop_Forall_cons:
  forall {B}{A} {NB: NatDed B} (P: B) F (a:A) b,
   P |-- !! F a && !! Forall F b ->
@@ -437,12 +410,7 @@ Ltac Forall_pTree_from_elements :=
    [ apply prop_Forall_cons1;
      [unfold check_one_temp_spec, check_one_var_spec;
      simpl; auto;
-     normalize;
-     solve [eapply force_val_sem_cast_neutral_lvar; eassumption
-              | eapply force_val_sem_cast_neutral_gvar; eassumption
-              | eapply force_val_sem_cast_neutral_sgvar; eassumption
-              | apply force_val_sem_cast_neutral_isptr; auto
-              ]
+     solve [normalize]
      | ]
    | apply prop_Forall_cons'
    | apply prop_Forall_cons

--- a/floyd/library.v
+++ b/floyd/library.v
@@ -64,7 +64,7 @@ Parameter body_exit:
     (EF_external "exit"
        {| sig_args := AST.Tint :: nil; sig_res := None; sig_cc := cc_default |})
    exit_spec'.
-Print malloc_compatible.
+
 Parameter malloc_token : forall {cs: compspecs}, share -> type -> val -> mpred.
 Parameter malloc_token_valid_pointer:
   forall {cs: compspecs} sh t p, malloc_token sh t p |-- valid_pointer p.

--- a/floyd/val_lemmas.v
+++ b/floyd/val_lemmas.v
@@ -200,7 +200,6 @@ rewrite Int.negate_cmp.
 unfold both_int, force_val, typed_false, strict_bool_val, sem_cast, classify_cast, tint in H.
 destruct Archi.ptr64 eqn:Hp; simpl in H.
 destruct (Int.cmp op i j); inv H; auto.
-rewrite Hp in H.
 destruct (Int.cmp op i j); inv H; auto.
 Qed.
 
@@ -215,7 +214,6 @@ unfold Cop.classify_cmp in H. simpl in H.
 unfold both_int, force_val, typed_false, strict_bool_val, sem_cast, classify_cast, tint in H.
 destruct Archi.ptr64 eqn:Hp; simpl in H.
 destruct (Int.cmp op i j); inv H; auto.
-rewrite Hp in H.
 destruct (Int.cmp op i j); inv H; auto.
 Qed.
 

--- a/hmacdrbg/drbg_protocol_proofs.v
+++ b/hmacdrbg/drbg_protocol_proofs.v
@@ -685,7 +685,7 @@ Proof.
   unfold return_value_relate_result, da_emp; simpl. 
   symmetry in Heqq.
   apply AUX in Heqq. rewrite Heqq.
-  Intros. inversion H0; clear H0; subst v.
+  Intros. inversion H; clear H; subst v.
   assert_PROP (n=Zlength(map Vint (map Int.repr bytes))) as HN by entailer!.
   entailer!. 
   Exists Info
@@ -726,7 +726,7 @@ Proof.
   unfold return_value_relate_result, da_emp; simpl. 
   Exists (hmac256drbgabs_generate I s n []).
   apply AUX in M. rewrite <- M.
-  Intros. inversion H0; clear H0; subst v.
+  Intros. inversion H; clear H; subst v.
   assert_PROP (n=Zlength(map Vint (map Int.repr bytes))) as HN by entailer!.
   entailer!.
   Exists Info
@@ -1059,7 +1059,7 @@ Proof. start_function.
       (* prove the function parameters match up *)
       apply prop_right. 
       rewrite hmac_common_lemmas.HMAC_Zlength, FA_ctx_MDCTX; simpl.
-      rewrite offset_val_force_ptr, isptr_force_ptr, sem_cast_neutral_ptr; trivial. auto.
+      rewrite offset_val_force_ptr, isptr_force_ptr; trivial. auto.
     }
     {
       split.

--- a/hmacdrbg/verif_hmac_drbg_update.v
+++ b/hmacdrbg/verif_hmac_drbg_update.v
@@ -817,7 +817,7 @@ Proof. intros.
       (* prove the function parameters match up *)
       apply prop_right. 
       rewrite hmac_common_lemmas.HMAC_Zlength, FA_ctx_MDCTX; simpl.
-      rewrite offset_val_force_ptr, isptr_force_ptr, sem_cast_neutral_ptr; trivial. auto.
+      rewrite offset_val_force_ptr, isptr_force_ptr; trivial. auto.
     }
     {
       split.

--- a/mailbox/verif_atomic_exchange.v
+++ b/mailbox/verif_atomic_exchange.v
@@ -170,7 +170,7 @@ Proof.
   { lock_props.
     unfold AE_inv.
     Exists (h' ++ [AE v' v]) v; entailer!.
-    cancel. }
+  }
   forward.
   Exists (length h') (Vint v'). unfold AE_loc; entailer!.
   apply hist_incl_lt; auto.

--- a/mailbox/verif_mailbox_init.v
+++ b/mailbox/verif_mailbox_init.v
@@ -38,13 +38,12 @@ Proof.
   start_function.
   forward.
   rewrite data_at__isptr; Intros.
-  rewrite sem_cast_neutral_ptr; auto.
   pose proof (sizeof_pos t).
   assert_PROP (sizeof t <= Int.max_unsigned).
   { entailer!.
-    destruct H3 as [? [_ [? _]]].
-    destruct p; inv H3.
-    simpl in H4.
+    destruct H2 as [? [_ [? _]]].
+    destruct p; inv H2.
+    simpl in H3.
     pose proof Ptrofs.unsigned_range i.
     rep_omega.
   }
@@ -73,7 +72,7 @@ Proof.
         constructor; intros.
         econstructor; [reflexivity |].
         inv H0.
-        inv H11.
+        inv H10.
         apply Z.divide_add_r; auto.
         apply Z.divide_mul_l.
         exists 1; auto.
@@ -242,7 +241,6 @@ Proof.
     replace (Z.to_nat (N - (Zlength locks + 1))) with (Z.to_nat (N - (i + 1))) by (subst; clear; rep_omega).
     subst; rewrite Zlength_correct, Nat2Z.id.
     rewrite <- lock_struct_array; unfold AE_inv.
-    rewrite !sem_cast_neutral_ptr by intuition.
     erewrite map_ext_in; [unfold comm_loc, AE_loc, AE_inv; cancel|].
     { apply derives_refl. }
     intros; rewrite In_upto, <- Zlength_correct in *.

--- a/progs/conclib.v
+++ b/progs/conclib.v
@@ -2931,19 +2931,6 @@ Proof.
   destruct (Map.get (ge_of rho) i); auto; contradiction.
 Qed.
 
-Lemma force_val_sem_cast_neutral_gvar' : forall i v rho, gvar_denote i v rho ->
-  force_val (sem_cast_pointer v) = v.
-Proof.
-  intros; apply force_val_sem_cast_neutral_gvar in H; inversion H as [Heq].
-  rewrite !Heq; auto.
-Qed.
-
-Lemma force_val_sem_cast_neutral_isptr' : forall v, isptr v -> force_val (sem_cast_pointer v) = v.
-Proof.
-  intros; apply force_val_sem_cast_neutral_isptr in H.
-  inversion H as [Heq]; rewrite !Heq; auto.
-Qed.
-
 Lemma gvar_denote_global : forall i v rho, gvar_denote i v rho -> gvar_denote i v (globals_only rho).
 Proof.
   unfold gvar_denote; intros; simpl.

--- a/progs/verif_bst.v
+++ b/progs/verif_bst.v
@@ -534,11 +534,8 @@ Proof.
   Intros pb pc.
   forward. (* mid=r->left *)
   forward. (* l->right=mid *)
-  assert_PROP (is_pointer_or_null pb) by entailer!.
   forward. (* r->left=l *)
-  assert_PROP (is_pointer_or_null l) by entailer!.
   forward. (* _l = r *)
-  assert_PROP (is_pointer_or_null r) by entailer!.
   Opaque tree_rep. forward. Transparent tree_rep. (* return *)
   (* TODO: simplify the following proof *)
   Exists pc.

--- a/progs/verif_bst.v
+++ b/progs/verif_bst.v
@@ -295,13 +295,6 @@ Qed.
 
 Hint Resolve tree_rep_nullval: saturate_local.
 
-Lemma is_pointer_or_null_force_val_sem_cast_pointer: forall p,
-  is_pointer_or_null p -> force_val (sem_cast_pointer p) = p.
-Proof.
-  intros.
-  destruct p; try contradiction; reflexivity.
-Qed.
-
 Lemma treebox_rep_leaf: forall x p b (v: val),
   is_pointer_or_null v ->
   Int.min_signed <= x <= Int.max_signed ->
@@ -417,7 +410,6 @@ Proof.
       assert_PROP (t1= (@E _)).
         1: entailer!.
       subst t1. simpl tree_rep. rewrite !prop_true_andp by auto.
-      rewrite is_pointer_or_null_force_val_sem_cast_pointer by auto.
       forward. (* *t = p; *)
       forward. (* return; *)
       apply modus_ponens_wand'.
@@ -543,13 +535,10 @@ Proof.
   forward. (* mid=r->left *)
   forward. (* l->right=mid *)
   assert_PROP (is_pointer_or_null pb) by entailer!.
-  rewrite is_pointer_or_null_force_val_sem_cast_pointer by auto.
   forward. (* r->left=l *)
   assert_PROP (is_pointer_or_null l) by entailer!.
-  rewrite is_pointer_or_null_force_val_sem_cast_pointer by auto.
   forward. (* _l = r *)
   assert_PROP (is_pointer_or_null r) by entailer!.
-  rewrite is_pointer_or_null_force_val_sem_cast_pointer by auto.
   Opaque tree_rep. forward. Transparent tree_rep. (* return *)
   (* TODO: simplify the following proof *)
   Exists pc.

--- a/progs/verif_int_or_ptr.v
+++ b/progs/verif_int_or_ptr.v
@@ -197,7 +197,6 @@ Proof.
   rename p into t.
   Intros p q.
   forward_call t.
-    entailer!.
   assert_PROP (isptr t) by entailer!.
   destruct t; try contradiction. clear H0.
   forward_if.
@@ -211,8 +210,6 @@ Proof.
      entailer!.
      destruct p; try contradiction; apply I.
    forward_call (t1,p).
-     entailer!.
-     destruct p; try contradiction; reflexivity.
    Intros p1.
    deadvars.
    forward.
@@ -220,19 +217,13 @@ Proof.
     entailer!.
      destruct q; try contradiction; apply I.
    forward_call (t2,q).
-     entailer!.
-     destruct q; try contradiction; reflexivity.
    Intros p2.
    forward.
    deadvars.
    forward_call (p1,p2).
-     entailer!.
-  split.
-  destruct p2; try contradiction; reflexivity.
-  destruct p1; try contradiction; reflexivity.
   Intros r.
   assert_PROP (valid_int_or_ptr r). {
-    entailer!. 
+    entailer!.
     apply field_compatible_valid_int_or_ptr; auto.
   }
   forward_call r.

--- a/progs/verif_merge.v
+++ b/progs/verif_merge.v
@@ -269,7 +269,7 @@ rewrite (lseg_unfold LS _ _ b_).
 Time entailer!. (* 24.7 sec -> 10.16 sec*)
 Exists b_'.
 rewrite list_cell_field_at.
-unfold_data_at 3%nat.
+unfold_data_at 1%nat.
 Time entailer!.  (* 12.6 -> 3.2 sec *)
 }
 
@@ -361,7 +361,7 @@ simpl map. rewrite @lseg_cons_eq.
 Exists a_'.
 rewrite list_cell_field_at.
 entailer!.
-unfold_data_at 3%nat.
+unfold_data_at 1%nat.
 entailer!.
 
 (* we have now finished the case merged=nil, proceeding to the other case *)

--- a/progs/verif_queue.v
+++ b/progs/verif_queue.v
@@ -382,10 +382,10 @@ forward_if
    + Intros prefix.
       destruct prefix;
       entailer!.
-      contradiction (field_compatible_isptr _ _ _ H9).
+      contradiction (field_compatible_isptr _ _ _ H7).
       rewrite lseg_cons_eq by auto. simpl.
       Intros y. saturate_local.
-      contradiction (field_compatible_isptr _ _ _ H12).
+      contradiction (field_compatible_isptr _ _ _ H11).
 * (* else clause *)
   forward. (*  t = Q->tail; *)
   unfold fifo_body.

--- a/sha/call_memcpy.v
+++ b/sha/call_memcpy.v
@@ -395,15 +395,10 @@ eapply semax_pre_post';
  unfold_lift; simpl.
  rewrite <- H7, <- H8, <- H9.
  split3; auto.
- unfold field_address0; if_tac; try reflexivity.
- destruct H12; normalize.
- unfold field_address0; if_tac; try reflexivity.
- destruct H12; normalize.
  apply andp_right.
  apply prop_right; split3; auto.
- apply andp_right.
- apply prop_right; auto.
  subst Frame.
+ normalize.
  rewrite LENvqx, LENvpx; cancel.
  rewrite sepcon_comm.
  apply sepcon_derives.
@@ -627,11 +622,7 @@ eapply semax_pre_post';
  autorewrite with gather_prop.
  apply andp_right.
  apply prop_right. split3; auto.
- rewrite <- H1.
- unfold field_address0; if_tac; try reflexivity.
- destruct H1; normalize.
- rewrite <- H2; simpl. split3; auto.
- rewrite <- H6; reflexivity.
+ normalize.
  subst Frame.
  cancel.
  rewrite array_at_data_at' by  (try solve [clear - FC; intuition]; omega).

--- a/sha/verif_sha_bdo4.v
+++ b/sha/verif_sha_bdo4.v
@@ -143,7 +143,7 @@ assert_PROP (data_block sh (intlist_to_Zlist b) data =
 forward_call (* l = __builtin_read32_reversed(_data) *)
       (offset_val (i*4) data, sh,
          sublist (i*4) ((i+1)*4) (map Int.repr (intlist_to_Zlist b))).
- entailer!; make_Vptr data; reflexivity.
+ entailer!.
  rewrite H1; cancel.
  autorewrite with sublist; omega.
 gather_SEP 3 0 4.

--- a/veric/Cop2.v
+++ b/veric/Cop2.v
@@ -205,13 +205,7 @@ Qed.
 
 (** ** Casts and truth values *)
 
-Definition sem_cast_pointer (v : val) : option val :=
-      match v with
-      | Vptr _ _ => Some v
-      | Vint _ => if Archi.ptr64 then None else Some v
-      | Vlong _ => if Archi.ptr64 then Some v else None
-      | _ => None
-      end.
+Definition sem_cast_pointer (v : val) : option val := Some v.
 
 Definition sem_cast_i2i sz2 si2 (v : val) : option val :=
 match v with

--- a/veric/expr_lemmas.v
+++ b/veric/expr_lemmas.v
@@ -249,7 +249,7 @@ destruct (eqb_type t int_or_ptr_type) eqn:J.
   destruct (eqb_type (Tpointer t0 a) int_or_ptr_type) eqn:?; try contradiction.
   rewrite eqb_type_sym in Heqb. rewrite Heqb in H0.
   simpl. simpl in H0.
- rewrite Hp; auto.
+  reflexivity.
   destruct t0 as [ | [ | | | ] [ | ] ? | i1 ? | [ | ] ? | | | | | ]; try contradiction.
   unfold classify_cast in *. unfold int_or_ptr_type at 1 in H0.
   rewrite eqb_type_refl in H0|-*.
@@ -662,6 +662,14 @@ unfold denote_tc_iszero in H6; unfold_lift in H6;
 destruct (eval_expr e2 rho); try contradiction; inv H;
 apply is_true_e in H6; first [apply int_eq_e in H6 | apply int64_eq_e in H6; rewrite Int64.repr_unsigned in H6]; subst;
 hnf; rewrite Hp; solve [auto]).
+
+all:
+try (unfold is_pointer_type in H6; rewrite ?J,?J0 in H6; simpl in H6;
+simpl in H6; rewrite denote_tc_assert_iszero' in H6; simpl in H6; 
+unfold denote_tc_iszero in H6; unfold_lift in H6;
+destruct (eval_expr e2 rho); try contradiction; inv H;
+apply is_true_e in H6; first [apply int_eq_e in H6 | apply int64_eq_e in H6; rewrite Int64.repr_unsigned in H6]; subst;
+simpl in H8; rewrite Hp in H8; inv H8).
 Qed.
 
 

--- a/veric/expr_lemmas4.v
+++ b/veric/expr_lemmas4.v
@@ -265,7 +265,6 @@ apply weak_valid_pointer_dry in H0.
 apply H0.
 Qed.
 
-Print denote_tc_test_eq.
 Lemma cop2_sem_cast :
     forall t1 t2 v m,
  (classify_cast t1 t2 = cast_case_i2bool ->

--- a/wand_demo/wand_demo/VST_lemmas.v
+++ b/wand_demo/wand_demo/VST_lemmas.v
@@ -11,13 +11,6 @@ Proof.
   + rewrite emp_sepcon; auto.
 Qed.
 
-Lemma is_pointer_or_null_force_val_sem_cast_neutral: forall p,
-  is_pointer_or_null p -> force_val (sem_cast_pointer p) = p.
-Proof.
-  intros.
-  destruct p; try contradiction; reflexivity.
-Qed.
-
 Lemma modus_ponens_wand' {A}{ND: NatDed A}{SL: SepLog A}:
   forall P Q R: A, P |-- Q -> P * (Q -* R) |-- R.
 Proof.

--- a/wand_demo/wand_demo/verif_bst.v
+++ b/wand_demo/wand_demo/verif_bst.v
@@ -175,7 +175,6 @@ Proof.
       assert_PROP (t = (@E _)).
         1: entailer!.
       subst t. rewrite tree_rep_treebox_rep. rewrite !prop_true_andp by auto.
-      rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
       forward. (* * p = q; *)
       forward. (* return; *)
       entailer!.
@@ -249,7 +248,6 @@ Proof.
       assert_PROP (t = (@E _)).
         1: entailer!.
       subst t. rewrite tree_rep_treebox_rep. rewrite !prop_true_andp by auto.
-      rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
       forward. (* * p = q; *)
       forward. (* return; *)
       entailer!.
@@ -332,7 +330,6 @@ Proof.
       assert_PROP (t = (@E _)).
         1: entailer!.
       subst t. rewrite tree_rep_treebox_rep. rewrite !prop_true_andp by auto.
-      rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
       forward. (* * p = q; *)
       forward. (* return; *)
       entailer!.

--- a/wand_demo/wand_demo/verif_bst_other.v
+++ b/wand_demo/wand_demo/verif_bst_other.v
@@ -89,14 +89,8 @@ Proof.
   Intros pb pc.
   forward. (* mid=r->left *)
   forward. (* l->right=mid *)
-  assert_PROP (is_pointer_or_null pb) by entailer!.
-  rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
   forward. (* r->left=l *)
-  assert_PROP (is_pointer_or_null l) by entailer!.
-  rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
   forward. (* _l = r *)
-  assert_PROP (is_pointer_or_null r) by entailer!.
-  rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
   forward. (* return *)
   (* TODO: simplify the following proof *)
   Exists pc.

--- a/wand_demo/wand_demo/verif_list.v
+++ b/wand_demo/wand_demo/verif_list.v
@@ -237,7 +237,7 @@ Proof.
    entailer!.
    simpl app.
    sep_apply (singleton_lseg sh b t y).
-   sep_apply (lseg_lseg sh s1a [b] x t y) using (simpl app).
+   sep_apply (lseg_lseg sh s1a [b] x t y).
    sep_apply (list_lseg sh (s1a ++ [b]) s2 x y).
    auto.
 Qed.
@@ -350,7 +350,8 @@ Proof.
    entailer!.
    simpl app.
    sep_apply (singleton_lseg sh s2 b t y).
-   sep_apply (lseg_lseg sh s1a [b] s2 x t y) using (simpl app).
+   change (b :: s2) with ([b] ++ s2).
+   sep_apply (lseg_lseg sh s1a [b] s2 x t y).
    sep_apply (list_lseg sh (s1a ++ [b]) s2 x y).
    auto.
 Qed.
@@ -360,7 +361,7 @@ End ProofByWandFrame2.
 Module ProofByWandQFrame.
 
 Import LsegWandQFrame.
-  
+
 Lemma body_append1: semax_body Vprog Gprog f_append1 append1_spec.
 Proof.
   start_function.
@@ -408,7 +409,7 @@ Proof.
    entailer!.
    simpl app.
    sep_apply (singleton_lseg sh b t y).
-   sep_apply (lseg_lseg sh s1a [b] x t y) using (simpl app).
+   sep_apply (lseg_lseg sh s1a [b] x t y).
    sep_apply (list_lseg sh (s1a ++ [b]) s2 x y).
    auto.
 Qed.
@@ -421,7 +422,7 @@ Module VerifAppend2.
 
 Import ListLib.
 Import LBsegWandQFrame.
-  
+
 Definition append2_spec := append_spec _append2.
 
 Definition Gprog : funspecs :=
@@ -458,8 +459,6 @@ Proof.
     }
   Intros. freeze [1] Fr.
   forward. (* head = x; *)
-  assert_PROP (is_pointer_or_null head) by entailer!.
-  rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
   forward. (* curp = & head *)
   forward. (* cur = x *)
   forward. (* retp = & head *)
@@ -488,7 +487,7 @@ Proof.
       symmetry; apply field_address_eq_offset'; auto.
       auto with field_compatible.
     } Unfocus.
-    rewrite H1; clear H1.
+    rewrite H0; clear H0.
     rewrite (listrep_nonnull _ _ cur) by auto.
     Intros b s1c next.
     subst s1b.
@@ -505,8 +504,6 @@ Proof.
     rewrite (listrep_null _ _ cur) by auto.
     Intros.
     forward. (* * curp = y *)
-    assert_PROP (is_pointer_or_null y) by entailer!.
-    rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
     gather_SEP 1 2 3.
     replace_SEP 0 (listboxrep sh s2 curp).
     Focus 1. {
@@ -545,7 +542,7 @@ Module VerifAppend3.
 
 Import ListLib.
 Import LsegWandQFrame.
-  
+
 Definition append3_spec := append_spec _append3.
 
 Definition Gprog : funspecs :=
@@ -565,8 +562,6 @@ Proof.
     forward_call (sh, x', y, s1b, s2). (* t = append3(t, y); *)
     Intros x''.
     forward. (* x -> tail = t; *)
-    assert_PROP (is_pointer_or_null x'') by entailer!.
-    rewrite is_pointer_or_null_force_val_sem_cast_neutral by auto.
     forward. (* return x *)
     Exists x.
     entailer!.


### PR DESCRIPTION
When the C expression contains a cast (store and function call arguments will automatically have implicit casts besides explicit ones), (force_val (sem_cast_pointer _)) may appear in eval_expr's result.

Specifically, in previous version, storing a pointer always results in (force_val (sem_cast_pointer _)). Function calls with pointer requires extra tactics in forward_call to remove those (force_val (sem_cast_pointer _)).

Now, this is directly removed from sem_cast. And thus removed from expr_expr and msubst_eval_expr. Many proofs are simplified.