### PR TITLE
Remove head skip after forward_if.

### DIFF
--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -2059,11 +2059,13 @@ match goal with
        do_repr_inj HRE;
        repeat (apply semax_extract_PROP; intro);
        try rewrite Int.signed_repr in HRE by rep_omega;
+       repeat apply -> semax_skip_seq;
        abbreviate_semax
      | clear HRE; subst v; apply semax_extract_PROP; intro HRE;
        do_repr_inj HRE;
        repeat (apply semax_extract_PROP; intro);
        try rewrite Int.signed_repr in HRE by rep_omega;
+       repeat apply -> semax_skip_seq;
        abbreviate_semax
      ]
 | |- semax ?Delta (PROPx ?P (LOCALx ?Q (SEPx ?R))) (Ssequence (Sifthenelse ?e ?c1 ?c2) _) _ =>

--- a/hmacdrbg/drbg_protocol_proofs.v
+++ b/hmacdrbg/drbg_protocol_proofs.v
@@ -66,7 +66,7 @@ Proof.
     unfold_data_at 2%nat. thaw FIELDS. cancel.
     rewrite field_at_data_at. simpl.
     unfold field_address. rewrite if_true; simpl; trivial. rewrite ptrofs_add_repr_0_r; auto.  }
-  subst v. clear Hv. simpl. forward.
+  subst v. clear Hv. simpl.
   Intros p. rename H into MCp. simpl in MCp.
 
   (*Alloction / md_setup succeeded. Now get md_size*)
@@ -290,7 +290,6 @@ Proof.
     unfold_data_at 2%nat. thaw FIELDS. cancel. rewrite field_at_data_at. simpl.
     unfold field_address. rewrite if_true; simpl; trivial. rewrite ptrofs_add_repr_0_r; auto. }
   subst v; clear Hv. rewrite if_true; trivial.
-  forward.
   Intros p. rename H into MCp.
 
   forward_call tt.
@@ -455,7 +454,6 @@ Proof.
     simpl; cancel. entailer!.
     thaw FR1. cancel.
   }
-  forward.
   Intros. unfold POSTCONDITION, abbreviate; clear POSTCONDITION. rewrite H in *; clear H add_len_too_high.
   abbreviate_semax.
   symmetry in Heqadd_len_too_high; apply orb_false_iff in Heqadd_len_too_high; destruct Heqadd_len_too_high.
@@ -800,15 +798,7 @@ Proof. start_function.
       subst i; simpl. entailer!. (* simpl. *)
       thaw FR2. thaw FR1. thaw FR0. normalize.
       rewrite da_emp_ptr. normalize.
-      eapply denote_tc_test_eq_split. 
       auto 50 with valid_pointer. (* TODO regression, this should have solved it *)
-      apply sepcon_valid_pointer1.
-      apply sepcon_valid_pointer1.
-      apply sepcon_valid_pointer2. 
-      apply sepcon_valid_pointer2.
-      apply sepcon_valid_pointer2. 
-      apply sepcon_valid_pointer2. 
-      apply data_at_valid_ptr; auto. auto 50 with valid_pointer.
     }
 
     { entailer!.

--- a/hmacdrbg/verif_hmac_drbg_NISTseed.v
+++ b/hmacdrbg/verif_hmac_drbg_NISTseed.v
@@ -190,7 +190,7 @@ Proof.
     unfold_data_at 2%nat. thaw FIELDS. cancel.
     rewrite field_at_data_at. simpl.
     unfold field_address. rewrite if_true; simpl; trivial. rewrite ptrofs_add_repr_0_r; auto. }
-  subst v. clear Hv. simpl. forward.
+  subst v. clear Hv. simpl.
   Intros. Intros p. rename H into MCp. simpl in MCp.
 
   (*Alloction / md_setup succeeded. Now get md_size*)
@@ -461,7 +461,7 @@ Proof.
     unfold_data_at 2%nat. thaw FIELDS. cancel.
     rewrite field_at_data_at. simpl.
     unfold field_address. rewrite if_true; simpl; trivial. rewrite ptrofs_add_repr_0_r; auto. }
-  subst v. clear Hv. simpl. forward.
+  subst v. clear Hv. simpl.
   Intros. Intros p. rename H into MCp. simpl in MCp.
 
   (*Alloction / md_setup succeeded. Now get md_size*)
@@ -774,7 +774,7 @@ Proof.
     unfold_data_at 2%nat. thaw FIELDS. cancel.
     rewrite field_at_data_at. simpl.
     unfold field_address. rewrite if_true; simpl; trivial. rewrite ptrofs_add_repr_0_r; auto. }
-  subst v. clear Hv. simpl. forward.
+  subst v. clear Hv. simpl.
   Intros p. rename H into MCp.
 
   (*Alloction / md_setup succeeded. Now get md_size*)

--- a/hmacdrbg/verif_hmac_drbg_other.v
+++ b/hmacdrbg/verif_hmac_drbg_other.v
@@ -32,7 +32,7 @@ Proof.
     { entailer!. (*unfold_data_at 1%nat. simpl. entailer.*) }
     forward_if.
     + elim H; trivial.
-    + clear H. Intros. forward.
+    + clear H. Intros.
       destruct CTX as [C1 [C2 [C3 [C4 [C5 C6]]]]]. simpl.
       assert_PROP (field_compatible t_struct_hmac256drbg_context_st [] (Vptr b i)) as FC by entailer!.
       unfold_data_at 1%nat.

--- a/hmacdrbg/verif_hmac_drbg_reseed.v
+++ b/hmacdrbg/verif_hmac_drbg_reseed.v
@@ -79,7 +79,6 @@ Proof.
     normalize. apply andp_right. apply prop_right; repeat split; trivial.
     thaw FR2. thaw FR1. cancel.
   }
-  forward.
   Intros. rewrite H in *; clear H add_len_too_high.
   symmetry in Heqadd_len_too_high; apply orb_false_iff in Heqadd_len_too_high; destruct Heqadd_len_too_high.
 

--- a/hmacdrbg/verif_hmac_drbg_seed.v
+++ b/hmacdrbg/verif_hmac_drbg_seed.v
@@ -55,7 +55,7 @@ Proof.
     unfold_data_at 2%nat. thaw FIELDS. cancel.
     rewrite field_at_data_at. simpl.
     unfold field_address. rewrite if_true; simpl; trivial. rewrite ptrofs_add_repr_0_r; auto. }
-  subst v. clear Hv. simpl. forward.
+  subst v. clear Hv. simpl.
   Intros. Intros p. rename H into MCp. simpl in MCp.
 
   (*Alloction / md_setup succeeded. Now get md_size*)

--- a/hmacdrbg/verif_hmac_drbg_seed_buf.v
+++ b/hmacdrbg/verif_hmac_drbg_seed_buf.v
@@ -47,7 +47,6 @@ Proof.
     unfold field_address. rewrite if_true; simpl; trivial. rewrite ptrofs_add_repr_0_r; auto.  }
   subst v; clear Hv. rewrite if_true; trivial.
   Intros. Intros p. rename H into MCp.
-  forward.
   forward_call tt.
 
   thaw FR0. unfold hmac256drbg_relate. destruct CTX. Intros; subst.

--- a/hmacdrbg/verif_hmac_drbg_update.v
+++ b/hmacdrbg/verif_hmac_drbg_update.v
@@ -547,14 +547,7 @@ Proof. intros.
       subst i; simpl. entailer!. (* simpl. *)
       thaw FR2. thaw FR1. thaw FR0. normalize.
       rewrite da_emp_ptr. normalize.
-      eapply denote_tc_test_eq_split. 
       auto 50 with valid_pointer. (* TODO regression, this should have solved it *)
-      apply sepcon_valid_pointer1.
-      apply sepcon_valid_pointer1.
-      apply sepcon_valid_pointer2. 
-      apply sepcon_valid_pointer2.
-      apply sepcon_valid_pointer1. 
-      apply data_at_valid_ptr; auto. auto 50 with valid_pointer.
     }
 
     { entailer!.

--- a/hmacdrbg/verif_mocked_md.v
+++ b/hmacdrbg/verif_mocked_md.v
@@ -152,6 +152,6 @@ Proof.
   destruct (eq_dec vret nullval); subst. elim H; trivial. clear n.
   Intros.
   unfold_data_at 1%nat.
-  forward. forward. forward. forward. Exists 0. simpl. entailer!.
+  forward. forward. forward. Exists 0. simpl. entailer!.
   Exists vret. unfold_data_at 1%nat. entailer!.
 Qed.

--- a/progs/verif_even.v
+++ b/progs/verif_even.v
@@ -14,7 +14,6 @@ forward_if.
 *
  forward.
 *
-  forward.
   forward_call (z-1, tt).
   (* Prove that PROP precondition is OK *)
   rep_omega.

--- a/progs/verif_odd.v
+++ b/progs/verif_odd.v
@@ -14,7 +14,6 @@ forward_if.
 *
  forward.
 *
-  forward.
   forward_call (z-1).
   omega.
   forward.

--- a/progs/verif_strlib.v
+++ b/progs/verif_strlib.v
@@ -135,8 +135,7 @@ forward_loop (EX i : Z,
     Exists (offset_val i str).
     entailer!.
     left. exists i. split3; auto. rewrite app_Znth1; auto. cstring. }
-  { forward.
-    forward_if.
+  { forward_if.
     { forward.
       Exists nullval; rewrite !map_app; entailer!.
       right. split; auto.
@@ -558,7 +557,6 @@ forward_if.
 forward.
 entailer!. f_equal. f_equal. cstring.
 forward. (* entailer!.  *)
-forward.
 Exists (i+1).
 entailer!. cstring.
 Qed.
@@ -597,7 +595,6 @@ forward_loop (EX i : Z,
     subst i.
     autorewrite with sublist in H2; auto. }
   forward. (* entailer!. *)
-  forward.
   Exists (i+1); entailer!.
   assert (i <> Zlength ls) by cstring.
   split. omega.
@@ -644,7 +641,7 @@ forward_loop (EX i : Z,
   +
     forward. entailer!. f_equal. f_equal. cstring. 
   +
-    forward. forward.
+    forward.
     Exists (i+1); entailer!. cstring.
 -
   abbreviate_semax.
@@ -694,7 +691,6 @@ forward_loop (EX i : Z,
     reflexivity.
  +
   forward. (* entailer!. *)
-  forward.
   Exists (j+1).
   destruct (zlt j (Zlength ls)); [ | cstring].
   entailer!.
@@ -793,7 +789,6 @@ forward_loop (EX i : Z,
      Byte.signed (Znth i (ls2 ++ [Byte.zero]))) by omega.
    normalize in H17. clear H7 H8.
    forward.
-   forward.
    Exists (i+1).
    entailer!.
    clear - H17 H6 Hs1 Hs2 H3 H1 H2 H H0.
@@ -866,7 +861,6 @@ forward_loop (EX i : Z,
   cancel.
 +
    assert (i < Zlength ls) by cstring.
-  forward.
   forward.
   Exists (i+1). entailer!.
   rewrite upd_Znth_app2 by list_solve.


### PR DESCRIPTION
If one branch is empty, another branch is break/continue/return. A redundant skip will appear in the head of the empty branch. Remove it automatically now.