### PR TITLE
Generalize sha_block_data_order_spec.

### DIFF
--- a/sha/spec_sha.v
+++ b/sha/spec_sha.v
@@ -108,16 +108,16 @@ Definition K_vector (gv: globals) : mpred :=
 
 Definition sha256_block_data_order_spec :=
   DECLARE _sha256_block_data_order
-    WITH hashed: list int, b: list int, ctx : val, data: val, sh: share, gv: globals
+    WITH regs: list int, b: list int, ctx : val, data: val, sh: share, gv: globals
    PRE [ _ctx OF tptr t_struct_SHA256state_st, _in OF tptr tvoid ]
-         PROP(Zlength b = LBLOCKz; (LBLOCKz | Zlength hashed); readable_share sh)
+         PROP(Zlength regs = 8; Zlength b = LBLOCKz; readable_share sh)
          LOCAL (temp _ctx ctx; temp _in data; gvars gv)
-         SEP (field_at Tsh t_struct_SHA256state_st [StructField _h] (map Vint (hash_blocks init_registers hashed)) ctx;
+         SEP (field_at Tsh t_struct_SHA256state_st [StructField _h] (map Vint regs) ctx;
                 data_block sh (intlist_to_Zlist b) data;
                 K_vector gv)
    POST [ tvoid ]
        PROP() LOCAL()
-       SEP(field_at Tsh t_struct_SHA256state_st  [StructField _h] (map Vint (hash_blocks init_registers (hashed++b))) ctx;
+       SEP(field_at Tsh t_struct_SHA256state_st  [StructField _h] (map Vint (hash_block regs b)) ctx;
              data_block sh (intlist_to_Zlist b) data;
              K_vector gv).
 

--- a/sha/verif_sha_bdo.v
+++ b/sha/verif_sha_bdo.v
@@ -13,11 +13,8 @@ Lemma body_sha256_block_data_order: semax_body Vprog Gtot f_sha256_block_data_or
 Proof.
 start_function.
 rename v_X into Xv.
-remember (hash_blocks init_registers hashed) as regs eqn:Hregs.
 assert (Lregs: length regs = 8%nat)
-  by (subst regs; apply length_hash_blocks; auto).
-assert (Zregs: Zlength regs = 8%Z)
- by (rewrite Zlength_correct; rewrite Lregs; reflexivity).
+ by (change 8%nat with (Z.to_nat 8); rewrite <- Zlength_length; auto).
 forward. (* data = in; *)
  match goal with |- semax _ _ ?c _ =>
   eapply seq_assocN with (cs := sequenceN 8 c)
@@ -65,8 +62,7 @@ eapply seq_assocN with (cs := add_them_back). {
 }
 simpl; abbreviate_semax.
 forward. (* return; *)
-fold (hash_block  (hash_blocks init_registers hashed) b).
-rewrite hash_blocks_last by auto.
+fold (hash_block regs b).
 entailer!.
 apply derives_refl.
 Qed.

--- a/sha/verif_sha_final2.v
+++ b/sha/verif_sha_final2.v
@@ -276,8 +276,10 @@ clearbody ddzw.
 forward.  (* n=0; *)
 erewrite field_at_data_at with (gfs := [StructField _data]) by reflexivity.
 rewrite semax_seq_skip.
+assert (Zlength (hash_blocks init_registers hashed) = 8)
+ by (rewrite Zlength_length;[apply length_hash_blocks|]; auto).
 forward_call (* sha256_block_data_order (c,p); *)
-  (hashed, ddzw, c,
+  (hash_blocks init_registers hashed, ddzw, c,
     field_address t_struct_SHA256state_st [StructField _data] c,
     Tsh, gv).
 {
@@ -293,6 +295,7 @@ forward_call (* sha256_block_data_order (c,p); *)
   rewrite map_id.
   apply derives_refl.
 }
+ rewrite hash_blocks_last by auto.
  set (pad := (CBLOCKz - (ddlen+1))%Z) in *.
  Exists (hashed ++ ddzw) (@nil Z) pad.
  entailer!.

--- a/sha/verif_sha_final3.v
+++ b/sha/verif_sha_final3.v
@@ -148,8 +148,10 @@ Proof.
   unfold sha_final_epilog.
   abbreviate_semax.
   Time unfold_data_at 1%nat.
+  assert (Zlength (hash_blocks init_registers hashed) = 8)
+   by (rewrite Zlength_length;[apply length_hash_blocks|]; auto).
   Time forward_call (* sha256_block_data_order (c,p); *)
-    (hashed, lastblock, c,
+    (hash_blocks init_registers hashed, lastblock, c,
       field_address t_struct_SHA256state_st [StructField _data] c,
        Tsh, gv).
   {
@@ -159,6 +161,7 @@ Proof.
     rewrite field_at_data_at with (gfs := [StructField _data]).
     Time cancel.
   }
+  rewrite hash_blocks_last by auto.
   unfold data_block.
   simpl. rewrite prop_true_andp by apply isbyte_intlist_to_Zlist.
   rewrite <- H1.

--- a/sha/verif_sha_update3.v
+++ b/sha/verif_sha_update3.v
@@ -313,14 +313,17 @@ forward_if.
    by (rewrite Zlength_app, Zlength_sublist; MyOmega).
  assert (Zlength (Zlist_to_intlist (dd ++ sublist 0 k data)) = LBLOCKz)
     by (apply Zlength_Zlist_to_intlist; assumption).
+ assert (Zlength (hash_blocks init_registers hashed) = 8)
+  by (rewrite Zlength_length;[apply length_hash_blocks|]; auto).
  forward_call (* sha256_block_data_order (c,p); *)
-   (hashed, Zlist_to_intlist (dd++(sublist 0 k data)), c,
+   (hash_blocks init_registers hashed, Zlist_to_intlist (dd++(sublist 0 k data)), c,
      (field_address t_struct_SHA256state_st [StructField _data] c),
       Tsh, gv).
  rewrite Zlist_to_intlist_to_Zlist;
    [ | rewrite H5; exists LBLOCKz; reflexivity
      | rewrite Forall_app; split; auto; apply Forall_firstn; auto
    ];   entailer!.
+ rewrite hash_blocks_last by auto.
  forward. (* data  += fragment; *)
  forward. (* len -= fragment; *)
  normalize_postcondition.

--- a/sha/verif_sha_update4.v
+++ b/sha/verif_sha_update4.v
@@ -220,14 +220,18 @@ assert (Zlength bl = LBLOCKz). {
      subst lo; Omega1.
   }
  rewrite H6.
+ assert (LBLOCKz | Zlength (hashed ++ blocks))
+  by (apply divide_length_app; auto).
+ assert (Zlength (hash_blocks init_registers (hashed ++ blocks)) = 8)
+  by (rewrite Zlength_length; [apply length_hash_blocks|]; auto).
  Time forward_call (* sha256_block_data_order (c,data); *)
-   (hashed++ blocks,  bl, c,
+   (hash_blocks init_registers (hashed++blocks),  bl, c,
     field_address0 (tarray tuchar (Zlength data))  [ArraySubsc lo] d,
     sh, gv). (*3.8*)
   { Time unfold_data_at 1%nat. (*0.8*)
     Time cancel. (*2.5*)
   }
- split3; auto. apply divide_length_app; auto.
+ rewrite hash_blocks_last by auto.
  Time forward. (* data += SHA_CBLOCK; *) (*5*)
  simpl (temp _data _).
  Time forward. (* len  -= SHA_CBLOCK; *) (*6*)


### PR DESCRIPTION
The new specificaiton generalizes the input registers so that they can be any value instead of just Sha-256 midstates.