### PR TITLE
Roconnor blockstream reptype

### DIFF
--- a/floyd/field_at.v
+++ b/floyd/field_at.v
@@ -1769,7 +1769,7 @@ Hint Extern 2 (field_compatible _ nil _) =>
   [assumption | reflexivity | reflexivity]).
 
 Lemma data_array_at_local_facts {cs: compspecs}:
- forall t' n a sh v p,
+ forall t' n a sh (v: list (reptype t')) p,
   data_at sh (Tarray t' n a) v p |--
   !! (field_compatible (Tarray t' n a) nil p
      /\ Zlength v = Z.max 0 n
@@ -1782,7 +1782,7 @@ intros [? ?]; split; auto.
 Qed.
 
 Lemma data_array_at_local_facts' {cs: compspecs}:
- forall t' n a sh v p,
+ forall t' n a sh (v: list (reptype t')) p,
   n >= 0 ->
   data_at sh (Tarray t' n a) v p |--
   !! (field_compatible (Tarray t' n a) nil p

--- a/floyd/field_compat.v
+++ b/floyd/field_compat.v
@@ -456,7 +456,7 @@ Hint Extern 2 (field_compatible0 (tarray _ _) (ArraySubsc _ :: nil) _) =>
     (eapply field_compatible0_Tarray_offset; [eassumption | omega | omega]) : field_compatible.
 *)
 
-Lemma split3_data_at_Tarray {cs: compspecs} sh t n n1 n2 v (v': list (reptype t)) v1 v2 v3 p:
+Lemma split3_data_at_Tarray {cs: compspecs} sh t n n1 n2 v (v' v1 v2 v3: list (reptype t)) p:
    naturally_aligned t ->
    0 <= n1 <= n2 ->
    n2 <= n <= Zlength v' ->
@@ -514,7 +514,7 @@ Proof. intros until 1. rename H into NA; intros.
   normalize. destruct H6 as [H6 _]; contradiction H6.
 Qed.
 
-Lemma split2_data_at_Tarray_tuchar {cs: compspecs} sh n n1 v p:
+Lemma split2_data_at_Tarray_tuchar {cs: compspecs} sh n n1 (v: list val) p:
    0 <= n1 <= n ->
    Zlength v = n ->
    data_at sh (Tarray tuchar n noattr) v p =
@@ -527,7 +527,7 @@ Proof. intros.
  rewrite sublist_same; try omega; auto.
 Qed.
 
-Lemma split3_data_at_Tarray_tuchar {cs: compspecs} sh n n1 n2 v p:
+Lemma split3_data_at_Tarray_tuchar {cs: compspecs} sh n n1 n2 (v: list val) p:
    0 <= n1 <= n2 ->
    n2 <= n ->
    Zlength v = n ->
@@ -654,7 +654,7 @@ Qed.
 
 Opaque sizeof.
  
-Lemma data_at_singleton_array_eq {cs} sh t v vl p:
+Lemma data_at_singleton_array_eq {cs} sh t v (vl: list (reptype t)) p:
   vl = [v] ->
   @data_at cs sh (tarray t 1) vl p = @data_at cs sh t v p.  
 Proof. 
@@ -668,11 +668,11 @@ Lemma data_at_tuchar_singleton_array {cs} sh v p:
   @data_at cs sh tuchar v p |-- @data_at cs sh (tarray tuchar 1) [v] p.  
 Proof. apply data_at_singleton_array. reflexivity. Qed.
 
-Lemma data_at_tuchar_singleton_array_inv {cs} sh v p:
+Lemma data_at_tuchar_singleton_array_inv {cs} sh (v: val) p:
   @data_at cs sh (tarray tuchar 1) [v] p |-- @data_at cs sh tuchar v p.  
 Proof. apply data_at_singleton_array_inv. reflexivity. Qed.
 
-Lemma data_at_tuchar_singleton_array_eq {cs} sh v p:
+Lemma data_at_tuchar_singleton_array_eq {cs} sh (v: val) p:
   @data_at cs sh (tarray tuchar 1) [v] p = @data_at cs sh tuchar v p.  
 Proof. apply data_at_singleton_array_eq. reflexivity. Qed.
 
@@ -766,3 +766,25 @@ unfold default_val. simpl. autorewrite with sublist. reflexivity.
 unfold default_val. simpl. autorewrite with sublist. reflexivity.
 unfold default_val. simpl. autorewrite with sublist. reflexivity.
 Qed. 
+
+Lemma split2_data_at_Tarray_app:
+ forall {cs: compspecs} mid n (sh: Share.t) (t: type)
+                           (v1 v2: list (reptype t)) p,
+    Zlength v1 = mid ->
+    Zlength v2 = n-mid ->
+    data_at sh (tarray t n) (v1 ++ v2) p =
+    data_at sh (tarray t mid) v1  p *
+    data_at sh (tarray t (n-mid)) v2
+            (field_address0 (tarray t n) [ArraySubsc mid] p).
+Proof.
+intros.
+pose proof (Zlength_nonneg v1).
+pose proof (Zlength_nonneg v2).
+apply split2_data_at_Tarray with (v1++v2); auto.
+omega.
+list_solve.
+autorewrite with sublist; auto.
+autorewrite with sublist; auto.
+autorewrite with sublist; auto.
+Qed.
+

--- a/floyd/field_compat.v
+++ b/floyd/field_compat.v
@@ -264,7 +264,7 @@ Hint Extern 2 (field_compatible0 _ _ (offset_val _ _)) =>
   (apply field_compatible0_nested_field_array; auto with field_compatible).
 
 Lemma split2_data_at_Tarray_unfold {cs: compspecs}
-     sh t n n1 v (v': list (reptype t)) v1 v2 p:
+     sh t n n1 (v v' v1 v2: list (reptype t)) p:
    0 <= n1 <= n ->
   v = v' ->
   v1 = (sublist 0 n1 v') ->
@@ -315,7 +315,7 @@ Proof.
   normalize.
 Qed.
 
-Lemma split2_data_at_Tarray_fold {cs: compspecs} sh t n n1 v (v': list (reptype t)) v1 v2 p:
+Lemma split2_data_at_Tarray_fold {cs: compspecs} sh t n n1 (v v' v1 v2: list (reptype t)) p:
    0 <= n1 <= n ->
    n <= Zlength v' ->
    v = (sublist 0 n v') ->
@@ -374,7 +374,7 @@ Proof.
   rewrite !nested_field_type_ind.  unfold gfield_type. simpl. f_equal; omega.
 Qed.
 
-Lemma split2_data_at_Tarray {cs: compspecs} sh t n n1 v (v': list (reptype t)) v1 v2 p:
+Lemma split2_data_at_Tarray {cs: compspecs} sh t n n1 (v v' v1 v2: list (reptype t)) p:
    0 <= n1 <= n ->
    n <= Zlength v' ->
    v = (sublist 0 n v') ->
@@ -664,7 +664,7 @@ Proof.
   apply data_at_singleton_array; auto.
 Qed.
 
-Lemma data_at_tuchar_singleton_array {cs} sh v p:
+Lemma data_at_tuchar_singleton_array {cs} sh (v: val) p:
   @data_at cs sh tuchar v p |-- @data_at cs sh (tarray tuchar 1) [v] p.  
 Proof. apply data_at_singleton_array. reflexivity. Qed.
 
@@ -676,7 +676,7 @@ Lemma data_at_tuchar_singleton_array_eq {cs} sh (v: val) p:
   @data_at cs sh (tarray tuchar 1) [v] p = @data_at cs sh tuchar v p.  
 Proof. apply data_at_singleton_array_eq. reflexivity. Qed.
 
-Lemma data_at_zero_array {cs} sh t v p:
+Lemma data_at_zero_array {cs} sh t (v: list (reptype t)) p:
   complete_legal_cosu_type t = true ->
   isptr p ->
   v = (@nil (reptype t)) ->
@@ -693,7 +693,7 @@ Proof. intros.
   split; auto. omega.
 Qed.
 
-Lemma data_at_zero_array_inv {cs} sh t v p:
+Lemma data_at_zero_array_inv {cs} sh t (v: list (reptype t)) p:
   complete_legal_cosu_type t = true ->
   v = (@nil (reptype t)) ->
   @data_at cs sh (tarray t 0) v p |-- emp.  
@@ -704,7 +704,7 @@ Proof. intros.
   rewrite array_at_len_0. normalize. 
 Qed.
 
-Lemma data_at_zero_array_eq {cs} sh t v p:
+Lemma data_at_zero_array_eq {cs} sh t (v: list (reptype t)) p:
   complete_legal_cosu_type t = true ->
   isptr p ->
   v = (@nil (reptype t)) ->

--- a/floyd/field_compat.v
+++ b/floyd/field_compat.v
@@ -266,9 +266,9 @@ Hint Extern 2 (field_compatible0 _ _ (offset_val _ _)) =>
 Lemma split2_data_at_Tarray_unfold {cs: compspecs}
      sh t n n1 v (v': list (reptype t)) v1 v2 p:
    0 <= n1 <= n ->
-  JMeq v v' ->
-  JMeq v1 (sublist 0 n1 v') ->
-  JMeq v2 (sublist n1 n v') ->
+  v = v' ->
+  v1 = (sublist 0 n1 v') ->
+  v2 = (sublist n1 n v') ->
   data_at sh (Tarray t n noattr) v p |--
   data_at sh (Tarray t n1 noattr) v1 p *
   data_at sh (Tarray t (n - n1) noattr) v2
@@ -278,8 +278,7 @@ Proof.
   assert_PROP (Zlength v' = n). {
     eapply derives_trans; [apply data_at_local_facts | apply prop_derives].
     intros [? ?]. destruct H4 as [? _]. rewrite Z.max_r in H4 by omega.
-    rewrite <- H4. f_equal. apply JMeq_eq. eapply JMeq_trans; [apply @JMeq_sym; exact H0 |].
-    apply @JMeq_sym. apply (unfold_reptype_JMeq _ v).
+    rewrite <- H0. exact H4.
   }
   assert_PROP (field_compatible0 (Tarray t n noattr) (ArraySubsc n1::nil) p). {
      eapply derives_trans; [apply data_at_local_facts | apply prop_derives].
@@ -292,9 +291,9 @@ Proof.
   rewrite data_at_isptr at 1.
   unfold data_at at 1. intros; simpl; normalize.
   erewrite (field_at_Tarray sh  (Tarray t n noattr) _ t); try reflexivity; trivial.
-  2: omega. 2: eauto.
+  2: omega.
   rewrite (split2_array_at sh (Tarray t n noattr) nil 0 n1).
-  2: auto. 2: rewrite Z.sub_0_r; auto.
+  2: auto. 2: rewrite Z.sub_0_r, H0; auto.
   do 2 rewrite array_at_data_at by tauto.
   rewrite Zminus_0_r.
   unfold at_offset.
@@ -302,12 +301,12 @@ Proof.
             (nested_field_array_type (Tarray t n noattr) nil 0 n1)
             (Tarray t n1 noattr) _ v1).
   2: unfold nested_field_array_type; simpl; rewrite Zminus_0_r; trivial.
-  2: eapply JMeq_trans; [| apply @JMeq_sym, H1]; apply @fold_reptype_JMeq.
+  2: rewrite H1, H0; apply @fold_reptype_JMeq.
   erewrite (data_at_type_changable sh
             (nested_field_array_type (Tarray t n noattr) nil n1 n)
             (Tarray t (n - n1) noattr) _  v2).
   2: unfold nested_field_array_type; simpl; trivial.
-  2: eapply JMeq_trans; [| apply @JMeq_sym, H2]; subst n; apply @fold_reptype_JMeq.
+  2: rewrite H2, <- H3, H0; apply @fold_reptype_JMeq.
   rewrite !nested_field_offset_ind by (repeat split; auto; omega).
   rewrite !nested_field_type_ind.
   unfold gfield_offset.
@@ -319,9 +318,9 @@ Qed.
 Lemma split2_data_at_Tarray_fold {cs: compspecs} sh t n n1 v (v': list (reptype t)) v1 v2 p:
    0 <= n1 <= n ->
    n <= Zlength v' ->
-   JMeq v (sublist 0 n v') ->
-   JMeq v1 (sublist 0 n1 v') ->
-   JMeq v2 (sublist n1 n v') ->
+   v = (sublist 0 n v') ->
+   v1 = (sublist 0 n1 v') ->
+   v2 = (sublist n1 n v') ->
    data_at sh (Tarray t n1 noattr) v1 p *
    data_at sh (Tarray t (n - n1) noattr) v2
         (field_address0 (Tarray t n noattr) (ArraySubsc n1::nil) p)
@@ -344,20 +343,21 @@ Proof.
   } clear H3; rename H4 into H3.
   rewrite data_at_isptr at 1. unfold at_offset. intros; normalize.
   unfold data_at at 3.  erewrite field_at_Tarray; try reflexivity; eauto; try omega.
+  rewrite H0.
   rewrite (split2_array_at sh (Tarray t n noattr) nil 0 n1); trivial.
   2: autorewrite with sublist; auto.
-  change (@reptype cs
-            (@nested_field_type cs (Tarray t n noattr) (ArraySubsc 0 ::nil)))
-   with (@reptype cs t).
   autorewrite with sublist.
   unfold data_at at 1; erewrite field_at_Tarray; try reflexivity; eauto; try omega.
   unfold data_at at 1; erewrite field_at_Tarray; try reflexivity; eauto; try omega.
   apply sepcon_derives.
   unfold array_at.
-  simpl. apply andp_derives; auto; try apply derives_refl. 
+  rewrite H1.
+  simpl. apply andp_derives; auto.
+  2: apply derives_refl. 
   apply prop_derives. intuition.
   assert (sublist n1 (Z.min n (Zlength v')) v' = sublist n1 n v').
   f_equal. autorewrite with sublist. auto.
+  rewrite H2.
   clear - H H3.
   rewrite array_at_data_at by omega. normalize.
   rewrite array_at_data_at by omega.
@@ -369,21 +369,17 @@ Proof.
   rewrite !nested_field_type_ind. unfold gfield_offset.
   rewrite !Z.add_0_l. rewrite Z.mul_0_r, Z.add_0_r.
   apply equal_f.
-  apply data_at_type_changable.
+  apply data_at_type_changable; auto.
   unfold nested_field_array_type.
   rewrite !nested_field_type_ind.  unfold gfield_type. simpl. f_equal; omega.
-  unfold nested_field_array_type. simpl.
-  eapply JMeq_trans; [apply fold_reptype_JMeq |].
-  eapply JMeq_trans; [| eapply @JMeq_sym; apply fold_reptype_JMeq].
-  apply JMeq_refl.
 Qed.
 
 Lemma split2_data_at_Tarray {cs: compspecs} sh t n n1 v (v': list (reptype t)) v1 v2 p:
    0 <= n1 <= n ->
    n <= Zlength v' ->
-   JMeq v (sublist 0 n v') ->
-   JMeq v1 (sublist 0 n1 v') ->
-   JMeq v2 (sublist n1 n v') ->
+   v = (sublist 0 n v') ->
+   v1 = (sublist 0 n1 v') ->
+   v2 = (sublist n1 n v') ->
    data_at sh (Tarray t n noattr) v p =
     data_at sh (Tarray t n1 noattr) v1 p *
     data_at sh (Tarray t (n - n1) noattr) v2 (field_address0 (Tarray t n noattr) (ArraySubsc n1::nil) p).
@@ -464,10 +460,10 @@ Lemma split3_data_at_Tarray {cs: compspecs} sh t n n1 n2 v (v': list (reptype t)
    naturally_aligned t ->
    0 <= n1 <= n2 ->
    n2 <= n <= Zlength v' ->
-   JMeq v (sublist 0 n v') ->
-   JMeq v1 (sublist 0 n1 v') ->
-   JMeq v2 (sublist n1 n2 v') ->
-   JMeq v3 (sublist n2 n v') ->
+   v = (sublist 0 n v') ->
+   v1 = (sublist 0 n1 v') ->
+   v2 = (sublist n1 n2 v') ->
+   v3 = (sublist n2 n v') ->
    data_at sh (Tarray t n noattr) v p =
     data_at sh (Tarray t n1 noattr) v1 p *
     data_at sh (Tarray t (n2 - n1) noattr) v2 (field_address0 (Tarray t n noattr) (ArraySubsc n1::nil) p) *
@@ -476,27 +472,25 @@ Proof. intros until 1. rename H into NA; intros.
   destruct (field_compatible0_dec (tarray t n) (ArraySubsc n2::nil) p).
   erewrite (split2_data_at_Tarray sh t n n1); try eassumption; try omega.
   instantiate (1:= @fold_reptype cs (Tarray t (n - n1) noattr) (sublist n1 n v')).
-  2: apply @fold_reptype_JMeq.
+  2: reflexivity.
   erewrite (split2_data_at_Tarray sh t (n-n1) (n2-n1)); try eassumption; try omega.
   2: instantiate (1:= sublist n1 n v'); autorewrite with sublist; omega.
-  2: autorewrite with sublist;
-     apply @fold_reptype_JMeq.
+  2: autorewrite with sublist; auto.
   2: autorewrite with sublist;
      instantiate (1:= @fold_reptype cs (Tarray t (n2-n1) noattr) (sublist n1 n2 v'));
-     apply @fold_reptype_JMeq.
+     auto.
   2: autorewrite with sublist;
      instantiate (1:= @fold_reptype cs (Tarray t (n-n1-(n2-n1)) noattr) (sublist n2 n v'));
-     apply @fold_reptype_JMeq.
+     auto.
   rewrite sepcon_assoc.
-  f_equal. f_equal. f_equal. apply JMeq_eq.
-  eapply JMeq_trans; [apply fold_reptype_JMeq | apply @JMeq_sym, H3].
+  f_equal. f_equal. f_equal. auto.
   replace  (field_address0 (Tarray t (n - n1) noattr) (SUB (n2 - n1))
      (field_address0 (Tarray t n noattr) (SUB n1) p))
    with (field_address0 (Tarray t n noattr) (SUB n2) p).
   apply equal_f.
   apply data_at_type_changable.
   f_equal. omega.
-  eapply JMeq_trans; [apply @fold_reptype_JMeq |]; apply JMeq_sym; auto.
+  rewrite H4; eapply JMeq_trans; [apply @fold_reptype_JMeq |]; apply JMeq_sym; auto.
   rewrite field_address0_offset by auto with field_compatible.
   rewrite (field_address0_offset (Tarray t n noattr) ) by auto with field_compatible.
   rewrite field_address0_offset.
@@ -509,7 +503,7 @@ Proof. intros until 1. rename H into NA; intros.
   rewrite !nested_field_type_ind;   unfold gfield_offset.
   rewrite Z.add_0_l.
   eapply field_compatible0_Tarray_offset; try eassumption; try omega.
-  f_equal. f_equal. f_equal. omega.
+  f_equal. f_equal. omega.
   apply pred_ext.
   eapply derives_trans. apply data_at_local_facts. normalize.
   contradiction n0. auto with field_compatible.
@@ -612,7 +606,7 @@ Qed.
 Transparent sizeof.
 
 Lemma data_at_singleton_array {cs} sh t vl v p:
-  JMeq vl [v] ->
+  vl = [v] ->
   @data_at cs sh t v p |-- @data_at cs sh (tarray t 1) vl p.  
 Proof.
   intros. rename H into Heq.
@@ -630,7 +624,8 @@ Proof.
   }
   unfold data_at at 2.
   erewrite field_at_Tarray.
-  2: simpl; trivial. 2: reflexivity. 2: omega. 2: apply Heq.
+  2: simpl; trivial. 2: reflexivity. 2: omega. 2:apply JMeq_refl.
+  rewrite Heq.
   erewrite array_at_len_1 by apply JMeq_refl.
   rewrite field_at_data_at; simpl.
   rewrite field_address_offset; trivial.
@@ -639,16 +634,16 @@ Proof.
   eapply field_compatible_cons_Tarray. reflexivity. trivial. omega.
 Qed.
 
-Lemma data_at_singleton_array_inv {cs} sh t vl v p:
-  JMeq vl [v] ->
+Lemma data_at_singleton_array_inv {cs} sh t (vl : list (reptype t)) v p:
+  vl = [v] ->
   @data_at cs sh (tarray t 1) vl p |-- @data_at cs sh t v p.  
-Proof. 
+Proof.
   rewrite data_at_isptr. normalize.
   assert_PROP (field_compatible (tarray t 1) [] p).
   { eapply derives_trans. eapply data_at_local_facts. normalize. }
   unfold data_at at 1.
   erewrite field_at_Tarray.
-  2: simpl; trivial. 2: reflexivity. 2: omega. 2: apply H.
+  2: simpl; trivial. 2: reflexivity. 2: omega. 2: apply JMeq_refl.
   erewrite array_at_len_1. 2: apply JMeq_refl.
   rewrite field_at_data_at; simpl. 
   rewrite field_address_offset; trivial.
@@ -661,35 +656,36 @@ Qed.
 Opaque sizeof.
  
 Lemma data_at_singleton_array_eq {cs} sh t v vl p:
-  JMeq vl [v] ->
+  vl = [v] ->
   @data_at cs sh (tarray t 1) vl p = @data_at cs sh t v p.  
 Proof. 
   intros.
    apply pred_ext.
-  apply data_at_singleton_array_inv; auto.
+  apply data_at_singleton_array_inv; rewrite H; auto.
   apply data_at_singleton_array; auto.
 Qed.
 
 Lemma data_at_tuchar_singleton_array {cs} sh v p:
   @data_at cs sh tuchar v p |-- @data_at cs sh (tarray tuchar 1) [v] p.  
-Proof. apply data_at_singleton_array. apply JMeq_refl. Qed.
+Proof. apply data_at_singleton_array. reflexivity. Qed.
 
 Lemma data_at_tuchar_singleton_array_inv {cs} sh v p:
   @data_at cs sh (tarray tuchar 1) [v] p |-- @data_at cs sh tuchar v p.  
-Proof.   apply data_at_singleton_array_inv. apply JMeq_refl. Qed.
+Proof. apply data_at_singleton_array_inv. reflexivity. Qed.
 
 Lemma data_at_tuchar_singleton_array_eq {cs} sh v p:
   @data_at cs sh (tarray tuchar 1) [v] p = @data_at cs sh tuchar v p.  
-Proof. apply data_at_singleton_array_eq. apply JMeq_refl. Qed.
+Proof. apply data_at_singleton_array_eq. reflexivity. Qed.
 
 Lemma data_at_zero_array {cs} sh t v p:
   complete_legal_cosu_type t = true ->
   isptr p ->
-  JMeq v (@nil (reptype t)) ->
+  v = (@nil (reptype t)) ->
   emp |-- @data_at cs sh (tarray t 0) v p.  
 Proof. intros.
   unfold data_at. 
-  erewrite field_at_Tarray. 3: reflexivity. 3: omega. 3: eassumption. 2: simpl; trivial. 
+  erewrite field_at_Tarray. 3: reflexivity. 3: omega. 3: apply JMeq_refl. 2: simpl; trivial.
+  rewrite H1.
   rewrite array_at_len_0. apply andp_right; try apply derives_refl.
   apply prop_right.
   apply field_compatible0_ArraySubsc0.
@@ -700,18 +696,19 @@ Qed.
 
 Lemma data_at_zero_array_inv {cs} sh t v p:
   complete_legal_cosu_type t = true ->
-  JMeq v (@nil (reptype t)) ->
+  v = (@nil (reptype t)) ->
   @data_at cs sh (tarray t 0) v p |-- emp.  
 Proof. intros.
   unfold data_at. 
-  erewrite field_at_Tarray. 3: reflexivity. 3: omega. 3: apply H0. 2: simpl; trivial. 
+  erewrite field_at_Tarray. 3: reflexivity. 3: omega. 3: rewrite H0; apply JMeq_refl. 2: simpl; trivial.
+  rewrite H0.
   rewrite array_at_len_0. normalize. 
 Qed.
 
 Lemma data_at_zero_array_eq {cs} sh t v p:
   complete_legal_cosu_type t = true ->
   isptr p ->
-  JMeq v (@nil (reptype t)) ->
+  v = (@nil (reptype t)) ->
   @data_at cs sh (tarray t 0) v p = emp.
 Proof. intros. 
   apply pred_ext.
@@ -766,7 +763,7 @@ trivial.
 simpl.
 instantiate (1:=list_repeat (Z.to_nat n) Vundef).
 list_solve.
-unfold default_val. simpl. autorewrite with sublist. apply JMeq_refl. 
-unfold default_val. simpl. autorewrite with sublist. apply JMeq_refl. 
-unfold default_val. simpl. autorewrite with sublist. apply JMeq_refl.
+unfold default_val. simpl. autorewrite with sublist. reflexivity.
+unfold default_val. simpl. autorewrite with sublist. reflexivity.
+unfold default_val. simpl. autorewrite with sublist. reflexivity.
 Qed. 

--- a/floyd/field_compat.v
+++ b/floyd/field_compat.v
@@ -301,12 +301,12 @@ Proof.
             (nested_field_array_type (Tarray t n noattr) nil 0 n1)
             (Tarray t n1 noattr) _ v1).
   2: unfold nested_field_array_type; simpl; rewrite Zminus_0_r; trivial.
-  2: rewrite H1, H0; apply @fold_reptype_JMeq.
+  2: rewrite H1, H0; auto.
   erewrite (data_at_type_changable sh
             (nested_field_array_type (Tarray t n noattr) nil n1 n)
             (Tarray t (n - n1) noattr) _  v2).
   2: unfold nested_field_array_type; simpl; trivial.
-  2: rewrite H2, <- H3, H0; apply @fold_reptype_JMeq.
+  2: rewrite H2, <- H3, H0; auto.
   rewrite !nested_field_offset_ind by (repeat split; auto; omega).
   rewrite !nested_field_type_ind.
   unfold gfield_offset.
@@ -471,16 +471,16 @@ Lemma split3_data_at_Tarray {cs: compspecs} sh t n n1 n2 v (v': list (reptype t)
 Proof. intros until 1. rename H into NA; intros.
   destruct (field_compatible0_dec (tarray t n) (ArraySubsc n2::nil) p).
   erewrite (split2_data_at_Tarray sh t n n1); try eassumption; try omega.
-  instantiate (1:= @fold_reptype cs (Tarray t (n - n1) noattr) (sublist n1 n v')).
+  instantiate (1:= sublist n1 n v').
   2: reflexivity.
   erewrite (split2_data_at_Tarray sh t (n-n1) (n2-n1)); try eassumption; try omega.
   2: instantiate (1:= sublist n1 n v'); autorewrite with sublist; omega.
   2: autorewrite with sublist; auto.
   2: autorewrite with sublist;
-     instantiate (1:= @fold_reptype cs (Tarray t (n2-n1) noattr) (sublist n1 n2 v'));
+     instantiate (1:= sublist n1 n2 v');
      auto.
   2: autorewrite with sublist;
-     instantiate (1:= @fold_reptype cs (Tarray t (n-n1-(n2-n1)) noattr) (sublist n2 n v'));
+     instantiate (1:= sublist n2 n v');
      auto.
   rewrite sepcon_assoc.
   f_equal. f_equal. f_equal. auto.
@@ -488,9 +488,8 @@ Proof. intros until 1. rename H into NA; intros.
      (field_address0 (Tarray t n noattr) (SUB n1) p))
    with (field_address0 (Tarray t n noattr) (SUB n2) p).
   apply equal_f.
-  apply data_at_type_changable.
-  f_equal. omega.
-  rewrite H4; eapply JMeq_trans; [apply @fold_reptype_JMeq |]; apply JMeq_sym; auto.
+  replace (n - n1 - (n2 - n1)) with (n - n2) by omega.
+  subst v3; reflexivity.
   rewrite field_address0_offset by auto with field_compatible.
   rewrite (field_address0_offset (Tarray t n noattr) ) by auto with field_compatible.
   rewrite field_address0_offset.

--- a/floyd/globals_lemmas.v
+++ b/floyd/globals_lemmas.v
@@ -464,8 +464,8 @@ simpl map.
 unfold id2pred_star; fold @id2pred_star.
 erewrite (split2_data_at_Tarray sh t (Z.succ (Zlength data)) 1).
 4: rewrite sublist_same.
-4: apply JMeq_refl.
-2: list_solve. 2: list_solve. 2: auto. 2: list_solve. 2: apply JMeq_refl. 2: apply JMeq_refl.
+4: apply eq_refl.
+2: list_solve. 2: list_solve. 2: auto. 2: list_solve. 2: apply eq_refl. 2: apply eq_refl.
 rewrite (sublist_one) by list_solve.
 autorewrite with sublist.
 rewrite sublist_1_cons.
@@ -474,7 +474,7 @@ rewrite sublist_same by list_solve.
 apply sepcon_derives.
 +
 clear IHdata.
-fold (tarray t 1). erewrite data_at_singleton_array_eq by apply JMeq_refl.
+fold (tarray t 1). erewrite data_at_singleton_array_eq by apply eq_refl.
 rewrite <- (mapsto_data_at sh t (Vint (Cop.cast_int_int sz sign a)) (Vint (Cop.cast_int_int sz sign a)) v); try reflexivity; auto.
 2: subst t; destruct sz, sign; reflexivity.
 Focus 2. {

--- a/floyd/reptype_lemmas.v
+++ b/floyd/reptype_lemmas.v
@@ -144,9 +144,7 @@ Definition reptype_gen {cs: compspecs} : type -> (sigT (fun x => x)) :=
      if (type_is_by_value t)
      then existT (fun x => x) val Vundef
      else existT (fun x => x) unit tt)
-  (fun t n a TV => match TV with existT T V =>
-                     existT (fun x => x) (list T) (list_repeat (Z.to_nat n) V)
-                   end)
+  (fun t n a TV => existT (fun x => x) (list (projT1 TV)) (list_repeat (Z.to_nat n) (projT2 TV)))
   (fun id a TVs => existT (fun x => x) (compact_prod_sigT_type (decay TVs)) (compact_prod_sigT_value (decay TVs)))
   (fun id a TVs => existT (fun x => x) (compact_sum_sigT_type (decay TVs)) (compact_sum_sigT_value (decay TVs))).
 
@@ -165,8 +163,7 @@ Context {cs: compspecs}.
 Lemma reptype_gen_eq: forall t,
   reptype_gen t =
   match t with
-  | Tarray t0 n _ => match reptype_gen t0
-                                 with existT T V => existT (fun x => x) (list T) (list_repeat (Z.to_nat n) V) end
+  | Tarray t0 n _ => existT (fun x => x) (list (projT1 (reptype_gen t0))) (list_repeat (Z.to_nat n) (projT2 (reptype_gen t0)))
   | Tstruct id _ => existT (fun x => x)
                      (compact_prod_sigT_type (map reptype_gen (map (fun it => field_type (fst it) (co_members (get_co id))) (co_members (get_co id)))))
                      (compact_prod_sigT_value (map reptype_gen (map (fun it => field_type (fst it) (co_members (get_co id))) (co_members (get_co id)))))
@@ -213,9 +210,6 @@ Proof.
   unfold reptype.
   rewrite reptype_gen_eq.
   destruct t as [| | | | | | | id ? | id ?]; auto.
-  + unfold reptype, default_val.
-    destruct (reptype_gen t).
-    reflexivity.
   + unfold compact_prod_sigT_type.
     pose proof get_co_members_no_replicate id.
     forget (co_members (get_co id)) as m.
@@ -412,9 +406,6 @@ Proof.
   unfold reptype at 1.
   rewrite reptype_gen_eq.
   destruct t; auto.
-  + unfold reptype, default_val.
-    destruct (reptype_gen t).
-    apply JMeq_refl.
   + unfold struct_default_val.
     rewrite map_map.
     apply (compact_prod_sigT_compact_prod_gen

--- a/floyd/stronger.v
+++ b/floyd/stronger.v
@@ -145,6 +145,8 @@ Proof.
   simpl.
   extensionality Vundef.
   f_equal. f_equal.
+  change (unfold_reptype v0) with v0.
+  change (unfold_reptype v1) with v1.
   rewrite H. auto.
 *
   assert_PROP (Zlength (unfold_reptype v0) = n). {

--- a/hmacdrbg/HMAC_DRBG_common_lemmas.v
+++ b/hmacdrbg/HMAC_DRBG_common_lemmas.v
@@ -123,7 +123,7 @@ Proof.
 Qed.
 
 Lemma data_at_complete_split:
-  forall A B lengthA lengthB AB length p offset sh,
+  forall (A B: list val) lengthA lengthB AB length p offset sh,
     field_compatible (tarray tuchar (Zlength A + Zlength B)) [] p ->
     lengthA = Zlength A ->
     lengthB = Zlength B ->

--- a/progs/verif_strlib.v
+++ b/progs/verif_strlib.v
@@ -157,36 +157,6 @@ forward_loop (EX i : Z,
  entailer!.
 Qed.
 
-Lemma split_data_at_app:
- forall sh t n (al bl: list (reptype t)) abl'
-         (al': reptype (tarray t (Zlength al)))
-         (bl': reptype (tarray t (n - Zlength al)))
-          p ,
-   n = Zlength (al++bl) ->
-   JMeq abl' (al++bl) ->
-   JMeq al' al ->
-   JMeq bl' bl ->
-   data_at sh (tarray t n) abl' p = 
-         data_at sh (tarray t (Zlength al)) al' p
-        * data_at sh (tarray t (n - Zlength al)) bl'
-                 (field_address0 (tarray t n) [ArraySubsc (Zlength al)] p).
-Proof.
-intros.
-unfold tarray.
-erewrite split2_data_at_Tarray.
-4: rewrite sublist_same; [eassumption | auto | auto ].
-4: rewrite sublist_app1.
-4: rewrite sublist_same; [eassumption | auto | auto ].
-2: rewrite Zlength_app in H by list_solve; list_solve.
-2: rewrite Zlength_app in H by list_solve; list_solve.
-2: list_solve.
-2: omega.
-2: rewrite sublist_app2.
-2: rewrite sublist_same; [eassumption | auto | auto ].
-auto.
-all: rewrite Zlength_app in H; rep_omega.
-Qed.
-
 Lemma split_data_at_app_tschar:
  forall sh n (al bl: list val) p ,
    n = Zlength (al++bl) ->
@@ -196,7 +166,9 @@ Lemma split_data_at_app_tschar:
                  (field_address0 (tarray tschar n) [ArraySubsc (Zlength al)] p).
 Proof.
 intros.
-apply (split_data_at_app sh tschar n al bl (al++bl)); auto.
+apply (split2_data_at_Tarray_app _ n  sh tschar al bl ); auto.
+rewrite Zlength_app in H.
+change ( Zlength bl = n - Zlength al); omega.
 Qed.
 
 Lemma body_strcat: semax_body Vprog Gprog f_strcat strcat_spec.

--- a/progs/verif_sumarray2.v
+++ b/progs/verif_sumarray2.v
@@ -98,31 +98,6 @@ apply H; auto.
 apply sublist_In in H0. auto.
 Qed.
 
-
-Lemma split_array:
- forall {cs: compspecs} mid n (sh: Share.t) (t: type)
-                            v (v1' v2': list (reptype t)) v1 v2 p,
-    Zlength v1' = mid ->
-    Zlength v2' = n-mid ->
-    JMeq v (v1'++v2') ->
-    JMeq v1 v1' ->
-    JMeq v2 v2' ->
-    data_at sh (tarray t n) v p =
-    data_at sh (tarray t mid) v1  p *
-    data_at sh (tarray t (n-mid)) v2
-            (field_address0 (tarray t n) [ArraySubsc mid] p).
-Proof.
-intros.
-pose proof (Zlength_nonneg v1').
-pose proof (Zlength_nonneg v2').
-apply split2_data_at_Tarray with (v1'++v2'); auto.
-omega.
-list_solve.
-autorewrite with sublist; auto.
-autorewrite with sublist; auto.
-autorewrite with sublist; auto.
-Qed.
-
 Lemma body_main:  semax_body Vprog Gprog f_main main_spec.
 Proof.
 start_function.
@@ -135,7 +110,7 @@ assert (Forall (fun x : Z => Int.min_signed <= x <= Int.max_signed) four_content
   by (repeat constructor; computable).
  rewrite <- (sublist_same 0 4 contents), (sublist_split 0 2 4)
     by now autorewrite with sublist.
-erewrite (split_array 2 4); try apply JMeq_refl; auto; try omega; try reflexivity.
+erewrite (split2_data_at_Tarray_app 2 4); try apply JMeq_refl; auto; try omega; try reflexivity.
 Intros.
 forward_call (*  s = sumarray(four+2,2); *)
   (field_address0 (tarray tuint 4) [ArraySubsc 2] four, Ews,
@@ -147,7 +122,7 @@ forward_call (*  s = sumarray(four+2,2); *)
 + split. auto. computable.
 +
   gather_SEP 1 2.
-  erewrite <- (split_array 2 4); try apply JMeq_refl; auto; try omega; try reflexivity.
+  erewrite <- (split2_data_at_Tarray_app 2 4); try apply JMeq_refl; auto; try omega; try reflexivity.
   rewrite <- !sublist_map. fold contents. autorewrite with sublist.
   rewrite (sublist_same 0 4) by auto.
   forward. (* return *)

--- a/sha/call_memcpy.v
+++ b/sha/call_memcpy.v
@@ -408,7 +408,6 @@ eapply semax_pre_post';
  unfold nested_field_array_type.
  rewrite nested_field_type_ind. rewrite H1. simpl.
  unfold tarray; f_equal; clear; omega.
- eapply JMeq_trans; [apply fold_reptype_JMeq |].
    rewrite <- sublist_map.
    apply JMeq_sublist; auto.
  rewrite array_at_data_at' by (try solve [clear - FC; intuition]; omega).
@@ -474,7 +473,6 @@ repeat apply sepcon_derives.
    unfold nested_field_array_type.
    rewrite nested_field_type_ind, H0.
    unfold tarray; f_equal. clear; omega.
-   eapply JMeq_trans; [| apply @JMeq_sym, fold_reptype_JMeq].
   admit. (* tedious *)
 +
  apply array_at_ext_derives.
@@ -495,7 +493,6 @@ repeat apply sepcon_derives.
    unfold nested_field_array_type.
    rewrite nested_field_type_ind, H1.
    unfold tarray; f_equal. clear; omega.
-   eapply JMeq_trans; [| apply @JMeq_sym, fold_reptype_JMeq].
    apply JMeq_sublist.
    rewrite nested_field_type_ind, H1. reflexivity.
    apply @JMeq_sym; auto.
@@ -694,7 +691,6 @@ cancel.
    unfold nested_field_array_type.
    rewrite nested_field_type_ind, H0.
    unfold tarray; f_equal. clear; omega.
-   eapply JMeq_trans; [| apply @JMeq_sym, fold_reptype_JMeq].
    apply (JMeq_sublist _ _ lop (lop + len) _ _ (eq_sym H99)) in H8.
    eapply JMeq_trans, H8.
    apply eq_JMeq.

--- a/tweetnacl20140427/split_array_lemmas.v
+++ b/tweetnacl20140427/split_array_lemmas.v
@@ -563,7 +563,7 @@ Proof.
 Qed.
 *)
 
-Definition Select_at {cs} sh n data2 d :=
+Definition Select_at {cs} sh n (data2: list val) d :=
    @data_at cs sh (Tarray tuchar (Zlength data2) noattr) data2
              (offset_val n d).
 
@@ -572,7 +572,7 @@ Definition Unselect_at {cs} sh (data1 data2 data3: list val) d :=
    @data_at cs sh (Tarray tuchar (Zlength data3) noattr) data3
              (offset_val (Zlength data2 + Zlength data1) d)).
 
-Lemma Select_Unselect_Tarray_at {cs} l d sh data1 data2 data3 data
+Lemma Select_Unselect_Tarray_at {cs} l d sh (data1 data2 data3 data: list val)
   (DATA: (data1 ++ data2 ++ data3) = data)
   (L: l = Zlength data)
   (F: @field_compatible cs (Tarray tuchar (Zlength (data1 ++ data2 ++ data3)) noattr) [] d)
@@ -585,6 +585,7 @@ Proof.
   specialize (Zlength_nonneg data2). intros.
   specialize (Zlength_nonneg data3). intros.
   rewrite split3_data_at_Tarray_tuchar with (n1:=Zlength data1)(n2:=Zlength data2 +Zlength data1); try omega.
+Locate split3_data_at_Tarray_tuchar.
   autorewrite with sublist.
   unfold Select_at, Unselect_at. simpl.
   unfold offset_val. red in F. destruct d; intuition.

--- a/tweetnacl20140427/verif_fcore_epilogue_htrue.v
+++ b/tweetnacl20140427/verif_fcore_epilogue_htrue.v
@@ -481,7 +481,7 @@ Sfor (Sset _i (Econst_int (Int.repr 0) tint))
      (Sset _i
         (Ebinop Oadd (Etempvar _i tint) (Econst_int (Int.repr 1) tint) tint)).
 
-Lemma HTrue_loop3 Espec (FR:mpred) t y x w nonce out c k h OUT xs (*ys Nonce C K*):
+Lemma HTrue_loop3 Espec (FR:mpred) t y x w nonce out c k h (OUT: list val) xs (*ys Nonce C K*):
 @semax CompSpecs Espec
   (initialized_list [_i] (func_tycontext f_core SalsaVarSpecs SalsaFunSpecs nil))
   (PROP  ()
@@ -747,7 +747,7 @@ Definition epilogue_htrue_statement:=
               (Ebinop Oadd (Etempvar _i tint) (Econst_int (Int.repr 1) tint)
                  tint)))).
 
-Lemma verif_fcore_epilogue_htrue Espec (FR:mpred) t y x w nonce out c k h OUT xs ys data:
+Lemma verif_fcore_epilogue_htrue Espec (FR:mpred) t y x w nonce out c k h (OUT: list val) xs ys data:
 @semax CompSpecs Espec
   (initialized_list [_i] (func_tycontext f_core SalsaVarSpecs SalsaFunSpecs nil))
   (PROP  ()


### PR DESCRIPTION
Now, reptype (tarray t _) is reducible to (list (reptype t)). Previously they are only provably equal.

Test whether examples work efficiently.