### PR TITLE
Switch iter_sepcon argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,8 @@ PROGS_FILES= \
   verif_sumarray2.v verif_switch.v verif_message.v verif_object.v \
   funcptr.v verif_funcptr.v tutorial1.v  \
   verif_int_or_ptr.v verif_union.v verif_cast_test.v verif_dotprod.v \
-  verif_strlib.v verif_fib.v bug83.v
+  verif_strlib.v verif_fib.v bug83.v \
+  tree.v verif_tree.v
 # verif_insertion_sort.v
 
 SHA_FILES= \
@@ -361,7 +362,7 @@ AES_FILES = \
 # SINGLE_C_FILES are those to be clightgen'd individually with -normalize flag
 # LINKED_C_FILES are those that need to be clightgen'd in a batch with others
 
-SINGLE_C_FILES = reverse.c reverse_client.c revarray.c queue.c queue2.c message.c object.c insertionsort.c float.c global.c logical_compare.c nest2.c nest3.c ptr_compare.c load_demo.c store_demo.c dotprod.c string.c field_loadstore.c merge.c append.c bin_search.c bst.c bst_oo.c min.c switch.c funcptr.c floyd_tests.c incr.c cond.c sumarray.c sumarray2.c int_or_ptr.c union.c cast_test.c strlib.c
+SINGLE_C_FILES = reverse.c reverse_client.c revarray.c queue.c queue2.c message.c object.c insertionsort.c float.c global.c logical_compare.c nest2.c nest3.c ptr_compare.c load_demo.c store_demo.c dotprod.c string.c field_loadstore.c merge.c append.c bin_search.c bst.c bst_oo.c min.c switch.c funcptr.c floyd_tests.c incr.c cond.c sumarray.c sumarray2.c int_or_ptr.c union.c cast_test.c strlib.c tree.c
 
 LINKED_C_FILES = even.c odd.c
 C_FILES = $(SINGLE_C_FILES) $(LINKED_C_FILES)

--- a/msl/iter_sepcon.v
+++ b/msl/iter_sepcon.v
@@ -54,22 +54,26 @@ Section IterSepCon.
   Context {ClS: ClassicalSep A}.
   Context {CoSL: CorableSepLog A}.
 
-Fixpoint iter_sepcon (l : list B) : (B -> A) -> A :=
+Section SingleSepPred.
+
+  Context (p : B -> A).
+
+Fixpoint iter_sepcon (l : list B) : A :=
   match l with
-    | nil => fun _ => emp
-    | x :: xl => fun p => p x * iter_sepcon xl p
+    | nil => emp
+    | x :: xl => p x * iter_sepcon xl
   end.
 
 Lemma iter_sepcon_app:
-  forall (l1 l2 : list B) (p : B -> A), iter_sepcon (l1 ++ l2) p = iter_sepcon l1 p * iter_sepcon l2 p.
+  forall (l1 l2 : list B), iter_sepcon (l1 ++ l2) = iter_sepcon l1 * iter_sepcon l2.
 Proof.
   induction l1; intros; simpl. rewrite emp_sepcon; auto. rewrite IHl1. rewrite sepcon_assoc. auto.
 Qed.
 
-Lemma iter_sepcon_app_comm: forall (l1 l2 : list B) (p : B -> A), iter_sepcon (l1 ++ l2) p = iter_sepcon (l2 ++ l1) p.
+Lemma iter_sepcon_app_comm: forall (l1 l2 : list B), iter_sepcon (l1 ++ l2) = iter_sepcon (l2 ++ l1).
 Proof. intros. do 2 rewrite iter_sepcon_app. rewrite sepcon_comm. auto. Qed.
 
-Lemma iter_sepcon_permutation: forall  (l1 l2 : list B) (p : B -> A), Permutation l1 l2 -> iter_sepcon l1 p = iter_sepcon l2 p.
+Lemma iter_sepcon_permutation: forall  (l1 l2 : list B), Permutation l1 l2 -> iter_sepcon l1 = iter_sepcon l2.
 Proof.
   intros. induction H; simpl; auto.
   + rewrite IHPermutation. auto.
@@ -77,29 +81,29 @@ Proof.
   + rewrite IHPermutation1. auto.
 Qed.
 
-Lemma iter_sepcon_in_true: forall (p : B -> A) (l : list B) x, In x l -> iter_sepcon l p |-- p x * TT.
+Lemma iter_sepcon_in_true: forall (l : list B) x, In x l -> iter_sepcon l |-- p x * TT.
 Proof.
   intros. apply in_split in H. destruct H as [l1 [l2 ?]]. subst.
   rewrite iter_sepcon_app_comm. rewrite <- app_comm_cons. simpl.
   apply sepcon_derives; auto. apply TT_right.
 Qed.
 
-Lemma iter_sepcon_incl_true: forall (p : B -> A) (l s: list B),
-    NoDup s -> incl s l -> iter_sepcon l p |-- iter_sepcon s p * TT.
+Lemma iter_sepcon_incl_true: forall (l s: list B),
+    NoDup s -> incl s l -> iter_sepcon l |-- iter_sepcon s * TT.
 Proof.
   intros. destruct (incl_Permutation l s H H0) as [l' ?].
-  apply (iter_sepcon_permutation p) in H1. rewrite H1, iter_sepcon_app.
+  apply iter_sepcon_permutation in H1. rewrite H1, iter_sepcon_app.
   apply sepcon_derives; auto. apply TT_right.
 Qed.
 
-Lemma iter_sepcon_unique_nodup: forall (p : B -> A) (l : list B), sepcon_unique1 p -> iter_sepcon l p |-- !!(NoDup l).
+Lemma iter_sepcon_unique_nodup: forall (l : list B), sepcon_unique1 p -> iter_sepcon l |-- !!(NoDup l).
 Proof.
   intros. induction l.
   + apply prop_right. constructor.
   + simpl.
-    assert (p a * iter_sepcon l p |-- !!(~ In a l)). {
+    assert (p a * iter_sepcon l |-- !!(~ In a l)). {
       apply not_prop_right.
-      intros. apply (iter_sepcon_in_true p) in H0.
+      intros. apply iter_sepcon_in_true in H0.
       apply derives_trans with (p a * p a * TT).
       + rewrite sepcon_assoc. apply sepcon_derives. apply derives_refl. auto.
       + specialize (H a). apply derives_trans with (FF * TT).
@@ -110,31 +114,7 @@ Proof.
   - normalize. constructor; auto.
 Qed.
 
-Lemma iter_sepcon_func: forall l P Q, (forall x, P x = Q x) -> iter_sepcon l P = iter_sepcon l Q.
-Proof. intros. induction l; simpl; [|f_equal]; auto. Qed.
-
-Lemma iter_sepcon_func_strong: forall l P Q, (forall x, In x l -> P x = Q x) -> iter_sepcon l P = iter_sepcon l Q.
-Proof.
-  intros. induction l.
-  + reflexivity.
-  + simpl.
-    f_equal.
-    - apply H.
-      simpl; auto.
-    - apply IHl.
-      intros; apply H.
-      simpl; auto.
-Qed. 
-
-Instance iter_sepcon_permutation_proper : Proper ((@Permutation B) ==> (pointwise_relation B eq) ==> eq) iter_sepcon.
-Proof.
-  repeat intro. transitivity (iter_sepcon x y0).
-  + apply iter_sepcon_func.
-    exact H0.
-  + apply iter_sepcon_permutation. auto.
-Qed.
-
-Lemma iter_sepcon_emp: forall (p : B -> A) (l l' : list B), (forall x, p x |-- emp) -> NoDup l' -> incl l' l -> iter_sepcon l p |-- iter_sepcon l' p.
+Lemma iter_sepcon_emp: forall (l l' : list B), (forall x, p x |-- emp) -> NoDup l' -> incl l' l -> iter_sepcon l |-- iter_sepcon l'.
 Proof.
   intros.
   revert l H1; induction l'; intros.
@@ -167,42 +147,45 @@ Proof.
     apply sepcon_derives; auto.
 Qed.
 
-Lemma iter_sepcon_nil: forall (p : B -> A), iter_sepcon nil p = emp.
+Lemma iter_sepcon_nil: iter_sepcon nil = emp.
 Proof. intros; reflexivity. Qed.
+
+End SingleSepPred.
+
+Lemma iter_sepcon_func: forall l P Q, (forall x, P x = Q x) -> iter_sepcon P l = iter_sepcon Q l.
+Proof. intros. induction l; simpl; [|f_equal]; auto. Qed.
+
+Lemma iter_sepcon_func_strong: forall l P Q, (forall x, In x l -> P x = Q x) -> iter_sepcon P l = iter_sepcon Q l.
+Proof.
+  intros. induction l.
+  + reflexivity.
+  + simpl.
+    f_equal.
+    - apply H.
+      simpl; auto.
+    - apply IHl.
+      intros; apply H.
+      simpl; auto.
+Qed. 
+
+Instance iter_sepcon_permutation_proper : Proper ((pointwise_relation B eq) ==> (@Permutation B) ==> eq) iter_sepcon.
+Proof.
+  repeat intro. transitivity (iter_sepcon x y0).
+  + apply iter_sepcon_permutation. auto.
+  + apply iter_sepcon_func.
+    exact H.
+Qed.
 
 End IterSepCon.
 
 Lemma iter_sepcon_map: forall {A B C: Type} {ND : NatDed A} {SL : SepLog A} (l : list C) (f : B -> A) (g: C -> B),
-                         iter_sepcon l (fun x : C => f (g x)) = iter_sepcon (map g l) f.
+                         iter_sepcon (fun x : C => f (g x)) l = iter_sepcon f (map g l).
 Proof. intros. induction l; simpl; [|f_equal]; auto. Qed.
 
 Global Existing Instance iter_sepcon_permutation_proper.
 
-Section IterSepCon'.
-
-  Context {A : Type}.
-  Context {B : Type}.
-  Context {ND : NatDed A}.
-  Context {SL : SepLog A}.
-  Context {ClS: ClassicalSep A}.
-  Context {CoSL: CorableSepLog A}.
-  Context (p : B -> A).
-
-Fixpoint iter_sepcon' (l : list B) : A :=
-  match l with
-    | nil => emp
-    | x :: xl => p x * iter_sepcon' xl
-  end.
-
-Lemma iter_sepcon'_spec: forall l,
-  iter_sepcon' l = iter_sepcon l p.
-Proof.
-  induction l; auto.
-  simpl.
-  rewrite IHl; auto.
-Qed.
-
-End IterSepCon'.
+Definition uncurry {A B C} (f: A -> B -> C) (xy: A*B) : C :=
+  f (fst xy) (snd xy).
 
 Section IterSepCon2.
 
@@ -212,26 +195,24 @@ Section IterSepCon2.
   Context {SL : SepLog A}.
   Context {ClS: ClassicalSep A}.
   Context {CoSL: CorableSepLog A}.
+  Context (p : B1 -> B2 -> A).
 
-Fixpoint iter_sepcon2 (l1 : list B1) : list B2 -> (B1 -> B2 -> A) -> A :=
-  match l1 with
-  | nil => fun l2 _ =>
-    match l2 with
-    | nil => emp
-    | _ => FF
-    end
-  | x :: xl => fun l2 p =>
-    match l2 with
-    | nil => FF
-    | y :: yl => p x y * iter_sepcon2 xl yl p
-    end
+Fixpoint iter_sepcon2 (l : list B1) : list B2 -> A :=
+    match l with
+    | nil => fun l2 =>
+       match l2 with
+       | nil => emp
+       | _ => FF
+       end
+    | x :: xl => fun l' =>
+       match l' with
+       | nil => FF
+       | y :: yl => p x y * iter_sepcon2 xl yl
+       end
   end.
 
-Definition uncurry {A B C} (f: A -> B -> C) (xy: A*B) : C :=
-  f (fst xy) (snd xy).
-
-Lemma iter_sepcon2_spec: forall l1 l2 p,
-  iter_sepcon2 l1 l2 p = EX l: list (B1 * B2), !! (l1 = map fst l /\ l2 = map snd l) && iter_sepcon l (uncurry p).
+Lemma iter_sepcon2_spec: forall l1 l2,
+  iter_sepcon2 l1 l2 = EX l: list (B1 * B2), !! (l1 = map fst l /\ l2 = map snd l) && iter_sepcon (uncurry p) l.
 Proof.
   intros.
   apply pred_ext.
@@ -264,64 +245,6 @@ Qed.
 
 End IterSepCon2.
 
-Section IterSepCon2'.
-
-  Context {A : Type}.
-  Context {B1 B2 : Type}.
-  Context {ND : NatDed A}.
-  Context {SL : SepLog A}.
-  Context {ClS: ClassicalSep A}.
-  Context {CoSL: CorableSepLog A}.
-  Context (p : B1 -> B2 -> A).
-
-Fixpoint iter_sepcon2' (l : list B1) : list B2 -> A :=
-    match l with
-    | nil => fun l2 =>
-       match l2 with
-       | nil => emp
-       | _ => FF
-       end
-    | x :: xl => fun l' =>
-       match l' with
-       | nil => FF
-       | y :: yl => p x y * iter_sepcon2' xl yl
-       end
-  end.
-
-Lemma iter_sepcon2'_spec: forall l1 l2,
-  iter_sepcon2' l1 l2 = EX l: list (B1 * B2), !! (l1 = map fst l /\ l2 = map snd l) && iter_sepcon l (uncurry p).
-Proof.
-  intros.
-  apply pred_ext.
-  + revert l2; induction l1; intros; destruct l2.
-    - apply (exp_right nil); simpl.
-      apply andp_right; auto.
-      apply prop_right; auto.
-    - simpl.
-      apply FF_left.
-    - simpl.
-      apply FF_left.
-    - simpl.
-      specialize (IHl1 l2).
-      eapply derives_trans; [apply sepcon_derives; [apply derives_refl | apply IHl1] | clear IHl1].
-      normalize.
-      destruct H.
-      apply (exp_right ((a, b) :: l)).
-      simpl.
-      apply andp_right; [apply prop_right; subst; auto |].
-      apply derives_refl.
-  + apply exp_left; intros l.
-    normalize.
-    destruct H; subst.
-    induction l.
-    - simpl. auto.
-    - simpl.
-      eapply derives_trans; [apply sepcon_derives; [apply derives_refl | apply IHl] | clear IHl].
-      apply derives_refl.
-Qed.
-
-End IterSepCon2'.
-
 Section IterPredSepCon.
 
   Context {A : Type}.
@@ -330,12 +253,12 @@ Section IterPredSepCon.
   Context {SL : SepLog A}.
   Context {ClS: ClassicalSep A}.
 
-Definition pred_sepcon (P: B -> Prop) (p: B -> A): A :=
-  EX l: list B, !! (forall x, In x l <-> P x) && !! NoDup l && iter_sepcon l p.
+Definition pred_sepcon (p: B -> A) (P: B -> Prop): A :=
+  EX l: list B, !! (forall x, In x l <-> P x) && !! NoDup l && iter_sepcon p l.
 
 Lemma pred_sepcon_eq: forall (P: B -> Prop) (p: B -> A),
-    pred_sepcon P p = 
-    (EX l: list B, !! ((forall x, In x l <-> P x) /\ NoDup l) && iter_sepcon l p).
+    pred_sepcon p P = 
+    (EX l: list B, !! ((forall x, In x l <-> P x) /\ NoDup l) && iter_sepcon p l).
 Proof.
   intros. unfold pred_sepcon. f_equal. extensionality l. rewrite prop_and. auto.
 Qed.
@@ -343,12 +266,12 @@ Qed.
 Lemma pred_sepcon_strong_proper: forall P1 P2 p1 p2,
   (forall x, P1 x <-> P2 x) ->
   (forall x, P1 x -> P2 x -> p1 x = p2 x) ->
-  pred_sepcon P1 p1 = pred_sepcon P2 p2.
+  pred_sepcon p1 P1 = pred_sepcon p2 P2.
 Proof.
   assert (forall P1 P2 p1 p2,
     (forall x, P1 x <-> P2 x) ->
     (forall x, P1 x -> P2 x -> p1 x = p2 x) ->
-    pred_sepcon P1 p1 |-- pred_sepcon P2 p2).
+    pred_sepcon p1 P1 |-- pred_sepcon p2 P2).
   2: intros; apply pred_ext; apply H; [auto | auto | symmetry; auto | symmetry; auto].
   intros.
   unfold pred_sepcon.
@@ -362,7 +285,7 @@ Proof.
   apply H0; tauto.
 Qed.
 
-Instance pred_sepcon_proper: Proper (pointwise_relation B iff ==> pointwise_relation B eq ==> eq) pred_sepcon.
+Instance pred_sepcon_proper: Proper (pointwise_relation B eq ==> pointwise_relation B iff ==> eq) pred_sepcon.
 Proof.
   intros.
   do 2 (hnf; intros).
@@ -372,7 +295,7 @@ Defined.
 Global Existing Instance pred_sepcon_proper.
 
 Lemma pred_sepcon1: forall p x0,
-  pred_sepcon (fun x => x = x0) p = p x0.
+  pred_sepcon p (fun x => x = x0) = p x0.
 Proof.
   intros.
   unfold pred_sepcon.
@@ -459,7 +382,7 @@ Qed.
 
 Lemma pred_sepcon_unique_sepcon1: forall (P: B -> Prop) p x0,
   sepcon_unique1 p ->
-  pred_sepcon P p * p x0 |-- !! (~ P x0).
+  pred_sepcon p P * p x0 |-- !! (~ P x0).
 Proof.
   intros.
   apply not_prop_right; intro.
@@ -494,7 +417,7 @@ Qed.
 
 Lemma pred_sepcon_prop_true: forall (P: B -> Prop) p x,
   P x ->
-  pred_sepcon P p |-- p x * TT.
+  pred_sepcon p P |-- p x * TT.
 Proof.
   intros.
   unfold pred_sepcon; normalize.
@@ -525,7 +448,7 @@ Proof.
 Qed.
 *)
 Lemma pred_sepcon_False: forall p,
-  pred_sepcon (fun _ => False) p = emp.
+  pred_sepcon p (fun _ => False) = emp.
 Proof.
   intros.
   unfold pred_sepcon.

--- a/progs/tree.c
+++ b/progs/tree.c
@@ -1,0 +1,67 @@
+#include <stddef.h>
+
+struct Xnode {
+  struct XList * list;
+  int v;
+};
+
+struct XList {
+  struct Xnode * node;
+  struct XList * next;
+};
+
+struct Ynode {
+  struct YList * list;
+  int v;
+};
+
+struct YList {
+  struct BinaryTree * tree;
+  struct YList * next;
+};
+
+struct BinaryTree {
+  struct Ynode * node;
+  struct BinaryTree * left;
+  struct BinaryTree * right;
+};
+
+void Xnode_add(struct Xnode * p) {
+  struct XList * q;
+  if (p == NULL)
+    return;
+  p -> v ++;
+  for (q = p -> list; q != NULL; q = q -> next)
+    Xnode_add(q -> node);
+}
+
+void Ynode_add(struct Ynode * p);
+void YList_add(struct YList * p);
+void YTree_add(struct BinaryTree * p);
+
+void Ynode_add(struct Ynode * p) {
+  if (p == NULL)
+    return;
+  p -> v ++;
+  YList_add (p -> list);
+}
+
+void YList_add(struct YList * p) {
+  if (p == NULL)
+    return;
+  YTree_add(p -> tree);
+  YList_add(p -> next);
+}
+
+void YTree_add(struct BinaryTree * p) {
+  if (p == NULL)
+    return;
+  Ynode_add(p -> node);
+  YTree_add(p -> left);
+  YTree_add(p -> right);
+}
+
+int main () {
+}
+
+  

--- a/progs/tree.v
+++ b/progs/tree.v
@@ -1,0 +1,561 @@
+From Coq Require Import String List ZArith.
+From compcert Require Import Coqlib Integers Floats AST Ctypes Cop Clight Clightdefs.
+Local Open Scope Z_scope.
+
+Definition _BinaryTree : ident := 9%positive.
+Definition _XList : ident := 1%positive.
+Definition _Xnode : ident := 4%positive.
+Definition _Xnode_add : ident := 66%positive.
+Definition _YList : ident := 7%positive.
+Definition _YList_add : ident := 67%positive.
+Definition _YTree_add : ident := 69%positive.
+Definition _Ynode : ident := 8%positive.
+Definition _Ynode_add : ident := 68%positive.
+Definition ___builtin_annot : ident := 19%positive.
+Definition ___builtin_annot_intval : ident := 20%positive.
+Definition ___builtin_bswap : ident := 13%positive.
+Definition ___builtin_bswap16 : ident := 15%positive.
+Definition ___builtin_bswap32 : ident := 14%positive.
+Definition ___builtin_bswap64 : ident := 45%positive.
+Definition ___builtin_clz : ident := 46%positive.
+Definition ___builtin_clzl : ident := 47%positive.
+Definition ___builtin_clzll : ident := 48%positive.
+Definition ___builtin_ctz : ident := 49%positive.
+Definition ___builtin_ctzl : ident := 50%positive.
+Definition ___builtin_ctzll : ident := 51%positive.
+Definition ___builtin_debug : ident := 63%positive.
+Definition ___builtin_fabs : ident := 16%positive.
+Definition ___builtin_fmadd : ident := 54%positive.
+Definition ___builtin_fmax : ident := 52%positive.
+Definition ___builtin_fmin : ident := 53%positive.
+Definition ___builtin_fmsub : ident := 55%positive.
+Definition ___builtin_fnmadd : ident := 56%positive.
+Definition ___builtin_fnmsub : ident := 57%positive.
+Definition ___builtin_fsqrt : ident := 17%positive.
+Definition ___builtin_membar : ident := 21%positive.
+Definition ___builtin_memcpy_aligned : ident := 18%positive.
+Definition ___builtin_nop : ident := 62%positive.
+Definition ___builtin_read16_reversed : ident := 58%positive.
+Definition ___builtin_read32_reversed : ident := 59%positive.
+Definition ___builtin_va_arg : ident := 23%positive.
+Definition ___builtin_va_copy : ident := 24%positive.
+Definition ___builtin_va_end : ident := 25%positive.
+Definition ___builtin_va_start : ident := 22%positive.
+Definition ___builtin_write16_reversed : ident := 60%positive.
+Definition ___builtin_write32_reversed : ident := 61%positive.
+Definition ___compcert_i64_dtos : ident := 30%positive.
+Definition ___compcert_i64_dtou : ident := 31%positive.
+Definition ___compcert_i64_sar : ident := 42%positive.
+Definition ___compcert_i64_sdiv : ident := 36%positive.
+Definition ___compcert_i64_shl : ident := 40%positive.
+Definition ___compcert_i64_shr : ident := 41%positive.
+Definition ___compcert_i64_smod : ident := 38%positive.
+Definition ___compcert_i64_smulh : ident := 43%positive.
+Definition ___compcert_i64_stod : ident := 32%positive.
+Definition ___compcert_i64_stof : ident := 34%positive.
+Definition ___compcert_i64_udiv : ident := 37%positive.
+Definition ___compcert_i64_umod : ident := 39%positive.
+Definition ___compcert_i64_umulh : ident := 44%positive.
+Definition ___compcert_i64_utod : ident := 33%positive.
+Definition ___compcert_i64_utof : ident := 35%positive.
+Definition ___compcert_va_composite : ident := 29%positive.
+Definition ___compcert_va_float64 : ident := 28%positive.
+Definition ___compcert_va_int32 : ident := 26%positive.
+Definition ___compcert_va_int64 : ident := 27%positive.
+Definition _left : ident := 11%positive.
+Definition _list : ident := 2%positive.
+Definition _main : ident := 70%positive.
+Definition _next : ident := 6%positive.
+Definition _node : ident := 5%positive.
+Definition _p : ident := 64%positive.
+Definition _q : ident := 65%positive.
+Definition _right : ident := 12%positive.
+Definition _tree : ident := 10%positive.
+Definition _v : ident := 3%positive.
+Definition _t'1 : ident := 71%positive.
+Definition _t'2 : ident := 72%positive.
+Definition _t'3 : ident := 73%positive.
+
+Definition f_Xnode_add := {|
+  fn_return := tvoid;
+  fn_callconv := cc_default;
+  fn_params := ((_p, (tptr (Tstruct _Xnode noattr))) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_q, (tptr (Tstruct _XList noattr))) :: (_t'2, tint) ::
+               (_t'1, (tptr (Tstruct _Xnode noattr))) :: nil);
+  fn_body :=
+(Ssequence
+  (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr (Tstruct _Xnode noattr)))
+                 (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) tint)
+    (Sreturn None)
+    Sskip)
+  (Ssequence
+    (Ssequence
+      (Sset _t'2
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _Xnode noattr)))
+            (Tstruct _Xnode noattr)) _v tint))
+      (Sassign
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _Xnode noattr)))
+            (Tstruct _Xnode noattr)) _v tint)
+        (Ebinop Oadd (Etempvar _t'2 tint) (Econst_int (Int.repr 1) tint)
+          tint)))
+    (Ssequence
+      (Sset _q
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _Xnode noattr)))
+            (Tstruct _Xnode noattr)) _list (tptr (Tstruct _XList noattr))))
+      (Sloop
+        (Ssequence
+          (Sifthenelse (Ebinop One
+                         (Etempvar _q (tptr (Tstruct _XList noattr)))
+                         (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid))
+                         tint)
+            Sskip
+            Sbreak)
+          (Ssequence
+            (Sset _t'1
+              (Efield
+                (Ederef (Etempvar _q (tptr (Tstruct _XList noattr)))
+                  (Tstruct _XList noattr)) _node
+                (tptr (Tstruct _Xnode noattr))))
+            (Scall None
+              (Evar _Xnode_add (Tfunction
+                                 (Tcons (tptr (Tstruct _Xnode noattr)) Tnil)
+                                 tvoid cc_default))
+              ((Etempvar _t'1 (tptr (Tstruct _Xnode noattr))) :: nil))))
+        (Sset _q
+          (Efield
+            (Ederef (Etempvar _q (tptr (Tstruct _XList noattr)))
+              (Tstruct _XList noattr)) _next (tptr (Tstruct _XList noattr))))))))
+|}.
+
+Definition f_Ynode_add := {|
+  fn_return := tvoid;
+  fn_callconv := cc_default;
+  fn_params := ((_p, (tptr (Tstruct _Ynode noattr))) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_t'2, tint) :: (_t'1, (tptr (Tstruct _YList noattr))) :: nil);
+  fn_body :=
+(Ssequence
+  (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr (Tstruct _Ynode noattr)))
+                 (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) tint)
+    (Sreturn None)
+    Sskip)
+  (Ssequence
+    (Ssequence
+      (Sset _t'2
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _Ynode noattr)))
+            (Tstruct _Ynode noattr)) _v tint))
+      (Sassign
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _Ynode noattr)))
+            (Tstruct _Ynode noattr)) _v tint)
+        (Ebinop Oadd (Etempvar _t'2 tint) (Econst_int (Int.repr 1) tint)
+          tint)))
+    (Ssequence
+      (Sset _t'1
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _Ynode noattr)))
+            (Tstruct _Ynode noattr)) _list (tptr (Tstruct _YList noattr))))
+      (Scall None
+        (Evar _YList_add (Tfunction
+                           (Tcons (tptr (Tstruct _YList noattr)) Tnil) tvoid
+                           cc_default))
+        ((Etempvar _t'1 (tptr (Tstruct _YList noattr))) :: nil)))))
+|}.
+
+Definition f_YList_add := {|
+  fn_return := tvoid;
+  fn_callconv := cc_default;
+  fn_params := ((_p, (tptr (Tstruct _YList noattr))) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_t'2, (tptr (Tstruct _BinaryTree noattr))) ::
+               (_t'1, (tptr (Tstruct _YList noattr))) :: nil);
+  fn_body :=
+(Ssequence
+  (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr (Tstruct _YList noattr)))
+                 (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) tint)
+    (Sreturn None)
+    Sskip)
+  (Ssequence
+    (Ssequence
+      (Sset _t'2
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _YList noattr)))
+            (Tstruct _YList noattr)) _tree
+          (tptr (Tstruct _BinaryTree noattr))))
+      (Scall None
+        (Evar _YTree_add (Tfunction
+                           (Tcons (tptr (Tstruct _BinaryTree noattr)) Tnil)
+                           tvoid cc_default))
+        ((Etempvar _t'2 (tptr (Tstruct _BinaryTree noattr))) :: nil)))
+    (Ssequence
+      (Sset _t'1
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _YList noattr)))
+            (Tstruct _YList noattr)) _next (tptr (Tstruct _YList noattr))))
+      (Scall None
+        (Evar _YList_add (Tfunction
+                           (Tcons (tptr (Tstruct _YList noattr)) Tnil) tvoid
+                           cc_default))
+        ((Etempvar _t'1 (tptr (Tstruct _YList noattr))) :: nil)))))
+|}.
+
+Definition f_YTree_add := {|
+  fn_return := tvoid;
+  fn_callconv := cc_default;
+  fn_params := ((_p, (tptr (Tstruct _BinaryTree noattr))) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_t'3, (tptr (Tstruct _Ynode noattr))) ::
+               (_t'2, (tptr (Tstruct _BinaryTree noattr))) ::
+               (_t'1, (tptr (Tstruct _BinaryTree noattr))) :: nil);
+  fn_body :=
+(Ssequence
+  (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr (Tstruct _BinaryTree noattr)))
+                 (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) tint)
+    (Sreturn None)
+    Sskip)
+  (Ssequence
+    (Ssequence
+      (Sset _t'3
+        (Efield
+          (Ederef (Etempvar _p (tptr (Tstruct _BinaryTree noattr)))
+            (Tstruct _BinaryTree noattr)) _node
+          (tptr (Tstruct _Ynode noattr))))
+      (Scall None
+        (Evar _Ynode_add (Tfunction
+                           (Tcons (tptr (Tstruct _Ynode noattr)) Tnil) tvoid
+                           cc_default))
+        ((Etempvar _t'3 (tptr (Tstruct _Ynode noattr))) :: nil)))
+    (Ssequence
+      (Ssequence
+        (Sset _t'2
+          (Efield
+            (Ederef (Etempvar _p (tptr (Tstruct _BinaryTree noattr)))
+              (Tstruct _BinaryTree noattr)) _left
+            (tptr (Tstruct _BinaryTree noattr))))
+        (Scall None
+          (Evar _YTree_add (Tfunction
+                             (Tcons (tptr (Tstruct _BinaryTree noattr)) Tnil)
+                             tvoid cc_default))
+          ((Etempvar _t'2 (tptr (Tstruct _BinaryTree noattr))) :: nil)))
+      (Ssequence
+        (Sset _t'1
+          (Efield
+            (Ederef (Etempvar _p (tptr (Tstruct _BinaryTree noattr)))
+              (Tstruct _BinaryTree noattr)) _right
+            (tptr (Tstruct _BinaryTree noattr))))
+        (Scall None
+          (Evar _YTree_add (Tfunction
+                             (Tcons (tptr (Tstruct _BinaryTree noattr)) Tnil)
+                             tvoid cc_default))
+          ((Etempvar _t'1 (tptr (Tstruct _BinaryTree noattr))) :: nil))))))
+|}.
+
+Definition f_main := {|
+  fn_return := tint;
+  fn_callconv := cc_default;
+  fn_params := nil;
+  fn_vars := nil;
+  fn_temps := nil;
+  fn_body :=
+(Sreturn (Some (Econst_int (Int.repr 0) tint)))
+|}.
+
+Definition composites : list composite_definition :=
+(Composite _Xnode Struct
+   ((_list, (tptr (Tstruct _XList noattr))) :: (_v, tint) :: nil)
+   noattr ::
+ Composite _XList Struct
+   ((_node, (tptr (Tstruct _Xnode noattr))) ::
+    (_next, (tptr (Tstruct _XList noattr))) :: nil)
+   noattr ::
+ Composite _Ynode Struct
+   ((_list, (tptr (Tstruct _YList noattr))) :: (_v, tint) :: nil)
+   noattr ::
+ Composite _YList Struct
+   ((_tree, (tptr (Tstruct _BinaryTree noattr))) ::
+    (_next, (tptr (Tstruct _YList noattr))) :: nil)
+   noattr ::
+ Composite _BinaryTree Struct
+   ((_node, (tptr (Tstruct _Ynode noattr))) ::
+    (_left, (tptr (Tstruct _BinaryTree noattr))) ::
+    (_right, (tptr (Tstruct _BinaryTree noattr))) :: nil)
+   noattr :: nil).
+
+Definition global_definitions : list (ident * globdef fundef type) :=
+((___builtin_bswap,
+   Gfun(External (EF_builtin "__builtin_bswap"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap32,
+   Gfun(External (EF_builtin "__builtin_bswap32"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap16,
+   Gfun(External (EF_builtin "__builtin_bswap16"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tushort Tnil) tushort cc_default)) ::
+ (___builtin_fabs,
+   Gfun(External (EF_builtin "__builtin_fabs"
+                   (mksignature (AST.Tfloat :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_fsqrt,
+   Gfun(External (EF_builtin "__builtin_fsqrt"
+                   (mksignature (AST.Tfloat :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_memcpy_aligned,
+   Gfun(External (EF_builtin "__builtin_memcpy_aligned"
+                   (mksignature
+                     (AST.Tint :: AST.Tint :: AST.Tint :: AST.Tint :: nil)
+                     None cc_default))
+     (Tcons (tptr tvoid)
+       (Tcons (tptr tvoid) (Tcons tuint (Tcons tuint Tnil)))) tvoid
+     cc_default)) ::
+ (___builtin_annot,
+   Gfun(External (EF_builtin "__builtin_annot"
+                   (mksignature (AST.Tint :: nil) None
+                     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot_intval,
+   Gfun(External (EF_builtin "__builtin_annot_intval"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) (Some AST.Tint)
+                     cc_default)) (Tcons (tptr tschar) (Tcons tint Tnil))
+     tint cc_default)) ::
+ (___builtin_membar,
+   Gfun(External (EF_builtin "__builtin_membar"
+                   (mksignature nil None cc_default)) Tnil tvoid cc_default)) ::
+ (___builtin_va_start,
+   Gfun(External (EF_builtin "__builtin_va_start"
+                   (mksignature (AST.Tint :: nil) None cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___builtin_va_arg,
+   Gfun(External (EF_builtin "__builtin_va_arg"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) None
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_va_copy,
+   Gfun(External (EF_builtin "__builtin_va_copy"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) None
+                     cc_default))
+     (Tcons (tptr tvoid) (Tcons (tptr tvoid) Tnil)) tvoid cc_default)) ::
+ (___builtin_va_end,
+   Gfun(External (EF_builtin "__builtin_va_end"
+                   (mksignature (AST.Tint :: nil) None cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___compcert_va_int32,
+   Gfun(External (EF_external "__compcert_va_int32"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons (tptr tvoid) Tnil) tuint cc_default)) ::
+ (___compcert_va_int64,
+   Gfun(External (EF_external "__compcert_va_int64"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tlong)
+                     cc_default)) (Tcons (tptr tvoid) Tnil) tulong
+     cc_default)) ::
+ (___compcert_va_float64,
+   Gfun(External (EF_external "__compcert_va_float64"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons (tptr tvoid) Tnil) tdouble
+     cc_default)) ::
+ (___compcert_va_composite,
+   Gfun(External (EF_external "__compcert_va_composite"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) (Some AST.Tint)
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     (tptr tvoid) cc_default)) ::
+ (___compcert_i64_dtos,
+   Gfun(External (EF_runtime "__compcert_i64_dtos"
+                   (mksignature (AST.Tfloat :: nil) (Some AST.Tlong)
+                     cc_default)) (Tcons tdouble Tnil) tlong cc_default)) ::
+ (___compcert_i64_dtou,
+   Gfun(External (EF_runtime "__compcert_i64_dtou"
+                   (mksignature (AST.Tfloat :: nil) (Some AST.Tlong)
+                     cc_default)) (Tcons tdouble Tnil) tulong cc_default)) ::
+ (___compcert_i64_stod,
+   Gfun(External (EF_runtime "__compcert_i64_stod"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons tlong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_utod,
+   Gfun(External (EF_runtime "__compcert_i64_utod"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tfloat)
+                     cc_default)) (Tcons tulong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_stof,
+   Gfun(External (EF_runtime "__compcert_i64_stof"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tsingle)
+                     cc_default)) (Tcons tlong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_utof,
+   Gfun(External (EF_runtime "__compcert_i64_utof"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tsingle)
+                     cc_default)) (Tcons tulong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_sdiv,
+   Gfun(External (EF_runtime "__compcert_i64_sdiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tlong Tnil)) tlong cc_default)) ::
+ (___compcert_i64_udiv,
+   Gfun(External (EF_runtime "__compcert_i64_udiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tulong (Tcons tulong Tnil)) tulong cc_default)) ::
+ (___compcert_i64_smod,
+   Gfun(External (EF_runtime "__compcert_i64_smod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tlong Tnil)) tlong cc_default)) ::
+ (___compcert_i64_umod,
+   Gfun(External (EF_runtime "__compcert_i64_umod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tulong (Tcons tulong Tnil)) tulong cc_default)) ::
+ (___compcert_i64_shl,
+   Gfun(External (EF_runtime "__compcert_i64_shl"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tint Tnil)) tlong cc_default)) ::
+ (___compcert_i64_shr,
+   Gfun(External (EF_runtime "__compcert_i64_shr"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tulong (Tcons tint Tnil)) tulong cc_default)) ::
+ (___compcert_i64_sar,
+   Gfun(External (EF_runtime "__compcert_i64_sar"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tint Tnil)) tlong cc_default)) ::
+ (___compcert_i64_smulh,
+   Gfun(External (EF_runtime "__compcert_i64_smulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tlong (Tcons tlong Tnil)) tlong cc_default)) ::
+ (___compcert_i64_umulh,
+   Gfun(External (EF_runtime "__compcert_i64_umulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil)
+                     (Some AST.Tlong) cc_default))
+     (Tcons tulong (Tcons tulong Tnil)) tulong cc_default)) ::
+ (___builtin_bswap64,
+   Gfun(External (EF_builtin "__builtin_bswap64"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tlong)
+                     cc_default)) (Tcons tulong Tnil) tulong cc_default)) ::
+ (___builtin_clz,
+   Gfun(External (EF_builtin "__builtin_clz"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzl,
+   Gfun(External (EF_builtin "__builtin_clzl"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzll,
+   Gfun(External (EF_builtin "__builtin_clzll"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tint)
+                     cc_default)) (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_ctz,
+   Gfun(External (EF_builtin "__builtin_ctz"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzl,
+   Gfun(External (EF_builtin "__builtin_ctzl"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzll,
+   Gfun(External (EF_builtin "__builtin_ctzll"
+                   (mksignature (AST.Tlong :: nil) (Some AST.Tint)
+                     cc_default)) (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_fmax,
+   Gfun(External (EF_builtin "__builtin_fmax"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble Tnil)) tdouble cc_default)) ::
+ (___builtin_fmin,
+   Gfun(External (EF_builtin "__builtin_fmin"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble Tnil)) tdouble cc_default)) ::
+ (___builtin_fmadd,
+   Gfun(External (EF_builtin "__builtin_fmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fmsub,
+   Gfun(External (EF_builtin "__builtin_fmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmadd,
+   Gfun(External (EF_builtin "__builtin_fnmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmsub,
+   Gfun(External (EF_builtin "__builtin_fnmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     (Some AST.Tfloat) cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_read16_reversed,
+   Gfun(External (EF_builtin "__builtin_read16_reversed"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons (tptr tushort) Tnil) tushort cc_default)) ::
+ (___builtin_read32_reversed,
+   Gfun(External (EF_builtin "__builtin_read32_reversed"
+                   (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
+     (Tcons (tptr tuint) Tnil) tuint cc_default)) ::
+ (___builtin_write16_reversed,
+   Gfun(External (EF_builtin "__builtin_write16_reversed"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) None
+                     cc_default)) (Tcons (tptr tushort) (Tcons tushort Tnil))
+     tvoid cc_default)) ::
+ (___builtin_write32_reversed,
+   Gfun(External (EF_builtin "__builtin_write32_reversed"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) None
+                     cc_default)) (Tcons (tptr tuint) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_nop,
+   Gfun(External (EF_builtin "__builtin_nop"
+                   (mksignature nil None cc_default)) Tnil tvoid cc_default)) ::
+ (___builtin_debug,
+   Gfun(External (EF_external "__builtin_debug"
+                   (mksignature (AST.Tint :: nil) None
+                     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tint Tnil) tvoid
+     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
+ (_Xnode_add, Gfun(Internal f_Xnode_add)) ::
+ (_Ynode_add, Gfun(Internal f_Ynode_add)) ::
+ (_YList_add, Gfun(Internal f_YList_add)) ::
+ (_YTree_add, Gfun(Internal f_YTree_add)) ::
+ (_main, Gfun(Internal f_main)) :: nil).
+
+Definition public_idents : list ident :=
+(_main :: _YTree_add :: _YList_add :: _Ynode_add :: _Xnode_add ::
+ ___builtin_debug :: ___builtin_nop :: ___builtin_write32_reversed ::
+ ___builtin_write16_reversed :: ___builtin_read32_reversed ::
+ ___builtin_read16_reversed :: ___builtin_fnmsub :: ___builtin_fnmadd ::
+ ___builtin_fmsub :: ___builtin_fmadd :: ___builtin_fmin ::
+ ___builtin_fmax :: ___builtin_ctzll :: ___builtin_ctzl :: ___builtin_ctz ::
+ ___builtin_clzll :: ___builtin_clzl :: ___builtin_clz ::
+ ___builtin_bswap64 :: ___compcert_i64_umulh :: ___compcert_i64_smulh ::
+ ___compcert_i64_sar :: ___compcert_i64_shr :: ___compcert_i64_shl ::
+ ___compcert_i64_umod :: ___compcert_i64_smod :: ___compcert_i64_udiv ::
+ ___compcert_i64_sdiv :: ___compcert_i64_utof :: ___compcert_i64_stof ::
+ ___compcert_i64_utod :: ___compcert_i64_stod :: ___compcert_i64_dtou ::
+ ___compcert_i64_dtos :: ___compcert_va_composite ::
+ ___compcert_va_float64 :: ___compcert_va_int64 :: ___compcert_va_int32 ::
+ ___builtin_va_end :: ___builtin_va_copy :: ___builtin_va_arg ::
+ ___builtin_va_start :: ___builtin_membar :: ___builtin_annot_intval ::
+ ___builtin_annot :: ___builtin_memcpy_aligned :: ___builtin_fsqrt ::
+ ___builtin_fabs :: ___builtin_bswap16 :: ___builtin_bswap32 ::
+ ___builtin_bswap :: nil).
+
+Definition prog : Clight.program := 
+  mkprogram composites global_definitions public_idents _main Logic.I.
+
+

--- a/progs/verif_bst.v
+++ b/progs/verif_bst.v
@@ -65,63 +65,6 @@ Fixpoint tree_rep (t: tree val) (p: val) : mpred :=
     tree_rep a pa * tree_rep b pb
  end.
 
-Parameter list_rep: forall (l: list val) (p: val), mpred.
-Require Import VST.msl.iter_sepcon.
-Section IterTreeSepCon2.
-
-  Context {A : Type}.
-  Context {B1 B2 : Type}.
-  Context {ND : NatDed A}.
-  Context {SL : SepLog A}.
-  Context {ClS: ClassicalSep A}.
-  Context {CoSL: CorableSepLog A}.
-  Context (p : B1 -> B2 -> A).
-
-Fixpoint iter_tree_sepcon2 (t1 : tree B1) : tree B2 -> A :=
-    match t1 with
-    | E => fun t2 =>
-       match t2 with
-       | E => emp
-       | _ => FF
-       end
-    | T xa _ x xb => fun t2 =>
-       match t2 with
-       | E => FF
-       | T ya _ y yb => p x y * iter_tree_sepcon2 xa ya * iter_tree_sepcon2 xb yb
-       end
-  end.
-
-End IterTreeSepCon2.
-
-Inductive stree (V: Type) : Type :=
-| Leaf: V -> stree V
-| Internal: list (tree (stree V * bool) * V) -> stree V.
-
-Fixpoint stree_rep (st: stree val) (p: val): mpred :=
-  match st with
-  | Leaf v =>
-      data_at Tsh (tptr tvoid) v p
-  | Internal ls =>
-      EX ps: list val,
-      list_rep ps p *
-      iter_sepcon2'
-        (fun tvp p =>
-           EX pt: tree val,
-           tree_rep pt p *
-           iter_tree_sepcon2 (fun sb p => stree_rep (fst sb) p) (fst tvp) pt *       
-           data_at Tsh (tptr tvoid) (snd tvp) p) ls ps
-  end.
-
-
-
-
-
-
-
-
-
-
-
 Definition treebox_rep (t: tree val) (b: val) :=
  EX p: val, data_at Tsh (tptr t_struct_tree) p b * tree_rep t p.
 
@@ -814,4 +757,3 @@ Proof.
   cancel.
   forward.
 Qed.
-

--- a/progs/verif_tree.v
+++ b/progs/verif_tree.v
@@ -1,0 +1,113 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.progs.tree.
+Require Import VST.msl.iter_sepcon.
+
+Instance CompSpecs : compspecs. make_compspecs prog. Defined.
+Definition Vprog : varspecs. mk_varspecs prog. Defined.
+
+Definition t_struct_Xnode := Tstruct _Xnode noattr.
+Definition t_struct_Xlist := Tstruct _XList noattr.
+Definition t_struct_Ynode := Tstruct _Ynode noattr.
+Definition t_struct_Ylist := Tstruct _YList noattr.
+Definition t_struct_Ytree := Tstruct _BinaryTree noattr.
+
+Section LISTS.
+Variable V: Type.
+
+Variable list_cell: V -> val -> val -> mpred.
+
+Fixpoint list_rep (l: list V) (x: val) : mpred :=
+ match l with
+ | h::hs => 
+    EX y:val, list_cell h y x * list_rep hs y
+ | nil => 
+    !! (x = nullval) && emp
+ end.
+
+End LISTS.
+Arguments list_rep {V} _ _ _.
+
+Section TREES.
+Variable V : Type.
+
+Inductive tree : Type :=
+ | E : tree
+ | T: tree -> V -> tree -> tree.
+
+Variable tree_cell: V -> val -> val -> val -> mpred.
+
+Fixpoint tree_rep (t: tree) (p: val) : mpred :=
+ match t with
+ | E => !!(p=nullval) && emp
+ | T a v b =>
+    EX pa:val, EX pb:val,
+    tree_cell v pa pb p *
+    tree_rep a pa * tree_rep b pb
+ end.
+
+End TREES.
+Arguments E {V}.
+Arguments T {V} _ _ _.
+Arguments tree_rep {V} _ _ _.
+
+Section IterTreeSepCon2.
+
+  Context {A : Type}.
+  Context {B1 B2 : Type}.
+  Context {ND : NatDed A}.
+  Context {SL : SepLog A}.
+  Context {ClS: ClassicalSep A}.
+  Context {CoSL: CorableSepLog A}.
+  Context (p : B1 -> B2 -> A).
+
+Fixpoint iter_tree_sepcon2 (t1 : tree B1) : tree B2 -> A :=
+    match t1 with
+    | E => fun t2 =>
+       match t2 with
+       | E => emp
+       | _ => FF
+       end
+    | T xa x xb => fun t2 =>
+       match t2 with
+       | E => FF
+       | T ya y yb => p x y * iter_tree_sepcon2 xa ya * iter_tree_sepcon2 xb yb
+       end
+  end.
+
+End IterTreeSepCon2.
+
+Inductive XTree: Type :=
+| XLeaf: XTree
+| XNode: list XTree -> Z -> XTree.
+
+Fixpoint xtree_rep (t: XTree) (p: val): mpred :=
+  match t with
+  | XLeaf =>
+      !!(p = nullval) && emp
+  | XNode tl v =>
+      EX q: val, EX r: list val,
+        data_at Tsh t_struct_Xnode (Vint (Int.repr v), q) p *
+        list_rep (fun p n q => data_at Tsh t_struct_Xlist (p, n) q) r q *
+        iter_sepcon2 xtree_rep tl r
+  end.
+
+Inductive YTree: Type :=
+| YLeaf: YTree
+| YNode: list (tree (unit * YTree) * unit) -> Z -> YTree.
+
+Fixpoint ytree_rep (t: YTree) (p: val): mpred :=
+  match t with
+  | YLeaf =>
+      !!(p = nullval) && emp
+  | YNode ttl v =>
+      EX q: val, EX r: list val,
+        data_at Tsh t_struct_Ynode (Vint (Int.repr v), q) p *
+        list_rep (fun r n q => data_at Tsh t_struct_Ylist (r, n) q) r q *
+        iter_sepcon2 (fun tt_u_pair r =>
+          EX s: tree val,
+          tree_rep (fun p L R r => data_at Tsh t_struct_Ytree (p, (L, R)) r) s r *
+          iter_tree_sepcon2 (fun u_t_pair s => ytree_rep (snd u_t_pair) s) (fst tt_u_pair) s) ttl r
+  end.
+
+
+


### PR DESCRIPTION
Switch the argument of iter_sepcon. The reason is
1. To allow users write nested recursion in Coq (see progs/verif_tree.v).
1.1. To use the theory of list, we'd better use nested recursion instead of mutual recursion.
1.2. Coq has difficulty to detect that decreasing in a nested recursion, the new definition of iter_sepcon can overcome this.
1.3. Why not define iter_sepcon as a function composition of 'flip' and 'new iter_sepcon'. If so, it will be inconvenient to do induction.
2. The argument order of iter_sepcon are now the same as map.