### PR TITLE
Top-level program correctness for IO programs

### DIFF
--- a/concurrency/semax_conc.v
+++ b/concurrency/semax_conc.v
@@ -860,23 +860,6 @@ Definition spawn_spec := mk_funspec
 
 (*+ Adding the specifications to a void ext_spec *)
 
-(*! The void ext_spec *)
-Definition void_spec T : external_specification juicy_mem external_function T :=
-    Build_external_specification
-      juicy_mem external_function T
-      (fun ef => False)
-      (fun ef Hef ge tys vl m z => False)
-      (fun ef Hef ge ty vl m z => False)
-      (fun rv m z => False).
-
-Definition ok_void_spec (T : Type) : OracleKind.
- refine (Build_OracleKind T (Build_juicy_ext_spec _ (void_spec T) _ _ _)).
-Proof.
-  simpl; intros; contradiction.
-  simpl; intros; contradiction.
-  simpl; intros; intros ? ? ? ?; contradiction.
-Defined.
-
 Definition concurrent_simple_specs (cs : compspecs) (ext_link : string -> ident) :=
   (ext_link "acquire"%string, acquire_spec) ::
   (ext_link "release"%string, release_spec) ::

--- a/floyd/closed_lemmas.v
+++ b/floyd/closed_lemmas.v
@@ -808,7 +808,17 @@ Lemma closed_wrtl_main_pre:
   forall prog u v S, closed_wrt_lvars S (main_pre prog u v).
 Proof.
 intros. apply closed_wrtl_globvars. Qed.
-Hint Resolve closed_wrt_main_pre closed_wrtl_main_pre : closed.
+Lemma closed_wrt_main_pre_ext:
+  forall {Espec : OracleKind} prog z u v S, closed_wrt_vars S (main_pre_ext prog z u v).
+Proof.
+intros. unfold main_pre_ext. apply closed_wrt_sepcon; [apply closed_wrt_globvars | apply closed_wrt_const].
+Qed.
+Lemma closed_wrtl_main_pre_ext:
+  forall {Espec : OracleKind} prog z u v S, closed_wrt_lvars S (main_pre_ext prog z u v).
+Proof.
+intros. unfold main_pre_ext. apply closed_wrtl_sepcon; [apply closed_wrtl_globvars | apply closed_wrtl_const].
+Qed.
+Hint Resolve closed_wrt_main_pre closed_wrtl_main_pre closed_wrt_main_pre_ext closed_wrtl_main_pre_ext : closed.
 
 Lemma closed_wrt_not1:
   forall (i j: ident),

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -297,11 +297,11 @@ Proof.
 Qed.
 
 Lemma typecheck_return_value:
-  forall (f: val -> Prop)  (v: val) (gx: genviron) (ret: option val),
+  forall (f: val -> Prop)  (v: val) (gx: genviron) (ret: option val) P R,
  f v -> 
- (PROP ( )
-  LOCAL (temp ret_temp v)
-  SEP ()) (make_ext_rval gx ret) |-- !! f (force_val ret).
+ (PROPx P
+ (LOCAL (temp ret_temp v)
+ (SEPx R))) (make_ext_rval gx ret) |-- !! f (force_val ret).
 Proof.
 intros.
  rewrite <- insert_local.

--- a/progs/io_specs.v
+++ b/progs/io_specs.v
@@ -1,7 +1,5 @@
 Require Import VST.floyd.proofauto.
-Require Import VST.veric.semax_ext.
-Require Import VST.sepcomp.extspec.
-Require Import VST.veric.juicy_mem.
+Require Import VST.veric.juicy_extspec.
 Require Import DeepWeb.Free.Monad.Free.
 Import MonadNotations.
 Require Import DeepWeb.Free.Monad.Common.
@@ -92,22 +90,6 @@ Definition char0 : Z := 48.
 Definition newline := 10.
 
 (* Build the external specification. *)
-Definition void_spec T :=
-    Build_external_specification
-      juicy_mem external_function T
-      (fun ef => False)
-      (fun ef Hef ge tys vl m z => False)
-      (fun ef Hef ge ty vl m z => False)
-      (fun rv m z => False).
-
-Definition ok_void_spec (T : Type) : OracleKind.
- refine (Build_OracleKind T (Build_juicy_ext_spec _ (void_spec T) _ _ _)).
-Proof.
-  simpl; intros; contradiction.
-  simpl; intros; contradiction.
-  simpl; intros; intros ? ? ? ?; contradiction.
-Defined.
-
 Definition IO_specs (ext_link : string -> ident) :=
   [(ext_link "putchar"%string, putchar_spec); (ext_link "getchar"%string, getchar_spec)].
 

--- a/progs/verif_io.v
+++ b/progs/verif_io.v
@@ -265,3 +265,19 @@ Proof.
   Intros n c'.
   forward.
 Qed.
+
+Instance Espec : OracleKind := add_funspecs IO_Espec (ext_link_prog prog) Gprog.
+
+Lemma prog_correct:
+  semax_prog_ext prog main_itree Vprog Gprog.
+Proof.
+prove_semax_prog.
+repeat (apply semax_func_cons_ext_vacuous; [reflexivity | reflexivity | ]).
+semax_func_cons_ext.
+{ simpl; Intro i.
+  apply typecheck_return_value; auto. }
+semax_func_cons_ext.
+semax_func_cons body_print_intr.
+semax_func_cons body_print_int.
+semax_func_cons body_main.
+Qed.

--- a/veric/juicy_extspec.v
+++ b/veric/juicy_extspec.v
@@ -23,6 +23,23 @@ Class OracleKind := {
   OK_spec: juicy_ext_spec OK_ty
 }.
 
+(*! The void ext_spec *)
+Definition void_spec T : external_specification juicy_mem external_function T :=
+    Build_external_specification
+      juicy_mem external_function T
+      (fun ef => False)
+      (fun ef Hef ge tys vl m z => False)
+      (fun ef Hef ge ty vl m z => False)
+      (fun rv m z => False).
+
+Definition ok_void_spec (T : Type) : OracleKind.
+ refine (Build_OracleKind T (Build_juicy_ext_spec _ (void_spec T) _ _ _)).
+Proof.
+  simpl; intros; contradiction.
+  simpl; intros; contradiction.
+  simpl; intros; intros ? ? ? ?; contradiction.
+Defined.
+
 Definition jstep {G C} (csem: @CoreSemantics G C mem)
   (ge: G)  (q: C) (jm: juicy_mem) (q': C) (jm': juicy_mem) : Prop :=
  corestep csem ge q (m_dry jm) q' (m_dry jm') /\ resource_decay (nextblock (m_dry jm)) (m_phi jm) (m_phi jm') /\


### PR DESCRIPTION
We can now use the standard tactics to prove semax_prog_ext (semax_prog with initial external state) for programs that use external state.