### PR TITLE
Improve sha

### DIFF
--- a/floyd/field_at_wand.v
+++ b/floyd/field_at_wand.v
@@ -205,12 +205,12 @@ Qed.
 
 End SingletonHole.
 
-Module SegmentHole.
-
 Definition splice_into_list {A} (lo hi: Z) (source target : list A) : list A :=
    sublist 0 lo target
    ++ source 
    ++ sublist hi (Zlength target) target.
+
+Module SegmentHole.
 
 Definition array_with_hole {cs: compspecs} sh (t: type) lo hi n (al': list (reptype t)) p :=
 ALL v: list (reptype t),

--- a/floyd/proofauto.v
+++ b/floyd/proofauto.v
@@ -21,6 +21,7 @@ Require Export VST.floyd.reptype_lemmas.
 Require Export VST.floyd.simpl_reptype.
 Require Export VST.floyd.data_at_rec_lemmas.
 Require Export VST.floyd.field_at.
+Require Export VST.floyd.field_at_wand.
 Require Export VST.floyd.field_compat.
 Require Export VST.floyd.stronger.
 Require Export VST.floyd.loadstore_mapsto.

--- a/sha/verif_sha_final2.v
+++ b/sha/verif_sha_final2.v
@@ -239,7 +239,7 @@ replace (ddlen + 1 + (CBLOCKz - (ddlen + 1))) with CBLOCKz by (clear; omega).
 change 64 with CBLOCKz.
 pose (ddz := ((map Int.repr dd ++ [Int.repr 128]) ++ list_repeat (Z.to_nat (CBLOCKz-(ddlen+1))) Int.zero)).
 
-replace (splice_into_list (ddlen + 1) CBLOCKz CBLOCKz
+replace (splice_into_list (ddlen + 1) CBLOCKz
            (list_repeat (Z.to_nat (CBLOCKz - (ddlen + 1))) (Vint Int.zero))
            (map Vint (map Int.repr dd) ++
             Vint (Int.repr 128) :: list_repeat (Z.to_nat fill_len) Vundef))

--- a/sha/verif_sha_update.v
+++ b/sha/verif_sha_update.v
@@ -260,6 +260,10 @@ hnf.  unfold s256_h, s256_data, s256_num, s256_Nh, s256_Nl, s256a_regs, fst, snd
  apply isbyte_intlist_to_Zlist.
  unfold_data_at 1%nat.
  rewrite H2. rewrite !sublist_map. cancel.
+ subst dd'.
+ autorewrite with sublist.
+ replace (b4d + (len - b4d)) with len by omega.
+ cancel.
 + (* else-clause *)
  forward. (* skip; *)
  unfold sha256state_.

--- a/sha/verif_sha_update3.v
+++ b/sha/verif_sha_update3.v
@@ -415,7 +415,6 @@ forward_if.
   replace (CBLOCKz - (Zlength dd + (CBLOCKz - Zlength dd)))%Z
     with 0%Z by (clear; omega).
   change (list_repeat (Z.to_nat 0) Vundef) with (@nil val).
-  rewrite <- app_nil_end.
   autorewrite with sublist.
   rewrite sublist_list_repeat by Omega1.
   clear H5 H6.

--- a/sha/verif_sha_update3.v
+++ b/sha/verif_sha_update3.v
@@ -288,10 +288,6 @@ forward_if.
    (*len*) k
         Frame);
   try reflexivity; auto; try omega.
-  try (* this line needed for Coq 8.7 compatibility *)
-      apply Zlength_nonneg.
-  try (* this line needed for Coq 8.7 compatibility *)
-       (subst k; omega).
   unfold_data_at 1%nat.
   entailer!.
   rewrite field_address_offset by auto.
@@ -395,10 +391,6 @@ forward_if.
    (*len*) (len)
         Frame);
     try reflexivity; auto; try omega.
-  try (* this line needed for Coq 8.7 compatibility *)
-      apply Zlength_nonneg.
-  try (* this line needed for Coq 8.7 compatibility *)
-    (repeat rewrite Zlength_map; unfold k in *; omega).
   entailer!.
   rewrite field_address_offset by auto with field_compatible.
   rewrite field_address0_offset by


### PR DESCRIPTION
Improve sha. Fill some holes about reroot field_compatible which have been left there for me to solve for a long time. This fix is another good example of using wand-as-frame.

Remove redundant lines for 8.7 compatibility.

This commit also helps to port remove-init later.