### PR TITLE
Changes in Makefile for better compability with external CompCert 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ compcert/clightgen
 compcert/clightgen.byte
 compcert/tools/ndfun
 compcert/tools/modorder
-compcert/Makefile.config
 # Generated files
 compcert/.depend.extr
 compcert/compcert.ini

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,18 @@ endif
 endif
 endif
 
-EXTFLAGS= -R $(COMPCERT) compcert
+ARCH=$(shell awk 'BEGIN{FS="="}$$1=="ARCH"{print $$2}' $(COMPCERT)/Makefile.config)
+BITSIZE=$(shell awk 'BEGIN{FS="="}$$1=="BITSIZE"{print $$2}' $(COMPCERT)/Makefile.config)
+
+ifeq ($(wildcard $(COMPCERT)/$(ARCH)_$(BITSIZE)),)
+ARCHDIRS=$(ARCH)
+else
+ARCHDIRS=$(ARCH)_$(BITSIZE)
+endif
+
+COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend flocq exportclight
+
+EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -R $(COMPCERT)/$(d) compcert.$(d))
 
 # for SSReflect
 ifdef MATHCOMP
@@ -537,7 +548,7 @@ ifeq ($(COMPCERT), compcert_new)
 	echo "" >>.depend
 	$(COQDEP) 2>&1 concurrency/shim/Clight_core.v | grep -v 'Warning:.*found in the loadpath' | awk '{gsub(/veric[/]Clight_core/,"concurrency/shim/Clight_core",$$0); print}' >>.depend || true
 else
-	$(COQDEP) 2>&1 >.depend `find $(COMPCERT) $(filter $(wildcard *), $(DIRS)) -name "*.v"` | grep -v 'Warning:.*found in the loadpath' || true
+	$(COQDEP) 2>&1 >.depend `find $(COMPCERT)/{cfrontend,common,exportclight,flocq,lib} $(filter $(wildcard *), $(DIRS)) -name "*.v"` | grep -v 'Warning:.*found in the loadpath' || true
 endif
 
 depend-paco:

--- a/compcert/Makefile.config
+++ b/compcert/Makefile.config
@@ -1,0 +1,2 @@
+ARCH=x86
+BITSIZE=32

--- a/util/GRAB
+++ b/util/GRAB
@@ -12,7 +12,7 @@
 #
 if [ -e "$1" -a ./GRAB ]; then
   rm -f */*.v flocq/*/*.v
-  cp $1/LICENSE $1/README.md $1/VERSION .
+  cp $1/LICENSE $1/README.md $1/VERSION $1/Makefile.config .
   cp $1/x86_32/Archi.v x86_32
   cp $1/lib/*.v lib
   cp $1/common/*.v common


### PR DESCRIPTION
(i.e., method B in BUILD_ORGANIZATION)
In particular, the -R flags to coqc are more selective of which subdirectories of compcert they import.
