### PR TITLE
Unbreak build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,14 +558,14 @@ ifeq ($(COMPCERT), compcert_new)
 	echo "" >>.depend
 	$(COQDEP) 2>&1 concurrency/shim/Clight_core.v | grep -v 'Warning:.*found in the loadpath' | awk '{gsub(/veric[/]Clight_core/,"concurrency/shim/Clight_core",$$0); print}' >>.depend || true
 else
-	$(COQDEP) 2>&1 >.depend `find $(COMPCERT)/{cfrontend,common,exportclight,flocq,lib} $(filter $(wildcard *), $(DIRS)) -name "*.v"` | grep -v 'Warning:.*found in the loadpath' || true
+	$(COQDEP) 2>&1 >.depend `find $(addprefix $(COMPCERT)/,$(COMPCERTDIRS)) $(filter $(wildcard *), $(DIRS)) -name "*.v"` | grep -v 'Warning:.*found in the loadpath' || true
 endif
 
 depend-paco:
 	$(COQDEP) > .depend-paco $(PACO_FILES:%.v=concurrency/paco/src/%.v)
 
 clean:
-	rm -f veric/version.{v,vo,glob} .lia.cache .nia.cache floyd/floyd.coq .depend _CoqProject _CoqProject-export $(wildcard */.*.aux)  $(wildcard */*.glob) $(wildcard */*.vo) compcert/*/*.vo compcert/*/*/*.vo
+	rm -f $(addprefix veric/version., v vo glob) .lia.cache .nia.cache floyd/floyd.coq .depend _CoqProject _CoqProject-export $(wildcard */.*.aux)  $(wildcard */*.glob) $(wildcard */*.vo) compcert/*/*.vo compcert/*/*/*.vo
 	rm -fr doc/html
 
 clean-concur:


### PR DESCRIPTION
#276 broke the build in 2 ways:
- make uses /bin/sh which (at least on ubuntu) doesn't support brace expansion
- compcert ARCH directories were not coqdep'd 

This break was hidden by the travis cache, which made it so that compcert did not have to be recompiled. However Coq CI can't cache VST so we detected the issue.
eg in https://travis-ci.org/PrincetonUniversity/VST/jobs/419203907#L762
>find: `compcert/{cfrontend,common,exportclight,flocq,lib}': No such file or directory