### PR TITLE
Import prim token notations before using them

### DIFF
--- a/compcert/cfrontend/Ctypes.v
+++ b/compcert/cfrontend/Ctypes.v
@@ -15,6 +15,7 @@
 
 (** Type expressions for the Compcert C and Clight languages *)
 
+Require Import Coq.Strings.String.
 Require Import Axioms Coqlib Maps Errors.
 Require Import AST Linking.
 Require Archi.

--- a/veric/Clight_core.v
+++ b/veric/Clight_core.v
@@ -1,3 +1,4 @@
+Require Import Coq.Strings.String.
 Require Import VST.sepcomp.semantics.
 Require Import VST.veric.base.
 Require Import VST.veric.Clight_lemmas.

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -1,3 +1,4 @@
+Require Import Coq.Strings.String.
 Require Import VST.veric.base.
 Require Export compcert.lib.Axioms.
 Require Import compcert.lib.Coqlib.

--- a/veric/expr_lemmas3.v
+++ b/veric/expr_lemmas3.v
@@ -1,3 +1,4 @@
+Require Import Coq.Reals.Rdefinitions.
 Require Import VST.msl.msl_standard.
 Require Import VST.veric.base.
 Require Import VST.veric.compcert_rmaps.


### PR DESCRIPTION
This is required for compatibility with
https://github.com/coq/coq/pull/8064, where prim token notations no longer
follow `Require`, but instead follow `Import`.

c.f. https://github.com/coq/coq/pull/8064#issuecomment-415493362

All changes were made via
https://gist.github.com/JasonGross/5d4558edf8f5c2c548a3d96c17820169#file-fix-py

See also https://github.com/AbsInt/CompCert/pull/246 for the corresponding changes on CompCert proper.

Closes #281.

Pick whether to merge this or #281 based on whether https://github.com/AbsInt/CompCert/pull/246 or https://github.com/AbsInt/CompCert/pull/250  gets merged.