### PR TITLE
Import prim token notations before using them (Alternative to #280)

### DIFF
--- a/compcert/lib/Coqlib.v
+++ b/compcert/lib/Coqlib.v
@@ -17,6 +17,7 @@
     used throughout the development.  It complements the Coq standard
     library. *)
 
+Require Export String.
 Require Export ZArith.
 Require Export Znumtheory.
 Require Export List.

--- a/progs/ghosts.v
+++ b/progs/ghosts.v
@@ -4,6 +4,7 @@ Require Import VST.msl.sepalg.
 Require Import VST.msl.sepalg_generators.
 Require Import VST.veric.SeparationLogic.
 Require Import VST.progs.conclib.
+Import List.
 
 (* Lemmas about ghost state and common instances *)
 (* Where should this sit? *)

--- a/sha/HMAC_common_defs.v
+++ b/sha/HMAC_common_defs.v
@@ -8,6 +8,7 @@ Require Import sha.general_lemmas.
 Require Import sha.hmac_pure_lemmas.
 Require Import sha.XorCorrespondence.
 Require Import sha.ByteBitRelations.
+Import List.
 
 Definition concat {A : Type} (l : list (list A)) : list A :=
   flat_map id l.
@@ -144,5 +145,3 @@ Proof.
     rewrite H3, firstn_exact; trivial.
     rewrite H3, skipn_exact; trivial.
 Qed.
-
-

--- a/sha/ShaInstantiation.v
+++ b/sha/ShaInstantiation.v
@@ -16,6 +16,7 @@ Require Import sha.hmac_common_lemmas.
 Require Import sha.pure_lemmas.
 Require Import sha.sha_padding_lemmas.
 Require Import VST.floyd.sublist. (*for Forall_list_repeat*)
+Import List.
 
 Definition c := (32 * 8)%nat.
 Definition p := (32 * 8)%nat.

--- a/veric/expr.v
+++ b/veric/expr.v
@@ -719,9 +719,9 @@ end.
 Definition same_base_type t1 t2 : bool :=
 match t1, t2 with
 | (Tarray _ _ _ | Tfunction _ _ _),
-   (Tpointer _ _ | Tarray _ _ _ | Tfunction _ _ _) => 
-     eqb (eqb_type t1 int_or_ptr_type)
-         (eqb_type t2 int_or_ptr_type)
+   (Tpointer _ _ | Tarray _ _ _ | Tfunction _ _ _) =>
+     Bool.eqb (eqb_type t1 int_or_ptr_type)
+              (eqb_type t2 int_or_ptr_type)
 | (Tstruct _ _ | Tunion _ _), (Tstruct _ _ | Tunion _ _ ) => true
 | _, _ => false
 end.

--- a/veric/expr2.v
+++ b/veric/expr2.v
@@ -335,7 +335,7 @@ intros.
       destruct Archi.ptr64; simpl; try simple_if_tac; try apply I].
   apply orb_true_iff in H.
   unfold classify_cast.
-  destruct (eqb (eqb_type (Tpointer t a0) int_or_ptr_type)
+  destruct (Bool.eqb (eqb_type (Tpointer t a0) int_or_ptr_type)
          (eqb_type (Tpointer t' a) int_or_ptr_type)) eqn:J.
   destruct (eqb_type (Tpointer t' a) (Tpointer t a0)) eqn:?H.
   apply I.

--- a/veric/expr_lemmas3.v
+++ b/veric/expr_lemmas3.v
@@ -1,3 +1,4 @@
+Require Import Coq.Reals.Rdefinitions.
 Require Import VST.msl.msl_standard.
 Require Import VST.veric.base.
 Require Import VST.veric.compcert_rmaps.


### PR DESCRIPTION
This is required for compatibility with
https://github.com/coq/coq/pull/8064, where prim token notations no longer
follow `Require`, but instead follow `Import`.

c.f. https://github.com/coq/coq/pull/8064#issuecomment-415493362

Alternative to https://github.com/PrincetonUniversity/VST/pull/280
following https://github.com/AbsInt/CompCert/pull/250 rather than
https://github.com/AbsInt/CompCert/pull/246.

Closes #280

Pick whether to merge this or #280 based on whether https://github.com/AbsInt/CompCert/pull/250 or https://github.com/AbsInt/CompCert/pull/246 gets merged.