### PR TITLE
Add several lemmas about weak_valid_pointer.

### DIFF
--- a/floyd/entailer.v
+++ b/floyd/entailer.v
@@ -290,6 +290,22 @@ intros.
  hnf; eauto.
 Qed.
 
+Lemma extend_weak_valid_pointer:
+  forall p Q, weak_valid_pointer p * Q |-- weak_valid_pointer p.
+Proof.
+  intros. unfold weak_valid_pointer.
+  pose proof (extend_tc.extend_valid_pointer' p 0).
+  pose proof (predicates_hered.boxy_e _ _ H). 
+  pose proof (extend_tc.extend_valid_pointer' p (-1)).
+  pose proof (predicates_hered.boxy_e _ _ H1).
+  change (_ |-- _) with
+      (predicates_hered.derives
+         (predicates_hered.orp (valid_pointer' p 0) (valid_pointer' p (-1)) * Q)
+         (predicates_hered.orp (valid_pointer' p 0) (valid_pointer' p (-1)))).
+  intros ? (w1 & w2 & Hj & Hp & ?). simpl in Hp |- * .
+  destruct Hp; [left; apply (H0 w1) | right; apply (H2 w1)]; auto; hnf; eauto.
+Qed.
+
 Lemma sepcon_valid_pointer1:
      forall (P Q: mpred) p,
         P |-- valid_pointer p ->

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -524,6 +524,11 @@ Lemma memory_block_valid_pointer: forall {cs: compspecs} sh n p i,
   memory_block sh n p |-- valid_pointer (offset_val i p).
 Proof. exact @memory_block_valid_pointer. Qed.
 
+Lemma memory_block_weak_valid_pointer: forall {cs: compspecs} sh n p i,
+  0 <= i <= n -> 0 < n -> sepalg.nonidentity sh ->
+  memory_block sh n p |-- weak_valid_pointer (offset_val i p).
+Proof. exact @memory_block_weak_valid_pointer. Qed.
+
 Lemma mapsto_zeros_memory_block: forall sh n p,
   readable_share sh ->
   mapsto_zeros n sh p |--

--- a/veric/valid_pointer.v
+++ b/veric/valid_pointer.v
@@ -140,5 +140,54 @@ Proof.
     - auto.
 Qed.
 
+Lemma VALspec_range_weak_valid_pointer: forall sh b ofs n i,
+  0 <= ofs /\ ofs + n < Ptrofs.modulus -> 0 <= i <= n -> 0 < n ->
+  VALspec_range n sh (b, ofs) |-- weak_valid_pointer (Vptr b (Ptrofs.repr (ofs + i))).
+Proof.
+  intros. unfold VALspec_range, weak_valid_pointer. intros w ?. simpl in H2 |- *.
+  rewrite Ptrofs.unsigned_repr by (unfold Ptrofs.max_unsigned; omega).
+  rewrite Z.add_0_r. destruct H2 as [H2 _].
+  assert (0 <= i < n \/ i = n) by omega. destruct H3.
+  - specialize (H2 (b, ofs + i)). if_tac in H2.
+    + left. destruct H2 as [? [? ?]]. rewrite H2; auto.
+    + exfalso. simpl in H4. apply H4. split; auto. omega.
+  - subst i. specialize (H2 (b, ofs + n - 1)). right. if_tac in H2.
+    + destruct H2 as [? [? ?]]. replace (ofs + n + -1) with (ofs + n - 1) by omega.
+      rewrite H2; auto.
+    + exfalso. simpl in H3. apply H3. split; auto. omega.
+Qed.
 
+Lemma nonlock_permission_bytes_weak_valid_pointer: forall sh b ofs n i,
+  0 <= ofs /\ ofs + n < Ptrofs.modulus -> 0 <= i <= n -> 0 < n -> nonidentity sh ->
+  nonlock_permission_bytes sh (b, ofs) n |--
+                           weak_valid_pointer (Vptr b (Ptrofs.repr (ofs + i))).
+Proof.
+  intros. unfold nonlock_permission_bytes, weak_valid_pointer.
+  intros w ?. simpl in H3 |- *.
+  rewrite Ptrofs.unsigned_repr by (unfold Ptrofs.max_unsigned; omega).
+  rewrite Z.add_0_r. destruct H3 as [H3 _].
+  assert (0 <= i < n \/ i = n) by omega. destruct H4.
+  - left. specialize (H3 (b, ofs + i)). if_tac in H3.
+    + destruct H3. destruct (w @ (b, ofs + i)); inv H3; auto.
+    + exfalso. simpl in H5. apply H5. split; auto. omega.
+  - subst i. right. specialize (H3 (b, ofs + n - 1)). if_tac in H3.
+    + destruct H3. replace (ofs + n + -1) with (ofs + n - 1) by omega.
+      destruct (w @ (b, ofs + n - 1)); inv H3; auto.
+    + exfalso. simpl in H4. apply H4. split; auto. omega.
+Qed.
 
+Lemma memory_block_weak_valid_pointer: forall {cs: compspecs} sh n p i,
+  0 <= i <= n -> 0 < n -> nonidentity sh ->
+  memory_block sh n p |-- weak_valid_pointer (offset_val i p).
+Proof.
+  intros. unfold memory_block. destruct p; auto. normalize.
+  pose proof Ptrofs.unsigned_range i0. rewrite memory_block'_eq.
+  2: omega. 2: rewrite Z2Nat.id; omega. unfold memory_block'_alt.
+  rewrite Z2Nat.id by omega. destruct (readable_share_dec sh).
+  + apply VALspec_range_weak_valid_pointer; auto.
+    - split; try omega.
+    - rewrite Ptrofs.unsigned_repr by (unfold Ptrofs.max_unsigned; omega). auto.
+  + apply nonlock_permission_bytes_weak_valid_pointer; auto.
+    - omega.
+    - rewrite Ptrofs.unsigned_repr by (unfold Ptrofs.max_unsigned; omega). omega.
+Qed.


### PR DESCRIPTION
In proving a program using VST, when it goes through a pointer comparison like "if (s < t)", it requires that s and t should both be weak_valid_pointer and in the same block. In my case, it is possible that s or t is in the end of an array. Thus, I can not apply the following lemma:

Lemma valid_pointer_weak: forall a : val, valid_pointer a |-- weak_valid_pointer a.

because it is not a valid_pointer. So I proved a new one for my case:

Lemma memory_block_weak_valid_pointer: forall {cs: compspecs} sh n p i,
  0 <= i <= n -> 0 < n -> nonidentity sh ->
  memory_block sh n p |-- weak_valid_pointer (offset_val i p).

When I sep_apply this entailment, I found that I also need the following lemma to finish the whole thing:

Lemma extend_weak_valid_pointer:
  forall p Q, weak_valid_pointer p * Q |-- weak_valid_pointer p.

I think they are also helpful for other users.

Thank you,

Shengyi Wang
