### PR TITLE
Use Defined for Instances instead of Qed

### DIFF
--- a/fcf/EqDec.v
+++ b/fcf/EqDec.v
@@ -189,7 +189,7 @@ Section Vector_EqDec.
   subst.
   apply eqb_vector_refl.
   
-  Qed.
+  Defined.
 End Vector_EqDec.
 
 (*
@@ -208,11 +208,11 @@ destruct x.
 destruct y.
 trivial.
 
-Qed.
+Defined.
 
 Instance bool_EqDec : EqDec bool := {eqb := Bool.eqb}.
 eapply eqb_true_iff.
-Qed.
+Defined.
 
 (* Bvector decidable equality was added before Vector.t decidable equality.  Definitions remain for compatibility. *)
 Definition eqbBvector n (v1 v2 : Bvector n) : bool :=
@@ -255,7 +255,7 @@ eapply leb_iff; eauto.
 apply andb_true_iff.
 intuition;
 eapply leb_iff; subst; eapply le_refl.
-Qed.
+Defined.
 
 
 Definition eqbPair (A B : Set)(dA : EqDec A)(dB : EqDec B)(p1 p2 : (A*B)) :=
@@ -332,7 +332,7 @@ subst.
 destruct y.
 eapply eqb_leibniz; trivial.
 trivial.
-Qed.
+Defined.
 
 Local Open Scope list_scope.
 Fixpoint eqbList(A : Set)(eqd : EqDec A)(ls1 ls2 : list A) :=
@@ -381,7 +381,7 @@ Instance list_EqDec : forall (A : Set)(dA : EqDec A), EqDec (list A) := {eqb := 
 intuition.
 eapply eqbList_correct1; trivial.
 eapply eqbList_correct2; trivial.
-Qed.
+Defined.
 
 Theorem eqb_false_iff : 
   forall (A : Set)(eqd : EqDec A)(a1 a2 : A),


### PR DESCRIPTION
Using `Qed` for typeclass instances creates opaque identifiers that can't be evaluated during computation.
```coq
Compute 1 ?= 1.
     = (let (eqb, _) := nat_EqDec in eqb) 1 1
```
If we use `Defined` instead, the definitions are transparent and can be evaluated as expected.
```coq
Compute 1 ?= 1.
     = true
```