### PR TITLE
Compatibility for coq/coq#8817 (SProp)

### DIFF
--- a/floyd/find_nth_tactic.v
+++ b/floyd/find_nth_tactic.v
@@ -13,8 +13,11 @@ Inductive find_nth_preds_rec {A: Type} (pred: A -> Prop): nat -> list A -> optio
 | find_nth_preds_rec_cons_tail: forall n R0 R R_res, find_nth_preds_rec pred (S n) R R_res -> find_nth_preds_rec pred n (R0 :: R) R_res
 | find_nth_preds_rec_nil: forall n, find_nth_preds_rec pred n nil None.
 
+Local Unset Elimination Schemes. (* ensure that we avoid name collision with the above *)
 Inductive find_nth_preds {A: Type} (pred: A -> Prop): list A -> option (nat * A) -> Prop :=
 | find_nth_preds_constr: forall R R_res, find_nth_preds_rec pred 0 R R_res -> find_nth_preds pred R R_res.
+Scheme Minimality for find_nth_preds Sort Prop.
+Local Set Elimination Schemes.
 
 Lemma find_nth_preds_Some: forall {A: Type} (pred: A -> Prop) R n R0, find_nth_preds pred R (Some (n, R0)) ->
   nth_error R n = Some R0 /\ pred R0.

--- a/floyd/seplog_tactics.v
+++ b/floyd/seplog_tactics.v
@@ -733,10 +733,13 @@ Inductive construct_fold_right_sepcon_rec: mpred -> list mpred -> list mpred -> 
 | construct_fold_right_sepcon_rec_single: forall P R,
     construct_fold_right_sepcon_rec P R (P :: R).
 
+Local Unset Elimination Schemes. (* ensure that we avoid name collision with the above *)
 Inductive construct_fold_right_sepcon: mpred -> list mpred-> Prop :=
 | construct_fold_right_sepcon_constr: forall P R,
     construct_fold_right_sepcon_rec P nil R ->
     construct_fold_right_sepcon P R.
+Scheme Minimality for construct_fold_right_sepcon Sort Prop.
+Local Set Elimination Schemes.
 
 Lemma construct_fold_right_sepcon_spec: forall P R,
   construct_fold_right_sepcon P R ->


### PR DESCRIPTION
Coq now detects that the R and R_res arguments to
find_nth_preds_constr shouldn't count to its level as they're wholly
determined from the type. This causes generation of the _rec induction
principle whose name is already used.

Same for construct_fold_right_sepcon.

This is backward compatible so should be fine to merge.