### PR TITLE
Improve go lower

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ VERIC_FILES= \
 FLOYD_FILES= \
    coqlib3.v base.v seplog_tactics.v typecheck_lemmas.v val_lemmas.v assert_lemmas.v find_nth_tactic.v const_only_eval.v \
    base2.v functional_base.v go_lower.v \
-   library.v proofauto.v computable_theorems.v \
+   library.v proofauto.v computable_theorems.v computable_functions.v \
    type_induction.v align_compatible_dec.v reptype_lemmas.v aggregate_type.v aggregate_pred.v \
    nested_pred_lemmas.v compact_prod_sum.v \
    sublist.v extract_smt.v \
@@ -449,7 +449,7 @@ else
 endif
 
 # you can also write, COQVERSION= 8.6 or-else 8.6pl2 or-else 8.6pl3   (etc.)
-COQVERSION= 8.8.0 or-else 8.8.1 or-else 8.8.2 or-else 8.9+alpha or-else 8.9.0
+COQVERSION= 8.9+alpha or-else 8.9.0
 COQV=$(shell $(COQC) -v)
 ifeq ($(IGNORECOQVERSION),true)
 else

--- a/floyd/base2.v
+++ b/floyd/base2.v
@@ -3,6 +3,7 @@ Require Export VST.floyd.typecheck_lemmas.
 Require Export VST.floyd.functional_base.
 Require Export VST.floyd.seplog_tactics.
 Require Export VST.floyd.const_only_eval.
+Require Export VST.floyd.computable_functions.
 
 Fixpoint delete_id {A: Type} i (al: list (ident*A)) : option (A * list (ident*A)) :=
  match al with

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -2087,16 +2087,16 @@ Qed.
 Inductive return_inner_gen (S: list mpred): option val -> (environ -> mpred) -> (environ -> mpred) -> Prop :=
 | return_inner_gen_main: forall ov_gen P ts u,
     return_inner_gen S ov_gen (main_post P ts u) (PROPx nil (LOCALx nil (SEPx (TT :: S))))
-| return_inner_gen_canon_nil:
-    forall ov_gen P R Res,
-      PROPx P (LOCALx nil (SEPx (R ++ S))) = Res ->
+| return_inner_gen_canon_nil':
+    forall ov_gen P R,
       return_inner_gen S ov_gen
-        (PROPx P (LOCALx nil (SEPx R))) Res
-| return_inner_gen_canon_Some:
-    forall P v R v_gen Res,
-      PROPx (P ++ (v_gen = v) :: nil) (LOCALx nil (SEPx (R ++ S))) = Res ->
+        (PROPx P (LOCALx nil (SEPx R)))
+        (PROPx P (LOCALx nil (SEPx (R ++ S))))
+| return_inner_gen_canon_Some':
+    forall P v R v_gen,
       return_inner_gen S (Some v_gen)
-        (PROPx P (LOCALx (temp ret_temp v :: nil) (SEPx R))) Res
+        (PROPx P (LOCALx (temp ret_temp v :: nil) (SEPx R)))
+        (PROPx (P ++ (v_gen = v) :: nil) (LOCALx nil (SEPx (R ++ S))))
 | return_inner_gen_EX':
     forall ov_gen (A: Type) (post1 post2: A -> environ -> mpred),
       (forall a: A, return_inner_gen S ov_gen (post1 a) (post2 a)) ->
@@ -2111,6 +2111,24 @@ Proof.
   intro a; specialize (H a).
   destruct H as [? [? ?]]; subst.
   auto.
+Qed.
+
+Lemma return_inner_gen_canon_nil S: forall ov_gen P R Res,
+  PROPx P (LOCALx nil (SEPx (VST_floyd_app R S))) = Res ->
+  return_inner_gen S ov_gen (PROPx P (LOCALx nil (SEPx R))) Res.
+Proof.
+  intros.
+  subst Res.
+  apply return_inner_gen_canon_nil'.
+Qed.
+
+Lemma return_inner_gen_canon_Some S: forall P v R v_gen Res,
+  PROPx (VST_floyd_app P ((v_gen = v) :: nil)) (LOCALx nil (SEPx (VST_floyd_app R S))) = Res ->
+  return_inner_gen S (Some v_gen) (PROPx P (LOCALx (temp ret_temp v :: nil) (SEPx R))) Res.
+Proof.
+  intros.
+  subst Res.
+  apply return_inner_gen_canon_Some'.
 Qed.
 
 Lemma return_inner_gen_None_spec: forall S post1 post2,

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -2088,15 +2088,15 @@ Inductive return_inner_gen (S: list mpred): option val -> (environ -> mpred) -> 
 | return_inner_gen_main: forall ov_gen P ts u,
     return_inner_gen S ov_gen (main_post P ts u) (PROPx nil (LOCALx nil (SEPx (TT :: S))))
 | return_inner_gen_canon_nil:
-    forall ov_gen P R,
+    forall ov_gen P R Res,
+      PROPx P (LOCALx nil (SEPx (R ++ S))) = Res ->
       return_inner_gen S ov_gen
-        (PROPx P (LOCALx nil (SEPx R)))
-        (PROPx P (LOCALx nil (SEPx (R ++ S))))
+        (PROPx P (LOCALx nil (SEPx R))) Res
 | return_inner_gen_canon_Some:
-    forall P v R v_gen,
+    forall P v R v_gen Res,
+      PROPx (P ++ (v_gen = v) :: nil) (LOCALx nil (SEPx (R ++ S))) = Res ->
       return_inner_gen S (Some v_gen)
-        (PROPx P (LOCALx (temp ret_temp v :: nil) (SEPx R)))
-        (PROPx (P ++ (v_gen = v) :: nil) (LOCALx nil (SEPx (R ++ S))))
+        (PROPx P (LOCALx (temp ret_temp v :: nil) (SEPx R))) Res
 | return_inner_gen_EX':
     forall ov_gen (A: Type) (post1 post2: A -> environ -> mpred),
       (forall a: A, return_inner_gen S ov_gen (post1 a) (post2 a)) ->

--- a/floyd/client_lemmas.v
+++ b/floyd/client_lemmas.v
@@ -377,33 +377,16 @@ Fixpoint fold_right_and_True (l: list Prop) : Prop :=
  | b::r => b /\ fold_right_and_True r
  end.
 
-Fixpoint fold_right_sepcon_emp (l: list mpred) : mpred :=
- match l with
- | nil => emp
- | b :: nil => b
- | b::r => b * fold_right_sepcon_emp r
- end.
-
 Definition fold_right_PROP_SEP (l1: list Prop) (l2: list mpred) : mpred :=
  match l1 with
- | nil => fold_right_sepcon_emp l2
- | l => !! (fold_right_and_True l) && fold_right_sepcon_emp l2
+ | nil => fold_right_sepcon l2
+ | l => !! (fold_right_and_True l) && fold_right_sepcon l2
  end.
 
 Lemma fold_right_PROP_SEP_spec: forall l1 l2,
   fold_right_PROP_SEP l1 l2 = !! (fold_right and True l1) && fold_right_sepcon l2.
 Proof.
   intros.
-  assert (fold_right_sepcon_emp l2 = fold_right_sepcon l2).
-  {
-    destruct l2; auto.
-    revert m; induction l2; intros.
-    + simpl.
-      rewrite sepcon_emp; auto.
-    + specialize (IHl2 a).
-      simpl in *.
-      rewrite IHl2; auto.
-  }
   assert (fold_right_and_True l1 <-> fold_right and True l1).
   {
     destruct l1; [tauto |].
@@ -417,7 +400,7 @@ Proof.
   + simpl.
     normalize.
   + unfold fold_right_PROP_SEP.
-    rewrite H, H0.
+    rewrite H.
     auto.
 Qed.
 

--- a/floyd/computable_functions.v
+++ b/floyd/computable_functions.v
@@ -1,0 +1,64 @@
+Require Import VST.floyd.base.
+
+Ltac simpl_PTree_get :=
+  repeat match goal with
+         | |- context [PTree.get ?i' ?t] =>
+           let i'' := eval hnf in i' in
+               change (PTree.get i' t) with
+               ((fix get (A : Type) (i : positive) (m : PTree.t A) {struct i} : option A :=
+                 match m with
+                 | PTree.Leaf => None
+                 | PTree.Node l o r =>
+                     match i with
+                     | (ii~1)%positive => get A ii r
+                     | (ii~0)%positive => get A ii l
+                     | 1%positive => o
+                     end
+                 end) _ i'' t)
+         end;
+  cbv iota zeta beta.
+
+Ltac simpl_eqb_type :=
+  repeat
+  match goal with
+  | |- context [eqb_type ?t1 ?t2] =>
+    let b := eval hnf in (eqb_type t1 t2) in
+    change (eqb_type t1 t2) with b;
+    cbv beta iota zeta
+  end.
+
+Ltac simpl_temp_types_get :=
+  repeat
+  match goal with
+  | |- context [(temp_types ?Delta) ! ?i] =>
+          let ret := eval hnf in ((temp_types Delta) ! i) in
+          change ((temp_types Delta) ! i) with ret
+  end.
+
+Ltac pos_eqb_tac :=
+  let H := fresh "H" in
+  match goal with
+  | |- context [Pos.eqb ?i ?j] => destruct (Pos.eqb i j) eqn:H; [apply Pos.eqb_eq in H | apply Pos.eqb_neq in H]
+  end.
+
+
+Definition VST_floyd_map {A B : Type} (f: A -> B): list A -> list B :=
+  fix map (l : list A) : list B := match l with
+                                   | nil => nil
+                                   | a :: t => f a :: map t
+                                   end.
+
+Definition VST_floyd_app {A: Type}: list A -> list A -> list A :=
+  fix app (l m : list A) {struct l} : list A :=
+  match l with
+  | nil => m
+  | a :: l1 => a :: app l1 m
+  end.
+
+Definition VST_floyd_concat {A: Type}: list (list A) -> list A :=
+  fix concat (l : list (list A)) : list A :=
+  match l with
+  | nil => nil
+  | x :: l0 => VST_floyd_app x (concat l0)
+  end.
+

--- a/floyd/entailer.v
+++ b/floyd/entailer.v
@@ -614,21 +614,6 @@ Ltac entailer' :=
               | simple apply FF_left
               | simple apply TT_right].
 
-(*
-Fixpoint app_mpred (al bl: list mpred) :=
- match al with a::al' => a :: app_mpred al' bl | nil => bl end.
-*)
-Ltac fixup_folds_from_return := idtac. (*
- (* Really this should not be necessary.  The right thing to do is 
-   fix foward_return so that it uses app_Prop and app_mpred
-   instead of the general app, so that they can be unfolded without
-   bothering the user's instances of app. *)
-fold fold_right_and; fold app_Prop;
-change (@app Prop) with app_Prop;
-change (@app mpred) with app_mpred;
-unfold app_mpred, app_Prop, fold_right_and, fold_right_sepcon;
-fold app_mpred; fold app_Prop; fold fold_right_and; fold fold_right_sepcon.
-*)
 Lemma empTrue:
  @derives mpred Nveric (@emp mpred Nveric Sveric) (@prop mpred Nveric True).
 Proof.
@@ -645,9 +630,7 @@ Ltac entailer :=
  match goal with
  | |- ?P |-- _ =>
     match type of P with
-    | ?T => unify T (environ->mpred); go_lower;
-                (*simpl;*)
-                fixup_folds_from_return
+    | ?T => unify T (environ->mpred); go_lower
     | _ => clear_Delta; pull_out_props
     end
  | |- _ => fail "The entailer tactic works only on entailments   _ |-- _ "

--- a/floyd/entailer.v
+++ b/floyd/entailer.v
@@ -693,6 +693,18 @@ Ltac entbang :=
     end
  | |- _ => fail "The entailer tactic works only on entailments  _ |-- _ "
  end;
+ (* The following lines are only a temporary solution. Many current proofs
+ depend on one original feature of "entailer!": sem_cast expressions and
+ sem_binary_operation' expressions will be simplified. This step was done
+ in go_lower. But that is not a reasonable design. Current version of
+ go_lower does not "simpl" user's expressions any longer---go_lower should
+ be safe. Thus we add the following lines here. *)
+ repeat match goal with
+        | |- context [force_val (sem_binary_operation' ?op ?t1 ?t2 ?v1 ?v2)] =>
+          progress simpl (force_val (sem_binary_operation' op t1 t2 v1 v2))
+        end;
+ simpl sem_cast;
+ (* end of temporary solution *)
  saturate_local;
  ent_iter;
  first [ contradiction

--- a/floyd/entailer.v
+++ b/floyd/entailer.v
@@ -614,10 +614,11 @@ Ltac entailer' :=
               | simple apply FF_left
               | simple apply TT_right].
 
+(*
 Fixpoint app_mpred (al bl: list mpred) :=
  match al with a::al' => a :: app_mpred al' bl | nil => bl end.
-
-Ltac fixup_folds_from_return := 
+*)
+Ltac fixup_folds_from_return := idtac. (*
  (* Really this should not be necessary.  The right thing to do is 
    fix foward_return so that it uses app_Prop and app_mpred
    instead of the general app, so that they can be unfolded without
@@ -627,7 +628,7 @@ change (@app Prop) with app_Prop;
 change (@app mpred) with app_mpred;
 unfold app_mpred, app_Prop, fold_right_and, fold_right_sepcon;
 fold app_mpred; fold app_Prop; fold fold_right_and; fold fold_right_sepcon.
-
+*)
 Lemma empTrue:
  @derives mpred Nveric (@emp mpred Nveric Sveric) (@prop mpred Nveric True).
 Proof.

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -2878,18 +2878,12 @@ Ltac solve_return_inner_gen :=
     | PROPx _ (LOCALx _ (SEPx _)) =>
       match v with
       | Some _ => first [ simple apply return_inner_gen_canon_Some;
-                          unfold app at 1;
-                          match goal with
-                          | |- context [SEPx (?P ++ ?Q)] =>
-                            let PQ := eval unfold app at 1 in (P ++ Q) in
-                            change (P ++ Q) with PQ;
-                            reflexivity
-                          end
+                          unfold VST_floyd_app; reflexivity
                         | simple apply return_inner_gen_canon_nil;
-                          unfold app at 1; reflexivity
+                          unfold VST_floyd_app; reflexivity
                         | fail 1000 "the LOCAL clauses of this POSTCONDITION should only contain ret_temp. Other variables appears there now."]
       | None   => first [ simple apply return_inner_gen_canon_nil;
-                          unfold app at 1; reflexivity
+                          unfold VST_floyd_app; reflexivity
                         | fail 1000 "the LOCAL clauses of this POSTCONDITION should not contain any variable."]
       end
     | _ => first [ simple apply return_inner_gen_main

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -2877,10 +2877,19 @@ Ltac solve_return_inner_gen :=
       ]
     | PROPx _ (LOCALx _ (SEPx _)) =>
       match v with
-      | Some _ => first [ simple apply return_inner_gen_canon_Some
-                        | simple apply return_inner_gen_canon_nil
+      | Some _ => first [ simple apply return_inner_gen_canon_Some;
+                          unfold app at 1;
+                          match goal with
+                          | |- context [SEPx (?P ++ ?Q)] =>
+                            let PQ := eval unfold app at 1 in (P ++ Q) in
+                            change (P ++ Q) with PQ;
+                            reflexivity
+                          end
+                        | simple apply return_inner_gen_canon_nil;
+                          unfold app at 1; reflexivity
                         | fail 1000 "the LOCAL clauses of this POSTCONDITION should only contain ret_temp. Other variables appears there now."]
-      | None   => first [ simple apply return_inner_gen_canon_nil
+      | None   => first [ simple apply return_inner_gen_canon_nil;
+                          unfold app at 1; reflexivity
                         | fail 1000 "the LOCAL clauses of this POSTCONDITION should not contain any variable."]
       end
     | _ => first [ simple apply return_inner_gen_main
@@ -2931,12 +2940,12 @@ Ltac solve_Forall2_fn_data_at :=
 
 Ltac solve_canon_derives_stackframe :=
   solve
-    [ try unfold stackframe_of;
+    [ simple apply canonicalize_stackframe_emp
+    | try unfold stackframe_of;
       simple eapply canonicalize_stackframe;
       [ prove_local2ptree
       | solve_Forall2_fn_data_at
       ]
-    | simple apply canonicalize_stackframe_emp
     ].
 
 Ltac fold_frame_function_body :=

--- a/floyd/go_lower.v
+++ b/floyd/go_lower.v
@@ -11,10 +11,8 @@ Local Open Scope logic.
 Ltac unfold_for_go_lower :=
   cbv delta [PROPx LOCALx SEPx locald_denote
                        eval_exprlist eval_expr eval_lvalue cast_expropt
-                       sem_cast eval_binop eval_unop force_val1 force_val2
-                      tc_expropt tc_expr tc_exprlist tc_lvalue tc_LR tc_LR_strong
+                       eval_binop eval_unop force_val1 force_val2
                       msubst_tc_expropt msubst_tc_expr msubst_tc_exprlist msubst_tc_lvalue msubst_tc_LR (* msubst_tc_LR_strong *) msubst_tc_efield msubst_simpl_tc_assert 
-                      typecheck_expr typecheck_exprlist typecheck_lvalue typecheck_LR typecheck_LR_strong typecheck_efield
                       function_body_ret_assert frame_ret_assert
                       make_args' bind_ret get_result1 retval
                        classify_cast

--- a/sha/verif_sha_update3.v
+++ b/sha/verif_sha_update3.v
@@ -389,8 +389,8 @@ forward_if.
   repeat rewrite TT_andp.
   unfold data_block.
   subst k.
-  rewrite (prop_true_andp (_ /\ _));
-     [ | split; [apply update_inner_if_update_abs; auto; omega | auto ]].
+  rewrite (prop_true_andp);
+     [ | apply update_inner_if_update_abs; auto; omega ].
  rewrite (sepcon_comm (K_vector gv)).
  apply sepcon_derives; [ | auto].
  rewrite map_Vubyte_eq'. 


### PR DESCRIPTION
1. When the RHS is existentially quantified PROP_LOCAL_SEP, previous version's go_lower will leave "_ * emp" unsimplified. Now, "_ * emp" is removed.

2. When the RHS has PROP_LOCAL_SEP form, previous version's go_lower will leave "!! (_ /\ True)". Now, "_ /\ True" is removed.

3. Previous version's go_lower will do "simpl" on LOCAL expressions, which may affect user's expressions. Now, it does not.

3b. Some previous proofs are based on the feature that entailer! does some simpl. Now, such simpl commands (removed from go_lower) are added into entailer!.

4. In some computational functions used by VST-Floyd, we used app, map etc in previous versions. When we unfold them, it is possible that we unfold some users' expressions as well. Now, we use VST_floyd_app, VST_floyd_map etc. to distinguish floyd's code and users' code.