### PR TITLE
Use Z.log2 and Z.log2_up instead of the deprecated log_inf and log_sup

### DIFF
--- a/compcert/lib/Coqlib.v
+++ b/compcert/lib/Coqlib.v
@@ -183,6 +183,12 @@ Hint Resolve Ple_refl Plt_Ple Ple_succ Plt_strict: coqlib.
 Ltac xomega := unfold Plt, Ple in *; zify; omega.
 Ltac xomegaContradiction := exfalso; xomega.
 
+Lemma Psize_Zlog2 (p: positive) :
+  Zpos (Pos.size p) = Z.succ (Z.log2 (Zpos p)).
+Proof.
+  destruct p; simpl; rewrite ?Pos.add_1_r; reflexivity.
+Qed.
+
 (** Peano recursion over positive numbers. *)
 
 Section POSITIVE_ITERATION.

--- a/compcert/lib/Floats.v
+++ b/compcert/lib/Floats.v
@@ -118,7 +118,7 @@ Next Obligation.
   simpl. rewrite Z.ltb_lt in *.
   assert (forall x, Fcore_digits.digits2_pos x = Pos.size x).
   { induction x0; simpl; auto; rewrite IHx0; zify; omega. }
-  rewrite H, Psize_log_inf, <- Zlog2_log_inf in *. clear H.
+  rewrite H, Psize_Zlog2 in *; clear H.
   change (Z.pos (Pos.lor x 2251799813685248)) with (Z.lor (Z.pos x) 2251799813685248%Z).
   rewrite Z.log2_lor by (zify; omega).
   apply Z.max_case. auto. simpl. omega.
@@ -911,7 +911,7 @@ Next Obligation.
   simpl. rewrite Z.ltb_lt in *.
   assert (forall x, Fcore_digits.digits2_pos x = Pos.size x).
   { induction x0; simpl; auto; rewrite IHx0; zify; omega. }
-  rewrite H, Psize_log_inf, <- Zlog2_log_inf in *. clear H.
+  rewrite H, Psize_Zlog2 in *. clear H.
   change (Z.pos (Pos.lor x 4194304)) with (Z.lor (Z.pos x) 4194304%Z).
   rewrite Z.log2_lor by (zify; omega).
   apply Z.max_case. auto. simpl. omega.

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -3638,7 +3638,7 @@ apply Z.geb_le in H. omega.
 Qed.
 
 Lemma prove_alignof_two_p (i: Z) : 
-    i = two_power_nat (Z.to_nat (log_sup (Z.to_pos i))) ->
+    i = two_power_nat (Z.to_nat (Z.log2_up i)) ->
 exists n: nat, i = two_power_nat n.
 Proof.
 intros. eexists; eassumption.


### PR DESCRIPTION
The module `Zlogarithm` has been deprecated for many years. It will soon be removed from the standard library (https://github.com/coq/coq/pull/9811).