### PR TITLE
[CompCert] Do not use compatibility notations for 8.7

### DIFF
--- a/compcert/flocq/Appli/Fappli_IEEE.v
+++ b/compcert/flocq/Appli/Fappli_IEEE.v
@@ -496,13 +496,13 @@ Definition Bcompare (f1 f2 : binary_float) : option comparison :=
     | true, false => Some Lt
     | false, true => Some Gt
     | false, false =>
-      match Zcompare e1 e2 with
+      match Z.compare e1 e2 with
       | Lt => Some Lt
       | Gt => Some Gt
       | Eq => Some (Pcompare m1 m2 Eq)
       end
     | true, true =>
-      match Zcompare e1 e2 with
+      match Z.compare e1 e2 with
       | Lt => Some Gt
       | Gt => Some Lt
       | Eq => Some (CompOpp (Pcompare m1 m2 Eq))
@@ -586,7 +586,7 @@ destruct (ln_beta radix2 (F2R (Float radix2 (Zpos mx) ex))) as (e',Ex).
 unfold ln_beta_val.
 intros H.
 apply Rlt_le_trans with (bpow radix2 e').
-change (Zpos mx) with (Zabs (Zpos mx)).
+change (Zpos mx) with (Z.abs (Zpos mx)).
 rewrite F2R_Zabs.
 apply Ex.
 apply Rgt_not_eq.
@@ -631,11 +631,11 @@ unfold canonic, Fexp in Cx.
 rewrite Cx.
 unfold canonic_exp, fexp, FLT_exp.
 destruct (ln_beta radix2 (F2R (Float radix2 (Zpos mx) ex))) as (e',Ex). simpl.
-apply Zmax_lub.
+apply Z.max_lub.
 cut (e' - 1 < emax)%Z. clear ; omega.
 apply lt_bpow with radix2.
 apply Rle_lt_trans with (2 := Bx).
-change (Zpos mx) with (Zabs (Zpos mx)).
+change (Zpos mx) with (Z.abs (Zpos mx)).
 rewrite F2R_Zabs.
 apply Ex.
 apply Rgt_not_eq.
@@ -753,7 +753,7 @@ rewrite Zplus_0_r.
 now destruct l as [|[| |]].
 rewrite iter_nat_S.
 rewrite inj_S.
-unfold Zsucc.
+unfold Z.succ.
 rewrite Zplus_assoc.
 revert IHn0.
 apply inbetween_shr_1.
@@ -902,17 +902,17 @@ assert (Hm: (m1 <= m1')%Z).
 (* . *)
 unfold m1', choice_mode, cond_incr.
 case m ;
-  try apply Zle_refl ;
+  try apply Z.le_refl ;
   match goal with |- (m1 <= if ?b then _ else _)%Z =>
-    case b ; [ apply Zle_succ | apply Zle_refl ] end.
+    case b ; [ apply Zle_succ | apply Z.le_refl ] end.
 assert (Hr: Rabs (round radix2 fexp (round_mode m) x) = F2R (Float radix2 m1' e1)).
 (* . *)
-rewrite <- (Zabs_eq m1').
-replace (Zabs m1') with (Zabs (cond_Zopp (Rlt_bool x 0) m1')).
+rewrite <- (Z.abs_eq m1').
+replace (Z.abs m1') with (Z.abs (cond_Zopp (Rlt_bool x 0) m1')).
 rewrite F2R_Zabs.
 now apply f_equal.
 apply abs_cond_Zopp.
-apply Zle_trans with (2 := Hm).
+apply Z.le_trans with (2 := Hm).
 apply Zlt_succ_le.
 apply F2R_gt_0_reg with radix2 e1.
 apply Rle_lt_trans with (1 := Rabs_pos x).
@@ -922,7 +922,7 @@ assert (Br: inbetween_float radix2 m1' e1 (Rabs (round radix2 fexp (round_mode m
 now apply inbetween_Exact.
 destruct m1' as [|m1'|m1'].
 (* . m1' = 0 *)
-rewrite shr_truncate. 2: apply Zle_refl.
+rewrite shr_truncate. 2: apply Z.le_refl.
 generalize (truncate_0 radix2 fexp e1 loc_Exact).
 destruct (truncate radix2 fexp (Z0, e1, loc_Exact)) as ((m2, e2), l2).
 rewrite shr_m_shr_record_of_loc.
@@ -962,7 +962,7 @@ elim Rgt_not_eq with (2 := H3).
 rewrite F2R_0.
 now apply F2R_gt_0_compat.
 rewrite F2R_cond_Zopp, H3, abs_cond_Ropp, <- F2R_abs.
-simpl Zabs.
+simpl Z.abs.
 case_eq (Zle_bool e2 (emax - prec)) ; intros He2.
 assert (bounded m2 e2 = true).
 apply andb_true_intro.
@@ -1003,7 +1003,7 @@ intros p Hp.
 apply Zle_antisym.
 cut (prec - 1 < Zdigits radix2 (Zpos p))%Z. clear ; omega.
 apply Zdigits_gt_Zpower.
-simpl Zabs. rewrite <- Hp.
+simpl Z.abs. rewrite <- Hp.
 cut (Zpower radix2 (prec - 1) < Zpower radix2 prec)%Z. clear ; omega.
 apply lt_Z2R.
 rewrite 2!Z2R_Zpower. 2: now apply Zlt_le_weak.
@@ -1011,7 +1011,7 @@ apply bpow_lt.
 apply Zlt_pred.
 now apply Zlt_0_le_0_pred.
 apply Zdigits_le_Zpower.
-simpl Zabs. rewrite <- Hp.
+simpl Z.abs. rewrite <- Hp.
 apply Zlt_pred.
 intros p Hp.
 generalize (Zpower_gt_1 radix2 _ (prec_gt_0 prec)).
@@ -1199,7 +1199,7 @@ case_eq (ex' - ex)%Z.
 intros H.
 repeat split.
 rewrite Zminus_eq with (1 := H).
-apply Zle_refl.
+apply Z.le_refl.
 (* d > 0 *)
 intros d Hd.
 repeat split.
@@ -1211,7 +1211,7 @@ now apply Zplus_le_compat_r.
 intros d Hd.
 rewrite shift_pos_correct, Zmult_comm.
 change (Zpower_pos 2 d) with (Zpower radix2 (Zpos d)).
-change (Zpos d) with (Zopp (Zneg d)).
+change (Zpos d) with (Z.opp (Zneg d)).
 rewrite <- Hd.
 split.
 replace (- (ex' - ex))%Z with (ex - ex')%Z by ring.
@@ -1219,7 +1219,7 @@ apply F2R_change_exp.
 apply Zle_0_minus_le.
 replace (ex - ex')%Z with (- (ex' - ex))%Z by ring.
 now rewrite Hd.
-apply Zle_refl.
+apply Z.le_refl.
 Qed.
 
 Theorem snd_shl_align :
@@ -1378,7 +1378,7 @@ Definition Bplus plus_nan m x y :=
   | B754_zero _, _ => y
   | _, B754_zero _ => x
   | B754_finite sx mx ex Hx, B754_finite sy my ey Hy =>
-    let ez := Zmin ex ey in
+    let ez := Z.min ex ey in
     binary_normalize m (Zplus (cond_Zopp sx (Zpos (fst (shl_align mx ex ez)))) (cond_Zopp sy (Zpos (fst (shl_align my ey ez)))))
       ez (match m with mode_DN => true | _ => false end)
   end.
@@ -1431,15 +1431,15 @@ apply generic_format_B2R.
 clear Fx Fy.
 simpl.
 set (szero := match m with mode_DN => true | _ => false end).
-set (ez := Zmin ex ey).
+set (ez := Z.min ex ey).
 set (mz := (cond_Zopp sx (Zpos (fst (shl_align mx ex ez))) + cond_Zopp sy (Zpos (fst (shl_align my ey ez))))%Z).
 assert (Hp: (F2R (Float radix2 (cond_Zopp sx (Zpos mx)) ex) +
   F2R (Float radix2 (cond_Zopp sy (Zpos my)) ey))%R = F2R (Float radix2 mz ez)).
 rewrite 2!F2R_cond_Zopp.
 generalize (shl_align_correct mx ex ez).
 generalize (shl_align_correct my ey ez).
-generalize (snd_shl_align mx ex ez (Zle_min_l ex ey)).
-generalize (snd_shl_align my ey ez (Zle_min_r ex ey)).
+generalize (snd_shl_align mx ex ez (Z.le_min_l ex ey)).
+generalize (snd_shl_align my ey ez (Z.le_min_r ex ey)).
 destruct (shl_align mx ex ez) as (mx', ex').
 destruct (shl_align my ey ez) as (my', ey').
 simpl.
@@ -1617,8 +1617,8 @@ replace (xorb sx sy) with (Rlt_bool (F2R (Float radix2 (cond_Zopp sx (Zpos mx)) 
 unfold Rdiv.
 destruct mz as [|mz|mz].
 (* . mz = 0 *)
-elim (Zlt_irrefl prec).
-now apply Zle_lt_trans with Z0.
+elim (Z.lt_irrefl prec).
+now apply Z.le_lt_trans with Z0.
 (* . mz > 0 *)
 apply binary_round_aux_correct.
 rewrite Rabs_mult, Rabs_Rinv.
@@ -1646,7 +1646,7 @@ apply Rinv_0_lt_compat.
 now apply F2R_gt_0_compat.
 (* *)
 case sy ; simpl.
-change (Zneg my) with (Zopp (Zpos my)).
+change (Zneg my) with (Z.opp (Zpos my)).
 rewrite F2R_Zopp.
 rewrite <- Ropp_inv_permute.
 rewrite Ropp_mult_distr_r_reverse.
@@ -1746,7 +1746,7 @@ Qed.
 
 Definition Fsqrt_core_binary m e :=
   let d := Zdigits2 m in
-  let s := Zmax (2 * prec - d) 0 in
+  let s := Z.max (2 * prec - d) 0 in
   let e' := (e - s)%Z in
   let (s', e'') := if Zeven e' then (s, e') else (s + 1, e' - 1)%Z in
   let m' :=
@@ -1758,7 +1758,7 @@ Definition Fsqrt_core_binary m e :=
   let l :=
     if Zeq_bool r 0 then loc_Exact
     else loc_Inexact (if Zle_bool r q then Lt else Gt) in
-  (q, Zdiv2 e'', l).
+  (q, Z.div2 e'', l).
 
 Lemma Bsqrt_correct_aux :
   forall m mx ex (Hx : bounded mx ex = true),
@@ -1781,8 +1781,8 @@ destruct (Fsqrt_core radix2 prec (Zpos mx) ex) as ((mz, ez), lz).
 intros (Pz, Bz).
 destruct mz as [|mz|mz].
 (* . mz = 0 *)
-elim (Zlt_irrefl prec).
-now apply Zle_lt_trans with Z0.
+elim (Z.lt_irrefl prec).
+now apply Z.le_lt_trans with Z0.
 (* . mz > 0 *)
 refine (_ (binary_round_aux_correct m (sqrt (F2R (Float radix2 (Zpos mx) ex))) mz ez lz _ _)).
 rewrite Rlt_bool_false. 2: apply sqrt_ge_0.
@@ -1845,7 +1845,7 @@ unfold emin.
 clear -Hmax ; omega.
 apply generic_format_ge_bpow with fexp.
 intros.
-apply Zle_max_r.
+apply Z.le_max_r.
 now apply F2R_gt_0_compat.
 apply generic_format_canonic.
 apply (canonic_canonic_mantissa false).

--- a/compcert/flocq/Appli/Fappli_IEEE_bits.v
+++ b/compcert/flocq/Appli/Fappli_IEEE_bits.v
@@ -79,7 +79,7 @@ split.
   clear -He ; omega.
   now rewrite Zmult_0_l.
   clear -Hm ; omega.
-- apply Zlt_le_trans with (((if s then 2 ^ ew else 0) + e + 1) * 2 ^ mw)%Z.
+- apply Z.lt_le_trans with (((if s then 2 ^ ew else 0) + e + 1) * 2 ^ mw)%Z.
   rewrite (Zmult_plus_distr_l _ 1).
   apply Zplus_lt_compat_l.
   now rewrite Zmult_1_l.
@@ -98,7 +98,7 @@ Qed.
 Definition split_bits x :=
   let mm := Zpower 2 mw in
   let em := Zpower 2 ew in
-  (Zle_bool (mm * em) x, Zmod x mm, Zmod (Zdiv x mm) em)%Z.
+  (Zle_bool (mm * em) x, Zmod x mm, Zmod (Z.div x mm) em)%Z.
 
 Theorem split_join_bits :
   forall s m e,
@@ -125,7 +125,7 @@ apply Zle_bool_false.
 apply Zplus_lt_reg_l with (2^mw * (-e))%Z.
 replace (2 ^ mw * - e + ((0 + e) * 2 ^ mw + m))%Z with (m * 1)%Z by ring.
 rewrite <- Zmult_plus_distr_r.
-apply Zlt_le_trans with (2^mw * 1)%Z.
+apply Z.lt_le_trans with (2^mw * 1)%Z.
 now apply Zmult_lt_compat_r.
 apply Zmult_le_compat_l.
 clear -He. omega.
@@ -173,12 +173,12 @@ cut (x / (2^mw * 2^ew) < 2)%Z. clear ; omega.
 apply Zdiv_lt_upper_bound.
 try apply Hx. (* 8.2/8.3 compatibility *)
 now apply Zmult_lt_0_compat.
-rewrite <- Zpower_exp ; try ( apply Zle_ge ; apply Zlt_le_weak ; assumption ).
+rewrite <- Zpower_exp ; try ( apply Z.le_ge ; apply Zlt_le_weak ; assumption ).
 change 2%Z at 1 with (Zpower 2 1).
 rewrite <- Zpower_exp.
 now rewrite Zplus_comm.
 discriminate.
-apply Zle_ge.
+apply Z.le_ge.
 now apply Zplus_le_0_compat ; apply Zlt_le_weak.
 apply Zdiv_le_lower_bound.
 try apply Hx. (* 8.2/8.3 compatibility *)
@@ -245,7 +245,7 @@ simpl. apply split_join_bits; split; try (zify; omega).
 destruct (digits2_Pnat_correct plx).
 rewrite Zpos_digits2_pos, <- Z_of_nat_S_digits2_Pnat in Hplx.
 rewrite Zpower_nat_Z in H0.
-eapply Zlt_le_trans. apply H0.
+eapply Z.lt_le_trans. apply H0.
 change 2%Z with (radix_val radix2). apply Zpower_le.
 rewrite Z.ltb_lt in Hplx.
 unfold prec in *. zify; omega.
@@ -271,7 +271,7 @@ apply (Zpower_gt_Zdigits radix2 _ (Zpos mx)).
 apply Hf.
 unfold prec.
 rewrite Zplus_comm.
-apply Zpower_exp ; apply Zle_ge.
+apply Zpower_exp ; apply Z.le_ge.
 discriminate.
 now apply Zlt_le_weak.
 (* *)
@@ -285,9 +285,9 @@ generalize (Zle_bool_imp_le _ _ Hx').
 clear ; omega.
 apply sym_eq.
 rewrite (Zsucc_pred ew).
-unfold Zsucc.
+unfold Z.succ.
 rewrite Zplus_comm.
-apply Zpower_exp ; apply Zle_ge.
+apply Zpower_exp ; apply Z.le_ge.
 discriminate.
 now apply Zlt_0_le_0_pred.
 Qed.
@@ -371,7 +371,7 @@ apply Zdigits_le_Zpower.
 simpl.
 rewrite <- Hm.
 eapply Z_mod_lt.
-now apply Zlt_gt.
+now apply Z.lt_gt.
 apply bounded_canonic_lt_emax ; try assumption.
 unfold canonic, canonic_exp.
 fold emin.
@@ -414,7 +414,7 @@ rewrite Zdigits_ln_beta. 2: discriminate.
 apply sym_eq.
 apply ln_beta_unique.
 rewrite <- Z2R_abs.
-unfold Zabs.
+unfold Z.abs.
 replace (prec - 1)%Z with mw by ( unfold prec ; ring ).
 rewrite <- Z2R_Zpower with (1 := Zlt_le_weak _ _ Hmw).
 rewrite <- Z2R_Zpower. 2: now apply Zlt_le_weak.
@@ -424,14 +424,14 @@ apply Z2R_le.
 change (radix2^mw)%Z with (0 + 2^mw)%Z.
 apply Zplus_le_compat_r.
 eapply Z_mod_lt.
-now apply Zlt_gt.
+now apply Z.lt_gt.
 apply Z2R_lt.
 unfold prec.
-rewrite Zpower_exp. 2: now apply Zle_ge ; apply Zlt_le_weak. 2: discriminate.
+rewrite Zpower_exp. 2: now apply Z.le_ge ; apply Zlt_le_weak. 2: discriminate.
 rewrite <- Zplus_diag_eq_mult_2.
 apply Zplus_lt_compat_r.
 eapply Z_mod_lt.
-now apply Zlt_gt.
+now apply Z.lt_gt.
 (* . *)
 apply bounded_canonic_lt_emax ; try assumption.
 unfold canonic, canonic_exp.
@@ -448,7 +448,7 @@ cut (0 <= ex)%Z.
 unfold emin.
 clear ; intros H1 H2 ; omega.
 eapply Z_mod_lt.
-apply Zlt_gt.
+apply Z.lt_gt.
 apply (Zpower_gt_0 radix2).
 now apply Zlt_le_weak.
 apply Rnot_le_lt.
@@ -472,7 +472,7 @@ apply refl_equal.
 discriminate.
 clear -Hew ; omega.
 eapply Z_mod_lt.
-apply Zlt_gt.
+apply Z.lt_gt.
 apply (Zpower_gt_0 radix2).
 now apply Zlt_le_weak.
 apply bpow_gt_0.
@@ -563,7 +563,7 @@ intros (sx, mx) ex Sx.
 assert (Bm: (0 <= mx < 2^mw)%Z).
 inversion_clear Sx.
 apply Z_mod_lt.
-now apply Zlt_gt.
+now apply Z.lt_gt.
 case Zeq_bool_spec ; intros He1.
 (* subnormal *)
 case_eq mx.

--- a/compcert/flocq/Appli/Fappli_rnd_odd.v
+++ b/compcert/flocq/Appli/Fappli_rnd_odd.v
@@ -41,16 +41,16 @@ split.
 intros x y Hxy.
 assert (Zfloor x <= Zrnd_odd y)%Z.
 (* .. *)
-apply Zle_trans with (Zfloor y).
+apply Z.le_trans with (Zfloor y).
 now apply Zfloor_le.
 unfold Zrnd_odd; destruct (Req_EM_T  y (Z2R (Zfloor y))).
-now apply Zle_refl.
+now apply Z.le_refl.
 case (Zeven (Zfloor y)).
 apply le_Z2R.
 apply Rle_trans with y.
 apply Zfloor_lb.
 apply Zceil_ub.
-now apply Zle_refl.
+now apply Z.le_refl.
 unfold Zrnd_odd at 1.
 (* . *)
 destruct (Req_EM_T  x (Z2R (Zfloor x))) as [Hx|Hx].
@@ -556,7 +556,7 @@ intros Y.
 apply generic_format_bpow.
 apply valid_exp.
 rewrite <- Fexp_d; trivial.
-apply Zlt_le_trans with  (ln_beta beta (F2R d))%Z.
+apply Z.lt_le_trans with  (ln_beta beta (F2R d))%Z.
 rewrite Cd; apply ln_beta_generic_gt...
 now apply Rgt_not_eq.
 apply Hd.
@@ -788,7 +788,7 @@ apply generic_format_F2R' with g.
 assumption.
 intros H; unfold canonic_exp; rewrite Hg2.
 rewrite ln_beta_m_0; try assumption.
-apply Zle_trans with (1:=fexpe_fexp _).
+apply Z.le_trans with (1:=fexpe_fexp _).
 assert (fexp (ln_beta beta (F2R u)-1) < fexp (ln_beta beta (F2R u))+1)%Z;[idtac|omega].
 now apply fexp_m_eq_0.
 Qed.
@@ -816,7 +816,7 @@ apply exists_even_fexp_lt.
 exists g; split; trivial.
 rewrite Hg2.
 rewrite ln_beta_m_0; trivial.
-apply Zle_lt_trans with (1:=fexpe_fexp _).
+apply Z.le_lt_trans with (1:=fexpe_fexp _).
 assert (fexp (ln_beta beta (F2R u)-1) < fexp (ln_beta beta (F2R u))+1)%Z;[idtac|omega].
 now apply fexp_m_eq_0.
 Qed.
@@ -903,7 +903,7 @@ destruct (exists_even_fexp_lt fexpe o) as (k',(Hk'1,(Hk'2,Hk'3))).
 eexists; split.
 apply sym_eq, Y.
 simpl; unfold canonic_exp.
-apply Zle_lt_trans with (1:=fexpe_fexp _).
+apply Z.le_lt_trans with (1:=fexpe_fexp _).
 omega.
 absurd (true=false).
 discriminate.

--- a/compcert/flocq/Calc/Fcalc_bracket.v
+++ b/compcert/flocq/Calc/Fcalc_bracket.v
@@ -390,7 +390,7 @@ rewrite <- Z2R_mult.
 apply Rcompare_not_Lt.
 apply Z2R_le.
 rewrite Hk.
-apply Zle_refl.
+apply Z.le_refl.
 exact Hstep.
 Qed.
 
@@ -419,7 +419,7 @@ Definition new_location_even k l :=
     match l with loc_Exact => l | _ => loc_Inexact Lt end
   else
     loc_Inexact
-    match Zcompare (2 * k) nb_steps with
+    match Z.compare (2 * k) nb_steps with
     | Lt => Lt
     | Eq => match l with loc_Exact => Eq | _ => Gt end
     | Gt => Gt
@@ -476,7 +476,7 @@ Definition new_location_odd k l :=
     match l with loc_Exact => l | _ => loc_Inexact Lt end
   else
     loc_Inexact
-    match Zcompare (2 * k + 1) nb_steps with
+    match Z.compare (2 * k + 1) nb_steps with
     | Lt => Lt
     | Eq => match l with loc_Inexact l => l | loc_Exact => Lt end
     | Gt => Gt
@@ -529,7 +529,7 @@ Theorem new_location_correct :
 Proof.
 intros x k l Hk Hx.
 unfold new_location.
-generalize (refl_equal nb_steps) (Zle_lt_trans _ _ _ (proj1 Hk) (proj2 Hk)).
+generalize (refl_equal nb_steps) (Z.le_lt_trans _ _ _ (proj1 Hk) (proj2 Hk)).
 pattern nb_steps at 2 3 5 ; case nb_steps.
 now intros _.
 (* . *)
@@ -619,7 +619,7 @@ Theorem inbetween_float_new_location :
   forall x m e l k,
   (0 < k)%Z ->
   inbetween_float m e x l ->
-  inbetween_float (Zdiv m (Zpower beta k)) (e + k) x (new_location (Zpower beta k) (Zmod m (Zpower beta k)) l).
+  inbetween_float (Z.div m (Zpower beta k)) (e + k) x (new_location (Zpower beta k) (Zmod m (Zpower beta k)) l).
 Proof.
 intros x m e l k Hk Hx.
 unfold inbetween_float in *.
@@ -630,7 +630,7 @@ apply (f_equal (fun r => F2R (Float beta (m * Zpower _ r) e))).
 ring.
 omega.
 assert (Hp: (Zpower beta k > 0)%Z).
-apply Zlt_gt.
+apply Z.lt_gt.
 apply Zpower_gt_0.
 now apply Zlt_le_weak.
 (* . *)
@@ -650,7 +650,7 @@ Qed.
 Theorem inbetween_float_new_location_single :
   forall x m e l,
   inbetween_float m e x l ->
-  inbetween_float (Zdiv m beta) (e + 1) x (new_location beta (Zmod m beta) l).
+  inbetween_float (Z.div m beta) (e + 1) x (new_location beta (Zmod m beta) l).
 Proof.
 intros x m e l Hx.
 replace (radix_val beta) with (Zpower beta 1).

--- a/compcert/flocq/Calc/Fcalc_div.v
+++ b/compcert/flocq/Calc/Fcalc_div.v
@@ -52,7 +52,7 @@ Definition Fdiv_core prec m1 e1 m2 e2 :=
     | Zpos p => (m1 * Zpower_pos beta p, e + Zneg p)%Z
     | _ => (m1, e)
     end in
-  let '(q, r) :=  Zdiv_eucl m m2 in
+  let '(q, r) :=  Z.div_eucl m m2 in
   (q, e', new_location m2 r loc_Exact).
 
 Theorem Fdiv_core_correct :
@@ -82,7 +82,7 @@ destruct (d2 + prec - d1)%Z as [|p|p] ;
 ring_simplify (e1 - e2 + e2)%Z.
 repeat split.
 now rewrite <- H0.
-apply Zle_refl.
+apply Z.le_refl.
 replace (e1 - e2 + Zneg p + e2)%Z with (e1 - Zpos p)%Z by (unfold Zminus ; simpl ; ring).
 fold (Zpower beta (Zpos p)).
 split.
@@ -97,7 +97,7 @@ exact Hm1.
 now apply Zpower_gt_0.
 rewrite Zdigits_mult_Zpower.
 rewrite Zplus_comm.
-apply Zle_refl.
+apply Z.le_refl.
 apply sym_not_eq.
 now apply Zlt_not_eq.
 easy.
@@ -108,8 +108,8 @@ omega.
 (* . *)
 destruct Hs as (Hs1, (Hs2, Hs3)).
 rewrite <- Hs1.
-generalize (Z_div_mod m' m2 (Zlt_gt _ _ Hm2)).
-destruct (Zdiv_eucl m' m2) as (q, r).
+generalize (Z_div_mod m' m2 (Z.lt_gt _ _ Hm2)).
+destruct (Z.div_eucl m' m2) as (q, r).
 intros (Hq, Hr).
 split.
 (* . the result mantissa q has enough digits *)
@@ -126,13 +126,13 @@ clear -Hprec Hs3 ; omega.
 cut (q * m2 = m' - r)%Z. clear -Hr H ; omega.
 rewrite Hq.
 ring.
-apply Zle_trans with (Zdigits beta (m2 + q + m2 * q)).
+apply Z.le_trans with (Zdigits beta (m2 + q + m2 * q)).
 apply Zdigits_le.
 rewrite <- Hq.
 now apply Zlt_le_weak.
 clear -Hr Hq'. omega.
 apply Zdigits_mult_strong ; apply Zlt_le_weak.
-now apply Zle_lt_trans with r.
+now apply Z.le_lt_trans with r.
 exact Hq'.
 (* . the location is correctly computed *)
 unfold inbetween_float, F2R. simpl.

--- a/compcert/flocq/Calc/Fcalc_ops.v
+++ b/compcert/flocq/Calc/Fcalc_ops.v
@@ -54,7 +54,7 @@ Qed.
 
 Theorem Falign_spec_exp:
   forall f1 f2 : float beta,
-  snd (Falign f1 f2) = Zmin (Fexp f1) (Fexp f2).
+  snd (Falign f1 f2) = Z.min (Fexp f1) (Fexp f2).
 Proof.
 intros (m1,e1) (m2,e2).
 unfold Falign; simpl.
@@ -76,7 +76,7 @@ Qed.
 
 Definition Fabs (f1 : float beta) : float beta :=
   let '(Float m1 e1) := f1 in
-  Float (Zabs m1)%Z e1.
+  Float (Z.abs m1)%Z e1.
 
 Theorem F2R_abs :
   forall f1 : float beta,
@@ -116,7 +116,7 @@ Qed.
 
 Theorem Fexp_Fplus :
   forall f1 f2 : float beta,
-  Fexp (Fplus f1 f2) = Zmin (Fexp f1) (Fexp f2).
+  Fexp (Fplus f1 f2) = Z.min (Fexp f1) (Fexp f2).
 Proof.
 intros f1 f2.
 unfold Fplus.

--- a/compcert/flocq/Calc/Fcalc_round.v
+++ b/compcert/flocq/Calc/Fcalc_round.v
@@ -240,7 +240,7 @@ rewrite H.
 apply Zceil_Z2R.
 apply Zceil_imp.
 split.
-change (m + 1 - 1)%Z with (Zpred (Zsucc m)).
+change (m + 1 - 1)%Z with (Z.pred (Z.succ m)).
 now rewrite <- Zpred_succ.
 now apply Rlt_le.
 now apply Rge_le.
@@ -538,7 +538,7 @@ Qed.
 Definition truncate_aux t k :=
   let '(m, e, l) := t in
   let p := Zpower beta k in
-  (Zdiv m p, (e + k)%Z, new_location p (Zmod m p) l).
+  (Z.div m p, (e + k)%Z, new_location p (Zmod m p) l).
 
 Theorem truncate_aux_comp :
   forall t k1 k2,
@@ -603,17 +603,17 @@ rewrite Zdigits_div_Zpower with (1 := Hm).
 replace (Zdigits beta m - k + (e + k))%Z with (Zdigits beta m + e)%Z by ring.
 unfold k.
 ring_simplify.
-apply Zle_refl.
+apply Z.le_refl.
 split.
 now apply Zlt_le_weak.
 apply Znot_gt_le.
 contradict Hd.
 apply Zdiv_small.
 apply conj with (1 := Hm).
-rewrite <- Zabs_eq with (1 := Hm).
+rewrite <- Z.abs_eq with (1 := Hm).
 apply Zpower_gt_Zdigits.
 apply Zlt_le_weak.
-now apply Zgt_lt.
+now apply Z.gt_lt.
 (* *)
 destruct (Zle_lt_or_eq _ _ Hm) as [Hm'|Hm'].
 apply generic_format_F2R.
@@ -721,7 +721,7 @@ simpl.
 apply sym_eq.
 apply valid_exp.
 exact H2.
-apply Zle_trans with e.
+apply Z.le_trans with e.
 eapply bpow_lt_bpow.
 apply Rle_lt_trans with (1 := proj1 Hex).
 rewrite Rabs_pos_eq.
@@ -764,8 +764,8 @@ exact H4.
 now left.
 (* . not enough digits but loc_Exact *)
 destruct H2 as [H2|H2].
-elim (Zlt_irrefl e).
-now apply Zle_lt_trans with (1 := H2).
+elim (Z.lt_irrefl e).
+now apply Z.le_lt_trans with (1 := H2).
 rewrite H2 in H1 |- *.
 unfold truncate.
 generalize (Zlt_cases 0 (fexp (Zdigits beta m + e) - e)).
@@ -915,7 +915,7 @@ now apply Rge_le.
 (* *)
 destruct (Rlt_bool_spec x 0) as [Zx|Zx].
 (* . *)
-apply Zopp_inj.
+apply Z.opp_inj.
 change (- m = cond_Zopp true (choice true m loc_Exact))%Z.
 rewrite <- (Zrnd_Z2R rnd (-m)) at 1.
 assert (Z2R (-m) < 0)%R.
@@ -1048,7 +1048,7 @@ Definition truncate_FIX t :=
   let k := (emin - e)%Z in
   if Zlt_bool 0 k then
     let p := Zpower beta k in
-    (Zdiv m p, (e + k)%Z, new_location p (Zmod m p) l)
+    (Z.div m p, (e + k)%Z, new_location p (Zmod m p) l)
   else t.
 
 Theorem truncate_FIX_correct :

--- a/compcert/flocq/Calc/Fcalc_sqrt.v
+++ b/compcert/flocq/Calc/Fcalc_sqrt.v
@@ -50,7 +50,7 @@ Complexity is fine as long as p1 <= 2p-1.
 
 Definition Fsqrt_core prec m e :=
   let d := Zdigits beta m in
-  let s := Zmax (2 * prec - d) 0 in
+  let s := Z.max (2 * prec - d) 0 in
   let e' := (e - s)%Z in
   let (s', e'') := if Zeven e' then (s, e') else (s + 1, e' - 1)%Z in
   let m' :=
@@ -62,7 +62,7 @@ Definition Fsqrt_core prec m e :=
   let l :=
     if Zeq_bool r 0 then loc_Exact
     else loc_Inexact (if Zle_bool r q then Lt else Gt) in
-  (q, Zdiv2 e'', l).
+  (q, Z.div2 e'', l).
 
 Theorem Fsqrt_core_correct :
   forall prec m e,
@@ -74,7 +74,7 @@ Proof.
 intros prec m e Hm.
 unfold Fsqrt_core.
 set (d := Zdigits beta m).
-set (s := Zmax (2 * prec - d) 0).
+set (s := Z.max (2 * prec - d) 0).
 (* . exponent *)
 case_eq (if Zeven (e - s) then (s, (e - s)%Z) else ((s + 1)%Z, (e - s - 1)%Z)).
 intros s' e' Hse.
@@ -84,19 +84,19 @@ case_eq (Zeven (e - s)) ; intros He Hse ; inversion Hse.
 repeat split.
 exact He.
 unfold s.
-apply Zle_max_r.
-apply Zle_max_l.
+apply Z.le_max_r.
+apply Z.le_max_l.
 ring.
-assert (H: (Zmax (2 * prec - d) 0 <= s + 1)%Z).
+assert (H: (Z.max (2 * prec - d) 0 <= s + 1)%Z).
 fold s.
 apply Zle_succ.
 repeat split.
 unfold Zminus at 1.
 now rewrite Zeven_plus, He.
-apply Zle_trans with (2 := H).
-apply Zle_max_r.
-apply Zle_trans with (2 := H).
-apply Zle_max_l.
+apply Z.le_trans with (2 := H).
+apply Z.le_max_r.
+apply Z.le_trans with (2 := H).
+apply Z.le_max_l.
 ring.
 clear -Hm He.
 destruct He as (He1, (He2, (He3, He4))).
@@ -143,9 +143,9 @@ split.
 apply Zmult_le_reg_r with 2%Z.
 easy.
 rewrite Zmult_comm.
-apply Zle_trans with (1 := Hs2).
+apply Z.le_trans with (1 := Hs2).
 rewrite Hq.
-apply Zle_trans with (Zdigits beta (q + q + q * q)).
+apply Z.le_trans with (Zdigits beta (q + q + q * q)).
 apply Zdigits_le.
 rewrite <- Hq.
 now apply Zlt_le_weak.
@@ -162,7 +162,7 @@ rewrite sqrt_mult.
 destruct (Zeven_ex e') as (e2, Hev).
 rewrite He1, Zplus_0_r in Hev. clear He1.
 rewrite Hev.
-replace (Zdiv2 (2 * e2)) with e2 by now case e2.
+replace (Z.div2 (2 * e2)) with e2 by now case e2.
 replace (2 * e2)%Z with (e2 + e2)%Z by ring.
 rewrite bpow_plus.
 fold (Rsqr (bpow e2)).

--- a/compcert/flocq/Core/Fcore_FIX.v
+++ b/compcert/flocq/Core/Fcore_FIX.v
@@ -49,7 +49,7 @@ unfold FIX_exp.
 split ; intros H.
 now apply Zlt_le_weak.
 split.
-apply Zle_refl.
+apply Z.le_refl.
 now intros _ _.
 Qed.
 
@@ -82,7 +82,7 @@ Qed.
 Global Instance FIX_exp_monotone : Monotone_exp FIX_exp.
 Proof.
 intros ex ey H.
-apply Zle_refl.
+apply Z.le_refl.
 Qed.
 
 Theorem ulp_FIX: forall x, ulp beta FIX_exp x = bpow emin.

--- a/compcert/flocq/Core/Fcore_FLT.v
+++ b/compcert/flocq/Core/Fcore_FLT.v
@@ -41,9 +41,9 @@ Context { prec_gt_0_ : Prec_gt_0 prec }.
 (* floating-point format with gradual underflow *)
 Definition FLT_format (x : R) :=
   exists f : float beta,
-  x = F2R f /\ (Zabs (Fnum f) < Zpower beta prec)%Z /\ (emin <= Fexp f)%Z.
+  x = F2R f /\ (Z.abs (Fnum f) < Zpower beta prec)%Z /\ (emin <= Fexp f)%Z.
 
-Definition FLT_exp e := Zmax (e - prec) emin.
+Definition FLT_exp e := Z.max (e - prec) emin.
 
 (** Properties of the FLT format *)
 Global Instance FLT_exp_valid : Valid_exp FLT_exp.
@@ -66,7 +66,7 @@ apply generic_format_F2R.
 intros Zmx.
 unfold canonic_exp, FLT_exp.
 rewrite ln_beta_F2R with (1 := Zmx).
-apply Zmax_lub with (2 := H3).
+apply Z.max_lub with (2 := H3).
 apply Zplus_le_reg_r with (prec - ex)%Z.
 ring_simplify.
 now apply ln_beta_le_Zpower.
@@ -87,7 +87,7 @@ rewrite Z2R_Zpower. 2: now apply Zlt_le_weak.
 apply Rmult_lt_reg_r with (bpow ex).
 apply bpow_gt_0.
 rewrite <- bpow_plus.
-change (F2R (Float beta (Zabs mx) ex) < bpow (prec + ex))%R.
+change (F2R (Float beta (Z.abs mx) ex) < bpow (prec + ex))%R.
 rewrite F2R_Zabs.
 rewrite <- Hx.
 destruct (Req_dec x 0) as [Hx0|Hx0].
@@ -101,8 +101,8 @@ apply Rlt_le_trans with (1 := proj2 He).
 apply bpow_le.
 cut (ex' - prec <= ex)%Z. omega.
 unfold ex, FLT_exp.
-apply Zle_max_l.
-apply Zle_max_r.
+apply Z.le_max_l.
+apply Z.le_max_r.
 Qed.
 
 
@@ -174,7 +174,7 @@ apply generic_format_F2R.
 intros _.
 rewrite <- Hx.
 unfold canonic_exp, FLX_exp, FLT_exp.
-apply Zle_max_l.
+apply Z.le_max_l.
 Qed.
 
 Theorem round_FLT_FLX : forall rnd x,
@@ -214,7 +214,7 @@ rewrite Hx.
 apply generic_format_F2R.
 intros _.
 rewrite <- Hx.
-apply Zle_max_r.
+apply Z.le_max_r.
 Qed.
 
 Theorem generic_format_FLT_FIX :
@@ -226,9 +226,9 @@ Proof with auto with typeclass_instances.
 apply generic_inclusion_le...
 intros e He.
 unfold FIX_exp.
-apply Zmax_lub.
+apply Z.max_lub.
 omega.
-apply Zle_refl.
+apply Z.le_refl.
 Qed.
 
 Theorem ulp_FLT_small: forall x, (Rabs x < bpow (emin+prec))%R ->
@@ -240,7 +240,7 @@ unfold ulp; case Req_bool_spec; intros Hx2.
 case (negligible_exp_spec FLT_exp).
 intros T; specialize (T (emin-1)%Z); contradict T.
 apply Zle_not_lt; unfold FLT_exp.
-apply Zle_trans with (2:=Z.le_max_r _ _); omega.
+apply Z.le_trans with (2:=Z.le_max_r _ _); omega.
 assert (V:FLT_exp emin = emin).
 unfold FLT_exp; apply Z.max_r.
 unfold Prec_gt_0 in prec_gt_0_; omega.

--- a/compcert/flocq/Core/Fcore_FLX.v
+++ b/compcert/flocq/Core/Fcore_FLX.v
@@ -43,7 +43,7 @@ Context { prec_gt_0_ : Prec_gt_0 }.
 (* unbounded floating-point format *)
 Definition FLX_format (x : R) :=
   exists f : float beta,
-  x = F2R f /\ (Zabs (Fnum f) < Zpower beta prec)%Z.
+  x = F2R f /\ (Z.abs (Fnum f) < Zpower beta prec)%Z.
 
 Definition FLX_exp (e : Z) := (e - prec)%Z.
 
@@ -135,14 +135,14 @@ apply FLX_format_generic.
 apply generic_format_FIX in Fx.
 revert Fx.
 apply generic_inclusion with (e := e)...
-apply Zle_refl.
+apply Z.le_refl.
 Qed.
 
 (** unbounded floating-point format with normal mantissas *)
 Definition FLXN_format (x : R) :=
   exists f : float beta,
   x = F2R f /\ (x <> R0 ->
-  Zpower beta (prec - 1) <= Zabs (Fnum f) < Zpower beta prec)%Z.
+  Zpower beta (prec - 1) <= Z.abs (Fnum f) < Zpower beta prec)%Z.
 
 Theorem generic_format_FLXN :
   forall x, FLXN_format x -> generic_format beta FLX_exp x.

--- a/compcert/flocq/Core/Fcore_Raux.v
+++ b/compcert/flocq/Core/Fcore_Raux.v
@@ -560,7 +560,7 @@ apply IZR_neq.
 Qed.
 
 Theorem Z2R_abs :
-  forall z, Z2R (Zabs z) = Rabs (Z2R z).
+  forall z, Z2R (Z.abs z) = Rabs (Z2R z).
 Proof.
 intros.
 repeat rewrite Z2R_IZR.
@@ -692,7 +692,7 @@ now apply Rcompare_Gt.
 Qed.
 
 Theorem Rcompare_Z2R :
-  forall x y, Rcompare (Z2R x) (Z2R y) = Zcompare x y.
+  forall x y, Rcompare (Z2R x) (Z2R y) = Z.compare x y.
 Proof.
 intros x y.
 case Rcompare_spec ; intros H ; apply sym_eq.
@@ -1032,7 +1032,7 @@ intros n x Hnx.
 apply Zlt_succ_le.
 apply lt_Z2R.
 apply Rle_lt_trans with (1 := Hnx).
-unfold Zsucc.
+unfold Z.succ.
 rewrite Z2R_plus.
 apply Zfloor_ub.
 Qed.
@@ -1095,7 +1095,7 @@ Proof.
 intros n x Hnx.
 unfold Zceil.
 apply Zopp_le_cancel.
-rewrite Zopp_involutive.
+rewrite Z.opp_involutive.
 apply Zfloor_lub.
 rewrite Z2R_opp.
 now apply Ropp_le_contravar.
@@ -1108,13 +1108,13 @@ Theorem Zceil_imp :
 Proof.
 intros n x Hnx.
 unfold Zceil.
-rewrite <- (Zopp_involutive n).
+rewrite <- (Z.opp_involutive n).
 apply f_equal.
 apply Zfloor_imp.
 split.
 rewrite Z2R_opp.
 now apply Ropp_le_contravar.
-rewrite <- (Zopp_involutive 1).
+rewrite <- (Z.opp_involutive 1).
 rewrite <- Zopp_plus_distr.
 rewrite Z2R_opp.
 now apply Ropp_lt_contravar.
@@ -1127,7 +1127,7 @@ Proof.
 intros n.
 unfold Zceil.
 rewrite <- Z2R_opp, Zfloor_Z2R.
-apply Zopp_involutive.
+apply Z.opp_involutive.
 Qed.
 
 Theorem Zceil_le :
@@ -1211,7 +1211,7 @@ case Rlt_bool_spec ; intro Hx.
 unfold Ztrunc.
 case Rlt_bool_spec ; intro Hy.
 now apply Zceil_le.
-apply Zle_trans with 0%Z.
+apply Z.le_trans with 0%Z.
 apply Zceil_glb.
 now apply Rlt_le.
 now apply Zfloor_lub.
@@ -1222,14 +1222,14 @@ Qed.
 
 Theorem Ztrunc_opp :
   forall x,
-  Ztrunc (- x) = Zopp (Ztrunc x).
+  Ztrunc (- x) = Z.opp (Ztrunc x).
 Proof.
 intros x.
 unfold Ztrunc at 2.
 case Rlt_bool_spec ; intros Hx.
 rewrite Ztrunc_floor.
 apply sym_eq.
-apply Zopp_involutive.
+apply Z.opp_involutive.
 rewrite <- Ropp_0.
 apply Ropp_le_contravar.
 now apply Rlt_le.
@@ -1242,7 +1242,7 @@ Qed.
 
 Theorem Ztrunc_abs :
   forall x,
-  Ztrunc (Rabs x) = Zabs (Ztrunc x).
+  Ztrunc (Rabs x) = Z.abs (Ztrunc x).
 Proof.
 intros x.
 rewrite Ztrunc_floor. 2: apply Rabs_pos.
@@ -1251,19 +1251,19 @@ case Rlt_bool_spec ; intro H.
 rewrite Rabs_left with (1 := H).
 rewrite Zabs_non_eq.
 apply sym_eq.
-apply Zopp_involutive.
+apply Z.opp_involutive.
 apply Zceil_glb.
 now apply Rlt_le.
 rewrite Rabs_pos_eq with (1 := H).
 apply sym_eq.
-apply Zabs_eq.
+apply Z.abs_eq.
 now apply Zfloor_lub.
 Qed.
 
 Theorem Ztrunc_lub :
   forall n x,
   (Z2R n <= Rabs x)%R ->
-  (n <= Zabs (Ztrunc x))%Z.
+  (n <= Z.abs (Ztrunc x))%Z.
 Proof.
 intros n x H.
 rewrite <- Ztrunc_abs.
@@ -1336,7 +1336,7 @@ Qed.
 
 Theorem Zaway_opp :
   forall x,
-  Zaway (- x) = Zopp (Zaway x).
+  Zaway (- x) = Z.opp (Zaway x).
 Proof.
 intros x.
 unfold Zaway at 2.
@@ -1348,14 +1348,14 @@ apply Rlt_le.
 now apply Ropp_0_gt_lt_contravar.
 rewrite Zaway_floor.
 apply sym_eq.
-apply Zopp_involutive.
+apply Z.opp_involutive.
 rewrite <- Ropp_0.
 now apply Ropp_le_contravar.
 Qed.
 
 Theorem Zaway_abs :
   forall x,
-  Zaway (Rabs x) = Zabs (Zaway x).
+  Zaway (Rabs x) = Z.abs (Zaway x).
 Proof.
 intros x.
 rewrite Zaway_ceil. 2: apply Rabs_pos.
@@ -1371,7 +1371,7 @@ apply Rle_lt_trans with (2 := H).
 apply Zfloor_lb.
 rewrite Rabs_pos_eq with (1 := H).
 apply sym_eq.
-apply Zabs_eq.
+apply Z.abs_eq.
 apply le_Z2R.
 apply Rle_trans with (1 := H).
 apply Zceil_ub.
@@ -1408,7 +1408,7 @@ split.
 apply Rmult_le_pos.
 apply (Z2R_le 0).
 refine (proj1 (Z_mod_lt _ _ _)).
-now apply Zlt_gt.
+now apply Z.lt_gt.
 apply Rlt_le.
 apply Rinv_0_lt_compat.
 now apply (Z2R_lt 0).
@@ -1417,7 +1417,7 @@ now apply (Z2R_lt 0).
 rewrite Rmult_1_l, Rmult_assoc, Rinv_l, Rmult_1_r.
 apply Z2R_lt.
 eapply Z_mod_lt.
-now apply Zlt_gt.
+now apply Z.lt_gt.
 apply Rgt_not_eq.
 now apply (Z2R_lt 0).
 (* . *)
@@ -1449,7 +1449,7 @@ Theorem radix_pos : (0 < Z2R r)%R.
 Proof.
 destruct r as (v, Hr). simpl.
 apply (Z2R_lt 0).
-apply Zlt_le_trans with 2%Z.
+apply Z.lt_le_trans with 2%Z.
 easy.
 now apply Zle_bool_imp_le.
 Qed.
@@ -1589,7 +1589,7 @@ Theorem lt_bpow :
   (bpow e1 < bpow e2)%R -> (e1 < e2)%Z.
 Proof.
 intros e1 e2 H.
-apply Zgt_lt.
+apply Z.gt_lt.
 apply Znot_le_gt.
 intros H'.
 apply Rlt_not_le with (1 := H).
@@ -1608,7 +1608,7 @@ intros e1 e2 H.
 apply Rnot_lt_le.
 intros H'.
 apply Zle_not_gt with (1 := H).
-apply Zlt_gt.
+apply Z.lt_gt.
 now apply lt_bpow.
 Qed.
 
@@ -1621,7 +1621,7 @@ apply Znot_gt_le.
 intros H'.
 apply Rle_not_lt with (1 := H).
 apply bpow_lt.
-now apply Zgt_lt.
+now apply Z.gt_lt.
 Qed.
 
 Theorem bpow_inj :
@@ -1970,7 +1970,7 @@ Qed.
 Theorem ln_beta_le_Zpower :
   forall m e,
   m <> Z0 ->
-  (Zabs m < Zpower r e)%Z->
+  (Z.abs m < Zpower r e)%Z->
   (ln_beta (Z2R m) <= e)%Z.
 Proof.
 intros m e Zm Hm.
@@ -1980,7 +1980,7 @@ destruct (Zle_or_lt 0 e).
 rewrite <- Z2R_abs, <- Z2R_Zpower with (1 := H).
 now apply Z2R_lt.
 elim Zm.
-cut (Zabs m < 0)%Z.
+cut (Z.abs m < 0)%Z.
 now case m.
 clear -Hm H.
 now destruct e.
@@ -1989,7 +1989,7 @@ Qed.
 Theorem ln_beta_gt_Zpower :
   forall m e,
   m <> Z0 ->
-  (Zpower r e <= Zabs m)%Z ->
+  (Zpower r e <= Z.abs m)%Z ->
   (e < ln_beta (Z2R m))%Z.
 Proof.
 intros m e Zm Hm.
@@ -2391,7 +2391,7 @@ destruct (Rle_lt_dec l 0) as [Hl|Hl].
   apply ub.
   now apply HE.
 left.
-set (N := Zabs_nat (up (/l) - 2)).
+set (N := Z.abs_nat (up (/l) - 2)).
 exists N.
 assert (HN: (INR N + 1 = IZR (up (/ l)) - 1)%R).
   unfold N.
@@ -2399,7 +2399,7 @@ assert (HN: (INR N + 1 = IZR (up (/ l)) - 1)%R).
   rewrite inj_Zabs_nat.
   replace (IZR (up (/ l)) - 1)%R with (IZR (up (/ l) - 2) + 1)%R.
   apply (f_equal (fun v => IZR v + 1)%R).
-  apply Zabs_eq.
+  apply Z.abs_eq.
   apply Zle_minus_le_0.
   apply (Zlt_le_succ 1).
   apply lt_IZR.
@@ -2484,10 +2484,10 @@ intros n; apply H.
 destruct K as (n, Hn).
 left; now exists (-Z.of_nat n)%Z.
 right; intros n; case (Zle_or_lt 0 n); intros M.
-rewrite <- (Zabs_eq n); trivial.
+rewrite <- (Z.abs_eq n); trivial.
 rewrite <- Zabs2Nat.id_abs.
 apply J.
-rewrite <- (Zopp_involutive n).
+rewrite <- (Z.opp_involutive n).
 rewrite <- (Z.abs_neq n).
 rewrite <- Zabs2Nat.id_abs.
 apply K.

--- a/compcert/flocq/Core/Fcore_Zaux.v
+++ b/compcert/flocq/Core/Fcore_Zaux.v
@@ -25,7 +25,7 @@ Section Zmissing.
 (** About Z *)
 Theorem Zopp_le_cancel :
   forall x y : Z,
-  (-y <= -x)%Z -> Zle x y.
+  (-y <= -x)%Z -> Z.le x y.
 Proof.
 intros x y Hxy.
 apply Zplus_le_reg_r with (-x - y)%Z.
@@ -37,7 +37,7 @@ Theorem Zgt_not_eq :
   (y < x)%Z -> (x <> y)%Z.
 Proof.
 intros x y H Hn.
-apply Zlt_irrefl with x.
+apply Z.lt_irrefl with x.
 now rewrite Hn at 1.
 Qed.
 
@@ -145,12 +145,12 @@ Theorem Zpower_plus :
   Zpower n (k1 + k2) = (Zpower n k1 * Zpower n k2)%Z.
 Proof.
 intros n k1 k2 H1 H2.
-now apply Zpower_exp ; apply Zle_ge.
+now apply Zpower_exp ; apply Z.le_ge.
 Qed.
 
 Theorem Zpower_Zpower_nat :
   forall b e, (0 <= e)%Z ->
-  Zpower b e = Zpower_nat b (Zabs_nat e).
+  Zpower b e = Zpower_nat b (Z.abs_nat e).
 Proof.
 intros b [|e|e] He.
 apply refl_equal.
@@ -199,7 +199,7 @@ omega.
 discriminate.
 (* b odd *)
 rewrite Zpower_Zpower_nat.
-induction (Zabs_nat e).
+induction (Z.abs_nat e).
 easy.
 unfold Zpower_nat. simpl.
 rewrite Zeven_mult.
@@ -239,7 +239,7 @@ Variable r : radix.
 
 Theorem radix_gt_0 : (0 < r)%Z.
 Proof.
-apply Zlt_le_trans with 2%Z.
+apply Z.lt_le_trans with 2%Z.
 easy.
 apply Zle_bool_imp_le.
 apply r.
@@ -248,7 +248,7 @@ Qed.
 Theorem radix_gt_1 : (1 < r)%Z.
 Proof.
 destruct r as (v, Hr). simpl.
-apply Zlt_le_trans with 2%Z.
+apply Z.lt_le_trans with 2%Z.
 easy.
 now apply Zle_bool_imp_le.
 Qed.
@@ -273,7 +273,7 @@ easy.
 rewrite Zpower_nat_S.
 apply Zmult_lt_0_compat with (2 := IHn).
 apply radix_gt_0.
-apply Zle_lt_trans with (1 * Zpower_nat r n)%Z.
+apply Z.le_lt_trans with (1 * Zpower_nat r n)%Z.
 rewrite Zmult_1_l.
 now apply (Zlt_le_succ 0).
 apply Zmult_lt_compat_r with (1 := H).
@@ -287,7 +287,7 @@ Theorem Zpower_gt_0 :
 Proof.
 intros p Hp.
 rewrite Zpower_Zpower_nat with (1 := Hp).
-induction (Zabs_nat p).
+induction (Z.abs_nat p).
 easy.
 rewrite Zpower_nat_S.
 apply Zmult_lt_0_compat with (2 := IHn).
@@ -336,7 +336,7 @@ rewrite <- (Zmult_1_r (r ^ e1)) at 1.
 apply Zmult_lt_compat2.
 split.
 now apply Zpower_gt_0.
-apply Zle_refl.
+apply Z.le_refl.
 split.
 easy.
 apply Zpower_gt_1.
@@ -380,7 +380,7 @@ rewrite Zopp_mult_distr_l.
 apply Z_mod_plus.
 easy.
 apply Zmult_gt_0_compat.
-now apply Zlt_gt.
+now apply Z.lt_gt.
 easy.
 now elim Hb.
 Qed.
@@ -411,7 +411,7 @@ Qed.
 
 Theorem Zdiv_mod_mult :
   forall n a b, (0 <= a)%Z -> (0 <= b)%Z ->
-  (Zdiv (Zmod n (a * b)) a) = Zmod (Zdiv n a) b.
+  (Z.div (Zmod n (a * b)) a) = Zmod (Z.div n a) b.
 Proof.
 intros n a b Ha Hb.
 destruct (Zle_lt_or_eq _ _ Ha) as [Ha'|Ha'].
@@ -421,12 +421,12 @@ rewrite (Zmult_comm a b) at 2.
 rewrite Zmult_assoc.
 unfold Zminus.
 rewrite Zopp_mult_distr_l.
-rewrite Z_div_plus by now apply Zlt_gt.
+rewrite Z_div_plus by now apply Z.lt_gt.
 rewrite <- Zdiv_Zdiv by easy.
 apply sym_eq.
 apply Zmod_eq.
-now apply Zlt_gt.
-now apply Zmult_gt_0_compat ; apply Zlt_gt.
+now apply Z.lt_gt.
+now apply Zmult_gt_0_compat ; apply Z.lt_gt.
 rewrite <- Hb'.
 rewrite Zmult_0_r, 2!Zmod_0_r.
 apply Zdiv_0_l.
@@ -439,7 +439,7 @@ Theorem ZOdiv_mod_mult :
   (Z.quot (Z.rem n (a * b)) a) = Z.rem (Z.quot n a) b.
 Proof.
 intros n a b.
-destruct (Z_eq_dec a 0) as [Za|Za].
+destruct (Z.eq_dec a 0) as [Za|Za].
 rewrite Za.
 now rewrite 2!Zquot_0_r, Zrem_0_l.
 assert (Z.rem n (a * b) = n + - (Z.quot (Z.quot n a) b * b) * a)%Z.
@@ -456,34 +456,34 @@ Qed.
 
 Theorem ZOdiv_small_abs :
   forall a b,
-  (Zabs a < b)%Z -> Z.quot a b = Z0.
+  (Z.abs a < b)%Z -> Z.quot a b = Z0.
 Proof.
 intros a b Ha.
 destruct (Zle_or_lt 0 a) as [H|H].
-apply Zquot_small.
+apply Z.quot_small.
 split.
 exact H.
-now rewrite Zabs_eq in Ha.
-apply Zopp_inj.
-rewrite <- Zquot_opp_l, Zopp_0.
-apply Zquot_small.
+now rewrite Z.abs_eq in Ha.
+apply Z.opp_inj.
+rewrite <- Zquot_opp_l, Z.opp_0.
+apply Z.quot_small.
 generalize (Zabs_non_eq a).
 omega.
 Qed.
 
 Theorem ZOmod_small_abs :
   forall a b,
-  (Zabs a < b)%Z -> Z.rem a b = a.
+  (Z.abs a < b)%Z -> Z.rem a b = a.
 Proof.
 intros a b Ha.
 destruct (Zle_or_lt 0 a) as [H|H].
-apply Zrem_small.
+apply Z.rem_small.
 split.
 exact H.
-now rewrite Zabs_eq in Ha.
-apply Zopp_inj.
+now rewrite Z.abs_eq in Ha.
+apply Z.opp_inj.
 rewrite <- Zrem_opp_l.
-apply Zrem_small.
+apply Z.rem_small.
 generalize (Zabs_non_eq a).
 omega.
 Qed.
@@ -493,7 +493,7 @@ Theorem ZOdiv_plus :
   (Z.quot (a + b) c = Z.quot a c + Z.quot b c + Z.quot (Z.rem a c + Z.rem b c) c)%Z.
 Proof.
 intros a b c Hab.
-destruct (Z_eq_dec c 0) as [Zc|Zc].
+destruct (Z.eq_dec c 0) as [Zc|Zc].
 now rewrite Zc, 4!Zquot_0_r.
 apply Zmult_reg_r with (1 := Zc).
 rewrite 2!Zmult_plus_distr_l.
@@ -632,8 +632,8 @@ Proof.
 intros x y Hxy.
 generalize (Zle_cases x y).
 case Zle_bool ; intros H.
-elim (Zlt_irrefl x).
-now apply Zle_lt_trans with y.
+elim (Z.lt_irrefl x).
+now apply Z.le_lt_trans with y.
 apply refl_equal.
 Qed.
 
@@ -672,8 +672,8 @@ Proof.
 intros x y Hxy.
 generalize (Zlt_cases x y).
 case Zlt_bool ; intros H.
-elim (Zlt_irrefl x).
-now apply Zlt_le_trans with y.
+elim (Z.lt_irrefl x).
+now apply Z.lt_le_trans with y.
 apply refl_equal.
 Qed.
 
@@ -707,32 +707,32 @@ Inductive Zcompare_prop (x y : Z) : comparison -> Prop :=
   | Zcompare_Gt_ : (y < x)%Z -> Zcompare_prop x y Gt.
 
 Theorem Zcompare_spec :
-  forall x y, Zcompare_prop x y (Zcompare x y).
+  forall x y, Zcompare_prop x y (Z.compare x y).
 Proof.
 intros x y.
 destruct (Z_dec x y) as [[H|H]|H].
 generalize (Zlt_compare _ _ H).
-case (Zcompare x y) ; try easy.
+case (Z.compare x y) ; try easy.
 now constructor.
 generalize (Zgt_compare _ _ H).
-case (Zcompare x y) ; try easy.
+case (Z.compare x y) ; try easy.
 constructor.
-now apply Zgt_lt.
+now apply Z.gt_lt.
 generalize (proj2 (Zcompare_Eq_iff_eq _ _) H).
-case (Zcompare x y) ; try easy.
+case (Z.compare x y) ; try easy.
 now constructor.
 Qed.
 
 Theorem Zcompare_Lt :
   forall x y,
-  (x < y)%Z -> Zcompare x y = Lt.
+  (x < y)%Z -> Z.compare x y = Lt.
 Proof.
 easy.
 Qed.
 
 Theorem Zcompare_Eq :
   forall x y,
-  (x = y)%Z -> Zcompare x y = Eq.
+  (x = y)%Z -> Z.compare x y = Eq.
 Proof.
 intros x y.
 apply <- Zcompare_Eq_iff_eq.
@@ -740,21 +740,21 @@ Qed.
 
 Theorem Zcompare_Gt :
   forall x y,
-  (y < x)%Z -> Zcompare x y = Gt.
+  (y < x)%Z -> Z.compare x y = Gt.
 Proof.
 intros x y.
-apply Zlt_gt.
+apply Z.lt_gt.
 Qed.
 
 End Zcompare.
 
 Section cond_Zopp.
 
-Definition cond_Zopp (b : bool) m := if b then Zopp m else m.
+Definition cond_Zopp (b : bool) m := if b then Z.opp m else m.
 
 Theorem abs_cond_Zopp :
   forall b m,
-  Zabs (cond_Zopp b m) = Zabs m.
+  Z.abs (cond_Zopp b m) = Z.abs m.
 Proof.
 intros [|] m.
 apply Zabs_Zopp.
@@ -763,14 +763,14 @@ Qed.
 
 Theorem cond_Zopp_Zlt_bool :
   forall m,
-  cond_Zopp (Zlt_bool m 0) m = Zabs m.
+  cond_Zopp (Zlt_bool m 0) m = Z.abs m.
 Proof.
 intros m.
 apply sym_eq.
 case Zlt_bool_spec ; intros Hm.
 apply Zabs_non_eq.
 now apply Zlt_le_weak.
-now apply Zabs_eq.
+now apply Z.abs_eq.
 Qed.
 
 End cond_Zopp.
@@ -808,11 +808,11 @@ Section faster_div.
 
 Lemma Zdiv_eucl_unique :
   forall a b,
-  Zdiv_eucl a b = (Zdiv a b, Zmod a b).
+  Z.div_eucl a b = (Z.div a b, Zmod a b).
 Proof.
 intros a b.
-unfold Zdiv, Zmod.
-now case Zdiv_eucl.
+unfold Z.div, Zmod.
+now case Z.div_eucl.
 Qed.
 
 Fixpoint Zpos_div_eucl_aux1 (a b : positive) {struct b} :=
@@ -835,7 +835,7 @@ intros a b.
 revert a.
 induction b ; intros a.
 - easy.
-- change (Z.pos_div_eucl a (Zpos b~0)) with (Zdiv_eucl (Zpos a) (Zpos b~0)).
+- change (Z.pos_div_eucl a (Zpos b~0)) with (Z.div_eucl (Zpos a) (Zpos b~0)).
   rewrite Zdiv_eucl_unique.
   change (Zpos b~0) with (2 * Zpos b)%Z.
   rewrite Z.rem_mul_r by easy.
@@ -843,7 +843,7 @@ induction b ; intros a.
   destruct a as [a|a|].
   + change (Zpos_div_eucl_aux1 a~1 b~0) with (let (q, r) := Zpos_div_eucl_aux1 a b in (q, 2 * r + 1)%Z).
     rewrite IHb. clear IHb.
-    change (Z.pos_div_eucl a (Zpos b)) with (Zdiv_eucl (Zpos a) (Zpos b)).
+    change (Z.pos_div_eucl a (Zpos b)) with (Z.div_eucl (Zpos a) (Zpos b)).
     rewrite Zdiv_eucl_unique.
     change (Zpos a~1) with (1 + 2 * Zpos a)%Z.
     rewrite (Zmult_comm 2 (Zpos a)).
@@ -853,7 +853,7 @@ induction b ; intros a.
     apply Zplus_comm.
   + change (Zpos_div_eucl_aux1 a~0 b~0) with (let (q, r) := Zpos_div_eucl_aux1 a b in (q, 2 * r)%Z).
     rewrite IHb. clear IHb.
-    change (Z.pos_div_eucl a (Zpos b)) with (Zdiv_eucl (Zpos a) (Zpos b)).
+    change (Z.pos_div_eucl a (Zpos b)) with (Z.div_eucl (Zpos a) (Zpos b)).
     rewrite Zdiv_eucl_unique.
     change (Zpos a~0) with (2 * Zpos a)%Z.
     rewrite (Zmult_comm 2 (Zpos a)).
@@ -861,7 +861,7 @@ induction b ; intros a.
     apply f_equal.
     now rewrite Z_mod_mult.
   + easy.
-- change (Z.pos_div_eucl a 1) with (Zdiv_eucl (Zpos a) 1).
+- change (Z.pos_div_eucl a 1) with (Z.div_eucl (Zpos a) 1).
   rewrite Zdiv_eucl_unique.
   now rewrite Zdiv_1_r, Zmod_1_r.
 Qed.
@@ -879,13 +879,13 @@ Lemma Zpos_div_eucl_aux_correct :
 Proof.
 intros a b.
 unfold Zpos_div_eucl_aux.
-change (Z.pos_div_eucl a (Zpos b)) with (Zdiv_eucl (Zpos a) (Zpos b)).
+change (Z.pos_div_eucl a (Zpos b)) with (Z.div_eucl (Zpos a) (Zpos b)).
 rewrite Zdiv_eucl_unique.
 case Pos.compare_spec ; intros H.
 now rewrite H, Z_div_same, Z_mod_same.
 now rewrite Zdiv_small, Zmod_small by (split ; easy).
 rewrite Zpos_div_eucl_aux1_correct.
-change (Z.pos_div_eucl a (Zpos b)) with (Zdiv_eucl (Zpos a) (Zpos b)).
+change (Z.pos_div_eucl a (Zpos b)) with (Z.div_eucl (Zpos a) (Zpos b)).
 apply Zdiv_eucl_unique.
 Qed.
 
@@ -920,7 +920,7 @@ Definition Zfast_div_eucl (a b : Z) :=
 
 Theorem Zfast_div_eucl_correct :
   forall a b : Z,
-  Zfast_div_eucl a b = Zdiv_eucl a b.
+  Zfast_div_eucl a b = Z.div_eucl a b.
 Proof.
 unfold Zfast_div_eucl.
 intros [|a|a] [|b|b] ; try rewrite Zpos_div_eucl_aux_correct ; easy.

--- a/compcert/flocq/Core/Fcore_digits.v
+++ b/compcert/flocq/Core/Fcore_digits.v
@@ -74,7 +74,7 @@ Qed.
 
 Theorem Zdigit_opp :
   forall n k,
-  Zdigit (-n) k = Zopp (Zdigit n k).
+  Zdigit (-n) k = Z.opp (Zdigit n k).
 Proof.
 intros n k.
 unfold Zdigit.
@@ -89,11 +89,11 @@ Theorem Zdigit_ge_Zpower_pos :
 Proof.
 intros e n Hn k Hk.
 unfold Zdigit.
-rewrite Zquot_small.
+rewrite Z.quot_small.
 apply Zrem_0_l.
 split.
 apply Hn.
-apply Zlt_le_trans with (1 := proj2 Hn).
+apply Z.lt_le_trans with (1 := proj2 Hn).
 replace k with (e + (k - e))%Z by ring.
 rewrite Zpower_plus.
 rewrite <- (Zmult_1_r (beta ^ e)) at 1.
@@ -102,8 +102,8 @@ apply (Zlt_le_succ 0).
 apply Zpower_gt_0.
 now apply Zle_minus_le_0.
 apply Zlt_le_weak.
-now apply Zle_lt_trans with n.
-generalize (Zle_lt_trans _ _ _ (proj1 Hn) (proj2 Hn)).
+now apply Z.le_lt_trans with n.
+generalize (Z.le_lt_trans _ _ _ (proj1 Hn) (proj2 Hn)).
 clear.
 now destruct e as [|e|e].
 now apply Zle_minus_le_0.
@@ -111,7 +111,7 @@ Qed.
 
 Theorem Zdigit_ge_Zpower :
   forall e n,
-  (Zabs n < Zpower beta e)%Z ->
+  (Z.abs n < Zpower beta e)%Z ->
   forall k, (e <= k)%Z -> Zdigit n k = Z0.
 Proof.
 intros e [|n|n] Hn k.
@@ -119,10 +119,10 @@ easy.
 apply Zdigit_ge_Zpower_pos.
 now split.
 intros He.
-change (Zneg n) with (Zopp (Zpos n)).
+change (Zneg n) with (Z.opp (Zpos n)).
 rewrite Zdigit_opp.
 rewrite Zdigit_ge_Zpower_pos with (2 := He).
-apply Zopp_0.
+apply Z.opp_0.
 now split.
 Qed.
 
@@ -134,17 +134,17 @@ Proof.
 intros e n He (Hn1,Hn2).
 unfold Zdigit.
 rewrite <- ZOdiv_mod_mult.
-rewrite Zrem_small.
+rewrite Z.rem_small.
 intros H.
 apply Zle_not_lt with (1 := Hn1).
 rewrite (Z.quot_rem' n (beta ^ e)).
 rewrite H, Zmult_0_r, Zplus_0_l.
 apply Zrem_lt_pos_pos.
-apply Zle_trans with (2 := Hn1).
+apply Z.le_trans with (2 := Hn1).
 apply Zpower_ge_0.
 now apply Zpower_gt_0.
 split.
-apply Zle_trans with (2 := Hn1).
+apply Z.le_trans with (2 := Hn1).
 apply Zpower_ge_0.
 replace (beta ^ e * beta)%Z with (beta ^ (e + 1))%Z.
 exact Hn2.
@@ -154,12 +154,12 @@ Qed.
 
 Theorem Zdigit_not_0 :
   forall e n, (0 <= e)%Z ->
-  (Zpower beta e <= Zabs n < Zpower beta (e + 1))%Z ->
+  (Zpower beta e <= Z.abs n < Zpower beta (e + 1))%Z ->
   Zdigit n e <> Z0.
 Proof.
 intros e n He Hn.
 destruct (Zle_or_lt 0 n) as [Hn'|Hn'].
-rewrite (Zabs_eq _ Hn') in Hn.
+rewrite (Z.abs_eq _ Hn') in Hn.
 now apply Zdigit_not_0_pos.
 intros H.
 rewrite (Zabs_non_eq n) in Hn by now apply Zlt_le_weak.
@@ -245,8 +245,8 @@ intros n k k' Hk.
 unfold Zdigit.
 rewrite ZOdiv_small_abs.
 apply Zrem_0_l.
-apply Zlt_le_trans with (Zpower beta k').
-rewrite <- (Zabs_eq (beta ^ k')) at 2 by apply Zpower_ge_0.
+apply Z.lt_le_trans with (Zpower beta k').
+rewrite <- (Z.abs_eq (beta ^ k')) at 2 by apply Zpower_ge_0.
 apply Zrem_lt.
 apply Zgt_not_eq.
 now apply Zpower_gt_0.
@@ -266,7 +266,7 @@ Proof.
 intros n.
 induction k.
 apply sym_eq.
-apply Zrem_1_r.
+apply Z.rem_1_r.
 simpl Zsum_digit.
 rewrite IHk.
 unfold Zdigit.
@@ -295,8 +295,8 @@ induction (nat_of_P n).
 easy.
 rewrite inj_S.
 change (Zpower_nat beta (S n0)) with (beta * Zpower_nat beta n0)%Z.
-unfold Zsucc.
-apply Zlt_le_trans with (beta * (Z_of_nat n0 + 1))%Z.
+unfold Z.succ.
+apply Z.lt_le_trans with (beta * (Z_of_nat n0 + 1))%Z.
 clear.
 apply Zlt_0_minus_lt.
 replace (beta * (Z_of_nat n0 + 1) - (Z_of_nat n0 + 1))%Z with ((beta - 1) * (Z_of_nat n0 + 1))%Z by ring.
@@ -308,7 +308,7 @@ apply (Zle_lt_succ 0).
 apply Zle_0_nat.
 apply Zmult_le_compat_l.
 now apply Zlt_le_succ.
-apply Zle_trans with 2%Z.
+apply Z.le_trans with 2%Z.
 easy.
 apply Zle_bool_imp_le.
 apply beta.
@@ -320,29 +320,29 @@ Theorem Zdigit_ext :
   n1 = n2.
 Proof.
 intros n1 n2 H.
-rewrite <- (ZOmod_small_abs n1 (Zpower beta (Zmax (Zabs n1) (Zabs n2)))).
-rewrite <- (ZOmod_small_abs n2 (Zpower beta (Zmax (Zabs n1) (Zabs n2)))) at 2.
-replace (Zmax (Zabs n1) (Zabs n2)) with (Z_of_nat (Zabs_nat (Zmax (Zabs n1) (Zabs n2)))).
+rewrite <- (ZOmod_small_abs n1 (Zpower beta (Z.max (Z.abs n1) (Z.abs n2)))).
+rewrite <- (ZOmod_small_abs n2 (Zpower beta (Z.max (Z.abs n1) (Z.abs n2)))) at 2.
+replace (Z.max (Z.abs n1) (Z.abs n2)) with (Z_of_nat (Z.abs_nat (Z.max (Z.abs n1) (Z.abs n2)))).
 rewrite <- 2!Zsum_digit_digit.
-induction (Zabs_nat (Zmax (Zabs n1) (Zabs n2))).
+induction (Z.abs_nat (Z.max (Z.abs n1) (Z.abs n2))).
 easy.
 simpl.
 rewrite H, IHn.
 apply refl_equal.
 apply Zle_0_nat.
 rewrite inj_Zabs_nat.
-apply Zabs_eq.
-apply Zle_trans with (Zabs n1).
+apply Z.abs_eq.
+apply Z.le_trans with (Z.abs n1).
 apply Zabs_pos.
-apply Zle_max_l.
-apply Zlt_le_trans with (Zpower beta (Zabs n2)).
+apply Z.le_max_l.
+apply Z.lt_le_trans with (Zpower beta (Z.abs n2)).
 apply Zpower_gt_id.
 apply Zpower_le.
-apply Zle_max_r.
-apply Zlt_le_trans with (Zpower beta (Zabs n1)).
+apply Z.le_max_r.
+apply Z.lt_le_trans with (Zpower beta (Z.abs n1)).
 apply Zpower_gt_id.
 apply Zpower_le.
-apply Zle_max_l.
+apply Z.le_max_l.
 Qed.
 
 Theorem ZOmod_plus_pow_digit :
@@ -354,11 +354,11 @@ intros u v n Huv Hd.
 destruct (Zle_or_lt 0 n) as [Hn|Hn].
 rewrite Zplus_rem with (1 := Huv).
 apply ZOmod_small_abs.
-generalize (Zle_refl n).
-pattern n at -2 ; rewrite <- Zabs_eq with (1 := Hn).
+generalize (Z.le_refl n).
+pattern n at -2 ; rewrite <- Z.abs_eq with (1 := Hn).
 rewrite <- (inj_Zabs_nat n).
-induction (Zabs_nat n) as [|p IHp].
-now rewrite 2!Zrem_1_r.
+induction (Z.abs_nat n) as [|p IHp].
+now rewrite 2!Z.rem_1_r.
 rewrite <- 2!Zsum_digit_digit.
 simpl Zsum_digit.
 rewrite inj_S.
@@ -367,39 +367,39 @@ replace (Zsum_digit (Zdigit u) p + Zdigit u (Z_of_nat p) * beta ^ Z_of_nat p +
   (Zsum_digit (Zdigit v) p + Zdigit v (Z_of_nat p) * beta ^ Z_of_nat p))%Z with
   (Zsum_digit (Zdigit u) p + Zsum_digit (Zdigit v) p +
   (Zdigit u (Z_of_nat p) + Zdigit v (Z_of_nat p)) * beta ^ Z_of_nat p)%Z by ring.
-apply (Zle_lt_trans _ _ _ (Zabs_triangle _ _)).
-replace (beta ^ Zsucc (Z_of_nat p))%Z with (beta ^ Z_of_nat p + (beta - 1) * beta ^ Z_of_nat p)%Z.
+apply (Z.le_lt_trans _ _ _ (Z.abs_triangle _ _)).
+replace (beta ^ Z.succ (Z_of_nat p))%Z with (beta ^ Z_of_nat p + (beta - 1) * beta ^ Z_of_nat p)%Z.
 apply Zplus_lt_le_compat.
 rewrite 2!Zsum_digit_digit.
 apply IHp.
 now apply Zle_succ_le.
 rewrite Zabs_Zmult.
-rewrite (Zabs_eq (beta ^ Z_of_nat p)) by apply Zpower_ge_0.
+rewrite (Z.abs_eq (beta ^ Z_of_nat p)) by apply Zpower_ge_0.
 apply Zmult_le_compat_r. 2: apply Zpower_ge_0.
 apply Zlt_succ_le.
-assert (forall u v, Zabs (Zdigit u v) < Zsucc (beta -  1))%Z.
+assert (forall u v, Z.abs (Zdigit u v) < Z.succ (beta -  1))%Z.
 clear ; intros n k.
 assert (0 < beta)%Z.
-apply Zlt_le_trans with 2%Z.
+apply Z.lt_le_trans with 2%Z.
 apply refl_equal.
 apply Zle_bool_imp_le.
 apply beta.
-replace (Zsucc (beta - 1)) with (Zabs beta).
+replace (Z.succ (beta - 1)) with (Z.abs beta).
 apply Zrem_lt.
 now apply Zgt_not_eq.
-rewrite Zabs_eq.
+rewrite Z.abs_eq.
 apply Zsucc_pred.
 now apply Zlt_le_weak.
 assert (0 <= Z_of_nat p < n)%Z.
 split.
 apply Zle_0_nat.
-apply Zgt_lt.
+apply Z.gt_lt.
 now apply Zle_succ_gt.
 destruct (Hd (Z_of_nat p) H0) as [K|K] ; rewrite K.
 apply H.
 rewrite Zplus_0_r.
 apply H.
-unfold Zsucc.
+unfold Z.succ.
 ring_simplify.
 rewrite Zpower_plus.
 change (beta ^1)%Z with (beta * 1)%Z.
@@ -422,7 +422,7 @@ rewrite <- ZOmod_plus_pow_digit by assumption.
 apply f_equal.
 destruct (Zle_or_lt 0 n) as [Hn|Hn].
 apply ZOdiv_small_abs.
-rewrite <- Zabs_eq.
+rewrite <- Z.abs_eq.
 apply Zrem_lt.
 apply Zgt_not_eq.
 now apply Zpower_gt_0.
@@ -562,7 +562,7 @@ rewrite Zle_bool_true.
 rewrite Zdigit_mod_pow by apply Hk.
 rewrite Zdigit_scale by apply Hk.
 unfold Zminus.
-now rewrite Zopp_involutive, Zplus_comm.
+now rewrite Z.opp_involutive, Zplus_comm.
 omega.
 Qed.
 
@@ -608,13 +608,13 @@ Qed.
 
 Theorem Zslice_slice :
   forall n k1 k2 k1' k2', (0 <= k1' <= k2)%Z ->
-  Zslice (Zslice n k1 k2) k1' k2' = Zslice n (k1 + k1') (Zmin (k2 - k1') k2').
+  Zslice (Zslice n k1 k2) k1' k2' = Zslice n (k1 + k1') (Z.min (k2 - k1') k2').
 Proof.
 intros n k1 k2 k1' k2' Hk1'.
 destruct (Zle_or_lt 0 k2') as [Hk2'|Hk2'].
 apply Zdigit_ext.
 intros k Hk.
-destruct (Zle_or_lt (Zmin (k2 - k1') k2') k) as [Hk'|Hk'].
+destruct (Zle_or_lt (Z.min (k2 - k1') k2') k) as [Hk'|Hk'].
 rewrite (Zdigit_slice_out n (k1 + k1')) with (1 := Hk').
 destruct (Zle_or_lt k2' k) as [Hk''|Hk''].
 now apply Zdigit_slice_out.
@@ -627,7 +627,7 @@ rewrite Zdigit_slice.
 now rewrite Zplus_assoc.
 zify ; omega.
 unfold Zslice.
-rewrite Zmin_r.
+rewrite Z.min_r.
 now rewrite Zle_bool_false.
 omega.
 Qed.
@@ -659,11 +659,11 @@ replace k1 with Z0 by omega.
 case Zle_bool_spec ; intros Hk'.
 replace k with Z0 by omega.
 simpl.
-now rewrite Zquot_1_r.
-rewrite Zopp_involutive.
+now rewrite Z.quot_1_r.
+rewrite Z.opp_involutive.
 apply Zmult_1_r.
 rewrite Zle_bool_false by omega.
-rewrite 2!Zopp_involutive, Zplus_comm.
+rewrite 2!Z.opp_involutive, Zplus_comm.
 rewrite Zpower_plus by assumption.
 apply Zquot_Zquot.
 Qed.
@@ -689,7 +689,7 @@ apply Zdigit_ext.
 intros k' Hk'.
 rewrite Zdigit_scale with (1 := Hk').
 unfold Zminus.
-rewrite (Zplus_comm k'), Zopp_involutive.
+rewrite (Zplus_comm k'), Z.opp_involutive.
 destruct (Zle_or_lt k2 k') as [Hk2|Hk2].
 rewrite Zdigit_slice_out with (1 := Hk2).
 apply sym_eq.
@@ -770,7 +770,7 @@ Definition Zdigits n :=
 
 Theorem Zdigits_correct :
   forall n,
-  (Zpower beta (Zdigits n - 1) <= Zabs n < Zpower beta (Zdigits n))%Z.
+  (Zpower beta (Zdigits n - 1) <= Z.abs n < Zpower beta (Zdigits n))%Z.
 Proof.
 cut (forall p, Zpower beta (Zdigits (Zpos p) - 1) <= Zpos p < Zpower beta (Zdigits (Zpos p)))%Z.
 intros H [|n|n] ; try exact (H n).
@@ -779,7 +779,7 @@ intros n.
 simpl.
 (* *)
 assert (U: (Zpos n < Zpower beta (Z_of_nat (S (digits2_Pnat n))))%Z).
-apply Zlt_le_trans with (1 := proj2 (digits2_Pnat_correct n)).
+apply Z.lt_le_trans with (1 := proj2 (digits2_Pnat_correct n)).
 rewrite Zpower_Zpower_nat.
 rewrite Zabs_nat_Z_of_nat.
 induction (S (digits2_Pnat n)).
@@ -797,7 +797,7 @@ apply Zle_0_nat.
 (* *)
 revert U.
 rewrite inj_S.
-unfold Zsucc.
+unfold Z.succ.
 generalize (digits2_Pnat n).
 intros u U.
 pattern (radix_val beta) at 2 4 ; replace (radix_val beta) with (Zpower beta 1) by apply Zmult_1_r.
@@ -805,12 +805,12 @@ assert (V: (Zpower beta (1 - 1) <= Zpos n)%Z).
 now apply (Zlt_le_succ 0).
 generalize (conj V U).
 clear.
-generalize (Zle_refl 1).
+generalize (Z.le_refl 1).
 generalize 1%Z at 2 3 5 6 7 9 10.
 (* *)
 induction u.
 easy.
-rewrite inj_S; unfold Zsucc.
+rewrite inj_S; unfold Z.succ.
 simpl Zdigits_aux.
 intros v Hv U.
 case Zlt_bool_spec ; intros K.
@@ -829,20 +829,20 @@ Qed.
 
 Theorem Zdigits_unique :
   forall n d,
-  (Zpower beta (d - 1) <= Zabs n < Zpower beta d)%Z ->
+  (Zpower beta (d - 1) <= Z.abs n < Zpower beta d)%Z ->
   Zdigits n = d.
 Proof.
 intros n d Hd.
 assert (Hd' := Zdigits_correct n).
 apply Zle_antisym.
 apply (Zpower_lt_Zpower beta).
-now apply Zle_lt_trans with (Zabs n).
+now apply Z.le_lt_trans with (Z.abs n).
 apply (Zpower_lt_Zpower beta).
-now apply Zle_lt_trans with (Zabs n).
+now apply Z.le_lt_trans with (Z.abs n).
 Qed.
 
 Theorem Zdigits_abs :
-  forall n, Zdigits (Zabs n) = Zdigits n.
+  forall n, Zdigits (Z.abs n) = Zdigits n.
 Proof.
 now intros [|n|n].
 Qed.
@@ -852,10 +852,10 @@ Theorem Zdigits_gt_0 :
 Proof.
 intros n Zn.
 rewrite <- (Zdigits_abs n).
-assert (Hn: (0 < Zabs n)%Z).
+assert (Hn: (0 < Z.abs n)%Z).
 destruct n ; [|easy|easy].
 now elim Zn.
-destruct (Zabs n) as [|p|p] ; try easy ; clear.
+destruct (Z.abs n) as [|p|p] ; try easy ; clear.
 simpl.
 generalize 1%Z (radix_val beta) (refl_equal Lt : (0 < 1)%Z).
 induction (digits2_Pnat p).
@@ -872,7 +872,7 @@ Theorem Zdigits_ge_0 :
   forall n, (0 <= Zdigits n)%Z.
 Proof.
 intros n.
-destruct (Z_eq_dec n 0) as [H|H].
+destruct (Z.eq_dec n 0) as [H|H].
 now rewrite H.
 apply Zlt_le_weak.
 now apply Zdigits_gt_0.
@@ -908,8 +908,8 @@ unfold Zslice.
 rewrite Zle_bool_true with (1 := Hl).
 destruct (Zdigits_correct (Z.rem (Zscale n (- k)) (Zpower beta l))) as (H1,H2).
 apply Zpower_lt_Zpower with beta.
-apply Zle_lt_trans with (1 := H1).
-rewrite <- (Zabs_eq (beta ^ l)) at 2 by apply Zpower_ge_0.
+apply Z.le_lt_trans with (1 := H1).
+rewrite <- (Z.abs_eq (beta ^ l)) at 2 by apply Zpower_ge_0.
 apply Zrem_lt.
 apply Zgt_not_eq.
 now apply Zpower_gt_0.
@@ -923,7 +923,7 @@ Proof.
 intros m e Hm He.
 assert (H := Zdigits_correct m).
 apply Zdigits_unique.
-rewrite Z.abs_mul, Z.abs_pow, (Zabs_eq beta).
+rewrite Z.abs_mul, Z.abs_pow, (Z.abs_eq beta).
 2: now apply Zlt_le_weak, radix_gt_0.
 split.
 replace (Zdigits m + e - 1)%Z with (Zdigits m - 1 + e)%Z by ring.
@@ -976,18 +976,18 @@ Qed.
 Theorem Zpower_le_Zdigits :
   forall e x,
   (e < Zdigits x)%Z ->
-  (Zpower beta e <= Zabs x)%Z.
+  (Zpower beta e <= Z.abs x)%Z.
 Proof.
 intros e x Hex.
 destruct (Zdigits_correct x) as [H1 H2].
-apply Zle_trans with (2 := H1).
+apply Z.le_trans with (2 := H1).
 apply Zpower_le.
 clear -Hex ; omega.
 Qed.
 
 Theorem Zdigits_le_Zpower :
   forall e x,
-  (Zabs x < Zpower beta e)%Z ->
+  (Z.abs x < Zpower beta e)%Z ->
   (Zdigits x <= e)%Z.
 Proof.
 intros e x.
@@ -998,17 +998,17 @@ Qed.
 Theorem Zpower_gt_Zdigits :
   forall e x,
   (Zdigits x <= e)%Z ->
-  (Zabs x < Zpower beta e)%Z.
+  (Z.abs x < Zpower beta e)%Z.
 Proof.
 intros e x Hex.
 destruct (Zdigits_correct x) as [H1 H2].
-apply Zlt_le_trans with (1 := H2).
+apply Z.lt_le_trans with (1 := H2).
 now apply Zpower_le.
 Qed.
 
 Theorem Zdigits_gt_Zpower :
   forall e x,
-  (Zpower beta e <= Zabs x)%Z ->
+  (Zpower beta e <= Z.abs x)%Z ->
   (e < Zdigits x)%Z.
 Proof.
 intros e x Hex.
@@ -1029,17 +1029,17 @@ Theorem Zdigits_mult_strong :
 Proof.
 intros x y Hx Hy.
 apply Zdigits_le_Zpower.
-rewrite Zabs_eq.
-apply Zlt_le_trans with ((x + 1) * (y + 1))%Z.
+rewrite Z.abs_eq.
+apply Z.lt_le_trans with ((x + 1) * (y + 1))%Z.
 ring_simplify.
-apply Zle_lt_succ, Zle_refl.
+apply Zle_lt_succ, Z.le_refl.
 rewrite Zpower_plus by apply Zdigits_ge_0.
 apply Zmult_le_compat.
 apply Zlt_le_succ.
-rewrite <- (Zabs_eq x) at 1 by easy.
+rewrite <- (Z.abs_eq x) at 1 by easy.
 apply Zdigits_correct.
 apply Zlt_le_succ.
-rewrite <- (Zabs_eq y) at 1 by easy.
+rewrite <- (Z.abs_eq y) at 1 by easy.
 apply Zdigits_correct.
 clear -Hx ; omega.
 clear -Hy ; omega.
@@ -1057,7 +1057,7 @@ intros x y.
 rewrite <- Zdigits_abs.
 rewrite <- (Zdigits_abs x).
 rewrite <- (Zdigits_abs y).
-apply Zle_trans with (Zdigits (Zabs x + Zabs y + Zabs x * Zabs y)).
+apply Z.le_trans with (Zdigits (Z.abs x + Z.abs y + Z.abs x * Z.abs y)).
 apply Zdigits_le.
 apply Zabs_pos.
 rewrite Zabs_Zmult.
@@ -1097,28 +1097,28 @@ intros m e Hm He.
 assert (H := Zdigits_correct m).
 apply Zdigits_unique.
 destruct (Zle_lt_or_eq _ _ (proj2 He)) as [He'|He'].
-  rewrite Zabs_eq in H by easy.
+  rewrite Z.abs_eq in H by easy.
   destruct H as [H1 H2].
-  rewrite Zabs_eq.
+  rewrite Z.abs_eq.
   split.
   replace (Zdigits m - e - 1)%Z with (Zdigits m - 1 - e)%Z by ring.
   rewrite Z.pow_sub_r.
   2: apply Zgt_not_eq, radix_gt_0.
   2: clear -He He' ; omega.
   apply Z_div_le with (2 := H1).
-  now apply Zlt_gt, Zpower_gt_0.
+  now apply Z.lt_gt, Zpower_gt_0.
   apply Zmult_lt_reg_r with (Zpower beta e).
   now apply Zpower_gt_0.
-  apply Zle_lt_trans with m.
+  apply Z.le_lt_trans with m.
   rewrite Zmult_comm.
   apply Z_mult_div_ge.
-  now apply Zlt_gt, Zpower_gt_0.
+  now apply Z.lt_gt, Zpower_gt_0.
   rewrite <- Zpower_plus.
   now replace (Zdigits m - e + e)%Z with (Zdigits m) by ring.
   now apply Zle_minus_le_0.
   apply He.
   apply Z_div_pos with (2 := Hm).
-  now apply Zlt_gt, Zpower_gt_0.
+  now apply Z.lt_gt, Zpower_gt_0.
 rewrite He'.
 rewrite (Zeq_minus _ (Zdigits m)) by reflexivity.
 simpl.
@@ -1126,7 +1126,7 @@ rewrite Zdiv_small.
 easy.
 split.
 exact Hm.
-now rewrite <- (Zabs_eq m) at 1.
+now rewrite <- (Z.abs_eq m) at 1.
 Qed.
 
 End Fcore_digits.
@@ -1143,7 +1143,7 @@ intros m.
 apply eq_sym, Zdigits_unique.
 rewrite <- Zpower_nat_Z.
 rewrite Nat2Z.inj_succ.
-change (_ - 1)%Z with (Zpred (Zsucc (Z.of_nat (digits2_Pnat m)))).
+change (_ - 1)%Z with (Z.pred (Z.succ (Z.of_nat (digits2_Pnat m)))).
 rewrite <- Zpred_succ.
 rewrite <- Zpower_nat_Z.
 apply digits2_Pnat_correct.
@@ -1152,8 +1152,8 @@ Qed.
 Fixpoint digits2_pos (n : positive) : positive :=
   match n with
   | xH => xH
-  | xO p => Psucc (digits2_pos p)
-  | xI p => Psucc (digits2_pos p)
+  | xO p => Pos.succ (digits2_pos p)
+  | xI p => Pos.succ (digits2_pos p)
   end.
 
 Theorem Zpos_digits2_pos :

--- a/compcert/flocq/Core/Fcore_float_prop.v
+++ b/compcert/flocq/Core/Fcore_float_prop.v
@@ -29,7 +29,7 @@ Notation bpow e := (bpow beta e).
 
 Theorem Rcompare_F2R :
   forall e m1 m2 : Z,
-  Rcompare (F2R (Float beta m1 e)) (F2R (Float beta m2 e)) = Zcompare m1 m2.
+  Rcompare (F2R (Float beta m1 e)) (F2R (Float beta m2 e)) = Z.compare m1 m2.
 Proof.
 intros e m1 m2.
 unfold F2R. simpl.
@@ -110,7 +110,7 @@ Qed.
 
 Theorem F2R_Zabs:
   forall m e : Z,
-   F2R (Float beta (Zabs m) e) = Rabs (F2R (Float beta m e)).
+   F2R (Float beta (Z.abs m) e) = Rabs (F2R (Float beta m e)).
 Proof.
 intros m e.
 unfold F2R.
@@ -125,7 +125,7 @@ Qed.
 
 Theorem F2R_Zopp :
   forall m e : Z,
-  F2R (Float beta (Zopp m) e) = Ropp (F2R (Float beta m e)).
+  F2R (Float beta (Z.opp m) e) = Ropp (F2R (Float beta m e)).
 Proof.
 intros m e.
 unfold F2R. simpl.
@@ -359,7 +359,7 @@ Qed.
 
 Theorem F2R_lt_bpow :
   forall f : float beta, forall e',
-  (Zabs (Fnum f) < Zpower beta (e' - Fexp f))%Z ->
+  (Z.abs (Fnum f) < Zpower beta (e' - Fexp f))%Z ->
   (Rabs (F2R f) < bpow e')%R.
 Proof.
 intros (m, e) e' Hm.
@@ -396,7 +396,7 @@ Qed.
 
 Theorem F2R_prec_normalize :
   forall m e e' p : Z,
-  (Zabs m < Zpower beta p)%Z ->
+  (Z.abs m < Zpower beta p)%Z ->
   (bpow (e' - 1)%Z <= Rabs (F2R (Float beta m e)))%R ->
   F2R (Float beta m e) = F2R (Float beta (m * Zpower beta (e - e' + p)) (e' - p)).
 Proof.
@@ -465,7 +465,7 @@ assert (He: (e2 < e1)%Z).
 apply Znot_ge_lt.
 intros H0.
 elim Rlt_not_le with (1 := H21).
-apply Zge_le in H0.
+apply Z.ge_le in H0.
 apply (F2R_change_exp e1 m2 e2) in H0.
 rewrite H0.
 apply F2R_le_compat.
@@ -486,14 +486,14 @@ simpl.
 apply sym_eq.
 apply ln_beta_unique.
 assert (H2 : (bpow (e1' - 1) <= F2R (Float beta m1 e1) < bpow e1')%R).
-rewrite <- (Zabs_eq m1), F2R_Zabs.
+rewrite <- (Z.abs_eq m1), F2R_Zabs.
 apply H1.
 apply Rgt_not_eq.
 apply Rlt_gt.
 now apply F2R_gt_0_compat.
 now apply Zlt_le_weak.
 clear H1.
-rewrite <- F2R_Zabs, Zabs_eq.
+rewrite <- F2R_Zabs, Z.abs_eq.
 split.
 apply Rlt_le.
 apply Rle_lt_trans with (2 := H12).

--- a/compcert/flocq/Core/Fcore_generic_fmt.v
+++ b/compcert/flocq/Core/Fcore_generic_fmt.v
@@ -53,7 +53,7 @@ Proof.
 intros k l Hk H.
 apply Znot_ge_lt.
 intros Hl.
-apply Zge_le in Hl.
+apply Z.ge_le in Hl.
 assert (H' := proj2 (proj2 (valid_exp l) Hl) k).
 omega.
 Qed.
@@ -66,8 +66,8 @@ Proof.
 intros k l Hk H.
 apply Znot_ge_lt.
 intros H'.
-apply Zge_le in H'.
-assert (Hl := Zle_trans _ _ _ H H').
+apply Z.ge_le in H'.
+assert (Hl := Z.le_trans _ _ _ H H').
 apply valid_exp in Hl.
 assert (H1 := proj2 Hl k H').
 omega.
@@ -140,7 +140,7 @@ now apply valid_exp_.
 rewrite <- H.
 apply valid_exp.
 rewrite H.
-apply Zle_refl.
+apply Z.le_refl.
 Qed.
 
 Theorem generic_format_F2R :
@@ -149,7 +149,7 @@ Theorem generic_format_F2R :
   generic_format (F2R (Float beta m e)).
 Proof.
 intros m e.
-destruct (Z_eq_dec m 0) as [Zm|Zm].
+destruct (Z.eq_dec m 0) as [Zm|Zm].
 intros _.
 rewrite Zm, F2R_0.
 apply generic_format_0.
@@ -194,7 +194,7 @@ Qed.
 Theorem canonic_abs :
   forall m e,
   canonic (Float beta m e) ->
-  canonic (Float beta (Zabs m) e).
+  canonic (Float beta (Z.abs m) e).
 Proof.
 intros m e H.
 unfold canonic.
@@ -379,7 +379,7 @@ simpl.
 specialize (Ex' Zx).
 apply (mantissa_small_pos _ _ Ex').
 assert (ex' <= fexp ex)%Z.
-apply Zle_trans with (2 := He).
+apply Z.le_trans with (2 := He).
 apply bpow_lt_bpow with beta.
 now apply Rle_lt_trans with (2 := Ex).
 now rewrite (proj2 (proj2 (valid_exp _) He)).
@@ -397,7 +397,7 @@ apply Rlt_le_trans with (1 := bpow_ln_beta_gt beta _).
 apply bpow_le.
 unfold scaled_mantissa.
 rewrite ln_beta_mult_bpow with (1 := Zx).
-apply Zle_refl.
+apply Z.le_refl.
 Qed.
 
 Theorem ln_beta_generic_gt :
@@ -411,13 +411,13 @@ unfold canonic_exp.
 destruct (ln_beta beta x) as (ex,Ex) ; simpl.
 specialize (Ex Zx).
 intros H.
-apply Zge_le in H.
+apply Z.ge_le in H.
 generalize (scaled_mantissa_small x ex (proj2 Ex) H).
 contradict Zx.
 rewrite Gx.
 replace (Ztrunc (scaled_mantissa x)) with Z0.
 apply F2R_0.
-cut (Zabs (Ztrunc (scaled_mantissa x)) < 1)%Z.
+cut (Z.abs (Ztrunc (scaled_mantissa x)) < 1)%Z.
 clear ; zify ; omega.
 apply lt_Z2R.
 rewrite Z2R_abs.
@@ -584,7 +584,7 @@ omega.
 intros H.
 rewrite <- H in Hx.
 rewrite Zfloor_Z2R, Zrnd_Z2R in Hx.
-apply Zlt_irrefl with (1 := Hx).
+apply Z.lt_irrefl with (1 := Hx).
 Qed.
 
 Theorem Zrnd_ZR_or_AW :
@@ -720,7 +720,7 @@ assert (Heq: fexp ex = fexp ey -> (round x <= round y)%R).
 destruct (Zle_or_lt ey (fexp ey)) as [Hy1|Hy1].
   apply Heq.
   apply valid_exp with (1 := Hy1).
-  now apply Zle_trans with ey.
+  now apply Z.le_trans with ey.
 destruct (Zle_lt_or_eq _ _ He) as [He'|He'].
 2: now apply Heq, f_equal.
 apply Rle_trans with (bpow (ey - 1)).
@@ -821,7 +821,7 @@ Section Zround_opp.
 Variable rnd : R -> Z.
 Context { valid_rnd : Valid_rnd rnd }.
 
-Definition Zrnd_opp x := Zopp (rnd (-x)).
+Definition Zrnd_opp x := Z.opp (rnd (-x)).
 
 Global Instance valid_rnd_opp : Valid_rnd Zrnd_opp.
 Proof with auto with typeclass_instances.
@@ -830,14 +830,14 @@ split.
 intros x y Hxy.
 unfold Zrnd_opp.
 apply Zopp_le_cancel.
-rewrite 2!Zopp_involutive.
+rewrite 2!Z.opp_involutive.
 apply Zrnd_le...
 now apply Ropp_le_contravar.
 (* *)
 intros n.
 unfold Zrnd_opp.
 rewrite <- Z2R_opp, Zrnd_Z2R...
-apply Zopp_involutive.
+apply Z.opp_involutive.
 Qed.
 
 Theorem round_opp :
@@ -849,7 +849,7 @@ unfold round.
 rewrite <- F2R_Zopp, canonic_exp_opp, scaled_mantissa_opp.
 apply F2R_eq_compat.
 apply sym_eq.
-exact (Zopp_involutive _).
+exact (Z.opp_involutive _).
 Qed.
 
 End Zround_opp.
@@ -1071,7 +1071,7 @@ unfold round.
 rewrite scaled_mantissa_opp.
 rewrite <- F2R_Zopp.
 unfold Zceil.
-rewrite Zopp_involutive.
+rewrite Z.opp_involutive.
 now rewrite canonic_exp_opp.
 Qed.
 
@@ -1418,7 +1418,7 @@ Theorem ln_beta_round :
   forall rnd {Hrnd : Valid_rnd rnd} x,
   (round rnd x <> 0)%R ->
   (ln_beta beta (round rnd x) = ln_beta beta x :> Z) \/
-  Rabs (round rnd x) = bpow (Zmax (ln_beta beta x) (fexp (ln_beta beta x))).
+  Rabs (round rnd x) = bpow (Z.max (ln_beta beta x) (fexp (ln_beta beta x))).
 Proof with auto with typeclass_instances.
 intros rnd Hrnd x.
 destruct (round_ZR_or_AW rnd x) as [Hr|Hr] ; rewrite Hr ; clear Hr rnd Hrnd.
@@ -1433,7 +1433,7 @@ rewrite <- ln_beta_abs.
 rewrite <- round_AW_abs.
 destruct (Zle_or_lt ex (fexp ex)) as [He|He].
 right.
-rewrite Zmax_r with (1 := He).
+rewrite Z.max_r with (1 := He).
 rewrite round_AW_pos with (1 := Rabs_pos _).
 now apply round_UP_small_pos.
 destruct (round_bounded_large_pos Zaway _ ex He Ex) as (H1,[H2|H2]).
@@ -1442,7 +1442,7 @@ apply ln_beta_unique.
 rewrite <- round_AW_abs, Rabs_Rabsolu.
 now split.
 right.
-now rewrite Zmax_l with (1 := Zlt_le_weak _ _ He).
+now rewrite Z.max_l with (1 := Zlt_le_weak _ _ He).
 Qed.
 
 Theorem ln_beta_DN :
@@ -1584,7 +1584,7 @@ Proof with auto with typeclass_instances.
 intros x.
 destruct (round_ZR_or_AW rnd x) as [H|H] ; rewrite H ; clear H ; intros Zr.
 rewrite ln_beta_round_ZR with (1 := Zr).
-apply Zle_refl.
+apply Z.le_refl.
 apply ln_beta_le_abs.
 contradict Zr.
 rewrite Zr.
@@ -1640,7 +1640,7 @@ Theorem Znearest_ge_floor :
 Proof.
 intros x.
 destruct (Znearest_DN_or_UP x) as [Hx|Hx] ; rewrite Hx.
-apply Zle_refl.
+apply Z.le_refl.
 apply le_Z2R.
 apply Rle_trans with x.
 apply Zfloor_lb.
@@ -1657,7 +1657,7 @@ apply le_Z2R.
 apply Rle_trans with x.
 apply Zfloor_lb.
 apply Zceil_ub.
-apply Zle_refl.
+apply Z.le_refl.
 Qed.
 
 Global Instance valid_rnd_N : Valid_rnd Znearest.
@@ -1666,8 +1666,8 @@ split.
 (* *)
 intros x y Hxy.
 destruct (Rle_or_lt (Z2R (Zceil x)) y) as [H|H].
-apply Zle_trans with (1 := Znearest_le_ceil x).
-apply Zle_trans with (2 := Znearest_ge_floor y).
+apply Z.le_trans with (1 := Znearest_le_ceil x).
+apply Z.le_trans with (2 := Znearest_ge_floor y).
 now apply Zfloor_lub.
 (* . *)
 assert (Hf: Zfloor y = Zfloor x).
@@ -1696,14 +1696,14 @@ elim Rlt_not_le with (1 := Hy).
 rewrite <- Hx.
 now apply Rplus_le_compat_r.
 replace y with x.
-apply Zle_refl.
+apply Z.le_refl.
 apply Rplus_eq_reg_l with (- Z2R (Zfloor x))%R.
 rewrite 2!(Rplus_comm (- (Z2R (Zfloor x)))).
 change (x - Z2R (Zfloor x) = y - Z2R (Zfloor x))%R.
 now rewrite Hy.
-apply Zle_trans with (Zceil x).
+apply Z.le_trans with (Zceil x).
 case choice.
-apply Zle_refl.
+apply Z.le_refl.
 apply le_Z2R.
 apply Rle_trans with x.
 apply Zfloor_lb.
@@ -1859,7 +1859,7 @@ Theorem Znearest_imp :
   Znearest x = n.
 Proof.
 intros x n Hd.
-cut (Zabs (Znearest x - n) < 1)%Z.
+cut (Z.abs (Znearest x - n) < 1)%Z.
 clear ; zify ; omega.
 apply lt_Z2R.
 rewrite Z2R_abs, Z2R_minus.
@@ -2090,10 +2090,10 @@ rewrite <- Zceil_floor_neq with (1 := Hx).
 unfold Zceil.
 rewrite Ropp_involutive.
 case Rcompare ; simpl ; trivial.
-rewrite Zopp_involutive.
+rewrite Z.opp_involutive.
 case (choice (Zfloor (- x))) ; simpl ; trivial.
-now rewrite Zopp_involutive.
-now rewrite Zopp_involutive.
+now rewrite Z.opp_involutive.
+now rewrite Z.opp_involutive.
 unfold Zceil.
 rewrite Z2R_opp.
 apply Rplus_comm.
@@ -2174,7 +2174,7 @@ intros Fx.
 apply generic_format_abs_inv.
 rewrite Hx2.
 apply generic_format_bpow'...
-apply Zle_trans with (1 := He).
+apply Z.le_trans with (1 := He).
 apply generic_format_bpow_inv...
 rewrite <- Hx2.
 now apply generic_format_abs.
@@ -2202,7 +2202,7 @@ apply generic_inclusion with (e := e2).
 apply He.
 split.
 apply He'.
-apply Zle_refl.
+apply Z.le_refl.
 rewrite Hx2.
 split.
 apply bpow_le.
@@ -2225,7 +2225,7 @@ apply He.
 now apply ln_beta_le_bpow.
 apply generic_inclusion with (e := e2).
 apply He.
-apply Zle_refl.
+apply Z.le_refl.
 rewrite Hx.
 split.
 apply bpow_le.

--- a/compcert/flocq/Core/Fcore_ulp.v
+++ b/compcert/flocq/Core/Fcore_ulp.v
@@ -159,7 +159,7 @@ rewrite ulp_neq_0.
 unfold F2R; simpl.
 apply Rmult_le_compat_r.
 apply bpow_ge_0.
-apply (Z2R_le (Zsucc 0)).
+apply (Z2R_le (Z.succ 0)).
 apply Zlt_le_succ.
 apply F2R_gt_0_reg with beta (canonic_exp beta fexp x).
 now rewrite <- Fx.
@@ -248,7 +248,7 @@ apply generic_format_bpow.
 case (Zle_or_lt (e+1) (fexp (e+1))); intros H4.
 absurd (e+1 <= e)%Z.
 omega.
-apply Zle_trans with (1:=H4).
+apply Z.le_trans with (1:=H4).
 replace (fexp (e+1)) with (fexp n).
 now apply le_bpow with beta.
 now apply fexp_negligible_exp_eq.
@@ -298,11 +298,11 @@ rewrite ulp_neq_0; trivial.
 apply bpow_le; unfold canonic_exp.
 generalize (ln_beta beta x); intros l.
 case (Zle_or_lt l (fexp l)); intros Hl.
-rewrite (fexp_negligible_exp_eq n l); trivial; apply Zle_refl.
+rewrite (fexp_negligible_exp_eq n l); trivial; apply Z.le_refl.
 case (Zle_or_lt (fexp n) (fexp l)); trivial; intros K.
 absurd (fexp n <= fexp l)%Z.
 omega.
-apply Zle_trans with (2:= H _).
+apply Z.le_trans with (2:= H _).
 apply Zeq_le, sym_eq, valid_exp; trivial.
 omega.
 Qed.
@@ -879,7 +879,7 @@ rewrite Lex.
 pattern (bpow (fexp ex)) at 1; rewrite <- Rmult_1_l.
 apply Rmult_le_compat_r.
 apply bpow_ge_0.
-replace 1%R with (Z2R (Zsucc 0)) by reflexivity.
+replace 1%R with (Z2R (Z.succ 0)) by reflexivity.
 apply Z2R_le.
 apply Zlt_le_succ.
 apply F2R_gt_0_reg with beta (canonic_exp beta fexp x).
@@ -1876,7 +1876,7 @@ case negligible_exp_spec.
 intros K; contradict Hx2.
 apply Rlt_not_eq.
 apply F2R_gt_0_compat; simpl.
-apply Zlt_le_trans with 1%Z.
+apply Z.lt_le_trans with 1%Z.
 apply Pos2Z.is_pos.
 apply Zfloor_lub.
 simpl; unfold scaled_mantissa, canonic_exp.

--- a/compcert/flocq/Prop/Fprop_Sterbenz.v
+++ b/compcert/flocq/Prop/Fprop_Sterbenz.v
@@ -37,7 +37,7 @@ Notation format := (generic_format beta fexp).
 Theorem generic_format_plus :
   forall x y,
   format x -> format y ->
-  (Rabs (x + y) < bpow (Zmin (ln_beta beta x) (ln_beta beta y)))%R ->
+  (Rabs (x + y) < bpow (Z.min (ln_beta beta x) (ln_beta beta y)))%R ->
   format (x + y)%R.
 Proof.
 intros x y Fx Fy Hxy.
@@ -72,7 +72,7 @@ case_eq (Fplus beta fx fy).
 intros mxy exy Pxy.
 rewrite <- Pxy, F2R_plus, <- Hx, <- Hy.
 unfold canonic_exp.
-replace exy with (fexp (Zmin ex ey)).
+replace exy with (fexp (Z.min ex ey)).
 apply monotone_exp.
 now apply ln_beta_le_bpow.
 replace exy with (Fexp (Fplus beta fx fy)) by exact (f_equal Fexp Pxy).
@@ -80,12 +80,12 @@ rewrite Fexp_Fplus.
 simpl. clear -monotone_exp.
 apply sym_eq.
 destruct (Zmin_spec ex ey) as [(H1,H2)|(H1,H2)] ; rewrite H2.
-apply Zmin_l.
+apply Z.min_l.
 now apply monotone_exp.
-apply Zmin_r.
+apply Z.min_r.
 apply monotone_exp.
 apply Zlt_le_weak.
-now apply Zgt_lt.
+now apply Z.gt_lt.
 Qed.
 
 Theorem generic_format_plus_weak :
@@ -103,11 +103,11 @@ apply generic_format_plus ; try assumption.
 apply Rle_lt_trans with (1 := Hxy).
 unfold Rmin.
 destruct (Rle_dec (Rabs x) (Rabs y)) as [Hxy'|Hxy'].
-rewrite Zmin_l.
+rewrite Z.min_l.
 destruct (ln_beta beta x) as (ex, Hx).
 now apply Hx.
 now apply ln_beta_le_abs.
-rewrite Zmin_r.
+rewrite Z.min_r.
 destruct (ln_beta beta y) as (ex, Hy).
 now apply Hy.
 apply ln_beta_le_abs.

--- a/compcert/flocq/Prop/Fprop_relative.v
+++ b/compcert/flocq/Prop/Fprop_relative.v
@@ -391,7 +391,7 @@ End Fprop_relative_generic.
 Section Fprop_relative_FLT.
 
 Variable emin prec : Z.
-Variable Hp : Zlt 0 prec.
+Variable Hp : Z.lt 0 prec.
 
 Lemma relative_error_FLT_aux :
   forall k, (emin + prec - 1 < k)%Z -> (prec <= k - FLT_exp emin prec k)%Z.
@@ -662,7 +662,7 @@ Qed.
 Section Fprop_relative_FLX.
 
 Variable prec : Z.
-Variable Hp : Zlt 0 prec.
+Variable Hp : Z.lt 0 prec.
 
 Lemma relative_error_FLX_aux :
   forall k, (prec <= k - FLX_exp prec k)%Z.


### PR DESCRIPTION
Waiting for #325 to be solved, here is a patch that removes the uses of compatibility notations for Coq 8.7.

This will enable the Coq development team to move forward on https://github.com/coq/coq/pull/8638.

Thanks.