### PR TITLE
Use binder feature in Coq notation system to redefine EX and ALL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,7 @@ else
 endif
 
 # you can also write, COQVERSION= 8.6 or-else 8.6pl2 or-else 8.6pl3   (etc.)
-COQVERSION= 8.9+alpha or-else 8.9.0 or-else 8.8.2
+COQVERSION= 8.9.1 or-else 8.9+alpha or-else 8.9.0 or-else 8.8.2
 COQV=$(shell $(COQC) -v)
 ifeq ($(IGNORECOQVERSION),true)
 else

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -302,7 +302,12 @@ Proof.
   apply SEPx_nonexpansive; auto.
 Qed.
 
-Notation "'EX'  x ':' T ',' P " := (@exp (environ->mpred) _ T (fun x:T => P%assert)) (at level 65, x ident, right associativity) : assert.
+Notation "'EX' x .. y , P " :=
+  (@exp (environ->mpred) _ _ (fun x =>
+    ..
+    (@exp (environ->mpred) _ _ (fun y => P%assert))
+    ..
+    )) (at level 65, x binder, y binder, right associativity) : assert.
 
 Notation " 'ENTAIL' d ',' P '|--' Q " :=
   (@derives (environ->mpred) _ (andp (local (tc_environ d)) P%assert) Q%assert) (at level 80, P at level 79, Q at level 79).

--- a/msl/predicates_hered.v
+++ b/msl/predicates_hered.v
@@ -284,8 +284,10 @@ Definition boxy {A} `{ageable A} (m: modality) (p: pred A): Prop :=  box m p = p
 
 (* A pile of notations for the operators we have defined *)
 Notation "P '|--' Q" := (derives P Q) (at level 80, no associativity).
-Notation "'EX'  x ':' T ',' P " := (exp (fun x:T => P%pred)) (at level 65, x ident, right associativity) : pred.
-Notation "'ALL'  x ':' T  ',' P " := (allp (fun x:T => P%pred)) (at level 65, x ident, right associativity) : pred.
+Notation "'EX' x .. y , P " :=
+  (exp (fun x => .. (exp (fun y => P%pred)) ..)) (at level 65, x binder, y binder, right associativity) : pred.
+Notation "'ALL' x .. y , P " :=
+  (allp (fun x => .. (allp (fun y => P%pred)) ..)) (at level 65, x binder, y binder, right associativity) : pred.
 Infix "||" := orp (at level 50, left associativity) : pred.
 Infix "&&" := andp (at level 40, left associativity) : pred.
 Notation "P '-->' Q" := (imp P Q) (at level 55, right associativity) : pred.

--- a/msl/predicates_sa.v
+++ b/msl/predicates_sa.v
@@ -60,8 +60,10 @@ Definition wand {A}  {JA: Join A}  (p q:pred A) := fun y =>
   forall x z, join x y z -> p x -> q z.
 
 Notation "P '|--' Q" := (derives P Q) (at level 80, no associativity).
-Notation "'EX'  x ':' T ',' P " := (exp (fun x:T => P%pred)) (at level 65, x ident, right associativity) : pred.
-Notation "'ALL'  x ':' T  ',' P " := (allp (fun x:T => P%pred)) (at level 65, x ident, right associativity) : pred.
+Notation "'EX' x .. y , P " :=
+  (exp (fun x => .. (exp (fun y => P%pred)) ..)) (at level 65, x binder, y binder, right associativity) : pred.
+Notation "'ALL' x .. y , P " :=
+  (allp (fun x => .. (allp (fun y => P%pred)) ..)) (at level 65, x binder, y binder, right associativity) : pred.
 Infix "||" := orp (at level 50, left associativity) : pred.
 Infix "&&" := andp (at level 40, left associativity) : pred.
 Notation "P '-->' Q" := (imp P Q) (at level 55, right associativity) : pred.

--- a/msl/seplog.v
+++ b/msl/seplog.v
@@ -101,8 +101,10 @@ Defined.
 Delimit Scope logic with logic.
 Local Open Scope logic.
 Notation "P '|--' Q" := (derives P Q) (at level 80, no associativity).
-Notation "'EX'  x ':' T ',' P " := (exp (fun x:T => P%logic)) (at level 65, x ident, right associativity) : logic.
-Notation "'ALL'  x ':' T  ',' P " := (allp (fun x:T => P%logic)) (at level 65, x ident, right associativity) : logic.
+Notation "'EX' x .. y , P " :=
+  (exp (fun x => .. (exp (fun y => P%logic)) ..)) (at level 65, x binder, y binder, right associativity) : logic.
+Notation "'ALL' x .. y , P " :=
+  (allp (fun x => .. (allp (fun y => P%logic)) ..)) (at level 65, x binder, y binder, right associativity) : logic.
 Infix "||" := orp (at level 50, left associativity) : logic.
 Infix "&&" := andp (at level 40, left associativity) : logic.
 Notation "P '-->' Q" := (imp P Q) (at level 55, right associativity) : logic.


### PR DESCRIPTION
Instead of writing `EX a: val, EX b: val, EX c: val, EX al: list val, EX bl: list val,` for quantifier notations `EX` and `ALL`, you can now write `EX (a b c: val) (al bl: list val),` for just as using `exists` and `forall` for `Prop`. This is compatible with old notations.