### PR TITLE
Itree submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "InteractionTrees"]
+	path = InteractionTrees
+	url = https://github.com/DeepSpec/InteractionTrees

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend flocq exportclight $(BACKEND)
 
 COMPCERT_R_FLAGS= $(foreach d, $(COMPCERTDIRS), -R $(COMPCERT)/$(d) compcert.$(d))
 EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT)/$(d) compcert.$(d))
+# for ITrees
+EXTFLAGS:=$(EXTFLAGS) -Q InteractionTrees/theories ITree
 
 # for SSReflect
 ifdef MATHCOMP

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ FLOYD_FILES= \
    for_lemmas.v semax_tactics.v diagnosis.v simple_reify.v simpl_reptype.v \
    freezer.v deadvars.v Clightnotations.v unfold_data_at.v hints.v reassoc_seq.v \
    SeparationLogicAsLogicSoundness.v SeparationLogicAsLogic.v SeparationLogicFacts.v \
-   subsume_funspec.v linking.v list_solver.v data_at_lemmas.v printf.v
+   subsume_funspec.v linking.v list_solver.v data_at_lemmas.v
 #real_forward.v
 
 # CONCPROGS must be kept separate (see util/PACKAGE), and
@@ -301,7 +301,7 @@ PROGS_FILES= \
   verif_strlib.v verif_fib.v bug83.v \
   tree.v verif_tree.v loop_minus1.v verif_loop_minus1.v \
   libglob.v verif_libglob.v peel.v verif_peel.v \
-  printf.v verif_printf.v
+  printf.v
 # verif_insertion_sort.v
 
 SHA_FILES= \
@@ -536,6 +536,7 @@ hkdf:    _CoqProject $(HKDF_FILES:%.v=sha/%.vo)
 # drbg: _CoqProject $(DRBG_FILES:%.v=verifiedDrbg/%.vo)
 mailbox: _CoqProject mailbox/verif_mailbox_all.vo
 atomics: _CoqProject atomics/verif_kvnode_atomic.vo atomics/verif_kvnode_atomic_ra.vo atomics/verif_hashtable_atomic.vo atomics/verif_hashtable_atomic_ra.vo
+io: _CoqProject progs/verif_printf.v progs/verif_io.v progs/verif_io_mem.v
 
 CGFLAGS =  -DCOMPCERT
 

--- a/floyd/io_events.v
+++ b/floyd/io_events.v
@@ -1,0 +1,76 @@
+Require Import VST.floyd.proofauto.
+Require Import ITree.ITree.
+Require Import ITree.Eq.Eq.
+Require Import ITree.Eq.SimUpToTaus.
+Require Import ITree.Interp.Traces.
+(*Import ITreeNotations.*)
+Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
+  (at level 100, right associativity) : itree_scope.
+
+Section IO_events.
+
+Context {file_id : Type}.
+
+Inductive IO_event : Type -> Type :=
+| ERead (f : file_id) : IO_event byte
+| EWrite (f : file_id) (c : byte) : IO_event unit.
+
+Definition read f : itree IO_event byte := embed (ERead f).
+
+Definition write f (c : byte) : itree IO_event unit := embed (EWrite f c).
+
+Definition IO_itree := itree IO_event unit.
+
+(* We need a layer of inclusion to allow us to use the monad laws. *)
+Definition ITREE (tr : IO_itree) := EX tr' : _, !!(sutt eq tr tr') &&
+  has_ext tr'.
+
+Lemma has_ext_ITREE : forall tr, has_ext tr |-- ITREE tr.
+Proof.
+  intro; unfold ITREE.
+  Exists tr; entailer!.
+  apply eutt_sutt; reflexivity.
+Qed.
+
+Lemma ITREE_impl' : forall tr tr', sutt eq tr' tr ->
+  ITREE tr |-- ITREE tr'.
+Proof.
+  intros.
+  unfold ITREE.
+  Intros tr1; Exists tr1; entailer!.
+  rewrite trace_incl_iff_sutt in *; unfold trace_incl in *; auto.
+Qed.
+
+Lemma ITREE_impl : forall tr tr', eutt eq tr tr' ->
+  ITREE tr |-- ITREE tr'.
+Proof.
+  intros; apply ITREE_impl'.
+  apply eutt_sutt; symmetry; auto.
+Qed.
+
+Lemma ITREE_ext : forall tr tr', eutt eq tr tr' ->
+  ITREE tr = ITREE tr'.
+Proof.
+  intros; apply pred_ext; apply ITREE_impl; auto.
+  symmetry; auto.
+Qed.
+
+Fixpoint write_list f l : IO_itree :=
+  match l with
+  | nil => Ret tt
+  | c :: rest => write f c ;; write_list f rest
+  end.
+
+Lemma write_list_app : forall f l1 l2,
+  eutt eq (write_list f (l1 ++ l2)) (write_list f l1;; write_list f l2).
+Proof.
+  induction l1; simpl in *; intros.
+  - rewrite bind_ret; reflexivity.
+  - rewrite bind_bind.
+    setoid_rewrite IHl1; reflexivity.
+Qed.
+
+Definition char0 : Z := 48.
+Definition newline := 10.
+
+End IO_events.

--- a/floyd/printf.v
+++ b/floyd/printf.v
@@ -1,8 +1,8 @@
 Require Import VST.floyd.proofauto.
-Require Import VST.floyd.io_events.
-Require Import ITree.ITree.
+Require Export VST.floyd.io_events.
+Require Export ITree.ITree.
 (*Import ITreeNotations.*)
-Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
+Global Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
   (at level 100, right associativity) : itree_scope.
 
 

--- a/progs/verif_printf.v
+++ b/progs/verif_printf.v
@@ -4,22 +4,54 @@ Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 
 Require Import VST.floyd.printf.
+Require Import VST.floyd.io_events.
+Require Import ITree.ITree.
+Require Import ITree.Eq.Eq.
+(*Import ITreeNotations.*)
+Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
+  (at level 100, right associativity) : itree_scope.
+
+Instance nat_id : FileId := { file_id := nat; FILEid := ___sFILE; get_file_id f := O; stdout := tt }.
+
+Definition stdout := O.
 
 Definition main_spec :=
  DECLARE _main
   WITH gv : globals
-  PRE  [] main_pre prog nil gv
+  PRE  [] main_pre_ext prog (write_list stdout (string2bytes "Hello, world!
+");; write_list stdout (string2bytes "This is line 2.
+")) nil gv
   POST [ tint ] main_post prog nil gv.
 
 Definition Gprog : funspecs :=  
    ltac:(with_library prog (ltac:(make_printf_specs prog) ++ [ main_spec ])).
+
+Lemma bind_ret' : forall E (s : itree E unit), eutt eq (s;; Ret tt) s.
+Proof.
+  intros.
+  etransitivity; [|apply eq_sub_eutt, bind_ret2].
+  apply eqit_bind; [intros []|]; reflexivity.
+Qed.
 
 Lemma body_main: semax_body Vprog Gprog f_main main_spec.
 Proof.
 start_function.
 repeat do_string2bytes.
 repeat (sep_apply data_at_to_cstring; []).
-forward_printf tt.
-forward_fprintf (gv __stdout) ((Ers, string2bytes "line", gv ___stringlit_2), (Int.repr 2, tt)).
+replace_SEP 3 (ITREE (write_list stdout (string2bytes "Hello, world!
+");; write_list stdout (string2bytes "This is line 2.
+"))).
+{ go_lower; apply has_ext_ITREE. }
+forward_printf tt (write_list stdout (string2bytes "This is line 2.
+")).
+{ rewrite sepcon_comm; apply sepcon_derives; cancel.
+  apply derives_refl. }
+forward_fprintf (gv __stdout) ((Ers, string2bytes "line", gv ___stringlit_2), (Int.repr 2, tt)) (tt, Ret tt : @IO_itree file_id).
+{ (* need to know that stdout actually points to a file object? or should that be a dummy? *)
+  rewrite <- emp_sepcon at 1.
+  rewrite !sepcon_assoc; apply sepcon_derives; [admit|].
+  rewrite sepcon_comm; apply sepcon_derives; cancel.
+  apply ITREE_impl.
+  rewrite bind_ret'; reflexivity. }
 forward.
-Qed.
+Admitted.

--- a/progs/verif_printf.v
+++ b/progs/verif_printf.v
@@ -4,12 +4,7 @@ Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 
 Require Import VST.floyd.printf.
-Require Import VST.floyd.io_events.
-Require Import ITree.ITree.
 Require Import ITree.Eq.Eq.
-(*Import ITreeNotations.*)
-Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
-  (at level 100, right associativity) : itree_scope.
 
 Instance nat_id : FileId := { file_id := nat; stdout := 1%nat }.
 


### PR DESCRIPTION
Added InteractionTrees as a submodule, and added external interaction to printf. Added new `io` target for I/O examples (and removed printf from Travis target).