### PR TITLE
Generalized IO events, switched printf to real reent struct

### DIFF
--- a/floyd/io_events.v
+++ b/floyd/io_events.v
@@ -16,11 +16,13 @@ Inductive IO_event : Type -> Type :=
 | ERead (f : file_id) : IO_event byte
 | EWrite (f : file_id) (c : byte) : IO_event unit.
 
-Definition read f : itree IO_event byte := embed (ERead f).
+Context {E : Type -> Type} `{IO_event -< E}.
 
-Definition write f (c : byte) : itree IO_event unit := embed (EWrite f c).
+Definition read f : itree E byte := embed (ERead f).
 
-Definition IO_itree := itree IO_event unit.
+Definition write f (c : byte) : itree E unit := embed (EWrite f c).
+
+Definition IO_itree := itree E unit.
 
 (* We need a layer of inclusion to allow us to use the monad laws. *)
 Definition ITREE (tr : IO_itree) := EX tr' : _, !!(sutt eq tr tr') &&

--- a/floyd/io_events.v
+++ b/floyd/io_events.v
@@ -28,11 +28,22 @@ Definition IO_itree := itree E unit.
 Definition ITREE (tr : IO_itree) := EX tr' : _, !!(sutt eq tr tr') &&
   has_ext tr'.
 
+(* this should be in ITrees *)
+Instance Reflexive_sutt {E R} : RelationClasses.Reflexive (@sutt E R R eq).
+Proof. intro; apply eutt_sutt; reflexivity. Qed.
+
+(* not in ITree currently because it's specific to unit *)
+Lemma bind_ret' : forall E (s : itree E unit), eutt eq (s;; Ret tt) s.
+Proof.
+  intros.
+  etransitivity; [|apply eq_sub_eutt, bind_ret2].
+  apply eqit_bind; [intros []|]; reflexivity.
+Qed.
+
 Lemma has_ext_ITREE : forall tr, has_ext tr |-- ITREE tr.
 Proof.
   intro; unfold ITREE.
   Exists tr; entailer!.
-  apply eutt_sutt; reflexivity.
 Qed.
 
 Lemma ITREE_impl' : forall tr tr', sutt eq tr' tr ->

--- a/progs/io_combine.v
+++ b/progs/io_combine.v
@@ -10,16 +10,6 @@ Require Import VST.veric.Clight_new.
 Require Import VST.progs.conclib.
 Require Import VST.sepcomp.semantics.
 Require Import ITree.ITree.
-(* Import ITreeNotations. *) (* one piece conflicts with subp notation *)
-Notation "t1 >>= k2" := (ITree.bind t1 k2)
-  (at level 50, left associativity) : itree_scope.
-Notation "x <- t1 ;; t2" := (ITree.bind t1 (fun x => t2))
-  (at level 100, t1 at next level, right associativity) : itree_scope.
-Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
-  (at level 100, right associativity) : itree_scope.
-Notation "' p <- t1 ;; t2" :=
-  (ITree.bind t1 (fun x_ => match x_ with p => t2 end))
-(at level 100, t1 at next level, p pattern, right associativity) : itree_scope.
 Require Import ITree.Interp.Traces.
 Require Import Ensembles.
 Require Import VST.progs.io_specs.
@@ -131,7 +121,7 @@ Proof.
 Qed.
 
 (* relate to OS's external events *)
-  Notation ge := (globalenv prog).
+Notation ge := (globalenv prog).
 
 (* for now, this is only proved for getchar *)
 Definition IO_ext_sem' e (args : list val) s :=
@@ -146,11 +136,11 @@ Definition IO_ext_sem' e (args : list val) s :=
 Definition IO_specs' (ext_link : string -> ident) :=
   [(ext_link "getchar"%string, getchar_spec)].
 
-Instance IO_Espec' : OracleKind := add_funspecs IO_void_Espec ext_link (IO_specs' ext_link).
+Instance IO_Espec' : OracleKind := add_funspecs (@IO_void_Espec (@IO_event nat)) ext_link (IO_specs' ext_link).
 
 Definition io_ext_spec := OK_spec.
 
-Program Definition io_dry_spec : external_specification mem external_function (@IO_itree nat).
+Program Definition io_dry_spec : external_specification mem external_function (@IO_itree (@IO_event nat)).
 Proof.
   unshelve econstructor.
   - intro e.

--- a/progs/io_combine.v
+++ b/progs/io_combine.v
@@ -28,7 +28,7 @@ Definition ext_link := ext_link_prog prog.
 
 Definition sys_getc_wrap_spec (abd : RData) : option (RData * val * trace) :=
   match sys_getc_spec abd with
-  | Some abd' => Some (abd', get_sys_ret abd', trace_of_ostrace (strip_common_prefix IOEvent_eq abd.(io_rx_log) abd'.(io_rx_log)))
+  | Some abd' => Some (abd', get_sys_ret abd', trace_of_ostrace (strip_common_prefix IOEvent_eq abd.(io_log) abd'.(io_log)))
   | None => None
   end.
 
@@ -38,7 +38,7 @@ Definition sys_putc_wrap_spec (cv : val) (abd : RData) : option (RData * val * t
   | Vint c, Vint c' =>
     if eq_dec.eq_dec c c' then
       match sys_putc_spec abd with
-      | Some abd' => Some (abd', get_sys_ret abd', trace_of_ostrace (strip_common_prefix IOEvent_eq abd.(io_tx_log) abd'.(io_tx_log)))
+      | Some abd' => Some (abd', get_sys_ret abd', trace_of_ostrace (strip_common_prefix IOEvent_eq abd.(io_log) abd'.(io_log)))
       | None => None
       end
     else None
@@ -67,7 +67,7 @@ Variable (R_mem : block -> Z).
 
 (* Because putchar and getchar don't use memory, these functions don't either. *)
 Definition IO_inj_mem (e : external_function) (args : list val) (m : mem) t s :=
-  valid_trace s /\ t = trace_of_ostrace s.(io_rx_log).
+  valid_trace s /\ t = trace_of_ostrace s.(io_log).
 Definition OS_mem (e : external_function) (args : list val) m (s : RData) : mem := m.
 (* In general, this could look like:
   if oi_eq_dec (Some (ext_link "putchars"%string, ...) (ef_id_sig ext_link e) then
@@ -123,159 +123,6 @@ Qed.
 (* relate to OS's external events *)
 Notation ge := (globalenv prog).
 
-(* for now, this is only proved for getchar *)
-Definition IO_ext_sem' e (args : list val) s :=
-  if oi_eq_dec  (Some (ext_link "getchar"%string, funsig2signature ([], tint) cc_default))
-    (ef_id_sig ext_link e) then
-    match sys_getc_wrap_spec s with
-    | Some (s', ret, t') => Some (s', Some ret, t')
-    | None => None
-    end
-  else Some (s, None, TEnd).
-
-Definition IO_specs' (ext_link : string -> ident) :=
-  [(ext_link "getchar"%string, getchar_spec)].
-
-Instance IO_Espec' : OracleKind := add_funspecs (@IO_void_Espec (@IO_event nat)) ext_link (IO_specs' ext_link).
-
-Definition io_ext_spec := OK_spec.
-
-Program Definition io_dry_spec : external_specification mem external_function (@IO_itree (@IO_event nat)).
-Proof.
-  unshelve econstructor.
-  - intro e.
-    pose (ext_spec_type io_ext_spec e) as T; simpl in T.
-    destruct (oi_eq_dec _ _); [|exact False];
-      match goal with T := (_ * ?A)%type |- _ => exact (mem * A)%type end.
-  - simpl; intros.
-    destruct (oi_eq_dec _ _); [|contradiction].
-    + destruct X as (m0 & _ & w).
-      exact (X1 = [] /\ m0 = X3 /\ getchar_pre X3 w X2).
-  - simpl; intros.
-    destruct (oi_eq_dec _ _); [|contradiction].
-    + destruct X as (m0 & _ & w).
-      destruct X1; [|exact False].
-      destruct v; [exact False | | exact False | exact False | exact False | exact False].
-      exact (getchar_post m0 X3 i w X2).
-  - intros; exact False.
-Defined.
-
-Definition dessicate : forall ef (jm : juicy_mem), ext_spec_type io_ext_spec ef -> ext_spec_type io_dry_spec ef.
-Proof.
-  simpl; intros.
-  destruct (oi_eq_dec _ _); [|assumption].
-  destruct X as [_ X]; exact (m_dry jm, X).
-Defined.
-
-Theorem juicy_dry_specs : juicy_dry_ext_spec _ io_ext_spec io_dry_spec dessicate.
-Proof.
-  split; [|split]; try reflexivity; simpl.
-  - unfold funspec2pre, dessicate; simpl.
-    intros ?; if_tac; [|contradiction].
-    + unfold funspec2pre; simpl.
-      intros; subst.
-      destruct t as (? & ? & k); simpl in *.
-      destruct H1 as (? & phi0 & phi1 & J & Hpre & Hr & Hext).
-      destruct e; inv H; simpl in *.
-      destruct vl; try contradiction.
-      unfold putchar_pre; split; auto; split; auto.
-      unfold SEPx in Hpre; simpl in Hpre.
-      rewrite seplog.sepcon_emp in Hpre.
-      destruct Hpre as (_ & _ & ? & ? & Htrace).
-      apply has_ext_eq in Htrace.
-      eapply join_sub_joins_trans in Hext; [|eexists; apply ghost_of_join; eauto].
-      unfold getchar_pre.
-      eapply has_ext_join in Hext as []; [| rewrite Htrace; reflexivity | apply join_comm, core_unit]; subst; auto.
-  - unfold funspec2pre, funspec2post, dessicate; simpl.
-    intros ?; if_tac; [|contradiction].
-    + unfold funspec2pre, funspec2post, dessicate; simpl.
-      intros; subst.
-      destruct H0 as (_ & vl & z0 & ? & _ & phi0 & phi1' & J & Hpre & ? & ?).
-      destruct t as (phi1 & t); subst; simpl in *.
-      destruct t as (? & k); simpl in *.
-      unfold SEPx in Hpre; simpl in Hpre.
-      rewrite seplog.sepcon_emp in Hpre.
-      destruct Hpre as (_ & _ & ? & ? & Htrace).
-      pose proof (has_ext_eq _ _ Htrace) as Hgx.
-      destruct v; try contradiction.
-      destruct v; try contradiction.
-      destruct H4 as (Hmem & ? & Hw); simpl in Hw; subst.
-      rewrite <- Hmem in *.
-      rewrite rebuild_same in H2.
-      unshelve eexists (age_to.age_to (level jm) (set_ghost phi0 [Some (ext_ghost x, NoneP)] _)), (age_to.age_to (level jm) phi1'); auto.
-      split; [|split3].
-      * eapply age_rejoin; eauto.
-        intro; rewrite H2; auto.
-      * exists i.
-        split3; simpl.
-        -- split; auto.
-        -- split; auto; split; unfold liftx; simpl; unfold lift.lift; auto; discriminate.
-        -- unfold SEPx; simpl.
-             rewrite seplog.sepcon_emp.
-             unfold ITREE; exists x; split; [if_tac; auto|].
-             { subst; apply eutt_sutt, Eq.Reflexive_eqit_eq. }
-             eapply age_to.age_to_pred, change_has_ext; eauto.
-      * eapply necR_trans; eauto; apply age_to.age_to_necR.
-      * rewrite H3; eexists; constructor; constructor.
-        instantiate (1 := (_, _)).
-        constructor; simpl; [|constructor; auto].
-        apply ext_ref_join.
-Qed.
-
-Instance mem_evolve_refl : Reflexive mem_evolve.
-Proof.
-  repeat intro.
-  destruct (access_at x loc Cur); auto.
-  destruct p; auto.
-Qed.
-
-Lemma dry_spec_mem : ext_spec_mem_evolve _ io_dry_spec.
-Proof.
-  intros ??????????? Hpre Hpost.
-  simpl in Hpre, Hpost.
-  simpl in *.
-  if_tac in Hpre; [|contradiction].
-  - destruct w as (m0 & _ & w).
-    destruct Hpre as (_ & ? & Hpre); subst.
-    destruct v; try contradiction.
-    destruct v; try contradiction.
-    destruct Hpost; subst.
-    reflexivity.
-Qed.
-
-Theorem IO_OS_soundness':
- forall {CS: compspecs} (initial_oracle: OK_ty) V G m,
-   semax_prog_ext prog initial_oracle V G ->
-   Genv.init_mem prog = Some m ->
-   exists b, exists q, exists m',
-     Genv.find_symbol (Genv.globalenv prog) (prog_main prog) = Some b /\
-     initial_core (cl_core_sem (globalenv prog))
-         0 m q m' (Vptr b Ptrofs.zero) nil /\
-   forall n, exists traces, ext_safeN_trace(J := OK_spec) prog IO_ext_sem' IO_inj_mem OS_mem valid_trace n TEnd traces initial_oracle q m' /\
-     forall t, In _ traces t -> exists z', consume_trace initial_oracle z' t.
-Proof.
-  intros; eapply OS_soundness with (dryspec := io_dry_spec); eauto.
-  - unfold IO_ext_sem'; intros; simpl in *.
-    destruct H2 as [Hvalid Htrace].
-    if_tac; [|contradiction].
-    + destruct w as (? & _ & ?).
-      destruct H1 as (? & ? & Hpre); subst.
-      destruct s; simpl in *.
-      unfold sys_getc_wrap_spec in *.
-      destruct (sys_getc_spec) eqn:Hspec; inv H3.
-      eapply sys_getc_correct with (m1 := m) in Hspec as (? & -> & [? Hpost ? ?]); eauto.
-      * split; auto; do 2 eexists; eauto.
-        unfold getchar_post, getchar_post' in *.
-        destruct Hpost as [? Hpost]; split; auto.
-        destruct Hpost as [[]|[-> ->]]; split; try (simpl in *; rep_omega).
-        -- rewrite if_false by omega; eauto.
-        -- rewrite if_true; auto.
-      * unfold getchar_pre, getchar_pre' in *.
-        apply Traces.sutt_trace_incl; auto.
-  - apply juicy_dry_specs.
-  - apply dry_spec_mem.
-Qed.
-
   Inductive OS_safeN_trace : nat -> @trace io_events.IO_event unit -> Ensemble (@trace io_events.IO_event unit * RData) -> OK_ty -> RData -> corestate -> mem -> Prop :=
   | OS_safeN_trace_0: forall t z s c m, OS_safeN_trace O t (Singleton _ (TEnd, s)) z s c m
   | OS_safeN_trace_step:
@@ -290,7 +137,7 @@ Qed.
          (Hargsty : Val.has_type_list args (sig_args (ef_sig e)))
          (Hretty : step_lemmas.has_opttyp ret (sig_res (ef_sig e))),
          IO_inj_mem e args m t s ->
-         IO_ext_sem' e args s = Some (s', ret, t') ->
+         IO_ext_sem e args s = Some (s', ret, t') ->
          m' = OS_mem e args m s' ->
          (n' <= n)%nat ->
          valid_trace s' /\ exists traces' z' c', consume_trace z z' t' /\
@@ -300,7 +147,7 @@ Qed.
       (forall t1, In _ traces t1 ->
         exists s s' ret m' t' n', Val.has_type_list args (sig_args (ef_sig e)) /\
          step_lemmas.has_opttyp ret (sig_res (ef_sig e)) /\
-         IO_inj_mem e args m t s /\ IO_ext_sem' e args s = Some (s', ret, t') /\ m' = OS_mem e args m s' /\
+         IO_inj_mem e args m t s /\ IO_ext_sem e args s = Some (s', ret, t') /\ m' = OS_mem e args m s' /\
          (n' <= n)%nat /\ valid_trace s' /\ exists traces' z' c', consume_trace z z' t' /\
            cl_after_external ret c = Some c' /\ OS_safeN_trace n' (app_trace t t') traces' z' s' c' m' /\
         exists t'' sf, In _ traces' (t'', sf) /\ t1 = (app_trace t' t'', sf)) ->
@@ -322,13 +169,26 @@ Local Ltac destruct_spec Hspec :=
   | match ?x with _ => _ end = _ => destruct x eqn:?; subst; inj; try discriminate
   end.
 
-  Lemma IO_ext_sem_trace : forall e args s s' ret t, valid_trace s -> IO_ext_sem' e args s = Some (s', ret, t) ->
-    s.(io_rx_log) = common_prefix IOEvent_eq s.(io_rx_log) s'.(io_rx_log) /\
-    t = trace_of_ostrace (strip_common_prefix IOEvent_eq s.(io_rx_log) s'.(io_rx_log)).
+  Lemma IO_ext_sem_trace : forall e args s s' ret t, valid_trace s -> IO_ext_sem e args s = Some (s', ret, t) ->
+    s.(io_log) = common_prefix IOEvent_eq s.(io_log) s'.(io_log) /\
+    t = trace_of_ostrace (strip_common_prefix IOEvent_eq s.(io_log) s'.(io_log)).
   Proof.
     intros until 1.
-    unfold IO_ext_sem'.
-    if_tac.
+    unfold IO_ext_sem.
+    if_tac; [|if_tac].
+    - unfold sys_putc_wrap_spec.
+      destruct args as [| [] [|]]; try discriminate.
+      destruct get_sys_arg1 eqn: Harg; try discriminate.
+      destruct (eq_dec _ _); try discriminate.
+      destruct sys_putc_spec eqn: Hputc; inversion 1; subst; split; auto.
+      pose proof Hputc as Hspec.
+      unfold sys_putc_spec in Hputc; destruct_spec Hputc.
+      unfold uctx_set_errno_spec in Hputc; destruct_spec Hputc.
+      unfold uctx_set_retval1_spec in Heqo3; destruct_spec Heqo3.
+      destruct r1; cbn in *.
+      eapply sys_putc_trace_case in Hspec as []; eauto.
+      unfold get_sys_ret; cbn.
+      repeat (rewrite ZMap.gss in * || rewrite ZMap.gso in * by easy); subst; inj; reflexivity.
     - unfold sys_getc_wrap_spec.
       destruct sys_getc_spec eqn: Hgetc; inversion 1; subst; split; auto.
       pose proof Hgetc as Hspec.
@@ -359,9 +219,9 @@ Local Ltac destruct_spec Hspec :=
   Qed.
 
   Lemma OS_trace_correct' : forall n t traces z s0 c m
-    (Hvalid : valid_trace s0) (Ht : t = trace_of_ostrace s0.(io_rx_log)),
+    (Hvalid : valid_trace s0) (Ht : t = trace_of_ostrace s0.(io_log)),
     OS_safeN_trace n t traces z s0 c m ->
-    forall t' sf, In _ traces (t', sf) -> valid_trace sf /\ app_trace (trace_of_ostrace s0.(io_rx_log)) t' = trace_of_ostrace sf.(io_rx_log).
+    forall t' sf, In _ traces (t', sf) -> valid_trace sf /\ app_trace (trace_of_ostrace s0.(io_log)) t' = trace_of_ostrace sf.(io_log).
   Proof.
     induction n as [n IHn] using lt_wf_ind; intros; inv H.
     - inv H0.
@@ -377,7 +237,7 @@ Local Ltac destruct_spec Hspec :=
       { rewrite Htrace, app_trace_strip; auto. }
   Qed.
 
-  Lemma init_log_valid : forall s, io_rx_log s = [] -> console s = {| cons_buf := []; rpos := 0 |} -> valid_trace s.
+  Lemma init_log_valid : forall s, io_log s = [] -> console s = {| cons_buf := []; rpos := 0 |} -> valid_trace s.
   Proof.
     intros s Hinit Hcon.
     constructor; rewrite Hinit; repeat intro; try (pose proof app_cons_not_nil; congruence).
@@ -387,9 +247,9 @@ Local Ltac destruct_spec Hspec :=
   Qed.
 
   Lemma OS_trace_correct : forall n traces z s0 c m
-    (Hinit : s0.(io_rx_log) = []) (Hcon : s0.(console) = {| cons_buf := []; rpos := 0 |}),
+    (Hinit : s0.(io_log) = []) (Hcon : s0.(console) = {| cons_buf := []; rpos := 0 |}),
     OS_safeN_trace n TEnd traces z s0 c m ->
-    forall t sf, In _ traces (t, sf) -> valid_trace sf /\ t = trace_of_ostrace sf.(io_rx_log).
+    forall t sf, In _ traces (t, sf) -> valid_trace sf /\ t = trace_of_ostrace sf.(io_log).
   Proof.
     intros; eapply OS_trace_correct' in H as [? Htrace]; eauto.
     split; auto.
@@ -423,7 +283,7 @@ Local Ltac destruct_spec Hspec :=
   Qed.
 
   Lemma ext_safe_OS_safe : forall n t traces z q m s0 (Hvalid : valid_trace s0),
-    ext_safeN_trace(J := OK_spec) prog IO_ext_sem' IO_inj_mem OS_mem valid_trace n t traces z q m ->
+    ext_safeN_trace(J := OK_spec) prog IO_ext_sem IO_inj_mem OS_mem valid_trace n t traces z q m ->
     exists traces', OS_safeN_trace n t traces' z s0 q m /\ forall t, In _ traces t <-> exists s, In _ traces' (t, s).
   Proof.
     induction n as [n IHn] using lt_wf_ind; intros; inv H.
@@ -436,7 +296,7 @@ Local Ltac destruct_spec Hspec :=
       eapply OS_safeN_trace_step; eauto.
     - exists (fun t1 => exists s s' ret m' t' n', Val.has_type_list args (sig_args (ef_sig e)) /\
          step_lemmas.has_opttyp ret (sig_res (ef_sig e)) /\
-         IO_inj_mem e args m t s /\ IO_ext_sem' e args s = Some (s', ret, t') /\ m' = OS_mem e args m s' /\
+         IO_inj_mem e args m t s /\ IO_ext_sem e args s = Some (s', ret, t') /\ m' = OS_mem e args m s' /\
          (n' <= n0)%nat /\ valid_trace s' /\ exists traces' z' c', consume_trace z z' t' /\
            cl_after_external ret q = Some c' /\ OS_safeN_trace n' (app_trace t t') traces' z' s' c' m' /\
         exists t'' sf, In _ traces' (t'', sf) /\ t1 = (app_trace t' t'', sf)); split.
@@ -465,12 +325,12 @@ Theorem IO_OS_ext:
      Genv.find_symbol (Genv.globalenv prog) (prog_main prog) = Some b /\
      initial_core (cl_core_sem (globalenv prog))
          0 m q m' (Vptr b Ptrofs.zero) nil /\
-   forall n s0, s0.(io_rx_log) = [] -> s0.(console) = {| cons_buf := []; rpos := 0 |} ->
+   forall n s0, s0.(io_log) = [] -> s0.(console) = {| cons_buf := []; rpos := 0 |} ->
     exists traces, OS_safeN_trace n TEnd traces initial_oracle s0 q m' /\
-     forall t s, In _ traces (t, s) -> exists z', consume_trace initial_oracle z' t /\ t = trace_of_ostrace s.(io_rx_log) /\
-      valid_trace_user s.(io_rx_log).
+     forall t s, In _ traces (t, s) -> exists z', consume_trace initial_oracle z' t /\ t = trace_of_ostrace s.(io_log) /\
+      valid_trace_user s.(io_log).
 Proof.
-  intros; eapply IO_OS_soundness' in H as (? & ? & ? & ? & ? & Hsafe); eauto.
+  intros; eapply IO_OS_soundness in H as (? & ? & ? & ? & ? & Hsafe); eauto.
   do 4 eexists; eauto; split; eauto; intros.
   destruct (Hsafe n) as (? & Hsafen & Htrace).
   eapply ext_safe_OS_safe in Hsafen as (? & Hsafen & Htrace').

--- a/progs/io_dry.v
+++ b/progs/io_dry.v
@@ -10,19 +10,10 @@ Require Import VST.veric.ghost_PCM.
 Require Import VST.veric.SequentialClight.
 Require Import VST.progs.conclib.
 Require Import VST.progs.dry_mem_lemmas.
-Require Import ITree.ITree.
-(* Import ITreeNotations. *) (* one piece conflicts with subp notation *)
-Notation "t1 >>= k2" := (ITree.bind t1 k2)
-  (at level 50, left associativity) : itree_scope.
-Notation "x <- t1 ;; t2" := (ITree.bind t1 (fun x => t2))
-  (at level 100, t1 at next level, right associativity) : itree_scope.
-Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
-  (at level 100, right associativity) : itree_scope.
-Notation "' p <- t1 ;; t2" :=
-  (ITree.bind t1 (fun x_ => match x_ with p => t2 end))
-(at level 100, t1 at next level, p pattern, right associativity) : itree_scope.
 
 Section IO_Dry.
+
+Context {E : Type -> Type} {IO_E : @IO_event nat -< E}.
 
 Definition getchar_pre (m : mem) (witness : byte -> IO_itree) (z : IO_itree) :=
   let k := witness in (sutt eq (r <- read stdin;; k r) z).
@@ -45,7 +36,7 @@ Instance Espec : OracleKind := IO_Espec ext_link.
 
 Definition io_ext_spec := OK_spec.
 
-Program Definition io_dry_spec : external_specification mem external_function (@IO_itree nat).
+Program Definition io_dry_spec : external_specification mem external_function (@IO_itree E).
 Proof.
   unshelve econstructor.
   - intro e.

--- a/progs/io_mem_specs.v
+++ b/progs/io_mem_specs.v
@@ -1,27 +1,27 @@
 Require Import VST.floyd.proofauto.
 Require Import VST.veric.juicy_extspec.
 Require Export VST.floyd.io_events.
-Require Import ITree.ITree.
+Require Export ITree.ITree.
 Require Export ITree.Eq.Eq.
 Require Export ITree.Eq.SimUpToTaus.
 (* Import ITreeNotations. *) (* one piece conflicts with subp notation *)
-Notation "t1 >>= k2" := (ITree.bind t1 k2)
-  (at level 50, left associativity) : itree_scope.
 Notation "x <- t1 ;; t2" := (ITree.bind t1 (fun x => t2))
   (at level 100, t1 at next level, right associativity) : itree_scope.
-Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
-  (at level 100, right associativity) : itree_scope.
 Notation "' p <- t1 ;; t2" :=
   (ITree.bind t1 (fun x_ => match x_ with p => t2 end))
 (at level 100, t1 at next level, p pattern, right associativity) : itree_scope.
 
-Fixpoint read_list_aux {file_id : Type} f n d : itree (@IO_event file_id) (list byte) :=
+Section specs.
+
+Context {E : Type -> Type} `{IO_event(file_id := nat) -< E}.
+
+Fixpoint read_list_aux f n d : itree E (list byte) :=
   match n with
   | O => Ret d
   | S n' => x <- read f ;; read_list_aux f n' (x :: d)
   end.
 
-Definition read_list {file_id : Type} f n : itree (@IO_event file_id) (list byte) := read_list_aux f n [].
+Definition read_list f n : itree E (list byte) := read_list_aux f n [].
 
 Definition stdin := 0%nat.
 Definition stdout := 1%nat.
@@ -52,10 +52,12 @@ Definition getchars_spec {CS : compspecs} :=
     SEP (ITREE (k msg); data_at sh (tarray tuchar len) (map Vubyte msg) buf).
 
 (* Build the external specification. *)
-Definition IO_void_Espec : OracleKind := ok_void_spec (@IO_itree nat).
+Definition IO_void_Espec : OracleKind := ok_void_spec (@IO_itree E).
 
 Definition IO_specs {CS : compspecs} (ext_link : string -> ident) :=
   [(ext_link "putchars"%string, putchars_spec); (ext_link "getchars"%string, getchars_spec)].
 
 Definition IO_Espec {CS : compspecs} (ext_link : string -> ident) : OracleKind :=
   add_funspecs IO_void_Espec ext_link (IO_specs ext_link).
+
+End specs.

--- a/progs/io_os_connection.v
+++ b/progs/io_os_connection.v
@@ -245,7 +245,7 @@ Definition getchar_pre' (m : mem) (witness : byte -> IO_itree) (z : IO_itree) :=
 
 (* CertiKOS specs must terminate. Could get blocking version back by
    wrapping getchar in a loop. *)
-Definition getchar_post' (m0 m : mem) r (witness : (byte -> IO_itree) * IO_itree) (z : @IO_itree nat) :=
+Definition getchar_post' (m0 m : mem) r (witness : (byte -> IO_itree) * IO_itree) (z : @IO_itree (@IO_event nat)) :=
   m0 = m /\
     (* Success *)
     ((0 <= Int.signed r <= two_p 8 - 1 /\ let (k, _) := witness in z = k (Byte.repr (Int.signed r))) \/

--- a/progs/io_os_connection.v
+++ b/progs/io_os_connection.v
@@ -21,7 +21,7 @@ Local Ltac inj :=
   | H: _ = _ |- _ => assert_succeeds (injection H); inv H
   end.
 
-Ltac prename' pat H name :=
+Local Ltac prename' pat H name :=
   match type of H with
   | context[?pat'] => unify pat pat'; rename H into name
   end.
@@ -337,19 +337,22 @@ Section Invariants.
       tr = pre ++ IOEvGetc logIdx strIdx c :: post ->
       In (IOEvRecv logIdx strIdx c) pre /\ hd_error (compute_console pre) = Some (c, logIdx, strIdx).
 
-  (* Every event in the trace is unique. *)
-  Definition valid_trace_unique (tr : ostrace) := NoDup tr.
+  (* Every read event in the trace is unique. *)
+  Definition valid_trace_unique (tr : ostrace) :=
+    let tr' := filter (fun ev =>
+      match ev with | IOEvRecv _ _ _ | IOEvGetc _ _ _ => true | _ => false end) tr in
+    NoDup tr'.
 
   (* The console matches compute_console. *)
   Definition valid_trace_console tr cons := cons = compute_console tr.
 
   (* All trace invariants hold. *)
   Record valid_trace (st : RData) := {
-    vt_trace_serial : valid_trace_serial st.(io_rx_log) st.(com1).(l1);
-    vt_trace_ordered : valid_trace_ordered st.(io_rx_log);
-    vt_trace_user : valid_trace_user st.(io_rx_log);
-    vt_trace_unique : valid_trace_unique st.(io_rx_log);
-    vt_trace_console : valid_trace_console st.(io_rx_log) st.(console).(cons_buf);
+    vt_trace_serial : valid_trace_serial st.(io_log) st.(com1).(l1);
+    vt_trace_ordered : valid_trace_ordered st.(io_log);
+    vt_trace_user : valid_trace_user st.(io_log);
+    vt_trace_unique : valid_trace_unique st.(io_log);
+    vt_trace_console : valid_trace_console st.(io_log) st.(console).(cons_buf);
   }.
 
   (* Console entries are ordered by logIdx and strIdx *)
@@ -803,6 +806,41 @@ Section Invariants.
   *)
   Context `{ThreadsConfigurationOps}.
 
+  Lemma valid_trace_tx_event : forall st ev,
+    match ev with
+    | IOEvSend _ _ | IOEvPutc _ _ => True
+    | _ => False
+    end ->
+    valid_trace st ->
+    valid_trace (st {io_log : st.(io_log) ++ ev :: nil}).
+  Proof.
+    destruct ev; try easy; intros _ Hvalid; inv Hvalid; constructor; red; destruct st; cbn in *.
+    - intros * Heq.
+      apply in_app_case in Heq; cbn in Heq; intuition (try easy).
+      all: destruct H2; subst; eapply vt_trace_serial0; eauto.
+    - intros * Heq.
+      rewrite app_comm_cons, app_assoc in Heq.
+      apply in_app_case in Heq; cbn in Heq; intuition (try easy).
+      destruct H2; subst; eauto. eapply vt_trace_ordered0; rewrite app_comm_cons, app_assoc; eauto.
+    - intros * Heq.
+      apply in_app_case in Heq; cbn in Heq; intuition (try easy).
+      all: destruct H2; subst; eapply vt_trace_user0; eauto.
+    - rewrite conclib.filter_app, app_nil_r; auto.
+    - simpl_rev; cbn; auto.
+    - intros * Heq.
+      apply in_app_case in Heq; cbn in Heq; intuition (try easy).
+      all: destruct H2; subst; eapply vt_trace_serial0; eauto.
+    - intros * Heq.
+      rewrite app_comm_cons, app_assoc in Heq.
+      apply in_app_case in Heq; cbn in Heq; intuition (try easy).
+      destruct H2; subst; eauto. eapply vt_trace_ordered0; rewrite app_comm_cons, app_assoc; eauto.
+    - intros * Heq.
+      apply in_app_case in Heq; cbn in Heq; intuition (try easy).
+      all: destruct H2; subst; eapply vt_trace_user0; eauto.
+    - rewrite conclib.filter_app, app_nil_r; auto.
+    - simpl_rev; cbn; auto.
+  Qed.
+
   Lemma cons_intr_aux_preserve_valid_trace : forall st st',
     valid_trace st ->
     cons_intr_aux st = Some st' ->
@@ -847,8 +885,10 @@ Section Invariants.
         eapply in_mkRecvEvents in Hin.
         destruct Hin as (? & ? & ? & ? & ?); inj; easy.
       + (* valid_trace_unique *)
-        rewrite conclib.NoDup_app_iff; repeat split; auto using mkRecvEvents_NoDup.
-        intros * Hin Hin'.
+        rewrite conclib.filter_app, conclib.NoDup_app_iff; repeat split;
+          auto using mkRecvEvents_NoDup, conclib.NoDup_filter.
+        intros *; rewrite !filter_In.
+        intros (Hin & ?) (Hin' & ?).
         eapply in_mkRecvEvents in Hin'.
         destruct Hin' as (? & ? & ? & ? & ?); inj; subst.
         apply in_split in Hin; destruct Hin as (? & ? & ?); subst.
@@ -905,8 +945,10 @@ Section Invariants.
         eapply in_mkRecvEvents in Hin.
         destruct Hin as (? & ? & ? & ? & ?); inj; easy.
       + (* valid_trace_unique *)
-        rewrite conclib.NoDup_app_iff; repeat split; auto using mkRecvEvents_NoDup.
-        intros * Hin Hin'.
+        rewrite conclib.filter_app, conclib.NoDup_app_iff; repeat split;
+          auto using mkRecvEvents_NoDup, conclib.NoDup_filter.
+        intros *; rewrite !filter_In.
+        intros (Hin & ?) (Hin' & ?).
         eapply in_mkRecvEvents in Hin'.
         destruct Hin' as (? & ? & ? & ? & ?); inj; subst.
         apply in_split in Hin; destruct Hin as (? & ? & ?); subst.
@@ -960,16 +1002,28 @@ Section Invariants.
     induction n; intros * Hvalid Hspec; cbn -[cons_intr_aux] in Hspec; inj; auto.
     destruct_spec Hspec; auto.
     - eapply IHn; [| eauto].
-      destruct st; inv Hvalid; constructor; cbn in *; auto.
-      destruct com1; cbn in *; red; intros; subst; edestruct vt_trace_serial0; eauto.
       prename serial_intr into Hspec'; unfold serial_intr in Hspec'; destruct_spec Hspec'.
-      cbn; split; auto; lia.
+      destruct o.
+      + enough (Hvalid': valid_trace (st {io_log : io_log st ++ IOEvSend 0 z :: nil}));
+          auto using valid_trace_tx_event.
+        destruct st; inv Hvalid'; constructor; cbn in *; auto.
+        destruct com1; cbn in *; red; intros; subst; edestruct vt_trace_serial0; eauto.
+        cbn; split; auto; lia.
+      + rewrite app_nil_r; destruct st; inv Hvalid; constructor; cbn in *; auto.
+        destruct com1; cbn in *; red; intros; subst; edestruct vt_trace_serial0; eauto.
+        cbn; split; auto; lia.
     - eapply IHn; [| eauto].
       eapply cons_intr_aux_preserve_valid_trace; [| eauto].
-      destruct st; inv Hvalid; constructor; cbn in *; auto.
-      destruct com1; cbn in *; red; intros; subst; edestruct vt_trace_serial0; eauto.
       prename serial_intr into Hspec'; unfold serial_intr in Hspec'; destruct_spec Hspec'.
-      cbn; split; auto; lia.
+      destruct o.
+      + enough (Hvalid': valid_trace (st {io_log : io_log st ++ IOEvSend 0 z :: nil}));
+          auto using valid_trace_tx_event.
+        destruct st; inv Hvalid'; constructor; cbn in *; auto.
+        destruct com1; cbn in *; red; intros; subst; edestruct vt_trace_serial0; eauto.
+        cbn; split; auto; lia.
+      + rewrite app_nil_r; destruct st; inv Hvalid; constructor; cbn in *; auto.
+        destruct com1; cbn in *; red; intros; subst; edestruct vt_trace_serial0; eauto.
+        cbn; split; auto; lia.
   Qed.
 
   Lemma serial_intr_disable_preserve_valid_trace : forall st st',
@@ -1026,7 +1080,9 @@ Section Invariants.
     valid_trace st'.
   Proof.
     unfold serial_putc_spec; intros * Hvalid Hspec; destruct_spec Hspec; eauto.
-    all: destruct st; inv Hvalid; constructor; cbn in *; subst; red; auto.
+    all: enough (Hvalid': valid_trace (st {io_log : io_log st ++ IOEvPutc l2 c :: nil}));
+      auto using valid_trace_tx_event.
+    all: destruct st; inv Hvalid'; constructor; cbn in *; subst; auto.
   Qed.
 
   Lemma cons_buf_read_preserve_valid_trace : forall st st' c,
@@ -1046,7 +1102,7 @@ Section Invariants.
       intros * Heq.
       apply (f_equal (@rev _)) in Heq; simpl_rev_in Heq.
       destruct (rev post); cbn in Heq; inj; prename (rev _ = _) into Heq.
-      apply (f_equal (@rev _)) in Heq; simpl_rev_in Heq; subst; info_eauto.
+      apply (f_equal (@rev _)) in Heq; simpl_rev_in Heq; subst; eauto.
     - (* valid_trace_user *)
       intros * Heq.
       symmetry in Heq.
@@ -1057,8 +1113,9 @@ Section Invariants.
       apply in_console_in_trace.
       rewrite <- vt_trace_console0, Hcons; cbn; auto.
     - (* valid_trace_unique *)
-      rewrite conclib.NoDup_app_swap; cbn.
+      rewrite conclib.filter_app, conclib.NoDup_app_swap; cbn.
       constructor; auto; intros Hin.
+      rewrite filter_In in Hin; destruct Hin as (Hin & _).
       apply in_split in Hin.
       destruct Hin as (post & pre & ?); subst.
       edestruct vt_trace_user0 as (Hin & Hhd); eauto.
@@ -1298,13 +1355,27 @@ Section Invariants.
     eauto.
   Qed.
 
-  (** At most one user-visible event is generated. *)
+  (** No user-visible events are generated. *)
+  Definition nil_trace_case t t' :=
+    let new := trace_of_ostrace (strip_common_prefix IOEvent_eq t t') in
+    t = common_prefix IOEvent_eq t t' /\
+    new = trace_of_ostrace nil.
+
+  (** At most one user-visible read event is generated. *)
   Definition getc_trace_case t t' ret :=
     let new := trace_of_ostrace (strip_common_prefix IOEvent_eq t t') in
     t = common_prefix IOEvent_eq t t' /\
     ((ret = -1 /\ new = trace_of_ostrace nil) \/
      (0 <= ret <= 255 /\ forall logIdx strIdx,
         new = trace_of_ostrace (IOEvGetc logIdx strIdx ret :: nil))).
+
+  (** At most one user-visible write event is generated. *)
+  Definition putc_trace_case t t' c ret :=
+    let new := trace_of_ostrace (strip_common_prefix IOEvent_eq t t') in
+    t = common_prefix IOEvent_eq t t' /\
+    ((ret = -1 /\ new = trace_of_ostrace nil) \/
+     (ret = c mod 256 /\ forall logIdx,
+        new = trace_of_ostrace (IOEvPutc logIdx c :: nil))).
 
   Lemma trace_of_ostrace_app : forall otr otr',
     let tr := trace_of_ostrace otr in
@@ -1332,16 +1403,38 @@ Section Invariants.
     destruct Hin as (? & ? & ? & ? & ?); eauto.
   Qed.
 
-  Lemma getc_trace_case_refl : forall st, getc_trace_case st st (-1).
+  Lemma nil_trace_getc_trace : forall t t',
+    nil_trace_case t t' <-> getc_trace_case t t' (-1).
+  Proof.
+    unfold nil_trace_case, getc_trace_case; intuition (auto; easy).
+  Qed.
+
+  Lemma nil_trace_putc_trace : forall t t' c,
+    nil_trace_case t t' <-> putc_trace_case t t' c (-1).
+  Proof.
+    unfold nil_trace_case, putc_trace_case; intuition auto.
+    pose proof (Z.mod_pos_bound c 256 ltac:(lia)); lia.
+  Qed.
+
+  Lemma nil_trace_case_refl : forall st, nil_trace_case st st.
   Proof.
     red; intros; unfold strip_common_prefix.
     rewrite common_prefix_full, leb_correct, skipn_exact_length; cbn; auto.
   Qed.
 
+  Local Hint Resolve nil_trace_case_refl.
+
+  Corollary getc_trace_case_refl : forall st, getc_trace_case st st (-1).
+  Proof. intros; rewrite <- nil_trace_getc_trace; auto. Qed.
+
+  Corollary putc_trace_case_refl : forall st c, putc_trace_case st st c (-1).
+  Proof. intros; rewrite <- nil_trace_putc_trace; auto. Qed.
+
   Local Hint Resolve getc_trace_case_refl.
+  Local Hint Resolve putc_trace_case_refl.
 
   Lemma getc_trace_case_trans : forall t t' t'' r,
-    getc_trace_case t t' (-1) ->
+    nil_trace_case t t' ->
     getc_trace_case t' t'' r ->
     getc_trace_case t t'' r.
   Proof.
@@ -1355,12 +1448,12 @@ Section Invariants.
     rewrite common_prefix_app, skipn_app1, skipn_exact_length in *;
       rewrite ?app_length; auto; cbn in *.
     rewrite trace_of_ostrace_app.
-    destruct Htr as [(? & ->) | ?], Htr' as [(? & ->) | ?]; subst; auto; easy.
+    rewrite Htr; destruct Htr' as [(? & ->) | ?]; subst; auto.
   Qed.
 
   Lemma getc_trace_case_trans' : forall t t' t'' r,
     getc_trace_case t t' r ->
-    getc_trace_case t' t'' (-1) ->
+    nil_trace_case t' t'' ->
     getc_trace_case t t'' r.
   Proof.
     intros * Htr Htr'; red.
@@ -1373,188 +1466,19 @@ Section Invariants.
     rewrite common_prefix_app, skipn_app1, skipn_exact_length in *;
       rewrite ?app_length; auto; cbn in *.
     rewrite trace_of_ostrace_app.
-    destruct Htr as [(? & ->) | (? & Heq)], Htr' as [(? & ->) | ?]; subst; auto; try easy.
-    rewrite Heq; cbn; auto; constructor.
+    rewrite Htr'; destruct Htr as [(? & ->) | (? & ->)]; subst; auto; constructor.
   Qed.
 
-  Lemma cons_intr_aux_getc_trace_case : forall st st',
-    cons_intr_aux st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
+  Corollary nil_trace_case_trans : forall t t' t'',
+    nil_trace_case t t' ->
+    nil_trace_case t' t'' ->
+    nil_trace_case t t''.
   Proof.
-    unfold cons_intr_aux, getc_trace_case; intros * Hspec; destruct_spec Hspec.
-    - prename (Coqlib.zeq _ _ = _) into Htmp; clear Htmp.
-      destruct st; cbn in *; subst; cbn in *.
-      rewrite common_prefix_app, app_length, leb_correct by lia.
-      rewrite skipn_app1, skipn_exact_length; cbn; auto using mkRecvEvents_not_visible.
-    - prename (Coqlib.zeq _ _ = _) into Htmp; clear Htmp.
-      destruct st; cbn in *; subst; cbn in *.
-      rewrite common_prefix_app, app_length, leb_correct by lia.
-      rewrite skipn_app1, skipn_exact_length; cbn; auto using mkRecvEvents_not_visible.
+    intros * ?; rewrite !nil_trace_getc_trace; eauto using getc_trace_case_trans.
   Qed.
-
-  Lemma serial_intr_enable_aux_getc_trace_case : forall n st st',
-    serial_intr_enable_aux n st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
-  Proof.
-    induction n; intros * Hspec; cbn -[cons_intr_aux] in Hspec; inj; auto.
-    destruct_spec Hspec; auto.
-    prename cons_intr_aux into Hspec'.
-    eapply getc_trace_case_trans; [eapply cons_intr_aux_getc_trace_case |]; eauto.
-  Qed.
-
-  Lemma serial_intr_enable_getc_trace_case : forall st st',
-    serial_intr_enable_spec st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
-  Proof.
-    unfold serial_intr_enable_spec; intros * Hspec; destruct_spec Hspec.
-    prename serial_intr_enable_aux into Hspec.
-    eapply serial_intr_enable_aux_getc_trace_case in Hspec.
-    destruct st, r; auto.
-  Qed.
-
-  Lemma serial_intr_disable_aux_getc_trace_case : forall n mask st st',
-    serial_intr_disable_aux n mask st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
-  Proof.
-    induction n; intros * Hspec; cbn -[cons_intr_aux] in Hspec; inj; auto.
-    destruct_spec Hspec; auto.
-    - eapply IHn in Hspec.
-      destruct st; auto.
-    - prename cons_intr_aux into Hspec'.
-      eapply cons_intr_aux_getc_trace_case in Hspec'.
-      eapply IHn in Hspec.
-      eapply getc_trace_case_trans; [| eapply Hspec]; eauto.
-      destruct st; auto.
-  Qed.
-
-  Lemma serial_intr_disable_getc_trace_case : forall st st',
-    serial_intr_disable_spec st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
-  Proof.
-    unfold serial_intr_disable_spec; intros * Hspec; destruct_spec Hspec.
-    prename serial_intr_disable_aux into Hspec.
-    eapply serial_intr_disable_aux_getc_trace_case in Hspec.
-    destruct st, r; auto.
-  Qed.
-
-  Lemma thread_serial_intr_enable_getc_trace_case : forall st st',
-    thread_serial_intr_enable_spec st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
-  Proof.
-    unfold thread_serial_intr_enable_spec; intros * Hspec; destruct_spec Hspec.
-    eapply serial_intr_enable_getc_trace_case; eauto.
-  Qed.
-
-  Lemma thread_serial_intr_disable_getc_trace_case : forall st st',
-    thread_serial_intr_disable_spec st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
-  Proof.
-    unfold thread_serial_intr_disable_spec; intros * Hspec; destruct_spec Hspec.
-    eapply serial_intr_disable_getc_trace_case; eauto.
-  Qed.
-
-  Lemma uctx_set_retval1_getc_trace_case : forall st v st',
-    uctx_set_retval1_spec v st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
-  Proof.
-    unfold uctx_set_retval1_spec; intros * Hspec; destruct_spec Hspec.
-    destruct st; auto.
-  Qed.
-
-  Lemma uctx_set_errno_getc_trace_case : forall st e st',
-    uctx_set_errno_spec e st = Some st' ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (-1).
-  Proof.
-    unfold uctx_set_errno_spec; intros * Hspec; destruct_spec Hspec.
-    destruct st; auto.
-  Qed.
-
-  Lemma cons_buf_read_getc_trace_case : forall st st' c,
-    valid_trace st ->
-    cons_buf_read_spec st = Some (st', c) ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) c /\ -1 <= c <= 255.
-  Proof.
-    unfold cons_buf_read_spec; intros * Hvalid Hspec; destruct_spec Hspec.
-    { split; eauto; lia. }
-    prename (cons_buf _ = _) into Hcons.
-    destruct st; cbn in *; unfold getc_trace_case.
-    unfold strip_common_prefix.
-    rewrite common_prefix_app, app_length, leb_correct by lia.
-    rewrite skipn_app1, skipn_exact_length; cbn; auto.
-    inv Hvalid; cbn in *.
-    rewrite vt_trace_console0 in Hcons.
-    assert (Hin: In (c, z0, n) (compute_console io_rx_log)) by (rewrite Hcons; cbn; auto).
-    apply in_console_in_trace in Hin.
-    apply in_split in Hin; destruct Hin as (? & ? & ?); subst.
-    edestruct vt_trace_serial0 as (_ & Henv); eauto.
-    destruct (SerialEnv z0) eqn:Hrange; try easy.
-    apply SerialRecv_in_range in Hrange.
-    rewrite Forall_forall in Hrange.
-    apply nth_error_In in Henv.
-    apply Hrange in Henv.
-    split; auto; lia.
-  Qed.
-
-  Lemma thread_cons_buf_read_getc_trace_case : forall st st' c,
-    valid_trace st ->
-    thread_cons_buf_read_spec st = Some (st', c) ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) c /\ -1 <= c <= 255.
-  Proof.
-    unfold thread_cons_buf_read_spec; intros * Hvalid Hspec; destruct_spec Hspec.
-    eapply cons_buf_read_getc_trace_case; eauto.
-  Qed.
-
-  Lemma sys_getc_trace_case : forall st st' ret,
-    valid_trace st ->
-    sys_getc_spec st = Some st' ->
-    get_sys_ret st' = Vint ret ->
-    getc_trace_case st.(io_rx_log) st'.(io_rx_log) (Int.signed ret).
-  Proof.
-    unfold sys_getc_spec, get_sys_ret; intros * Hvalid Hspec Hret; destruct_spec Hspec.
-    prename thread_serial_intr_disable_spec into Hspec1.
-    prename thread_cons_buf_read_spec into Hspec2.
-    prename thread_serial_intr_enable_spec into Hspec3.
-    prename uctx_set_retval1_spec into Hspec4.
-    assert (valid_trace r) by eauto using thread_serial_intr_disable_preserve_valid_trace.
-    assert (valid_trace r0) by eauto using thread_cons_buf_read_preserve_valid_trace.
-    assert (valid_trace r1) by eauto using thread_serial_intr_enable_preserve_valid_trace.
-    assert (valid_trace r2) by eauto using uctx_set_retval1_preserve_valid_trace.
-    assert (valid_trace st') by eauto using uctx_set_errno_preserve_valid_trace.
-    eapply thread_serial_intr_disable_getc_trace_case in Hspec1 as Htr.
-    eapply thread_cons_buf_read_getc_trace_case in Hspec2 as (Htr1 & Hrange); auto.
-    eapply thread_serial_intr_enable_getc_trace_case in Hspec3 as Htr2.
-    eapply uctx_set_retval1_getc_trace_case in Hspec4 as Htr3.
-    eapply uctx_set_errno_getc_trace_case in Hspec as Htr4.
-    eapply getc_trace_case_trans'; [| eapply Htr4].
-    eapply getc_trace_case_trans'; [| eapply Htr3].
-    eapply getc_trace_case_trans'; [| eapply Htr2].
-    eapply getc_trace_case_trans; [eapply Htr |]; eauto.
-    enough (z = Int.signed ret); subst; auto.
-    clear -Hspec Hspec4 Hret Htr1 Hrange.
-    unfold uctx_set_retval1_spec in Hspec4; destruct_spec Hspec4.
-    unfold uctx_set_errno_spec in Hspec; destruct_spec Hspec.
-    destruct r1; cbn in *; subst.
-    repeat (rewrite ZMap.gss in Hret || rewrite ZMap.gso in Hret by easy); inj.
-    rewrite Int.signed_repr; auto; cbn; lia.
-  Qed.
-
-  Definition putc_trace_case t t' c ret :=
-    let new := trace_of_ostrace (strip_common_prefix IOEvent_eq t t') in
-    t = common_prefix IOEvent_eq t t' /\
-    ((ret = -1 /\ new = trace_of_ostrace nil) \/
-     (ret = c mod 256 /\ forall logIdx,
-        new = trace_of_ostrace (IOEvPutc logIdx c :: nil))).
-
-  Lemma putc_trace_case_refl : forall st c, putc_trace_case st st c (-1).
-  Proof.
-    red; intros; unfold strip_common_prefix.
-    rewrite common_prefix_full, leb_correct, skipn_exact_length; cbn; auto.
-  Qed.
-
-  Local Hint Resolve putc_trace_case_refl.
 
   Lemma putc_trace_case_trans : forall t t' t'' c r,
-    putc_trace_case t t' c (-1) ->
+    nil_trace_case t t' ->
     putc_trace_case t' t'' c r ->
     putc_trace_case t t'' c r.
   Proof.
@@ -1569,12 +1493,12 @@ Section Invariants.
       rewrite ?app_length; auto; cbn in *.
     rewrite trace_of_ostrace_app.
     pose proof (Z.mod_pos_bound c 256 ltac:(lia)).
-    destruct Htr as [(? & ->) | (? & ?)], Htr' as [(? & ->) | ?]; subst; auto; exfalso; lia.
+    rewrite Htr; destruct Htr' as [(? & ->) | ?]; subst; auto.
   Qed.
 
   Lemma putc_trace_case_trans' : forall t t' t'' c r,
     putc_trace_case t t' c r ->
-    putc_trace_case t' t'' c (-1) ->
+    nil_trace_case t' t'' ->
     putc_trace_case t t'' c r.
   Proof.
     intros * Htr Htr'; red.
@@ -1588,120 +1512,120 @@ Section Invariants.
       rewrite ?app_length; auto; cbn in *.
     rewrite trace_of_ostrace_app.
     pose proof (Z.mod_pos_bound c 256 ltac:(lia)).
-    destruct Htr as [(? & ->) | (? & Heq)], Htr' as [(? & ->) | (? & ?)]; subst; auto; try easy.
-    rewrite Heq; cbn; auto; constructor.
-    exfalso; lia.
+    rewrite Htr'; destruct Htr as [(? & ->) | (? & ->)]; subst; auto.
   Qed.
 
-  Lemma cons_intr_aux_putc_trace_case : forall st st' c,
+  Lemma cons_intr_aux_trace_case : forall st st',
     cons_intr_aux st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
-    unfold cons_intr_aux, putc_trace_case; intros * Hspec; destruct_spec Hspec.
+    unfold cons_intr_aux, nil_trace_case; intros * Hspec; destruct_spec Hspec.
     - prename (Coqlib.zeq _ _ = _) into Htmp; clear Htmp.
       destruct st; cbn in *; subst; cbn in *.
-      rewrite common_prefix_full, leb_correct, skipn_exact_length by lia; auto.
+      rewrite common_prefix_app, app_length, leb_correct by lia.
+      rewrite skipn_app1, skipn_exact_length; cbn; auto using mkRecvEvents_not_visible.
     - prename (Coqlib.zeq _ _ = _) into Htmp; clear Htmp.
       destruct st; cbn in *; subst; cbn in *.
-      rewrite common_prefix_full, leb_correct, skipn_exact_length by lia; auto.
+      rewrite common_prefix_app, app_length, leb_correct by lia.
+      rewrite skipn_app1, skipn_exact_length; cbn; auto using mkRecvEvents_not_visible.
   Qed.
 
-  Lemma serial_intr_enable_aux_putc_trace_case : forall n st st' c,
+  Lemma serial_intr_enable_aux_trace_case : forall n st st',
     serial_intr_enable_aux n st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
     induction n; intros * Hspec; cbn -[cons_intr_aux] in Hspec; inj; auto.
     destruct_spec Hspec; auto.
     prename cons_intr_aux into Hspec'.
-    eapply putc_trace_case_trans; [eapply cons_intr_aux_putc_trace_case |]; eauto.
+    eapply nil_trace_case_trans; [eapply cons_intr_aux_trace_case |]; eauto.
   Qed.
 
-  Lemma serial_intr_enable_putc_trace_case : forall st st' c,
+  Lemma serial_intr_enable_trace_case : forall st st',
     serial_intr_enable_spec st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
     unfold serial_intr_enable_spec; intros * Hspec; destruct_spec Hspec.
     prename serial_intr_enable_aux into Hspec.
-    eapply serial_intr_enable_aux_putc_trace_case in Hspec.
-    destruct st, r; eauto.
+    eapply serial_intr_enable_aux_trace_case in Hspec.
+    destruct st, r; auto.
   Qed.
 
-  Lemma serial_intr_putc_trace_case : forall d d' tr,
-    serial_intr d = (d', tr) ->
-    trace_of_ostrace tr = TEnd.
-  Proof.
-    unfold serial_intr; intros * Hspec; destruct_spec Hspec.
-    destruct o; auto.
-  Qed.
-
-  Lemma serial_intr_disable_aux_putc_trace_case : forall n mask st st' c,
+  Lemma serial_intr_disable_aux_trace_case : forall n mask st st',
     serial_intr_disable_aux n mask st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
     induction n; intros * Hspec; cbn -[cons_intr_aux] in Hspec; inj; auto.
     destruct_spec Hspec; auto.
     - eapply IHn in Hspec.
-      destruct st; cbn in *.
+      destruct st, st'; cbn in *.
       prename serial_intr into Hspec'.
       unfold serial_intr in Hspec'; destruct_spec Hspec'.
-      destruct o; cbn in *.
-      + eapply putc_trace_case_trans; [| eauto].
-        red; unfold strip_common_prefix.
-        rewrite !app_length, leb_correct by lia.
-        rewrite common_prefix_app, skipn_app1, skipn_exact_length; auto.
-      + rewrite app_nil_r in Hspec; auto.
+      destruct o; [| rewrite app_nil_r in Hspec; auto].
+      destruct Hspec as (Heq & Htr).
+      apply common_prefix_correct in Heq.
+      destruct Heq; subst; red.
+      rewrite <- Htr; unfold strip_common_prefix.
+      rewrite common_prefix_app, <- app_assoc, common_prefix_app.
+      rewrite !app_length, !leb_correct by (cbn; lia).
+      rewrite skipn_app1, skipn_exact_length; auto.
+      rewrite (app_assoc io_log), <- app_length.
+      rewrite skipn_app1, skipn_exact_length; cbn; auto.
     - prename cons_intr_aux into Hspec'.
-      eapply cons_intr_aux_putc_trace_case in Hspec'.
+      eapply cons_intr_aux_trace_case in Hspec'.
       eapply IHn in Hspec.
-      eapply putc_trace_case_trans; [| eapply Hspec]; eauto.
-      destruct st; cbn in *.
+      eapply nil_trace_case_trans; [| eapply Hspec]; eauto.
+      destruct st, r, st'; cbn in *.
       prename serial_intr into Hspec''.
       unfold serial_intr in Hspec''; destruct_spec Hspec''.
-      destruct o; cbn in *.
-      + eapply putc_trace_case_trans; [| eauto].
-        red; unfold strip_common_prefix.
-        rewrite !app_length, leb_correct by lia.
-        rewrite common_prefix_app, skipn_app1, skipn_exact_length; auto.
-      + rewrite app_nil_r in Hspec'; auto.
+      destruct o; [| rewrite app_nil_r in Hspec'; auto].
+      destruct Hspec' as (Heq & Htr).
+      apply common_prefix_correct in Heq.
+      destruct Heq; subst; red.
+      rewrite <- Htr; unfold strip_common_prefix.
+      rewrite common_prefix_app, <- app_assoc, common_prefix_app.
+      rewrite !app_length, !leb_correct by (cbn; lia).
+      rewrite skipn_app1, skipn_exact_length; auto.
+      rewrite (app_assoc io_log), <- app_length.
+      rewrite skipn_app1, skipn_exact_length; cbn; auto.
   Qed.
 
-  Lemma serial_intr_disable_putc_trace_case : forall st st' c,
+  Lemma serial_intr_disable_trace_case : forall st st',
     serial_intr_disable_spec st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
     unfold serial_intr_disable_spec; intros * Hspec; destruct_spec Hspec.
     prename serial_intr_disable_aux into Hspec.
-    eapply serial_intr_disable_aux_putc_trace_case in Hspec.
-    destruct st, r; eauto.
+    eapply serial_intr_disable_aux_trace_case in Hspec.
+    destruct st, r; auto.
   Qed.
 
-  Lemma thread_serial_intr_enable_putc_trace_case : forall st st' c,
+  Lemma thread_serial_intr_enable_trace_case : forall st st',
     thread_serial_intr_enable_spec st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
     unfold thread_serial_intr_enable_spec; intros * Hspec; destruct_spec Hspec.
-    eapply serial_intr_enable_putc_trace_case; eauto.
+    eapply serial_intr_enable_trace_case; eauto.
   Qed.
 
-  Lemma thread_serial_intr_disable_putc_trace_case : forall st st' c,
+  Lemma thread_serial_intr_disable_trace_case : forall st st',
     thread_serial_intr_disable_spec st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
     unfold thread_serial_intr_disable_spec; intros * Hspec; destruct_spec Hspec.
-    eapply serial_intr_disable_putc_trace_case; eauto.
+    eapply serial_intr_disable_trace_case; eauto.
   Qed.
 
-  Lemma uctx_set_retval1_putc_trace_case : forall st v st' c,
+  Lemma uctx_set_retval1_trace_case : forall st v st',
     uctx_set_retval1_spec v st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
     unfold uctx_set_retval1_spec; intros * Hspec; destruct_spec Hspec.
     destruct st; auto.
   Qed.
 
-  Lemma uctx_set_errno_putc_trace_case : forall st e st' c,
+  Lemma uctx_set_errno_trace_case : forall st e st',
     uctx_set_errno_spec e st = Some st' ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c (-1).
+    nil_trace_case st.(io_log) st'.(io_log).
   Proof.
     unfold uctx_set_errno_spec; intros * Hspec; destruct_spec Hspec.
     destruct st; auto.
@@ -1709,7 +1633,7 @@ Section Invariants.
 
   Lemma serial_putc_putc_trace_case : forall st c st' r,
     serial_putc_spec c st = Some (st', r) ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c r.
+    putc_trace_case st.(io_log) st'.(io_log) c r.
   Proof.
     unfold serial_putc_spec; intros * Hspec; destruct_spec Hspec; eauto.
     - prename (Coqlib.zeq _ _ = _) into Htmp; clear Htmp.
@@ -1724,19 +1648,88 @@ Section Invariants.
       rewrite common_prefix_app, skipn_app1, skipn_exact_length; auto.
   Qed.
 
-  Lemma thread_serial_putc_putc_trace_case : forall st c st' r,
+  Lemma cons_buf_read_trace_case : forall st st' c,
+    valid_trace st ->
+    cons_buf_read_spec st = Some (st', c) ->
+    getc_trace_case st.(io_log) st'.(io_log) c /\ -1 <= c <= 255.
+  Proof.
+    unfold cons_buf_read_spec; intros * Hvalid Hspec; destruct_spec Hspec.
+    { split; eauto; lia. }
+    prename (cons_buf _ = _) into Hcons.
+    destruct st; cbn in *; unfold getc_trace_case.
+    unfold strip_common_prefix.
+    rewrite common_prefix_app, app_length, leb_correct by lia.
+    rewrite skipn_app1, skipn_exact_length; cbn; auto.
+    inv Hvalid; cbn in *.
+    rewrite vt_trace_console0 in Hcons.
+    assert (Hin: In (c, z0, n) (compute_console io_log)) by (rewrite Hcons; cbn; auto).
+    apply in_console_in_trace in Hin.
+    apply in_split in Hin; destruct Hin as (? & ? & ?); subst.
+    edestruct vt_trace_serial0 as (_ & Henv); eauto.
+    destruct (SerialEnv z0) eqn:Hrange; try easy.
+    apply SerialRecv_in_range in Hrange.
+    rewrite Forall_forall in Hrange.
+    apply nth_error_In in Henv.
+    apply Hrange in Henv.
+    split; auto; lia.
+  Qed.
+
+  Lemma thread_serial_putc_trace_case : forall st c st' r,
     thread_serial_putc_spec c st = Some (st', r) ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) c r.
+    putc_trace_case st.(io_log) st'.(io_log) c r.
   Proof.
     unfold thread_serial_putc_spec; intros * Hspec; destruct_spec Hspec.
     eapply serial_putc_putc_trace_case; eauto.
+  Qed.
+
+  Lemma thread_cons_buf_read_trace_case : forall st st' c,
+    valid_trace st ->
+    thread_cons_buf_read_spec st = Some (st', c) ->
+    getc_trace_case st.(io_log) st'.(io_log) c /\ -1 <= c <= 255.
+  Proof.
+    unfold thread_cons_buf_read_spec; intros * Hvalid Hspec; destruct_spec Hspec.
+    eapply cons_buf_read_trace_case; eauto.
+  Qed.
+
+  Lemma sys_getc_trace_case : forall st st' ret,
+    valid_trace st ->
+    sys_getc_spec st = Some st' ->
+    get_sys_ret st' = Vint ret ->
+    getc_trace_case st.(io_log) st'.(io_log) (Int.signed ret).
+  Proof.
+    unfold sys_getc_spec, get_sys_ret; intros * Hvalid Hspec Hret; destruct_spec Hspec.
+    prename thread_serial_intr_disable_spec into Hspec1.
+    prename thread_cons_buf_read_spec into Hspec2.
+    prename thread_serial_intr_enable_spec into Hspec3.
+    prename uctx_set_retval1_spec into Hspec4.
+    assert (valid_trace r) by eauto using thread_serial_intr_disable_preserve_valid_trace.
+    assert (valid_trace r0) by eauto using thread_cons_buf_read_preserve_valid_trace.
+    assert (valid_trace r1) by eauto using thread_serial_intr_enable_preserve_valid_trace.
+    assert (valid_trace r2) by eauto using uctx_set_retval1_preserve_valid_trace.
+    assert (valid_trace st') by eauto using uctx_set_errno_preserve_valid_trace.
+    eapply thread_serial_intr_disable_trace_case in Hspec1 as Htr.
+    eapply thread_cons_buf_read_trace_case in Hspec2 as (Htr1 & Hrange); auto.
+    eapply thread_serial_intr_enable_trace_case in Hspec3 as Htr2.
+    eapply uctx_set_retval1_trace_case in Hspec4 as Htr3.
+    eapply uctx_set_errno_trace_case in Hspec as Htr4.
+    eapply getc_trace_case_trans'; [| eapply Htr4].
+    eapply getc_trace_case_trans'; [| eapply Htr3].
+    eapply getc_trace_case_trans'; [| eapply Htr2].
+    eapply getc_trace_case_trans; [eapply Htr |]; eauto.
+    enough (z = Int.signed ret); subst; auto.
+    clear -Hspec Hspec4 Hret Htr1 Hrange.
+    unfold uctx_set_retval1_spec in Hspec4; destruct_spec Hspec4.
+    unfold uctx_set_errno_spec in Hspec; destruct_spec Hspec.
+    destruct r1; cbn in *; subst.
+    repeat (rewrite ZMap.gss in Hret || rewrite ZMap.gso in Hret by easy); inj.
+    rewrite Int.signed_repr; auto; cbn; lia.
   Qed.
 
   Lemma sys_putc_trace_case : forall st st' c ret,
     sys_putc_spec st = Some st' ->
     get_sys_arg1 st = Vint c ->
     get_sys_ret st' = Vint ret ->
-    putc_trace_case st.(io_tx_log) st'.(io_tx_log) (Int.unsigned c) (Int.signed ret).
+    putc_trace_case st.(io_log) st'.(io_log) (Int.unsigned c) (Int.signed ret).
   Proof.
     unfold sys_putc_spec, get_sys_arg1, get_sys_ret; intros * Hspec Harg Hret; destruct_spec Hspec.
     prename thread_serial_intr_disable_spec into Hspec1.
@@ -1744,11 +1737,11 @@ Section Invariants.
     prename thread_serial_intr_enable_spec into Hspec3.
     prename uctx_set_retval1_spec into Hspec4.
     prename uctx_arg2_spec into Hspec5.
-    eapply thread_serial_intr_disable_putc_trace_case in Hspec1 as Htr.
-    eapply thread_serial_putc_putc_trace_case in Hspec2 as (Htr1 & Hrange); auto.
-    eapply thread_serial_intr_enable_putc_trace_case in Hspec3 as Htr2.
-    eapply uctx_set_retval1_putc_trace_case in Hspec4 as Htr3.
-    eapply uctx_set_errno_putc_trace_case in Hspec as Htr4.
+    eapply thread_serial_intr_disable_trace_case in Hspec1 as Htr.
+    eapply thread_serial_putc_trace_case in Hspec2 as (Htr1 & Hrange); auto.
+    eapply thread_serial_intr_enable_trace_case in Hspec3 as Htr2.
+    eapply uctx_set_retval1_trace_case in Hspec4 as Htr3.
+    eapply uctx_set_errno_trace_case in Hspec as Htr4.
     eapply putc_trace_case_trans'; [| eapply Htr4].
     eapply putc_trace_case_trans'; [| eapply Htr3].
     eapply putc_trace_case_trans'; [| eapply Htr2].
@@ -1810,7 +1803,7 @@ Section SpecsCorrect.
     (* Post condition holds on new state, itree, and result *)
     getc_post_ok : getchar_post' m m ret (k, z) getc_z';
     (* The itrees and OS traces agree on the external events *)
-    getc_itree_trace_ok : trace_itree_match z getc_z' st.(io_rx_log) st'.(io_rx_log);
+    getc_itree_trace_ok : trace_itree_match z getc_z' st.(io_log) st'.(io_log);
     (* The new trace is valid *)
     getc_trace_ok : valid_trace st';
     (* The memory is unchanged *)
@@ -1834,7 +1827,7 @@ Section SpecsCorrect.
     pose proof Hspec as Htrace_case.
     unfold sys_getc_spec in Hspec; destruct_spec Hspec.
     prename (thread_cons_buf_read_spec) into Hread.
-    apply thread_cons_buf_read_getc_trace_case in Hread as (_ & ?).
+    apply thread_cons_buf_read_trace_case in Hread as (_ & ?).
     2: eapply (thread_serial_intr_disable_preserve_valid_trace st); eauto.
     unfold uctx_set_errno_spec in Hspec; destruct_spec Hspec.
     prename (uctx_set_retval1_spec) into Hspec.
@@ -1869,7 +1862,7 @@ Section SpecsCorrect.
     (* Post condition holds on new state, itree, and result *)
     putc_post_ok : putchar_post m m ret (c, k) putc_z';
     (* The itrees and OS traces agree on the external events *)
-    putc_itree_trace_ok : trace_itree_match z putc_z' st.(io_tx_log) st'.(io_tx_log);
+    putc_itree_trace_ok : trace_itree_match z putc_z' st.(io_log) st'.(io_log);
     (* The new trace is valid *)
     (* TODO: have to define valid trace condition for putc *)
     putc_trace_ok : valid_trace st';
@@ -1896,7 +1889,7 @@ Section SpecsCorrect.
     pose proof Hspec as Htrace_case.
     unfold sys_putc_spec in Hspec; destruct_spec Hspec.
     prename (thread_serial_putc_spec) into Hput.
-    apply thread_serial_putc_putc_trace_case in Hput.
+    apply thread_serial_putc_trace_case in Hput.
     assert (-1 <= z1 <= 255).
     { pose proof (Z.mod_pos_bound z0 256 ltac:(lia)).
       destruct Hput as (? & [(? & ?) | (? & ?)]); subst; lia.
@@ -1943,7 +1936,7 @@ Section SpecsCorrect.
     (* Post condition holds on new state, itree, and result *)
     getcs_post_ok : getchars_post m m ret (sh, buf, len, k) getcs_z';
     (* The itrees and OS traces agree on the external events *)
-    getcs_itree_trace_ok : trace_itree_match z getcs_z' st.(io_rx_log) st'.(io_rx_log);
+    getcs_itree_trace_ok : trace_itree_match z getcs_z' st.(io_log) st'.(io_log);
     (* The new trace is valid *)
     getcs_trace_ok : valid_trace st';
     (* The memory has changed *)

--- a/progs/io_os_specs.v
+++ b/progs/io_os_specs.v
@@ -220,8 +220,7 @@ Record RData := mkRData {
   ioapic : IoApicData; (* I/O Advanced Programmable Interrupt Controller *)
   intr_flag : bool;
   in_intr : bool; (* in the interrupt handler *)
-  io_rx_log : list IOEvent;
-  io_tx_log : list IOEvent
+  io_log : list IOEvent;
 }.
 
 Class ThreadsConfigurationOps := {
@@ -229,56 +228,53 @@ Class ThreadsConfigurationOps := {
 }.
 
 Definition update_CPU_ID (a : RData) b :=
-  let (_, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData b pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (_, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData b pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_log .
 Definition update_pg (a : RData) b :=
-  let (CPU_ID, _, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID b ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, _, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID b ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_ikern (a : RData) b :=
-  let (CPU_ID, pg, _, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg b ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, _, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg b ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_ihost (a : RData) b :=
-  let (CPU_ID, pg, ikern, _, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern b HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, _, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern b HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_HP (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, _, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost b cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, _, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost b cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_cid (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, _, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP b init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, _, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP b init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_init (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, _, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid b big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, _, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid b big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_big_log (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, _, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init b uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, _, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init b uctxt com1 drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_uctxt (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, _, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log b com1 drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, _, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init big_log b com1 drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_com1 (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, _, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt b drv_serial console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, _, drv_serial, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt b drv_serial console ioapic intr_flag in_intr io_log.
 Definition update_drv_serial (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, _, console, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 b console ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, _, console, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 b console ioapic intr_flag in_intr io_log.
 Definition update_console (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, _, ioapic, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial b ioapic intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, _, ioapic, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial b ioapic intr_flag in_intr io_log.
 Definition update_ioapic (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, _, intr_flag, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console b intr_flag in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, _, intr_flag, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console b intr_flag in_intr io_log.
 Definition update_intr_flag (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, _, in_intr, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic b in_intr io_rx_log io_tx_log.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, _, in_intr, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic b in_intr io_log.
 Definition update_in_intr (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, _, io_rx_log, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag b io_rx_log io_tx_log.
-Definition update_io_rx_log (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, _, io_tx_log) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr b io_tx_log.
-Definition update_io_tx_log (a : RData) b :=
-  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, io_rx_log, _) := a in
-  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr io_rx_log b.
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, _, io_log) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag b io_log.
+Definition update_io_log (a : RData) b :=
+  let (CPU_ID, pg, ikern, ihost, HP, cid, init, big_log, uctxt, com1, drv_serial, console, ioapic, intr_flag, in_intr, _) := a in
+  mkRData CPU_ID pg ikern ihost HP cid init big_log uctxt com1 drv_serial console ioapic intr_flag in_intr b.
 
 Notation "a '{' 'CPU_ID' : x }" := (update_CPU_ID a x) (at level 1).
 Notation "a '{' 'pg' : x }" := (update_pg a x) (at level 1).
@@ -295,8 +291,7 @@ Notation "a '{' 'console' : x }" := (update_console a x) (at level 1).
 Notation "a '{' 'ioapic' : x }" := (update_ioapic a x) (at level 1).
 Notation "a '{' 'intr_flag' : x }" := (update_intr_flag a x) (at level 1).
 Notation "a '{' 'in_intr' : x }" := (update_in_intr a x) (at level 1).
-Notation "a '{' 'io_rx_log' : x }" := (update_io_rx_log a x) (at level 1).
-Notation "a '{' 'io_tx_log' : x }" := (update_io_tx_log a x) (at level 1).
+Notation "a '{' 'io_log' : x }" := (update_io_log a x) (at level 1).
 
 Definition update_cons_buf (a : ConsoleDriver) b :=
   let (_, rpos) := a in mkConsoleDriver b rpos.
@@ -493,7 +488,7 @@ Definition cons_intr_aux (abd : RData) : option RData :=
                           {com1 / l1 : lrx + Zlength rxbuf' * 2 + 1}
                           {com1 / s / RxBuf : nil}
                           {com1 / s / SerialIrq : false}
-                          {io_rx_log : abd.(io_rx_log) ++ mkRecvEvents (lrx - 1) str}
+                          {io_log : abd.(io_log) ++ mkRecvEvents (lrx - 1) str}
             else Some abd {console / cons_buf :
                             skipn (Z.to_nat (Zlength (abd.(console).(cons_buf) ++ rxbuf') - CONS_BUFFER_MAX_CHARS))
                                   (abd.(console).(cons_buf) ++ rxbuf')}
@@ -501,7 +496,7 @@ Definition cons_intr_aux (abd : RData) : option RData :=
                           {com1 / l1 : lrx + Zlength rxbuf' * 2 + 1}
                           {com1 / s /RxBuf : nil}
                           {com1 / s /SerialIrq : false}
-                          {io_rx_log : abd.(io_rx_log) ++ mkRecvEvents (lrx - 1) str}
+                          {io_log : abd.(io_log) ++ mkRecvEvents (lrx - 1) str}
           else None
         | _ => None
         end
@@ -551,7 +546,7 @@ Fixpoint serial_intr_disable_aux (n : nat) (masked : bool) (abd : RData) : optio
   | O => Some abd
   | S n' =>
     let (data, new) := serial_intr abd.(com1) in
-    let d0 := abd {com1 : data} {io_tx_log : abd.(io_tx_log) ++ new}in
+    let d0 := abd {com1 : data} {io_log : abd.(io_log) ++ new}in
     if d0.(com1).(s).(SerialIrq) then
       if masked then serial_intr_disable_aux n' true d0
       else match cons_intr_aux d0 with
@@ -724,11 +719,11 @@ Definition serial_putc_spec (c : Z) (abd : RData) : option (RData * Z) :=
         let cs := if zeq c' CHAR_LF then CHAR_LF :: CHAR_CR :: nil else c' :: nil in
         match txbuf with
         | nil => Some (abd {com1 / s / TxBuf : cs} {com1 / l2 : ltx + 1}
-                           {io_tx_log : abd.(io_tx_log) ++ IOEvPutc ltx c :: nil}, c')
+                           {io_log : abd.(io_log) ++ IOEvPutc ltx c :: nil}, c')
         | _ =>
           match next_sendcomplete ltx with
           | Some ltx' => Some (abd {com1 / s / TxBuf : cs} {com1 / l2 : ltx'}
-                                   {io_tx_log : abd.(io_tx_log) ++ IOEvPutc ltx c :: nil}, c')
+                                   {io_log : abd.(io_log) ++ IOEvPutc ltx c :: nil}, c')
           | None => None
           end
         end
@@ -750,7 +745,7 @@ Definition cons_buf_read_spec (abd : RData) : option (RData * Z) :=
     | (c, logIdx, strIdx) :: tl =>
       Some (abd {console : s {cons_buf : tl}
                              {rpos : (r + 1) mod CONS_BUFFER_SIZE}}
-                {io_rx_log : abd.(io_rx_log) ++ IOEvGetc logIdx strIdx c :: nil}, c)
+                {io_log : abd.(io_log) ++ IOEvGetc logIdx strIdx c :: nil}, c)
     end
   | _ => None
   end.

--- a/progs/io_specs.v
+++ b/progs/io_specs.v
@@ -1,22 +1,22 @@
 Require Import VST.veric.juicy_extspec.
 Require Import VST.floyd.proofauto.
 Require Export VST.floyd.io_events.
-Require Import ITree.ITree.
-Require Import ITree.Interp.Traces.
+Require Export ITree.ITree.
+Require Export ITree.Eq.Eq.
 Require Export ITree.Eq.SimUpToTaus.
 (* Import ITreeNotations. *) (* one piece conflicts with subp notation *)
-Notation "t1 >>= k2" := (ITree.bind t1 k2)
-  (at level 50, left associativity) : itree_scope.
 Notation "x <- t1 ;; t2" := (ITree.bind t1 (fun x => t2))
   (at level 100, t1 at next level, right associativity) : itree_scope.
-Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
-  (at level 100, right associativity) : itree_scope.
 Notation "' p <- t1 ;; t2" :=
   (ITree.bind t1 (fun x_ => match x_ with p => t2 end))
 (at level 100, t1 at next level, p pattern, right associativity) : itree_scope.
 
 Definition stdin := 0%nat.
 Definition stdout := 1%nat.
+
+Section specs.
+
+Context {E : Type -> Type} `{IO_event(file_id := nat) -< E}.
 
 Definition putchar_spec :=
   WITH c : byte, k : IO_itree
@@ -43,9 +43,11 @@ Definition getchar_spec :=
     SEP (ITREE (if eq_dec (Int.signed i) (-1) then (r <- read stdin ;; k r) else k (Byte.repr (Int.signed i)))).
 
 (* Build the external specification. *)
-Definition IO_void_Espec : OracleKind := ok_void_spec (@IO_itree nat).
+Definition IO_void_Espec : OracleKind := ok_void_spec (@IO_itree E).
 
 Definition IO_specs (ext_link : string -> ident) :=
   [(ext_link "putchar"%string, putchar_spec); (ext_link "getchar"%string, getchar_spec)].
 
 Definition IO_Espec (ext_link : string -> ident) : OracleKind := add_funspecs IO_void_Espec ext_link (IO_specs ext_link).
+
+End specs.

--- a/progs/printf.c
+++ b/progs/printf.c
@@ -1,18 +1,4 @@
-#include <stddef.h>
-
-struct __sFILE;
-typedef struct __sFILE FILE;
-
-extern FILE _stdin, _stdout, _stderr;
-#define stdin (&_stdin)
-#define stdout (&_stdout)
-#define stderr (&_stderr)
-
-extern int fprintf (FILE *__restrict, const char *__restrict, ...)
-               __attribute__ ((__format__ (__printf__, 2, 3)));
-
-extern int printf (const char *__restrict, ...)
-               __attribute__ ((__format__ (__printf__, 1, 2)));
+#include <stdio.h>
 
 int main(void) {
   printf("Hello, world!\n");

--- a/progs/printf.v
+++ b/progs/printf.v
@@ -3,7 +3,7 @@ From compcert Require Import Coqlib Integers Floats AST Ctypes Cop Clight Clight
 Local Open Scope Z_scope.
 
 Module Info.
-  Definition version := "3.5"%string.
+  Definition version := "3.4"%string.
   Definition build_number := ""%string.
   Definition build_tag := ""%string.
   Definition arch := "x86"%string.
@@ -15,65 +15,182 @@ Module Info.
   Definition normalized := true.
 End Info.
 
-Definition ___builtin_annot : ident := 7%positive.
-Definition ___builtin_annot_intval : ident := 8%positive.
-Definition ___builtin_bswap : ident := 1%positive.
-Definition ___builtin_bswap16 : ident := 3%positive.
-Definition ___builtin_bswap32 : ident := 2%positive.
-Definition ___builtin_bswap64 : ident := 33%positive.
-Definition ___builtin_clz : ident := 34%positive.
-Definition ___builtin_clzl : ident := 35%positive.
-Definition ___builtin_clzll : ident := 36%positive.
-Definition ___builtin_ctz : ident := 37%positive.
-Definition ___builtin_ctzl : ident := 38%positive.
-Definition ___builtin_ctzll : ident := 39%positive.
-Definition ___builtin_debug : ident := 51%positive.
-Definition ___builtin_fabs : ident := 4%positive.
-Definition ___builtin_fmadd : ident := 42%positive.
-Definition ___builtin_fmax : ident := 40%positive.
-Definition ___builtin_fmin : ident := 41%positive.
-Definition ___builtin_fmsub : ident := 43%positive.
-Definition ___builtin_fnmadd : ident := 44%positive.
-Definition ___builtin_fnmsub : ident := 45%positive.
-Definition ___builtin_fsqrt : ident := 5%positive.
-Definition ___builtin_membar : ident := 9%positive.
-Definition ___builtin_memcpy_aligned : ident := 6%positive.
-Definition ___builtin_nop : ident := 50%positive.
-Definition ___builtin_read16_reversed : ident := 46%positive.
-Definition ___builtin_read32_reversed : ident := 47%positive.
-Definition ___builtin_va_arg : ident := 11%positive.
-Definition ___builtin_va_copy : ident := 12%positive.
-Definition ___builtin_va_end : ident := 13%positive.
-Definition ___builtin_va_start : ident := 10%positive.
-Definition ___builtin_write16_reversed : ident := 48%positive.
-Definition ___builtin_write32_reversed : ident := 49%positive.
-Definition ___compcert_i64_dtos : ident := 18%positive.
-Definition ___compcert_i64_dtou : ident := 19%positive.
-Definition ___compcert_i64_sar : ident := 30%positive.
-Definition ___compcert_i64_sdiv : ident := 24%positive.
-Definition ___compcert_i64_shl : ident := 28%positive.
-Definition ___compcert_i64_shr : ident := 29%positive.
-Definition ___compcert_i64_smod : ident := 26%positive.
-Definition ___compcert_i64_smulh : ident := 31%positive.
-Definition ___compcert_i64_stod : ident := 20%positive.
-Definition ___compcert_i64_stof : ident := 22%positive.
-Definition ___compcert_i64_udiv : ident := 25%positive.
-Definition ___compcert_i64_umod : ident := 27%positive.
-Definition ___compcert_i64_umulh : ident := 32%positive.
-Definition ___compcert_i64_utod : ident := 21%positive.
-Definition ___compcert_i64_utof : ident := 23%positive.
-Definition ___compcert_va_composite : ident := 17%positive.
-Definition ___compcert_va_float64 : ident := 16%positive.
-Definition ___compcert_va_int32 : ident := 14%positive.
-Definition ___compcert_va_int64 : ident := 15%positive.
-Definition ___sFILE : ident := 53%positive.
-Definition ___stringlit_1 : ident := 56%positive.
-Definition ___stringlit_2 : ident := 57%positive.
-Definition ___stringlit_3 : ident := 58%positive.
-Definition __stdout : ident := 52%positive.
-Definition _fprintf : ident := 54%positive.
-Definition _main : ident := 59%positive.
-Definition _printf : ident := 55%positive.
+Definition __193 : ident := 6%positive.
+Definition __194 : ident := 3%positive.
+Definition __254 : ident := 93%positive.
+Definition __255 : ident := 88%positive.
+Definition __256 : ident := 91%positive.
+Definition __Bigint : ident := 7%positive.
+Definition ___builtin_ais_annot : ident := 116%positive.
+Definition ___builtin_annot : ident := 123%positive.
+Definition ___builtin_annot_intval : ident := 124%positive.
+Definition ___builtin_bswap : ident := 117%positive.
+Definition ___builtin_bswap16 : ident := 119%positive.
+Definition ___builtin_bswap32 : ident := 118%positive.
+Definition ___builtin_bswap64 : ident := 149%positive.
+Definition ___builtin_clz : ident := 150%positive.
+Definition ___builtin_clzl : ident := 151%positive.
+Definition ___builtin_clzll : ident := 152%positive.
+Definition ___builtin_ctz : ident := 153%positive.
+Definition ___builtin_ctzl : ident := 154%positive.
+Definition ___builtin_ctzll : ident := 155%positive.
+Definition ___builtin_debug : ident := 167%positive.
+Definition ___builtin_fabs : ident := 120%positive.
+Definition ___builtin_fmadd : ident := 158%positive.
+Definition ___builtin_fmax : ident := 156%positive.
+Definition ___builtin_fmin : ident := 157%positive.
+Definition ___builtin_fmsub : ident := 159%positive.
+Definition ___builtin_fnmadd : ident := 160%positive.
+Definition ___builtin_fnmsub : ident := 161%positive.
+Definition ___builtin_fsqrt : ident := 121%positive.
+Definition ___builtin_membar : ident := 125%positive.
+Definition ___builtin_memcpy_aligned : ident := 122%positive.
+Definition ___builtin_nop : ident := 166%positive.
+Definition ___builtin_read16_reversed : ident := 162%positive.
+Definition ___builtin_read32_reversed : ident := 163%positive.
+Definition ___builtin_va_arg : ident := 127%positive.
+Definition ___builtin_va_copy : ident := 128%positive.
+Definition ___builtin_va_end : ident := 129%positive.
+Definition ___builtin_va_start : ident := 126%positive.
+Definition ___builtin_write16_reversed : ident := 164%positive.
+Definition ___builtin_write32_reversed : ident := 165%positive.
+Definition ___cleanup : ident := 104%positive.
+Definition ___compcert_i64_dtos : ident := 134%positive.
+Definition ___compcert_i64_dtou : ident := 135%positive.
+Definition ___compcert_i64_sar : ident := 146%positive.
+Definition ___compcert_i64_sdiv : ident := 140%positive.
+Definition ___compcert_i64_shl : ident := 144%positive.
+Definition ___compcert_i64_shr : ident := 145%positive.
+Definition ___compcert_i64_smod : ident := 142%positive.
+Definition ___compcert_i64_smulh : ident := 147%positive.
+Definition ___compcert_i64_stod : ident := 136%positive.
+Definition ___compcert_i64_stof : ident := 138%positive.
+Definition ___compcert_i64_udiv : ident := 141%positive.
+Definition ___compcert_i64_umod : ident := 143%positive.
+Definition ___compcert_i64_umulh : ident := 148%positive.
+Definition ___compcert_i64_utod : ident := 137%positive.
+Definition ___compcert_i64_utof : ident := 139%positive.
+Definition ___compcert_va_composite : ident := 133%positive.
+Definition ___compcert_va_float64 : ident := 132%positive.
+Definition ___compcert_va_int32 : ident := 130%positive.
+Definition ___compcert_va_int64 : ident := 131%positive.
+Definition ___count : ident := 4%positive.
+Definition ___getreent : ident := 168%positive.
+Definition ___locale_t : ident := 101%positive.
+Definition ___sFILE64 : ident := 61%positive.
+Definition ___sbuf : ident := 34%positive.
+Definition ___sdidinit : ident := 103%positive.
+Definition ___sf : ident := 115%positive.
+Definition ___sglue : ident := 114%positive.
+Definition ___stringlit_1 : ident := 171%positive.
+Definition ___stringlit_2 : ident := 172%positive.
+Definition ___stringlit_3 : ident := 173%positive.
+Definition ___tm : ident := 23%positive.
+Definition ___tm_hour : ident := 16%positive.
+Definition ___tm_isdst : ident := 22%positive.
+Definition ___tm_mday : ident := 17%positive.
+Definition ___tm_min : ident := 15%positive.
+Definition ___tm_mon : ident := 18%positive.
+Definition ___tm_sec : ident := 14%positive.
+Definition ___tm_wday : ident := 20%positive.
+Definition ___tm_yday : ident := 21%positive.
+Definition ___tm_year : ident := 19%positive.
+Definition ___value : ident := 5%positive.
+Definition ___wch : ident := 1%positive.
+Definition ___wchb : ident := 2%positive.
+Definition __add : ident := 67%positive.
+Definition __asctime_buf : ident := 71%positive.
+Definition __atexit : ident := 29%positive.
+Definition __atexit0 : ident := 112%positive.
+Definition __base : ident := 32%positive.
+Definition __bf : ident := 40%positive.
+Definition __blksize : ident := 55%positive.
+Definition __close : ident := 48%positive.
+Definition __cookie : ident := 44%positive.
+Definition __cvtbuf : ident := 110%positive.
+Definition __cvtlen : ident := 109%positive.
+Definition __data : ident := 43%positive.
+Definition __dso_handle : ident := 25%positive.
+Definition __emergency : ident := 99%positive.
+Definition __errno : ident := 94%positive.
+Definition __file : ident := 39%positive.
+Definition __flags : ident := 38%positive.
+Definition __flags2 : ident := 56%positive.
+Definition __fnargs : ident := 24%positive.
+Definition __fns : ident := 31%positive.
+Definition __fntypes : ident := 26%positive.
+Definition __freelist : ident := 108%positive.
+Definition __gamma_signgam : ident := 73%positive.
+Definition __getdate_err : ident := 81%positive.
+Definition __glue : ident := 62%positive.
+Definition __h_errno : ident := 87%positive.
+Definition __inc : ident := 98%positive.
+Definition __ind : ident := 30%positive.
+Definition __iobs : ident := 64%positive.
+Definition __is_cxa : ident := 27%positive.
+Definition __k : ident := 9%positive.
+Definition __l64a_buf : ident := 79%positive.
+Definition __lb : ident := 54%positive.
+Definition __lbfsize : ident := 41%positive.
+Definition __locale : ident := 102%positive.
+Definition __localtime_buf : ident := 72%positive.
+Definition __lock : ident := 59%positive.
+Definition __maxwds : ident := 10%positive.
+Definition __mblen_state : ident := 76%positive.
+Definition __mbrlen_state : ident := 82%positive.
+Definition __mbrtowc_state : ident := 83%positive.
+Definition __mbsrtowcs_state : ident := 84%positive.
+Definition __mbstate : ident := 60%positive.
+Definition __mbtowc_state : ident := 77%positive.
+Definition __mult : ident := 66%positive.
+Definition __nbuf : ident := 53%positive.
+Definition __new : ident := 111%positive.
+Definition __next : ident := 8%positive.
+Definition __nextf : ident := 89%positive.
+Definition __niobs : ident := 63%positive.
+Definition __nmalloc : ident := 90%positive.
+Definition __offset : ident := 57%positive.
+Definition __on_exit_args : ident := 28%positive.
+Definition __p : ident := 35%positive.
+Definition __p5s : ident := 107%positive.
+Definition __r : ident := 36%positive.
+Definition __r48 : ident := 75%positive.
+Definition __rand48 : ident := 68%positive.
+Definition __rand_next : ident := 74%positive.
+Definition __read : ident := 45%positive.
+Definition __reent : ident := 42%positive.
+Definition __result : ident := 105%positive.
+Definition __result_k : ident := 106%positive.
+Definition __seed : ident := 65%positive.
+Definition __seek : ident := 47%positive.
+Definition __seek64 : ident := 58%positive.
+Definition __sig_func : ident := 113%positive.
+Definition __sign : ident := 11%positive.
+Definition __signal_buf : ident := 80%positive.
+Definition __size : ident := 33%positive.
+Definition __stderr : ident := 97%positive.
+Definition __stdin : ident := 95%positive.
+Definition __stdout : ident := 96%positive.
+Definition __strtok_last : ident := 70%positive.
+Definition __ub : ident := 49%positive.
+Definition __ubuf : ident := 52%positive.
+Definition __unspecified_locale_info : ident := 100%positive.
+Definition __unused : ident := 92%positive.
+Definition __unused_rand : ident := 69%positive.
+Definition __up : ident := 50%positive.
+Definition __ur : ident := 51%positive.
+Definition __w : ident := 37%positive.
+Definition __wcrtomb_state : ident := 85%positive.
+Definition __wcsrtombs_state : ident := 86%positive.
+Definition __wctomb_state : ident := 78%positive.
+Definition __wds : ident := 12%positive.
+Definition __write : ident := 46%positive.
+Definition __x : ident := 13%positive.
+Definition _fprintf : ident := 169%positive.
+Definition _main : ident := 174%positive.
+Definition _printf : ident := 170%positive.
+Definition _t'1 : ident := 175%positive.
+Definition _t'2 : ident := 176%positive.
 
 Definition v___stringlit_3 := {|
   gvar_info := (tarray tschar 16);
@@ -112,19 +229,13 @@ Definition v___stringlit_1 := {|
   gvar_volatile := false
 |}.
 
-Definition v__stdout := {|
-  gvar_info := (Tstruct ___sFILE noattr);
-  gvar_init := nil;
-  gvar_readonly := false;
-  gvar_volatile := false
-|}.
-
 Definition f_main := {|
   fn_return := tint;
   fn_callconv := cc_default;
   fn_params := nil;
   fn_vars := nil;
-  fn_temps := nil;
+  fn_temps := ((_t'1, (tptr (Tstruct __reent noattr))) ::
+               (_t'2, (tptr (Tstruct ___sFILE64 noattr))) :: nil);
   fn_body :=
 (Ssequence
   (Ssequence
@@ -133,27 +244,156 @@ Definition f_main := {|
                       {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
       ((Evar ___stringlit_1 (tarray tschar 15)) :: nil))
     (Ssequence
-      (Scall None
-        (Evar _fprintf (Tfunction
-                         (Tcons (tptr (Tstruct ___sFILE noattr))
-                           (Tcons (tptr tschar) Tnil)) tint
-                         {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
-        ((Eaddrof (Evar __stdout (Tstruct ___sFILE noattr))
-           (tptr (Tstruct ___sFILE noattr))) ::
-         (Evar ___stringlit_3 (tarray tschar 16)) ::
-         (Evar ___stringlit_2 (tarray tschar 5)) ::
-         (Econst_int (Int.repr 2) tint) :: nil))
+      (Ssequence
+        (Scall (Some _t'1)
+          (Evar ___getreent (Tfunction Tnil (tptr (Tstruct __reent noattr))
+                              cc_default)) nil)
+        (Ssequence
+          (Sset _t'2
+            (Efield
+              (Ederef (Etempvar _t'1 (tptr (Tstruct __reent noattr)))
+                (Tstruct __reent noattr)) __stdout
+              (tptr (Tstruct ___sFILE64 noattr))))
+          (Scall None
+            (Evar _fprintf (Tfunction
+                             (Tcons (tptr (Tstruct ___sFILE64 noattr))
+                               (Tcons (tptr tschar) Tnil)) tint
+                             {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+            ((Etempvar _t'2 (tptr (Tstruct ___sFILE64 noattr))) ::
+             (Evar ___stringlit_3 (tarray tschar 16)) ::
+             (Evar ___stringlit_2 (tarray tschar 5)) ::
+             (Econst_int (Int.repr 2) tint) :: nil))))
       (Sreturn (Some (Econst_int (Int.repr 0) tint)))))
   (Sreturn (Some (Econst_int (Int.repr 0) tint))))
 |}.
 
 Definition composites : list composite_definition :=
-nil.
+(Composite __194 Union
+   ((___wch, tuint) :: (___wchb, (tarray tuchar 4)) :: nil)
+   noattr ::
+ Composite __193 Struct
+   ((___count, tint) :: (___value, (Tunion __194 noattr)) :: nil)
+   noattr ::
+ Composite __Bigint Struct
+   ((__next, (tptr (Tstruct __Bigint noattr))) :: (__k, tint) ::
+    (__maxwds, tint) :: (__sign, tint) :: (__wds, tint) ::
+    (__x, (tarray tuint 1)) :: nil)
+   noattr ::
+ Composite ___tm Struct
+   ((___tm_sec, tint) :: (___tm_min, tint) :: (___tm_hour, tint) ::
+    (___tm_mday, tint) :: (___tm_mon, tint) :: (___tm_year, tint) ::
+    (___tm_wday, tint) :: (___tm_yday, tint) :: (___tm_isdst, tint) :: nil)
+   noattr ::
+ Composite __on_exit_args Struct
+   ((__fnargs, (tarray (tptr tvoid) 32)) ::
+    (__dso_handle, (tarray (tptr tvoid) 32)) :: (__fntypes, tuint) ::
+    (__is_cxa, tuint) :: nil)
+   noattr ::
+ Composite __atexit Struct
+   ((__next, (tptr (Tstruct __atexit noattr))) :: (__ind, tint) ::
+    (__fns, (tarray (tptr (Tfunction Tnil tvoid cc_default)) 32)) ::
+    (__on_exit_args, (Tstruct __on_exit_args noattr)) :: nil)
+   noattr ::
+ Composite ___sbuf Struct
+   ((__base, (tptr tuchar)) :: (__size, tint) :: nil)
+   noattr ::
+ Composite ___sFILE64 Struct
+   ((__p, (tptr tuchar)) :: (__r, tint) :: (__w, tint) ::
+    (__flags, tshort) :: (__file, tshort) ::
+    (__bf, (Tstruct ___sbuf noattr)) :: (__lbfsize, tint) ::
+    (__data, (tptr (Tstruct __reent noattr))) :: (__cookie, (tptr tvoid)) ::
+    (__read,
+     (tptr (Tfunction
+             (Tcons (tptr (Tstruct __reent noattr))
+               (Tcons (tptr tvoid) (Tcons (tptr tschar) (Tcons tuint Tnil))))
+             tint cc_default))) ::
+    (__write,
+     (tptr (Tfunction
+             (Tcons (tptr (Tstruct __reent noattr))
+               (Tcons (tptr tvoid) (Tcons (tptr tschar) (Tcons tuint Tnil))))
+             tint cc_default))) ::
+    (__seek,
+     (tptr (Tfunction
+             (Tcons (tptr (Tstruct __reent noattr))
+               (Tcons (tptr tvoid) (Tcons tint (Tcons tint Tnil)))) tint
+             cc_default))) ::
+    (__close,
+     (tptr (Tfunction
+             (Tcons (tptr (Tstruct __reent noattr))
+               (Tcons (tptr tvoid) Tnil)) tint cc_default))) ::
+    (__ub, (Tstruct ___sbuf noattr)) :: (__up, (tptr tuchar)) ::
+    (__ur, tint) :: (__ubuf, (tarray tuchar 3)) ::
+    (__nbuf, (tarray tuchar 1)) :: (__lb, (Tstruct ___sbuf noattr)) ::
+    (__blksize, tint) :: (__flags2, tint) :: (__offset, tlong) ::
+    (__seek64,
+     (tptr (Tfunction
+             (Tcons (tptr (Tstruct __reent noattr))
+               (Tcons (tptr tvoid) (Tcons tlong (Tcons tint Tnil)))) tlong
+             cc_default))) :: (__lock, (tptr tvoid)) ::
+    (__mbstate, (Tstruct __193 noattr)) :: nil)
+   noattr ::
+ Composite __glue Struct
+   ((__next, (tptr (Tstruct __glue noattr))) :: (__niobs, tint) ::
+    (__iobs, (tptr (Tstruct ___sFILE64 noattr))) :: nil)
+   noattr ::
+ Composite __rand48 Struct
+   ((__seed, (tarray tushort 3)) :: (__mult, (tarray tushort 3)) ::
+    (__add, tushort) :: nil)
+   noattr ::
+ Composite __255 Struct
+   ((__unused_rand, tuint) :: (__strtok_last, (tptr tschar)) ::
+    (__asctime_buf, (tarray tschar 26)) ::
+    (__localtime_buf, (Tstruct ___tm noattr)) :: (__gamma_signgam, tint) ::
+    (__rand_next, tulong) :: (__r48, (Tstruct __rand48 noattr)) ::
+    (__mblen_state, (Tstruct __193 noattr)) ::
+    (__mbtowc_state, (Tstruct __193 noattr)) ::
+    (__wctomb_state, (Tstruct __193 noattr)) ::
+    (__l64a_buf, (tarray tschar 8)) :: (__signal_buf, (tarray tschar 24)) ::
+    (__getdate_err, tint) :: (__mbrlen_state, (Tstruct __193 noattr)) ::
+    (__mbrtowc_state, (Tstruct __193 noattr)) ::
+    (__mbsrtowcs_state, (Tstruct __193 noattr)) ::
+    (__wcrtomb_state, (Tstruct __193 noattr)) ::
+    (__wcsrtombs_state, (Tstruct __193 noattr)) :: (__h_errno, tint) :: nil)
+   noattr ::
+ Composite __256 Struct
+   ((__nextf, (tarray (tptr tuchar) 30)) :: (__nmalloc, (tarray tuint 30)) ::
+    nil)
+   noattr ::
+ Composite __254 Union
+   ((__reent, (Tstruct __255 noattr)) ::
+    (__unused, (Tstruct __256 noattr)) :: nil)
+   noattr ::
+ Composite __reent Struct
+   ((__errno, tint) :: (__stdin, (tptr (Tstruct ___sFILE64 noattr))) ::
+    (__stdout, (tptr (Tstruct ___sFILE64 noattr))) ::
+    (__stderr, (tptr (Tstruct ___sFILE64 noattr))) :: (__inc, tint) ::
+    (__emergency, (tarray tschar 25)) :: (__unspecified_locale_info, tint) ::
+    (__locale, (tptr (Tstruct ___locale_t noattr))) :: (___sdidinit, tint) ::
+    (___cleanup,
+     (tptr (Tfunction (Tcons (tptr (Tstruct __reent noattr)) Tnil) tvoid
+             cc_default))) :: (__result, (tptr (Tstruct __Bigint noattr))) ::
+    (__result_k, tint) :: (__p5s, (tptr (Tstruct __Bigint noattr))) ::
+    (__freelist, (tptr (tptr (Tstruct __Bigint noattr)))) ::
+    (__cvtlen, tint) :: (__cvtbuf, (tptr tschar)) ::
+    (__new, (Tunion __254 noattr)) ::
+    (__atexit, (tptr (Tstruct __atexit noattr))) ::
+    (__atexit0, (Tstruct __atexit noattr)) ::
+    (__sig_func,
+     (tptr (tptr (Tfunction (Tcons tint Tnil) tvoid cc_default)))) ::
+    (___sglue, (Tstruct __glue noattr)) ::
+    (___sf, (tarray (Tstruct ___sFILE64 noattr) 3)) :: nil)
+   noattr :: nil).
 
 Definition global_definitions : list (ident * globdef fundef type) :=
 ((___stringlit_3, Gvar v___stringlit_3) ::
  (___stringlit_2, Gvar v___stringlit_2) ::
  (___stringlit_1, Gvar v___stringlit_1) ::
+ (___builtin_ais_annot,
+   Gfun(External (EF_builtin "__builtin_ais_annot"
+                   (mksignature (AST.Tint :: nil) None
+                     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
  (___builtin_bswap,
    Gfun(External (EF_builtin "__builtin_bswap"
                    (mksignature (AST.Tint :: nil) (Some AST.Tint) cc_default))
@@ -395,13 +635,16 @@ Definition global_definitions : list (ident * globdef fundef type) :=
                      {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
      (Tcons tint Tnil) tvoid
      {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
- (__stdout, Gvar v__stdout) ::
+ (___getreent,
+   Gfun(External (EF_external "__getreent"
+                   (mksignature nil (Some AST.Tint) cc_default)) Tnil
+     (tptr (Tstruct __reent noattr)) cc_default)) ::
  (_fprintf,
    Gfun(External (EF_external "fprintf"
                    (mksignature (AST.Tint :: AST.Tint :: nil) (Some AST.Tint)
                      {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
-     (Tcons (tptr (Tstruct ___sFILE noattr)) (Tcons (tptr tschar) Tnil)) tint
-     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
+     (Tcons (tptr (Tstruct ___sFILE64 noattr)) (Tcons (tptr tschar) Tnil))
+     tint {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
  (_printf,
    Gfun(External (EF_external "printf"
                    (mksignature (AST.Tint :: nil) (Some AST.Tint)
@@ -411,7 +654,7 @@ Definition global_definitions : list (ident * globdef fundef type) :=
  (_main, Gfun(Internal f_main)) :: nil).
 
 Definition public_idents : list ident :=
-(_main :: _printf :: _fprintf :: __stdout :: ___builtin_debug ::
+(_main :: _printf :: _fprintf :: ___getreent :: ___builtin_debug ::
  ___builtin_nop :: ___builtin_write32_reversed ::
  ___builtin_write16_reversed :: ___builtin_read32_reversed ::
  ___builtin_read16_reversed :: ___builtin_fnmsub :: ___builtin_fnmadd ::
@@ -429,7 +672,7 @@ Definition public_idents : list ident :=
  ___builtin_va_start :: ___builtin_membar :: ___builtin_annot_intval ::
  ___builtin_annot :: ___builtin_memcpy_aligned :: ___builtin_fsqrt ::
  ___builtin_fabs :: ___builtin_bswap16 :: ___builtin_bswap32 ::
- ___builtin_bswap :: nil).
+ ___builtin_bswap :: ___builtin_ais_annot :: nil).
 
 Definition prog : Clight.program := 
   mkprogram composites global_definitions public_idents _main Logic.I.

--- a/progs/verif_io.v
+++ b/progs/verif_io.v
@@ -1,18 +1,6 @@
 Require Import VST.progs.io.
 Require Import VST.progs.io_specs.
 Require Import VST.floyd.proofauto.
-Require Import ITree.ITree.
-Require Import ITree.Eq.Eq.
-(*Import ITreeNotations.*)
-Notation "t1 >>= k2" := (ITree.bind t1 k2)
-  (at level 50, left associativity) : itree_scope.
-Notation "x <- t1 ;; t2" := (ITree.bind t1 (fun x => t2))
-  (at level 100, t1 at next level, right associativity) : itree_scope.
-Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
-  (at level 100, right associativity) : itree_scope.
-Notation "' p <- t1 ;; t2" :=
-  (ITree.bind t1 (fun x_ => match x_ with p => t2 end))
-(at level 100, t1 at next level, p pattern, right associativity) : itree_scope.
 
 Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
@@ -312,7 +300,7 @@ Lemma body_main: semax_body Vprog Gprog f_main main_spec.
 Proof.
   start_function.
   unfold main_pre_ext.
-  sep_apply (has_ext_ITREE(file_id := nat)).
+  sep_apply (has_ext_ITREE(E := @IO_event nat)).
   forward.
   unfold main_itree.
   rewrite <- !seq_assoc. (* Without this, forward_call gives a type error! *)

--- a/progs/verif_io_mem.v
+++ b/progs/verif_io_mem.v
@@ -2,17 +2,6 @@ Require Import VST.progs.io_mem.
 Require Import VST.progs.io_mem_specs.
 Require Import VST.floyd.proofauto.
 Require Import VST.floyd.library.
-Require Import ITree.ITree.
-(*Import ITreeNotations.*)
-Notation "t1 >>= k2" := (ITree.bind t1 k2)
-  (at level 50, left associativity) : itree_scope.
-Notation "x <- t1 ;; t2" := (ITree.bind t1 (fun x => t2))
-  (at level 100, t1 at next level, right associativity) : itree_scope.
-Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
-  (at level 100, right associativity) : itree_scope.
-Notation "' p <- t1 ;; t2" :=
-  (ITree.bind t1 (fun x_ => match x_ with p => t2 end))
-(at level 100, t1 at next level, p pattern, right associativity) : itree_scope.
 
 Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
@@ -105,7 +94,7 @@ Definition main_spec :=
  DECLARE _main
   WITH gv : globals
   PRE  [] main_pre_ext prog main_itree nil gv
-  POST [ tint ] PROP () LOCAL () SEP (mem_mgr gv; ITREE (Ret tt : @IO_itree nat)).
+  POST [ tint ] PROP () LOCAL () SEP (mem_mgr gv; ITREE (Ret tt : @IO_itree (@IO_event nat))).
 
 Definition Gprog : funspecs := ltac:(with_library prog [putchars_spec; getchars_spec;
   print_intr_spec; print_int_spec; main_spec]).
@@ -397,7 +386,7 @@ Qed.
 Lemma body_main: semax_body Vprog Gprog f_main main_spec.
 Proof.
   start_function.
-  sep_apply (has_ext_ITREE(file_id := nat)).
+  sep_apply (has_ext_ITREE(E := @IO_event nat)).
   rewrite <- (emp_sepcon (ITREE _)); Intros.
   replace_SEP 0 (mem_mgr gv) by (go_lower; apply create_mem_mgr).
   forward.

--- a/progs/verif_printf.v
+++ b/progs/verif_printf.v
@@ -20,13 +20,6 @@ Definition main_spec :=
 Definition Gprog : funspecs :=  
    ltac:(with_library prog (ltac:(make_printf_specs prog) ++ [ main_spec ])).
 
-Lemma bind_ret' : forall E (s : itree E unit), eutt eq (s;; Ret tt) s.
-Proof.
-  intros.
-  etransitivity; [|apply eq_sub_eutt, bind_ret2].
-  apply eqit_bind; [intros []|]; reflexivity.
-Qed.
-
 Lemma body_main: semax_body Vprog Gprog f_main main_spec.
 Proof.
 start_function.


### PR DESCRIPTION
In this PR, printf.c uses stdio.h directly, and the definitions and tactics in floyd/printf.v have been modified accordingly. A tactic make_stdio is provided to hide some of the messiness. See axiom init_stdio on line 188 of floyd/printf.v for the shape of the struct used in stdio.