### PR TITLE
Overlay for Coq PR #9918 fixing template-poly bug

### DIFF
--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -1366,7 +1366,7 @@ Proof.
     apply find_id_e in Heqo. destruct H4 as [post ?]. exists post.
     subst. split; auto. inv Hfind. auto. inv Hfind.
   } clear H4. rename H4' into H4.
-  assert ({ f | In (prog_main prog, f) (prog_funct prog)}).
+  assert (H5:{ f | In (prog_main prog, f) (prog_funct prog)}).
   forget (prog_main prog) as id.
   assert (H4': In id (map fst G)). {
   destruct H4 as [? [H4 _]].
@@ -1587,7 +1587,7 @@ destruct (find_id (prog_main prog) G) eqn:?.
 apply find_id_e in Heqo. destruct H4 as [post ?]. exists post.
 subst. split; auto. inv Hfind. auto. inv Hfind.
 } clear H4. rename H4' into H4.
-assert ({ f | In (prog_main prog, f) (prog_funct prog)}).
+assert (H5:{ f | In (prog_main prog, f) (prog_funct prog)}).
 forget (prog_main prog) as id.
 assert (H4': In id (map fst G)). {
 destruct H4 as [? [H4 _]].


### PR DESCRIPTION
This fixes an hypothesis name whose sort is Type now (so gets assigned X) but was assigned H5 before (which is definitely strange given it's a subset on a computational object). This is backwards compatible.