### PR TITLE
Added ExtLib as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "fcf"]
 	path = fcf
 	url = https://github.com/adampetcher/fcf.git
+[submodule "coq-ext-lib"]
+	path = coq-ext-lib
+	url = https://github.com/coq-ext-lib/coq-ext-lib.git

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend flocq exportclight $(BACKEND)
 COMPCERT_R_FLAGS= $(foreach d, $(COMPCERTDIRS), -R $(COMPCERT)/$(d) compcert.$(d))
 EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT)/$(d) compcert.$(d))
 ifneq ($(wildcard InteractionTrees/theories),)
-EXTFLAGS:=$(EXTFLAGS) -Q InteractionTrees/theories ITree
+EXTFLAGS:=$(EXTFLAGS) -Q coq-ext-lib/theories ExtLib -Q InteractionTrees/theories ITree
 endif
 ifneq ($(wildcard fcf/src/FCF),)
 EXTFLAGS:=$(EXTFLAGS) -Q fcf/src/FCF FCF
@@ -558,7 +558,7 @@ ifeq ($(COMPCERT), compcert_new)
 	@echo "" >>.depend
 else
 ifneq ($(wildcard InteractionTrees/theories),)
-	$(COQDEP) -Q InteractionTrees/theories ITree InteractionTrees/theories/*.v >>.depend 
+	$(COQDEP) -Q coq-ext-lib/theories ExtLib -Q InteractionTrees/theories ITree coq-ext-lib/theories InteractionTrees/theories >>.depend 
 endif
 ifneq ($(wildcard fcf/src/FCF),)
 	$(COQDEP) -Q fcf/src/FCF FCF fcf/src/FCF/*.v >>.depend 
@@ -573,7 +573,7 @@ endif
 
 clean:
 	rm -f $(addprefix veric/version., v vo glob) .lia.cache .nia.cache floyd/floyd.coq .depend _CoqProject _CoqProject-export $(wildcard */.*.aux)  $(wildcard */*.glob) $(wildcard */*.vo) compcert/*/*.vo compcert/*/*/*.vo  compcert_new/*/*.vo compcert_new/*/*/*.vo
-	rm -f InteractionTrees/theories/*.{vo,glob}
+	rm -f coq-ext-lib/theories/*.{vo,glob} InteractionTrees/theories/*.{vo,glob}
 	rm -f paco/src/*.{vo,glob}
 	rm -f fcf/src/FCF/*.{vo,glob}
 	rm -fr doc/html


### PR DESCRIPTION
It should now be possible to build the `io` target without anything installed via OPAM.