### PR TITLE
No clight new

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,13 +236,13 @@ VERIC_FILES= \
   binop_lemmas.v binop_lemmas2.v binop_lemmas3.v binop_lemmas4.v binop_lemmas5.v binop_lemmas6.v \
   expr_lemmas.v expr_lemmas2.v expr_lemmas3.v expr_lemmas4.v \
   extend_tc.v \
-  Clight_lemmas.v Clight_new.v Clightnew_coop.v Clight_core.v Clight_sim.v \
+  Clight_lemmas.v Clight_new.v Clightnew_coop.v Clight_core.v  \
   slice.v res_predicates.v own.v seplog.v Clight_seplog.v mapsto_memory_block.v Clight_mapsto_memory_block.v assert_lemmas.v Clight_assert_lemmas.v \
   juicy_mem.v juicy_mem_lemmas.v local.v juicy_mem_ops.v juicy_safety.v juicy_extspec.v \
   semax.v semax_lemmas.v semax_conseq.v semax_call.v semax_straight.v semax_loop.v semax_switch.v \
   initial_world.v Clight_initial_world.v initialize.v semax_prog.v semax_ext.v SeparationLogic.v SeparationLogicSoundness.v  \
   NullExtension.v SequentialClight.v superprecise.v jstep.v address_conflict.v valid_pointer.v coqlib4.v \
-  semax_ext_oracle.v mem_lessdef.v Clight_mem_lessdef.v Clight_sim.v age_to_resource_at.v aging_lemmas.v Clight_aging_lemmas.v ghost_PCM.v mpred.v
+  semax_ext_oracle.v mem_lessdef.v Clight_mem_lessdef.v age_to_resource_at.v aging_lemmas.v Clight_aging_lemmas.v ghost_PCM.v mpred.v
 
 FLOYD_FILES= \
    coqlib3.v base.v seplog_tactics.v typecheck_lemmas.v val_lemmas.v assert_lemmas.v find_nth_tactic.v const_only_eval.v \

--- a/floyd/SeparationLogicAsLogic.v
+++ b/floyd/SeparationLogicAsLogic.v
@@ -262,7 +262,7 @@ match spec with (_, mk_funspec fsig cc A P Q _ _) =>
 forall Espec ts x, 
   @semax C Espec (func_tycontext f V G nil)
       (Clight_seplog.close_precondition (map fst (fst fsig)) (map fst f.(fn_params)) (P ts x) * stackframe_of f)
-       (Ssequence f.(fn_body) (Sreturn None))
+       f.(fn_body)
       (frame_ret_assert (function_body_ret_assert (fn_return f) (Q ts x)) (stackframe_of f))
 end.
 

--- a/floyd/SeparationLogicAsLogicSoundness.v
+++ b/floyd/SeparationLogicAsLogicSoundness.v
@@ -224,8 +224,7 @@ Require Import VST.veric.Clight_core.
 Theorem semax_prog_rule :
   forall {Espec: OracleKind}{CS: compspecs},
   OK_ty = unit -> 
-       (forall (v : val) (ora : OK_ty) (jm : juicy_mem),
-        ext_spec_exit OK_spec (Some v) ora jm) ->
+   postcondition_allows_exit Espec tint ->
   forall ora V G prog m h,
      @DeepEmbedded.DeepEmbeddedDefs.semax_prog_ext Espec CS prog ora V G ->
      Genv.init_mem prog = Some m ->
@@ -250,8 +249,7 @@ Qed.
 Theorem semax_prog_rule_ext :
   forall {Espec: OracleKind}{CS: compspecs},
   forall V G prog m h z,
-       (forall (v : val) (ora : OK_ty) (jm : juicy_mem),
-        ext_spec_exit OK_spec (Some v) ora jm) ->
+  postcondition_allows_exit Espec tint ->
      @DeepEmbedded.DeepEmbeddedDefs.semax_prog_ext Espec CS prog z V G ->
      Genv.init_mem prog = Some m ->
      { b : block & { q : Clight_core.state &

--- a/floyd/SeparationLogicAsLogicSoundness.v
+++ b/floyd/SeparationLogicAsLogicSoundness.v
@@ -7,7 +7,6 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.juicy_extspec.
@@ -220,13 +219,17 @@ Proof.
   apply Sound.semax_prog_ext_sound, semax_prog_ext_sound'; auto.
 Qed.
 
+Require Import VST.veric.Clight_core.
+
 Theorem semax_prog_rule :
   forall {Espec: OracleKind}{CS: compspecs},
   OK_ty = unit -> 
-  forall V G prog m h,
-     @DeepEmbedded.DeepEmbeddedDefs.semax_prog Espec CS prog V G ->
+       (forall (v : val) (ora : OK_ty) (jm : juicy_mem),
+        ext_spec_exit OK_spec (Some v) ora jm) ->
+  forall ora V G prog m h,
+     @DeepEmbedded.DeepEmbeddedDefs.semax_prog_ext Espec CS prog ora V G ->
      Genv.init_mem prog = Some m ->
-     { b : block & { q : corestate &
+     { b : block & { q : Clight_core.state &
        (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
        (forall jm, m_dry jm = m -> exists jm', semantics.initial_core (juicy_core_sem (cl_core_sem (globalenv prog))) h
                     jm q jm' (Vptr b Ptrofs.zero) nil) *
@@ -240,40 +243,18 @@ Theorem semax_prog_rule :
      } } }%type.
 Proof.
   intros.
-  apply Sound.semax_prog_rule; auto.
-  apply semax_prog_sound'; auto.
-Qed.
-
-Theorem semax_prog_rule' :
-  forall {Espec: OracleKind}{CS: compspecs},
-  forall V G prog m h,
-     @DeepEmbedded.DeepEmbeddedDefs.semax_prog Espec CS prog V G ->
-     Genv.init_mem prog = Some m ->
-     { b : block & { q : corestate &
-       (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
-       (forall jm, m_dry jm = m -> exists jm', semantics.initial_core (juicy_core_sem (cl_core_sem (globalenv prog))) h
-                    jm q jm' (Vptr b Ptrofs.zero) nil) *
-       forall n z,
-         { jm |
-           m_dry jm = m /\ level jm = n /\
-           nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
-           jsafeN (@OK_spec Espec) (globalenv prog) n z q jm /\
-           no_locks (m_phi jm) /\
-           matchfunspecs (globalenv prog) G (m_phi jm) /\
-           app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)
-     } } }%type.
-Proof.
-  intros.
-  apply Sound.semax_prog_rule'; auto.
-  apply semax_prog_sound'; auto.
+  eapply Sound.semax_prog_rule; eauto.
+  apply semax_prog_ext_sound'; eauto.
 Qed.
 
 Theorem semax_prog_rule_ext :
   forall {Espec: OracleKind}{CS: compspecs},
   forall V G prog m h z,
+       (forall (v : val) (ora : OK_ty) (jm : juicy_mem),
+        ext_spec_exit OK_spec (Some v) ora jm) ->
      @DeepEmbedded.DeepEmbeddedDefs.semax_prog_ext Espec CS prog z V G ->
      Genv.init_mem prog = Some m ->
-     { b : block & { q : corestate &
+     { b : block & { q : Clight_core.state &
        (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
        (forall jm, m_dry jm = m -> exists jm', semantics.initial_core (juicy_core_sem (cl_core_sem (globalenv prog))) h
                     jm q jm' (Vptr b Ptrofs.zero) nil) *
@@ -288,8 +269,8 @@ Theorem semax_prog_rule_ext :
      } } }%type.
 Proof.
   intros.
-  apply Sound.semax_prog_rule_ext; auto.
-  apply semax_prog_ext_sound'; auto.
+  apply Sound.semax_prog_rule_ext; eauto.
+  eapply semax_prog_ext_sound'; eauto.
 Qed.
 
 End DeepEmbeddedSoundness.

--- a/floyd/assert_lemmas.v
+++ b/floyd/assert_lemmas.v
@@ -106,7 +106,8 @@ Ltac simpl_ret_assert :=
       normal_ret_assert overridePost loop1_ret_assert
       loop2_ret_assert function_body_ret_assert frame_ret_assert
       switch_ret_assert loop1x_ret_assert loop1y_ret_assert
-      for_ret_assert loop_nocontinue_ret_assert].
+      for_ret_assert loop_nocontinue_ret_assert];
+     try change (bind_ret None tvoid ?P) with P.
 
 Lemma RA_normal_loop2_ret_assert: (* MOVE TO assert_lemmas *)
   forall Inv R, RA_normal (loop2_ret_assert Inv R) = Inv.

--- a/floyd/entailer.v
+++ b/floyd/entailer.v
@@ -620,6 +620,8 @@ Proof.
 apply prop_right; auto.
 Qed.
 
+Ltac clean_up_stackframe := idtac.
+
 Ltac entailer :=
  try match goal with POSTCONDITION := @abbreviate ret_assert _ |- _ =>
         clear POSTCONDITION
@@ -630,7 +632,7 @@ Ltac entailer :=
  match goal with
  | |- ?P |-- _ =>
     match type of P with
-    | ?T => unify T (environ->mpred); go_lower
+    | ?T => unify T (environ->mpred); clean_up_stackframe; go_lower
     | _ => clear_Delta; pull_out_props
     end
  | |- _ => fail "The entailer tactic works only on entailments   _ |-- _ "
@@ -686,7 +688,7 @@ Ltac entbang :=
         clear MORE_COMMANDS
       end;
  match goal with
- | |- local _ && ?P |-- _ => go_lower; (*simpl;*) try (*simple*) apply empTrue
+ | |- local _ && ?P |-- _ => clean_up_stackframe; go_lower; (*simpl;*) try (*simple*) apply empTrue
  | |- ?P |-- _ =>
     match type of P with
     | ?T => unify T mpred; pull_out_props

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -224,7 +224,7 @@ Qed.
 
 Ltac process_stackframe_of :=
  match goal with |- semax _ (_ * stackframe_of ?F) _ _ =>
-   let sf := fresh "sf" in set (sf:= stackframe_of F) at 1;
+   let sf := fresh "sf" in set (sf:= stackframe_of F);
      unfold stackframe_of in sf; simpl map in sf; subst sf
   end;
  repeat
@@ -242,12 +242,12 @@ Ltac process_stackframe_of :=
      rewrite <- (@emp_sepcon (environ->mpred) _ _ _ (fold_right _ _ _));
      subst p
   end;
+*)
   repeat (simple apply postcondition_var_block;
    [reflexivity | reflexivity | reflexivity | reflexivity | reflexivity |  ]);
-*)
  change (fold_right sepcon emp (@nil (environ->mpred))) with
    (@emp (environ->mpred) _ _);
- rewrite ?sepcon_emp, ?emp_sepcon.
+ rewrite ?sepcon_emp, ?emp_sepcon, ?frame_ret_assert_emp.
 
 Definition tc_option_val' (t: type) : option val -> Prop :=
  match t with Tvoid => fun v => match v with None => True | _ => False end | _ => fun v => tc_val t (force_val v) end.
@@ -3694,6 +3694,7 @@ Qed.
 Definition must_return (ek: exitkind) : bool :=
   match ek with EK_return => true | _ => false end.
 
+(*
 Lemma eliminate_extra_return:
   forall Espec {cs: compspecs} Delta P c ty Q Post,
   quickflow c must_return = true ->
@@ -3705,6 +3706,13 @@ intros.
 apply semax_seq with FF; [  | apply semax_ff].
 replace (overridePost FF Post) with Post; auto.
 subst; clear.
+unfold function_body_ret_assert.
+simpl.
+destruct ty; auto.
+f_equal; auto.
+unfold_
+simpl.
+destruct 
 reflexivity.
 Qed.
 
@@ -3721,6 +3729,7 @@ replace (overridePost FF Post) with Post; auto.
 subst; clear.
 simpl; f_equal. extensionality rho; normalize.
 Qed.
+*)
 
 Ltac make_func_ptr id :=
   eapply (make_func_ptr id);
@@ -4126,9 +4135,11 @@ Ltac start_function :=
                  end
                | |- _ => intro
                end);
+(*
  first [ eapply eliminate_extra_return'; [ reflexivity | reflexivity | ]
         | eapply eliminate_extra_return; [ reflexivity | reflexivity | ]
         | idtac];
+*)
  abbreviate_semax;
  lazymatch goal with 
  | |- semax ?Delta (PROPx _ (LOCALx ?L _)) _ _ => check_parameter_vals Delta L

--- a/floyd/proofauto.v
+++ b/floyd/proofauto.v
@@ -7,7 +7,8 @@ Require Export VST.floyd.go_lower.
 Require Export VST.floyd.closed_lemmas.
 Require Export VST.floyd.compare_lemmas.
 Require Export VST.floyd.semax_tactics.
-Require Export VST.floyd.forward.
+Require Export VST.floyd.entailer.
+Require Export VST.floyd.forward. (* must come after entailer because of Ltac override *)
 Require Export VST.floyd.subsume_funspec.
 Require Export VST.floyd.call_lemmas.
 Require Export VST.floyd.forward_lemmas.
@@ -35,7 +36,6 @@ Require Export VST.floyd.proj_reptype_lemmas.
 Require Export VST.floyd.replace_refill_reptype_lemmas.
 Require Export VST.floyd.sc_set_load_store.
 Require Export VST.floyd.unfold_data_at.
-Require Export VST.floyd.entailer.
 Require Export VST.floyd.globals_lemmas.
 Require Export VST.floyd.diagnosis.
 Require Export VST.floyd.freezer.

--- a/floyd/semax_tactics.v
+++ b/floyd/semax_tactics.v
@@ -256,7 +256,7 @@ with is_sequential_ls co ls :=
  | LScons _ ?s ?ls' => is_sequential true co s; is_sequential_ls co ls'
  end.
 
-Ltac force_sequential :=
+Ltac force_sequential  :=
 match goal with
 | P := @abbreviate ret_assert (normal_ret_assert _) |- semax _ _ _ ?P' =>
     constr_eq P P'

--- a/mailbox/verif_mailbox_init.v
+++ b/mailbox/verif_mailbox_init.v
@@ -101,7 +101,6 @@ Hint Resolve malloc_compatible_isptr.
 Lemma body_initialize_channels : semax_body Vprog Gprog f_initialize_channels initialize_channels_spec.
 Proof.
   start_function.
-  rewrite <- seq_assoc.
   forward_for_simple_bound B (EX i : Z, PROP ()
     LOCAL (gvars gv)
     SEP (data_at_ Ews (tarray (tptr tint) N) (gv _comm); data_at_ Ews (tarray (tptr tlock) N) (gv _lock);
@@ -257,10 +256,7 @@ Proof.
   Intros locks comms g g0 g1 g2 reads lasts sh.
   match goal with H : sepalg_list.list_join sh1 (sublist N N shs) sh |- _ =>
     rewrite sublist_nil in H; inv H end.
-  forward.
   rewrite !app_nil_r.
   Exists comms locks bufs reads lasts g g0 g1 g2.
-  (* entailer! is slow *)
-  apply andp_right; [apply prop_right; repeat (split; auto)|].
-  cancel.
+  entailer!.
 Qed.

--- a/mailbox/verif_mailbox_write.v
+++ b/mailbox/verif_mailbox_write.v
@@ -30,7 +30,6 @@ Qed.
 Lemma body_start_write : semax_body Vprog Gprog f_start_write start_write_spec.
 Proof.
   start_function.
-  rewrite <- seq_assoc.
   forward_for_simple_bound B (EX i : Z, PROP ( )
    LOCAL (lvar _available (tarray tint B) v_available; gvars gv)
    SEP (data_at Tsh (tarray tint B) (repeat (vint 1) (Z.to_nat i) ++ repeat Vundef (Z.to_nat (B - i))) v_available;
@@ -43,7 +42,6 @@ Proof.
   rewrite Zminus_diag, app_nil_r.
   forward.
   forward.
-  rewrite <- seq_assoc.
   assert_PROP (Zlength lasts = N).
   { gather_SEP 3.
     go_lowerx.
@@ -112,7 +110,6 @@ Proof.
   rewrite sublist_same; auto.
   set (available := map (fun x => vint (if eq_dec x b0 then 0 else if in_dec eq_dec x lasts then 0 else 1))
          (upto (Z.to_nat B))).
-  rewrite <- seq_assoc.
   unfold Sfor.
   forward.
   eapply semax_seq, semax_ff.
@@ -706,7 +703,6 @@ Proof.
   forward.
   assert_PROP (Zlength (map (fun i => vint i) lasts) = N) by entailer!.
   rewrite Zlength_map in *.
-  rewrite <- seq_assoc.
   forward_for_simple_bound N (EX i : Z, PROP ( )
    LOCAL (temp _w (vint b); temp _last (vint b0); gvars gv)
    SEP (data_at Ews tint (vint b) (gv _writing); data_at Ews tint (vint b0) (gv _last_given);
@@ -996,7 +992,6 @@ Proof.
       * simpl; fast_cancel.
         replace (Zlength t') with (Zlength h') in *; eapply upd_write_shares; eauto.
   - Intros t' h'.
-    forward.
     forward.
     forward.
     rewrite sublist_nil, sublist_same; rewrite ?Zlength_map; auto.

--- a/progs/verif_bst.v
+++ b/progs/verif_bst.v
@@ -542,8 +542,6 @@ Proof.
   forward. (* l->right=mid *)
   forward. (* r->left=l *)
   forward. (* _l = r *)
-  Opaque tree_rep. forward. Transparent tree_rep. (* return *)
-  (* TODO: simplify the following proof *)
   Exists pc.
   entailer!.
   simpl.

--- a/progs/verif_libglob.v
+++ b/progs/verif_libglob.v
@@ -203,7 +203,6 @@ forward.
 entailer!.
 unfold LG.data_ok.
 entailer!.
-forward.
 *
 Intros.
 forward.
@@ -217,7 +216,6 @@ forward.
 unfold LG.data_ok.
 entailer!.
 inv H0.
-forward.
 Qed.
 
 Lemma body_bump:  semax_body Vprog Gprog f_LG_bump bump_spec.

--- a/progs/verif_queue.v
+++ b/progs/verif_queue.v
@@ -476,8 +476,6 @@ forward_if
        apply (lseg_cons_right_neq _ _ _ _ _ ((Vundef,Vundef) : elemtype QS));
         auto ].
      cancel.
-* (* after the if *)
-     forward. (* return ; *)
 Qed.
 
 Lemma body_fifo_get: semax_body Vprog Gprog f_fifo_get fifo_get_spec.

--- a/progs/verif_queue2.v
+++ b/progs/verif_queue2.v
@@ -268,8 +268,6 @@ forward_if
      eapply derives_trans;
         [ | apply (lseg_cons_right_neq QS Ews prefix hd last0 tl nullval p ); auto].
      simpl sizeof.  cancel.
-* (* after the if *)
-     forward. (* return ; *)
 Qed.
 
 Lemma body_fifo_get: semax_body Vprog Gprog f_fifo_get fifo_get_spec.

--- a/progs/verif_revarray.v
+++ b/progs/verif_revarray.v
@@ -188,6 +188,7 @@ forward. (* hi--; *)
  reflexivity.
 * (* after the loop *)
 forward. (* return; *)
+entailer!.
 rewrite map_rev. rewrite flip_fact_1; try omega; auto.
 cancel.
 Qed.

--- a/progs/verif_tree.v
+++ b/progs/verif_tree.v
@@ -698,9 +698,10 @@ Proof.
       Exists q'.
       cancel.
   }
-  forward.
-  simpl.
-  Exists q_root; cancel.
+  unfold POSTCONDITION, abbreviate.
+   simpl_ret_assert.
+  entailer!.
+  Exists q_root. cancel.
   Exists (map snd tl).
   cancel.
   rewrite iter_sepcon2_spec.
@@ -739,7 +740,8 @@ Proof.
     Exists q r.
     entailer!.
   }
-  deadvars!.
+ assert (XTree_inhabited := XLeaf).
+ deadvars!.
   forward_call (v_q, XNode tl v).
   simpl xtree_rep.
   Intros q' r'.
@@ -757,7 +759,6 @@ Proof.
   }
   change ((XNode (map x_add1 tl) (v + 1))) with (x_add1 (XNode tl v)).
   forget (XNode tl v) as t.
-  forward.
   Exists (x_add1 t).
   entailer!.
   apply add1_pos; auto.
@@ -810,6 +811,7 @@ Proof.
   unfold lt_ytree_rep.
   Intros r.
   destruct r; [simpl; normalize |].
+  abbreviate_semax.
   simpl.
   Intros y.
   forward.
@@ -852,6 +854,7 @@ Proof.
   unfold t_ytree_rep.
   Intros s.
   destruct s; [simpl; normalize |].
+  abbreviate_semax.
   simpl.
   Intros pa pb.
   forward.

--- a/sha/protocol_spec_hmac.v
+++ b/sha/protocol_spec_hmac.v
@@ -445,19 +445,22 @@ apply semax_pre with (P':=EX h1:hmacabs,
 Intros h1.
 eapply semax_post.
 5: apply (initbodyproof Espec c nullval l sh sh key gv h1 pad ctxkey); auto.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-
-  intros.
-  subst POSTCONDITION; unfold abbreviate; simpl_ret_assert.
++
+subst POSTCONDITION; unfold abbreviate;
+simpl_ret_assert.
 apply andp_left2.
 apply sepcon_derives; auto.
-apply bind_ret_derives.
   old_go_lower.
   entailer!.
   unfold hmacstate_, REP. Intros r. Exists r. entailer!.
   red. rewrite hmacUpdate_nil. assumption. 
++
+simpl_ret_assert; normalize.
++
+simpl_ret_assert; normalize.
++
+  intros.
+  subst POSTCONDITION; unfold abbreviate; simpl_ret_assert. auto.
 Qed.
 
 Lemma body_hmac_final: semax_body HmacVarSpecs HmacFunSpecs 
@@ -471,18 +474,17 @@ eapply semax_pre_post.
   6: apply (finalbodyproof Espec c md sh shmd gv buf (hmacUpdate data (hmacInit key)) SH SH0).
   
   apply andp_left2. unfold hmacstate_. Exists r. old_go_lower. entailer!.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-
++
   intros. apply andp_left2.
   subst POSTCONDITION; unfold abbreviate; simpl_ret_assert.
   apply sepcon_derives; auto.
-  apply bind_ret_derives.
   rewrite <- hmac_sound. unfold FULL.
   change (hmacFinal (hmacUpdate data (hmacInit key))) with (hmac key data).
   Exists (fst (hmac key data)). old_go_lower. entailer!.
   eapply hmacstate_PostFinal_PreInitNull; reflexivity.
++ simpl_ret_assert; normalize.
++ simpl_ret_assert; normalize.
++ intros; simpl_ret_assert; normalize.
 Qed.
 
 Lemma body_hmac_update: semax_body HmacVarSpecs HmacFunSpecs 
@@ -494,16 +496,16 @@ eapply semax_pre_post.
   6: apply (updatebodyproof Espec shc shd c d (Zlength data1) data1 gv (hmacUpdate data (hmacInit key))); auto.
 
   apply andp_left2. old_go_lower. entailer!; try apply derives_refl.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-
-  intros. apply andp_left2.
++
+  apply andp_left2.
   subst POSTCONDITION; unfold abbreviate; simpl_ret_assert.
   apply sepcon_derives; auto.
-  apply bind_ret_derives.
   rewrite hmacUpdate_app. old_go_lower. entailer!; try apply derives_refl.
-  apply derives_refl.
+
++ simpl_ret_assert; normalize.
++ simpl_ret_assert; normalize.
++ intros. simpl_ret_assert; normalize.
++ 
   split; trivial. split; trivial. simpl.
   unfold innerShaInit, s256a_len.
   rewrite Zlength_app, Zlength_mkArgZ, mkKey_length, Min.min_idempotent.
@@ -522,20 +524,17 @@ unfold EMPTY.
 remember (HMACabs (S256abs nil nil) (S256abs nil nil) (S256abs nil nil)) as hdummy.
 eapply semax_pre_post.
 6: apply (initbodyproof Espec c (Vptr b i) l sh shk key gv hdummy pad ctxkey); auto.
-
- entailer!; simpl.
-normalize.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-
-  intros. apply andp_left2.
++
+ entailer!; simpl. normalize.
++ apply andp_left2.
   subst POSTCONDITION; unfold abbreviate; simpl_ret_assert.
   apply sepcon_derives; auto.
-  apply bind_ret_derives.
   old_go_lower. entailer!.
    unfold hmacstate_, REP. Intros r. Exists r. entailer!.
    red. rewrite hmacUpdate_nil. assumption.
++ simpl_ret_assert; normalize.
++ simpl_ret_assert; normalize.
++ simpl_ret_assert; normalize.
 Qed.
 
 Lemma body_hmac_cleanup: semax_body HmacVarSpecs HmacFunSpecs 
@@ -547,22 +546,19 @@ assert_PROP (field_compatible t_struct_hmac_ctx_st [] c).
 { unfold hmacstate_PreInitNull. Intros r v. entailer!. }
 eapply semax_pre_post.
   6: apply (cleanupbodyproof1 Espec sh c h); auto.
-  Exists key. apply andp_left2. apply derives_refl. 
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-simpl_ret_assert; normalize.
-
-  intros. apply andp_left2.
++
+  Exists key. apply andp_left2. apply derives_refl.
++  apply andp_left2.
   subst POSTCONDITION; unfold abbreviate; simpl_ret_assert.
-  apply sepcon_derives; auto.
-  apply bind_ret_derives.
-  old_go_lower. entailer!.
-
+  Opaque list_repeat. old_go_lower. Transparent list_repeat.
+  normalize.
   unfold EMPTY. 
-  rewrite <- memory_block_data_at_. simpl. unfold data_block.
+  rewrite <- memory_block_data_at_.  unfold data_block.
   clear. simpl. apply data_at_memory_block.
   trivial.
-  apply derives_refl.
++ simpl_ret_assert; normalize.
++ simpl_ret_assert; normalize.
++ simpl_ret_assert; normalize.
 Qed. 
 
 End OPENSSL_HMAC_ABSTRACT_SPEC.

--- a/sha/verif_hmac_cleanup.v
+++ b/sha/verif_hmac_cleanup.v
@@ -24,7 +24,6 @@ forward_call (wsh, c, sizeof t_struct_hmac_ctx_st, Int.zero).
   { eapply derives_trans. apply data_at_data_at_.
     rewrite <- memory_block_data_at_; try reflexivity. cancel.
     trivial. }
-subst POSTCONDITION; unfold abbreviate.
 pose proof (sizeof_pos t_struct_hmac_ctx_st).
 forget (sizeof t_struct_hmac_ctx_st) as NN.
 forward.
@@ -40,15 +39,14 @@ Lemma cleanupbodyproof1 Espec wsh c h
   (PROP  ()
    LOCAL  (temp _ctx c)
    SEP  (EX  key : list byte, hmacstate_PreInitNull wsh key h c))
-  (Ssequence (fn_body f_HMAC_cleanup) (Sreturn None))
-  (frame_ret_assert
-     (function_body_ret_assert tvoid
-        (PROP  ()
-         LOCAL ()
-         SEP
-         (data_block wsh
-            (list_repeat (Z.to_nat (sizeof t_struct_hmac_ctx_st)) Byte.zero)
-            c))) emp).
+  (fn_body f_HMAC_cleanup)
+  (normal_ret_assert
+     (PROP ( )
+      LOCAL ()
+      SEP (data_block wsh
+             (list_repeat
+                (Z.to_nat (sizeof t_struct_hmac_ctx_st))
+                Byte.zero) c) * stackframe_of f_HMAC_cleanup)).
 Proof. abbreviate_semax.
 set (x := fn_body f_HMAC_cleanup); hnf in x; subst x.
 Intros key.
@@ -59,7 +57,6 @@ forward_call (wsh, c, sizeof t_struct_hmac_ctx_st, Int.zero).
   { eapply derives_trans. apply data_at_data_at_.
     rewrite <- memory_block_data_at_; try reflexivity. cancel.
     trivial. }
-subst POSTCONDITION; unfold abbreviate.
 pose proof (sizeof_pos t_struct_hmac_ctx_st).
 forget (sizeof t_struct_hmac_ctx_st) as NN.
 forward.
@@ -72,5 +69,6 @@ Lemma body_hmac_cleanup1: semax_body HmacVarSpecs HmacFunSpecs
        f_HMAC_cleanup HMAC_Cleanup_spec1.
 Proof.
 start_function.
+subst POSTCONDITION; unfold abbreviate.
 apply cleanupbodyproof1; auto.
 Qed.

--- a/sha/verif_hmac_final.v
+++ b/sha/verif_hmac_final.v
@@ -30,14 +30,15 @@ Lemma finalbodyproof Espec c md wsh shmd gv buf (h1 : hmacabs)
            temp _ctx c; gvars gv)
    SEP  (data_at_ Tsh (tarray tuchar 32) buf; hmacstate_ wsh h1 c;
          K_vector gv; memory_block shmd 32 md))
-  (Ssequence (fn_body f_HMAC_Final) (Sreturn None))
-  (frame_ret_assert
-     (function_body_ret_assert tvoid
-        (PROP  ()
-         LOCAL ()
-         SEP  (K_vector gv; hmacstate_PostFinal wsh (fst (hmacFinal h1)) c;
-               data_block shmd (snd (hmacFinal h1)) md)))
-     (stackframe_of f_HMAC_Final)%assert).
+  (fn_body f_HMAC_Final)
+  (normal_ret_assert
+                   (PROP ( )
+                    LOCAL ()
+                    SEP (K_vector gv;
+                    hmacstate_PostFinal wsh
+                      (fst (hmacFinal h1)) c;
+                    data_block shmd (snd (hmacFinal h1))
+                      md) * stackframe_of f_HMAC_Final)).
 Proof. intros. abbreviate_semax.
 Time assert_PROP (isptr md) as isptrMD by entailer!. (*0.6*)
 unfold hmacstate_.

--- a/sha/verif_hmac_init.v
+++ b/sha/verif_hmac_init.v
@@ -47,14 +47,14 @@ Lemma initbodyproof Espec c k l wsh sh key gv h1 pad ctxkey
    SEP  (data_at_ Tsh (tarray tuchar 64) ctxkey;
          data_at_ Tsh (tarray tuchar 64) pad;
          K_vector gv; initPre wsh sh c k h1 l key))
-  (Ssequence (fn_body f_HMAC_Init) (Sreturn None))
-  (frame_ret_assert
-     (function_body_ret_assert tvoid
-        (PROP  ()
-         LOCAL ()
-         SEP  (hmacstate_ wsh (hmacInit key) c; 
-                 initPostKey sh k key; K_vector gv)))
-     (stackframe_of f_HMAC_Init)).
+  (fn_body f_HMAC_Init)
+  (normal_ret_assert
+                   (PROP ( )
+                    LOCAL ()
+                    SEP (hmacstate_ wsh (hmacInit key) c;
+                    initPostKey sh k key; 
+                    K_vector gv) *
+                    stackframe_of f_HMAC_Init)).
 Proof. abbreviate_semax.
 simpl. 
 Time forward. (*0.8 versus 1.3*)
@@ -157,7 +157,6 @@ subst c.
 rename H0 into R.
 
 (*isolate branch if (reset) *)
-apply seq_assoc.
 forward_if (EX shaStates:_ ,
           PROP  (innerShaInit (HMAC_SHA256.mkKey key) =(fst shaStates) /\
                   s256_relate (fst shaStates) (fst (snd shaStates)) /\

--- a/sha/verif_hmac_update.v
+++ b/sha/verif_hmac_update.v
@@ -22,13 +22,14 @@ Lemma updatebodyproof Espec wsh sh c d len data gv (h1 : hmacabs)
    LOCAL  (temp _ctx c; temp _data d;
            temp _len (Vint (Int.repr len)); gvars gv)
    SEP  (K_vector gv; hmacstate_ wsh h1 c; data_block sh data d))
-  (Ssequence (fn_body f_HMAC_Update) (Sreturn None))
-  (frame_ret_assert
-     (function_body_ret_assert tvoid
-        (PROP  ()
-         LOCAL ()
-         SEP  (K_vector gv; hmacstate_ wsh (hmacUpdate data h1) c;
-         data_block sh data d))) emp).
+  (fn_body f_HMAC_Update)
+  (normal_ret_assert
+                   (PROP ( )
+                    LOCAL ()
+                    SEP (K_vector gv;
+                    hmacstate_ wsh (hmacUpdate data h1) c;
+                    data_block sh data d) *
+                    stackframe_of f_HMAC_Update)).
 Proof. abbreviate_semax.
 unfold hmacstate_.
 Intros ST.

--- a/sha/verif_sha_final.v
+++ b/sha/verif_sha_final.v
@@ -154,13 +154,14 @@ cancel.
 rewrite array_at_data_at'; auto; try apply derives_refl; omega.
 +
 subst POSTCONDITION; unfold abbreviate; simpl_ret_assert; normalize.
+rewrite hashed_data_recombine by auto.
+auto.
 +
 subst POSTCONDITION; unfold abbreviate; simpl_ret_assert; normalize.
 +
 subst POSTCONDITION; unfold abbreviate; simpl_ret_assert; normalize.
 +
-intros.
-subst POSTCONDITION; unfold abbreviate; simpl_ret_assert.
+intros. subst POSTCONDITION; unfold abbreviate; simpl_ret_assert.
 rewrite hashed_data_recombine by auto.
 apply ENTAIL_refl.
 +

--- a/sha/verif_sha_final3.v
+++ b/sha/verif_sha_final3.v
@@ -359,12 +359,7 @@ semax
       LOCAL ()
       SEP  (K_vector gv;
         data_at_ wsh t_struct_SHA256state_st c;
-        data_block shmd
-          (intlist_to_bytelist
-             (hash_blocks init_registers
-                (generate_and_pad
-                   (intlist_to_bytelist hashed ++ dd))))
-          md))) emp).
+        data_block shmd (SHA_256 (intlist_to_bytelist hashed ++ dd)) md))) emp).
 Proof.
   intros Espec hashed md c wsh shmd kv Hwsh H
   bitlen dd H4 H7 H3 hashed' dd' pad

--- a/veric/Clight_core_standard.v
+++ b/veric/Clight_core_standard.v
@@ -94,16 +94,9 @@ Definition cl_initial_core (ge: genv) (v: val) (args: list val) : option CC_core
     Vptr b i =>
     if Ptrofs.eq_dec i Ptrofs.zero then
       match Genv.find_funct_ptr ge b with
-        Some f =>
-        Some (State empty_function 
-                    (Scall None
-                                 (Etempvar 1%positive (type_of_fundef f))
-                                 (map (fun x => Etempvar (fst x) (snd x))
-                                      (params_of_types 2%positive
-                                                       (params_of_fundef f))))
-                     (Kseq (Sloop Sskip Sskip) Kstop)
-             empty_env
-             (temp_bindings 1%positive (v::args)))
+        Some (Internal f) =>
+        Some (Callstate (Internal f) args 
+                     (Kseq (Sloop Sskip Sskip) Kstop))
       | _ => None end
     else None
   | _ => None

--- a/veric/Clight_core_standard.v
+++ b/veric/Clight_core_standard.v
@@ -61,7 +61,11 @@ Lemma CC_core_to_CC_state_inj: forall c m c' m',
        apply  CC_core_CC_state_3 in H. rewrite  CC_core_CC_state_1 in H.  inv H. trivial.
   Qed.
 
-Definition cl_halted (c: CC_core) : option val := None.
+Definition cl_halted (c: CC_core) : option val := 
+  match c with
+  | Returnstate v Kstop => Some v
+  | _ => None
+  end.
 
 Definition empty_function : function := mkfunction Tvoid cc_default nil nil nil Sskip.
 
@@ -94,9 +98,8 @@ Definition cl_initial_core (ge: genv) (v: val) (args: list val) : option CC_core
     Vptr b i =>
     if Ptrofs.eq_dec i Ptrofs.zero then
       match Genv.find_funct_ptr ge b with
-        Some (Internal f) =>
-        Some (Callstate (Internal f) args 
-                     (Kseq (Sloop Sskip Sskip) Kstop))
+        Some f =>
+        Some (Callstate f args Kstop)
       | _ => None end
     else None
   | _ => None
@@ -255,7 +258,7 @@ Lemma cl_corestep_not_halted :
   forall ge m q m' q', cl_step ge q m q' m' -> cl_halted q = None.
 Proof.
   intros.
-  simpl; auto.
+  inv H; simpl; auto.
 Qed.
 
 Lemma cl_after_at_external_excl :

--- a/veric/Clight_core_standard.v
+++ b/veric/Clight_core_standard.v
@@ -255,9 +255,10 @@ Proof.
 Qed.
 
 Lemma cl_corestep_not_halted :
-  forall ge m q m' q', cl_step ge q m q' m' -> cl_halted q = None.
+  forall ge m q m' q' (i: int), cl_step ge q m q' m' -> ~ cl_halted q <> None.
 Proof.
   intros.
+  intro. apply H0.
   inv H; simpl; auto.
 Qed.
 
@@ -276,9 +277,9 @@ Program Definition cl_core_sem (ge: genv) :
     (fun _ m c m' v args => cl_initial_core ge v args = Some c(* /\ Mem.arg_well_formed args m /\ m' = m *))
     (fun c _ => cl_at_external c)
     (fun ret c _ => cl_after_external ret c)
-    (fun c _ =>  False (*cl_halted c <> None*))
+    (fun c _ =>  cl_halted c <> None)
     (cl_step ge)
-    _
+    (cl_corestep_not_halted ge)
     (cl_corestep_not_at_external ge).
 
 (*Clight_core is also a memsem!*)

--- a/veric/Clight_core_standard.v
+++ b/veric/Clight_core_standard.v
@@ -10,23 +10,26 @@ Require Import VST.sepcomp.semantics.
 Require Import VST.sepcomp.semantics_lemmas.
 Require Import VST.sepcomp.mem_lemmas.
 
-Inductive CC_core : Type :=
-    CC_core_State : function ->
-            statement -> cont -> env -> temp_env -> CC_core
-  | CC_core_Callstate : fundef -> list val -> cont -> CC_core
-  | CC_core_Returnstate : val -> cont -> CC_core.
+Inductive state : Type :=
+    State : function ->
+            statement -> cont -> env -> temp_env -> state
+  | Callstate : fundef -> list val -> cont -> state
+  | Returnstate : val -> cont -> state.
 
-Definition CC_core_to_CC_state (c:CC_core) (m:mem) : state :=
+Definition CC_core := state.
+
+Definition CC_core_to_CC_state (c:state) (m:mem) : Clight.state :=
   match c with
-     CC_core_State f st k e te => State f st k e te m
-  |  CC_core_Callstate fd args k => Callstate fd args k m
-  | CC_core_Returnstate v k => Returnstate v k m
+     State f st k e te => Clight.State f st k e te m
+  |  Callstate fd args k => Clight.Callstate fd args k m
+  | Returnstate v k => Clight.Returnstate v k m
  end.
-Definition CC_state_to_CC_core (c:state): CC_core * mem :=
+
+Definition CC_state_to_CC_core (c:Clight.state): state * mem :=
   match c with
-     State f st k e te m => (CC_core_State f st k e te, m)
-  |  Callstate fd args k m => (CC_core_Callstate fd args k, m)
-  | Returnstate v k m => (CC_core_Returnstate v k, m)
+     Clight.State f st k e te m => (State f st k e te, m)
+  |  Clight.Callstate fd args k m => (Callstate fd args k, m)
+  | Clight.Returnstate v k m => (Returnstate v k, m)
  end.
 
 Lemma  CC_core_CC_state_1: forall c m,
@@ -47,9 +50,9 @@ Lemma  CC_core_CC_state_3: forall s c m,
 
 Lemma  CC_core_CC_state_4: forall s, exists c, exists m, s =  CC_core_to_CC_state c m.
   Proof. intros. destruct s.
-             exists (CC_core_State f s k e le). exists m; reflexivity.
-             exists (CC_core_Callstate fd args k). exists m; reflexivity.
-             exists (CC_core_Returnstate res k). exists m; reflexivity.
+             exists (State f s k e le). exists m; reflexivity.
+             exists (Callstate fd args k). exists m; reflexivity.
+             exists (Returnstate res k). exists m; reflexivity.
   Qed.
 
 Lemma CC_core_to_CC_state_inj: forall c m c' m',
@@ -92,7 +95,7 @@ Definition cl_initial_core (ge: genv) (v: val) (args: list val) : option CC_core
     if Ptrofs.eq_dec i Ptrofs.zero then
       match Genv.find_funct_ptr ge b with
         Some f =>
-        Some (CC_core_State empty_function 
+        Some (State empty_function 
                     (Scall None
                                  (Etempvar 1%positive (type_of_fundef f))
                                  (map (fun x => Etempvar (fst x) (snd x))
@@ -110,29 +113,149 @@ Definition stuck_signature : signature := mksignature nil None cc_default.
 
 Definition cl_at_external (c: CC_core) : option (external_function * list val) :=
   match c with
-  | CC_core_Callstate (External ef _ _ _) args _ => Some (ef, args)
-  | CC_core_State _ (Sbuiltin _ ef _ args) _ _ _ => Some (EF_external "stuck" stuck_signature, nil)
+  | Callstate (External ef _ _ _) args _ => Some (ef, args)
+  | State _ (Sbuiltin _ ef _ args) _ _ _ => Some (EF_external "stuck" stuck_signature, nil)
   | _ => None
 end.
 
 Definition cl_after_external (vret: option val) (c: CC_core) : option CC_core :=
    match c with
-   | CC_core_Callstate (External ef _ _ _) _ k => 
-        Some (CC_core_Returnstate (match vret with Some v => v | _ => Vundef end) k)
+   | Callstate (External ef _ _ _) _ k => 
+        Some (Returnstate (match vret with Some v => v | _ => Vundef end) k)
    | _ => None
    end.
 
-Definition cl_step ge (q: CC_core) (m: mem) (q': CC_core) (m': mem) : Prop :=
-    cl_at_external q = None /\ 
-     Clight.step ge (Clight.function_entry2 ge)
+Inductive step: genv -> state -> mem -> state -> mem -> Prop :=
+
+  | step_assign:   forall ge f a1 a2 k e le m loc ofs v2 v m',
+      eval_lvalue ge e le m a1 loc ofs ->
+      eval_expr ge e le m a2 v2 ->
+      sem_cast v2 (typeof a2) (typeof a1) m = Some v ->
+      assign_loc ge (typeof a1) m loc ofs v m' ->
+      step ge (State f (Sassign a1 a2) k e le) m
+                  (State f Sskip k e le) m'
+
+  | step_set:   forall ge f id a k e le m v,
+      eval_expr ge e le m a v ->
+      step ge (State f (Sset id a) k e le) m
+              (State f Sskip k e (PTree.set id v le)) m
+
+  | step_call:   forall ge f optid a al k e le m tyargs tyres cconv vf vargs fd,
+      classify_fun (typeof a) = fun_case_f tyargs tyres cconv ->
+      eval_expr ge e le m a vf ->
+      eval_exprlist ge e le m al tyargs vargs ->
+      Genv.find_funct ge vf = Some fd ->
+      type_of_fundef fd = Tfunction tyargs tyres cconv ->
+      step ge (State f (Scall optid a al) k e le) m
+                  (Callstate fd vargs (Kcall optid f e le k)) m
+
+  | step_seq:  forall ge f s1 s2 k e le m,
+      step ge (State f (Ssequence s1 s2) k e le) m
+                 (State f s1 (Kseq s2 k) e le) m
+
+  | step_skip_seq: forall ge f s k e le m,
+      step ge (State f Sskip (Kseq s k) e le) m
+              (State f s k e le) m
+  | step_continue_seq: forall ge f s k e le m,
+      step ge (State f Scontinue (Kseq s k) e le) m
+             (State f Scontinue k e le) m
+  | step_break_seq: forall ge f s k e le m,
+      step ge (State f Sbreak (Kseq s k) e le) m
+            (State f Sbreak k e le) m
+
+  | step_ifthenelse:  forall ge f a s1 s2 k e le m v1 b,
+      eval_expr ge e le m a v1 ->
+      bool_val v1 (typeof a) m = Some b ->
+      step ge (State f (Sifthenelse a s1 s2) k e le) m
+            (State f (if b then s1 else s2) k e le) m
+
+  | step_loop: forall ge f s1 s2 k e le m,
+      step ge (State f (Sloop s1 s2) k e le) m
+            (State f s1 (Kloop1 s1 s2 k) e le) m
+  | step_skip_or_continue_loop1:  forall ge f s1 s2 k e le m x,
+      x = Sskip \/ x = Scontinue ->
+      step ge (State f x (Kloop1 s1 s2 k) e le) m
+            (State f s2 (Kloop2 s1 s2 k) e le) m
+  | step_break_loop1:  forall ge f s1 s2 k e le m,
+      step ge (State f Sbreak (Kloop1 s1 s2 k) e le) m
+             (State f Sskip k e le) m
+  | step_skip_loop2: forall ge f s1 s2 k e le m,
+      step ge (State f Sskip (Kloop2 s1 s2 k) e le) m
+             (State f (Sloop s1 s2) k e le) m
+  | step_break_loop2: forall ge f s1 s2 k e le m,
+      step ge (State f Sbreak (Kloop2 s1 s2 k) e le) m
+            (State f Sskip k e le) m
+
+  | step_return_0: forall ge f k e le m m',
+      Mem.free_list m (blocks_of_env ge e) = Some m' ->
+      step ge (State f (Sreturn None) k e le) m
+            (Returnstate Vundef (call_cont k)) m'
+  | step_return_1: forall ge f a k e le m v v' m',
+      eval_expr ge e le m a v ->
+      sem_cast v (typeof a) f.(fn_return) m = Some v' ->
+      Mem.free_list m (blocks_of_env ge e) = Some m' ->
+      step ge (State f (Sreturn (Some a)) k e le) m
+           (Returnstate v' (call_cont k)) m'
+  | step_skip_call: forall ge f k e le m m',
+      is_call_cont k ->
+      Mem.free_list m (blocks_of_env ge e) = Some m' ->
+      step ge (State f Sskip k e le) m
+              (Returnstate Vundef k) m'
+
+  | step_switch: forall ge f a sl k e le m v n,
+      eval_expr ge e le m a v ->
+      sem_switch_arg v (typeof a) = Some n ->
+      step ge (State f (Sswitch a sl) k e le) m
+            (State f (seq_of_labeled_statement (select_switch n sl)) (Kswitch k) e le) m
+  | step_skip_break_switch: forall ge f x k e le m,
+      x = Sskip \/ x = Sbreak ->
+      step ge (State f x (Kswitch k) e le) m
+             (State f Sskip k e le) m
+  | step_continue_switch: forall ge f k e le m,
+      step ge (State f Scontinue (Kswitch k) e le) m
+             (State f Scontinue k e le) m
+
+  | step_label: forall ge f lbl s k e le m,
+      step ge (State f (Slabel lbl s) k e le) m
+             (State f s k e le) m
+
+  | step_goto: forall ge f lbl k e le m s' k',
+      find_label lbl f.(fn_body) (call_cont k) = Some (s', k') ->
+      step ge (State f (Sgoto lbl) k e le) m
+             (State f s' k' e le) m
+
+  | step_internal_function: forall ge f vargs k m e le m1,
+      function_entry2 ge f vargs m e le m1 ->
+      step ge (Callstate (Internal f) vargs k) m
+            (State f f.(fn_body) k e le) m1
+
+  | step_returnstate: forall ge v optid f e le k m,
+      step ge (Returnstate v (Kcall optid f e le k)) m
+           (State f Sskip k e (set_opttemp optid v le)) m.
+
+Lemma cl_step_equiv: forall ge (q: CC_core) (m: mem) q' m',
+  cl_at_external q = None ->
+  step ge q m q' m' <-> Clight.step ge (Clight.function_entry2 ge) 
       (CC_core_to_CC_state q m) Events.E0 (CC_core_to_CC_state q' m').
+Proof.
+intros.
+split; intro H0; inv H0; inv H;
+repeat match goal with H: _ = CC_core_to_CC_state ?q _ |- _ => destruct q; inv H end;
+try solve [econstructor; eassumption].
+inv H4.
+inv H3.
+Qed.
+
+Definition cl_step: genv -> CC_core -> mem -> CC_core -> mem -> Prop := step.
 
 Lemma cl_corestep_not_at_external:
   forall ge m q m' q', 
           cl_step ge q m q' m' -> cl_at_external q = None.
 Proof.
-  intros.
-  unfold cl_step in H. destruct H; auto.  
+ simpl; intros.
+ inv H; try reflexivity; simpl.
+ destruct H0; subst; reflexivity.
+ destruct H0; subst; reflexivity.
 Qed.
 
 Lemma cl_corestep_not_halted :
@@ -174,7 +297,7 @@ Qed.
 
 Lemma CC_core_to_State_mem:
     forall f STEP k e le m c m',
-    State f STEP k e le m = CC_core_to_CC_state c m' ->
+    Clight.State f STEP k e le m = CC_core_to_CC_state c m' ->
     m = m'.
   Proof.
     intros;
@@ -197,37 +320,20 @@ Program Definition CLNC_memsem (ge: genv):
   @MemSem (*(Genv.t fundef type)*) CC_core.
 apply Build_MemSem with (csem := cl_core_sem ge).
   intros.
-  induction CS. simpl in H0.
-  inversion H0;
-  try solve [do 2 match goal with
-    | [ H: State _ _ _ _ _ ?m = CC_core_to_CC_state _ _ |- _ ] => apply CC_core_to_State_mem in H
-             end; subst; try apply mem_step_refl; trivial];
-  destruct c; inv H1; destruct c'; inv H2;
+  induction CS;
   try apply mem_step_refl;
   try ( eapply mem_step_freelist; eassumption).
 *
- inv H6.
- unfold Mem.storev in H2. apply Mem.store_storebytes in H2.
+ inv H2.
+ unfold Mem.storev in H4. apply Mem.store_storebytes in H4.
  eapply mem_step_storebytes; eauto.
- eapply mem_step_storebytes; eauto. 
-*
-  inv H.
-*
- inv H3.
- clear - H5.
- induction H5.
- apply mem_step_refl.
- eapply mem_step_trans. eapply mem_step_alloc; eassumption. auto.
+ eapply mem_step_storebytes; eauto.
 *
  inv H.
-*
- simpl in H4. inv H4.
+ clear - H3.
+ induction H3.
  apply mem_step_refl.
-*
- inv H4.
-*
- inv H4.
+ eapply mem_step_trans. eapply mem_step_alloc; eassumption. auto.
 Qed.
 
 Definition at_external c := cl_at_external (fst (CC_state_to_CC_core c)). (* Temporary definition for compatibility between CompCert 3.3 and new-compcert *)
-

--- a/veric/NullExtension.v
+++ b/veric/NullExtension.v
@@ -2,7 +2,7 @@ Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.base.
 (*Lenb - do we need these?
-  Require Import VST.veric.Clight_new.
+  Require Import VST.veric.Clight_core.
 Require Import VST.veric.Clight_lemmas.*)
 Require Import VST.veric.juicy_extspec.
 Require Import VST.veric.juicy_mem.

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -1197,7 +1197,8 @@ Definition semax_prog_ext
   @Def.semax_func Espec V G C (Genv.globalenv prog)  (prog_funct prog) G /\
   match_globvars (prog_vars prog) V = true /\
   match initial_world.find_id prog.(prog_main) G with
-  | Some s => exists post, s = main_spec_ext' prog z post
+  | Some s => exists post,
+             s = main_spec_ext' prog z post
   | None => False
   end.
 

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -1171,7 +1171,7 @@ match spec with (_, mk_funspec fsig cc A P Q _ _) =>
 forall Espec ts x, 
   @Def.semax C Espec (func_tycontext f V G nil)
       (Clight_seplog.close_precondition (map fst (fst fsig)) (map fst f.(fn_params)) (P ts x) * stackframe_of f)
-       (Ssequence f.(fn_body) (Sreturn None))
+       f.(fn_body)
       (frame_ret_assert (function_body_ret_assert (fn_return f) (Q ts x)) (stackframe_of f))
 end.
 

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -803,7 +803,7 @@ Definition loop2_ret_assert (Inv: environ->mpred) (R: ret_assert) : ret_assert :
  end.
 
 Definition function_body_ret_assert (ret: type) (Q: environ->mpred) : ret_assert :=
- {| RA_normal := seplog.FF;
+ {| RA_normal := bind_ret None ret Q;
     RA_break := seplog.FF; 
     RA_continue := seplog.FF;
     RA_return := fun vl => bind_ret vl ret Q |}.

--- a/veric/SeparationLogicSoundness.v
+++ b/veric/SeparationLogicSoundness.v
@@ -6,7 +6,7 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.juicy_extspec.

--- a/veric/SeparationLogicSoundness.v
+++ b/veric/SeparationLogicSoundness.v
@@ -49,10 +49,12 @@ Axiom semax_prog_ext_sound :
 Axiom semax_prog_rule :
   forall {Espec: OracleKind}{CS: compspecs},
   OK_ty = unit -> 
-  forall V G prog m h,
-     @semax_prog Espec CS prog V G ->
+ (forall (v : val) (ora : OK_ty) (jm : juicy_mem),
+  ext_spec_exit OK_spec (Some v) ora jm) ->
+  forall ora V G prog m h,
+     @semax_prog_ext Espec CS prog ora V G ->
      Genv.init_mem prog = Some m ->
-     { b : block & { q : corestate &
+     { b : block & { q : Clight_core.state &
        (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
        (forall jm, m_dry jm = m -> exists jm', semantics.initial_core (juicy_core_sem (cl_core_sem (globalenv prog))) h
                     jm q jm' (Vptr b Ptrofs.zero) nil) *
@@ -65,37 +67,20 @@ Axiom semax_prog_rule :
            app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)
      } } }%type.
 
-(* This version lets the user choose the external state instead of quantifying over it. *)
-Axiom semax_prog_rule' :
-  forall {Espec: OracleKind}{CS: compspecs},
-  forall V G prog m h,
-     @semax_prog Espec CS prog V G ->
-     Genv.init_mem prog = Some m ->
-     { b : block & { q : corestate &
-       (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
-       (forall jm, m_dry jm = m -> exists jm', semantics.initial_core (juicy_core_sem (cl_core_sem (globalenv prog))) h
-                    jm q jm' (Vptr b Ptrofs.zero) nil) *
-       forall n z,
-         { jm |
-           m_dry jm = m /\ level jm = n /\
-           nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
-           jsafeN (@OK_spec Espec) (globalenv prog) n z q jm /\
-           no_locks (m_phi jm) /\
-           matchfunspecs (globalenv prog) G (m_phi jm) /\
-           app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)
-     } } }%type.
-
 (* This version lets the user choose the external state instead of quantifying over it,
     and start with knowledge of that state in the precondition of main. *)
 Axiom semax_prog_rule_ext :
   forall {Espec: OracleKind}{CS: compspecs},
   forall V G prog m h z,
+    (forall v ora jm,
+     ext_spec_exit (JE_spec OK_ty OK_spec) (Some v) ora jm) ->
      @semax_prog_ext Espec CS prog z V G ->
      Genv.init_mem prog = Some m ->
-     { b : block & { q : corestate &
+     { b : block & { q : CC_core &
        (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
-       (forall jm, m_dry jm = m -> exists jm', semantics.initial_core (juicy_core_sem (cl_core_sem (globalenv prog))) h
-                    jm q jm' (Vptr b Ptrofs.zero) nil) *
+       (forall jm, m_dry jm = m -> exists jm',
+                    semantics.initial_core (juicy_core_sem (cl_core_sem (globalenv prog))) h
+                       jm q jm' (Vptr b Ptrofs.zero) nil) *
        forall n,
          { jm |
            m_dry jm = m /\ level jm = n /\
@@ -105,7 +90,6 @@ Axiom semax_prog_rule_ext :
            matchfunspecs (globalenv prog) G (m_phi jm) /\
            app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)
      } } }%type.
-
 
 End SEPARATION_HOARE_LOGIC_SOUNDNESS.
 
@@ -283,7 +267,6 @@ Proof.
 Qed.
 
 Definition semax_prog_rule := @semax_prog_rule.
-Definition semax_prog_rule' := @semax_prog_rule'.
 Definition semax_prog_rule_ext := @semax_prog_rule_ext.
 
 End VericSound.

--- a/veric/SeparationLogicSoundness.v
+++ b/veric/SeparationLogicSoundness.v
@@ -49,8 +49,7 @@ Axiom semax_prog_ext_sound :
 Axiom semax_prog_rule :
   forall {Espec: OracleKind}{CS: compspecs},
   OK_ty = unit -> 
- (forall (v : val) (ora : OK_ty) (jm : juicy_mem),
-  ext_spec_exit OK_spec (Some v) ora jm) ->
+  postcondition_allows_exit Espec tint ->
   forall ora V G prog m h,
      @semax_prog_ext Espec CS prog ora V G ->
      Genv.init_mem prog = Some m ->
@@ -72,8 +71,7 @@ Axiom semax_prog_rule :
 Axiom semax_prog_rule_ext :
   forall {Espec: OracleKind}{CS: compspecs},
   forall V G prog m h z,
-    (forall v ora jm,
-     ext_spec_exit (JE_spec OK_ty OK_spec) (Some v) ora jm) ->
+     postcondition_allows_exit Espec tint ->
      @semax_prog_ext Espec CS prog z V G ->
      Genv.init_mem prog = Some m ->
      { b : block & { q : CC_core &
@@ -115,6 +113,7 @@ Definition semax_func := @semax_func.
 
 Definition semax_external {Espec: OracleKind} ids ef A P Q :=
   forall n, semax_external Espec ids ef A P Q n.
+
 (*
 Definition semax_cssub := @semax_cssub.
   *)
@@ -265,7 +264,15 @@ Lemma semax_prog_ext_sound :
 Proof.
   intros; apply H.
 Qed.
-
+(*
+Lemma postcondition_allows_exit_sound :
+  forall {Espec} t,
+  @CSHL_Defs.postcondition_allows_exit Espec t ->
+  @semax_prog.postcondition_allows_exit Espec t.
+Proof.
+  intros; apply H.
+Qed.
+*)
 Definition semax_prog_rule := @semax_prog_rule.
 Definition semax_prog_rule_ext := @semax_prog_rule_ext.
 

--- a/veric/SequentialClight.v
+++ b/veric/SequentialClight.v
@@ -387,8 +387,7 @@ Qed.
 
 Lemma whole_program_sequential_safety_ext:
    forall {CS: compspecs} {Espec: OracleKind} (initial_oracle: OK_ty) 
-   (EXIT: forall (v : val) (ora : OK_ty) (jm : juicy_mem),
-       ext_spec_exit OK_spec (Some v) ora jm)
+     (EXIT: semax_prog.postcondition_allows_exit Espec tint)
      (dryspec: ext_spec OK_ty)
      (dessicate : forall (ef : external_function) jm,
                ext_spec_type OK_spec ef ->
@@ -555,8 +554,6 @@ Require Import VST.veric.juicy_safety.
 
 Definition fun_id (ext_link: Strings.String.string -> ident) (ef: external_function) : option ident :=
   match ef with EF_external id sig => Some (ext_link id) | _ => None end.
-
-Print genv.
 
 Lemma module_sequential_safety : (*TODO*)
    forall {CS: compspecs} (prog: program) (V: varspecs) (G: funspecs) ora m f f_id f_b f_body args,

--- a/veric/SequentialClight.v
+++ b/veric/SequentialClight.v
@@ -1,7 +1,7 @@
 Require Import VST.sepcomp.semantics.
 
 Require Import VST.veric.Clight_base.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.veric.Clight_lemmas.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.sepcomp.event_semantics.
@@ -9,7 +9,7 @@ Require Import VST.veric.SeparationLogic.
 Require Import VST.veric.juicy_extspec.
 Require Import VST.veric.juicy_mem.
 Require VST.veric.NullExtension.
-Require Import VST.veric.Clight_sim.
+(*Require Import VST.veric.Clight_sim.*)
 Require Import VST.veric.SeparationLogicSoundness.
 Require Import VST.sepcomp.extspec.
 Require Import VST.msl.msl_standard.

--- a/veric/SequentialClight.v
+++ b/veric/SequentialClight.v
@@ -385,175 +385,10 @@ rewrite nextblock_access_empty in * by auto.
 contradiction.
 Qed.
 
-(* In this version, the program doesn't start with any knowledge of the external state. *)
-Lemma whole_program_sequential_safety:
-   forall {CS: compspecs} {Espec: OracleKind} (initial_oracle: OK_ty) 
-     (dryspec: ext_spec OK_ty)
-     (dessicate : forall (ef : external_function) jm,
-               ext_spec_type OK_spec ef ->
-               ext_spec_type dryspec ef)
-     (JDE: juicy_dry_ext_spec _ (@JE_spec OK_ty OK_spec) dryspec dessicate)
-     (DME: ext_spec_mem_evolve _ dryspec)
-     prog V G m,
-     @semax_prog Espec (*NullExtension.Espec*) CS prog V G ->
-     Genv.init_mem prog = Some m ->
-     exists b, exists q, exists m',
-       Genv.find_symbol (Genv.globalenv prog) (prog_main prog) = Some b /\
-       initial_core  (cl_core_sem (globalenv prog))
-           0 m q m' (Vptr b Ptrofs.zero) nil /\
-       forall n,
-        @dry_safeN _ _ _ OK_ty (genv_symb_injective)
-            (coresem_extract_cenv  (cl_core_sem (globalenv prog))
-                (prog_comp_env prog)) 
-            (*(dryspec  OK_ty)*) dryspec
-            (Build_genv (Genv.globalenv prog) (prog_comp_env prog)) 
-             n initial_oracle q m'.
-Proof.
- intros.
- destruct (@semax_prog_rule' (*NullExtension.*)Espec CS _ _ _ _ 
-     0 (*additional temporary argument - TODO (Santiago): FIXME*)
-     H H0) as [b [q [[H1 H2] H3]]].
- destruct (H3 O initial_oracle) as [jmx [H4x [H5x [H6x [H7x _]]]]].
- destruct (H2 jmx H4x) as [jmx' [H8x H8y]].
- exists b, q, (m_dry jmx').
- split3; auto.
- rewrite H4x in H8y. auto.
- subst. simpl. clear H5x H6x H7x H8y.
- forget (m_dry jmx) as m. clear jmx.
- intro n.
- specialize (H3 n initial_oracle).
- destruct H3 as [jm [? [? [? [? _]]]]].
- unfold semax.jsafeN in H6.
- subst m.
- assert (joins (compcert_rmaps.RML.R.ghost_of (m_phi jm))
-   (Some (ghost_PCM.ext_ref initial_oracle, compcert_rmaps.RML.R.NoneP) :: nil)) as J.
- { destruct (compcert_rmaps.RML.R.ghost_of (m_phi jm)); inv H5.
-   eexists; constructor; constructor.
-   instantiate (1 := (_, _)); constructor; simpl; constructor; auto.
-   instantiate (1 := (Some _, _)); repeat constructor; simpl; auto. }
- clear - JDE DME H4 J H6.
-  rewrite <- H4 in H6|-*.
- assert (level jm <= n)%nat by omega.
- clear H4; rename H into H4.
- forget initial_oracle as ora.
- revert ora jm q H4 J H6; induction n; simpl; intros.
- assert (level (m_phi jm) = 0%nat) by omega. rewrite H; constructor.
- inv H6.
- - constructor.
- -
-   rewrite <- level_juice_level_phi in H4.
-   destruct H0 as (?&?&?&Hg).
-   eapply safeN_step.
-   + red. red. fold (globalenv prog). eassumption.
-   + destruct (H1 (Some (ghost_PCM.ext_ref ora, compcert_rmaps.RML.R.NoneP) :: nil)) as (m'' & J'' & (? & ? & ?) & ?); auto.
-     { eexists; apply join_comm, core_unit. }
-     { rewrite Hg.
-       destruct J; eexists; apply compcert_rmaps.RML.ghost_fmap_join; eauto. }
-     replace (m_dry m') with (m_dry m'') by auto.
-     change (level (m_phi jm)) with (level jm) in *.
-     replace n0 with (level m'') by omega.
-     apply IHn; auto. omega.
-     replace (level m'') with n0 by omega. auto.
- -
-(*
-   assert (JDE1': ext_spec_type dryspec = ext_spec_type OK_spec)
-      by apply JDE.
-*)
-(*   destruct JDE as [JDE1 [JDE2 [JDE3 JDE4]]]. *)
-   destruct dryspec as [ty pre post exit]. simpl in *. (* subst ty. *)
-   destruct JE_spec as [ty' pre' post' exit']. simpl in *.
-   change (level (m_phi jm)) with (level jm) in *.
-   destruct JDE as [JDE1 [JDE2 JDE3]].
-   specialize (JDE1 e x (dessicate e jm x)); simpl in JDE1.
-   eapply safeN_external.
-     eassumption.
-     apply JDE1. reflexivity. assumption.
-     simpl. intros.
-     assert (H20: exists jm', m_dry jm' = m' 
-                      /\ (level jm' = n')%nat
-                      /\ juicy_safety.pures_eq (m_phi jm) (m_phi jm')
-                      /\ resource_at (m_phi jm') = resource_fmap (approx (level jm')) (approx (level jm')) oo juicy_mem_lemmas.rebuild_juicy_mem_fmap jm (m_dry jm')
-                      /\ compcert_rmaps.RML.R.ghost_of (m_phi jm') = Some (ghost_PCM.ext_ghost z', compcert_rmaps.RML.R.NoneP) :: ghost_fmap (approx (level jm')) (approx (level jm')) (tl (ghost_of (m_phi jm)))). {
-     destruct (juicy_mem_lemmas.rebuild_juicy_mem_rmap jm m') 
-            as [phi [? [? ?]]].
-     assert (own.ghost_approx phi (Some (ghost_PCM.ext_ghost z', NoneP) :: tl (compcert_rmaps.RML.R.ghost_of phi)) =
-        Some (ghost_PCM.ext_ghost z', NoneP) :: tl (compcert_rmaps.RML.R.ghost_of phi)) as Happrox.
-     { simpl; f_equal.
-        rewrite <- compcert_rmaps.RML.ghost_of_approx at 2.
-        destruct (compcert_rmaps.RML.R.ghost_of phi); auto. }
-     set (phi1 := initial_world.set_ghost _ _ Happrox).
-     assert (level phi1 = level phi /\ resource_at phi1 = resource_at phi) as [Hl1 Hr1].
-     { subst phi1; unfold initial_world.set_ghost; rewrite level_make_rmap, resource_at_make_rmap; auto. }
-     pose (phi' := age_to.age_to n' phi1).
-     assert (mem_rmap_cohere m' phi'). {
-       clear - H1 Hr1 Hl1 H8 H7 H6 H3 DME JDE1.
-       apply JDE1 in H1; [ | reflexivity].
-       specialize (DME e _ _ _ _ _ _ _ _ _ _ H1 H6).
-     subst phi'.
-     apply age_to_cohere.
-     subst phi1.
-     apply set_ghost_cohere.
-     eapply mem_evolve_cohere; eauto.
-   }
-    destruct H10 as [H10 [H11 [H12 H13]]].
-     pose (jm' := mkJuicyMem _ _ H10 H11 H12 H13).
-     exists jm'.
-     split; [ | split3].
-     subst jm'; simpl; auto.
-     subst jm' phi'; simpl. apply age_to.level_age_to. omega.
-     hnf. split. intro loc. subst jm' phi'. simpl.
-     rewrite age_to_resource_at.age_to_resource_at.
-     rewrite Hr1, H8. unfold juicy_mem_lemmas.rebuild_juicy_mem_fmap.
-     destruct (m_phi jm @ loc); auto. rewrite age_to.level_age_to by omega.
-      reflexivity.
-     intro loc. subst jm' phi'. simpl.
-     rewrite age_to_resource_at.age_to_resource_at.
-     rewrite Hr1, H8. unfold juicy_mem_lemmas.rebuild_juicy_mem_fmap; simpl.
-     destruct (m_phi jm @ loc); auto.
-     if_tac; simpl; auto. destruct k; simpl; auto. if_tac; simpl; eauto. simpl; eauto.
-     subst jm' phi'. simpl m_phi.
-     rewrite age_to_resource_at.age_to_ghost_of.
-     subst phi1.
-     split.
-     extensionality; unfold compose; simpl.
-     rewrite age_to_resource_at.age_to_resource_at, age_to.level_age_to by omega.
-     unfold initial_world.set_ghost; rewrite resource_at_make_rmap.
-     rewrite H8; auto.
-     unfold initial_world.set_ghost; rewrite ghost_of_make_rmap; simpl.
-     rewrite age_to.level_age_to, H9 by (rewrite level_make_rmap; omega); simpl; auto.
-   }
-   destruct H20 as [jm'  [H26 [H27 [H28 [H29 Hg']]]]].
-   specialize (H2 ret jm' z' n' Hargsty Hretty).
-   spec H2. omega.
-    spec H2. hnf; split3; auto. omega.
-  spec H2.
-  eapply JDE2; eauto 6. omega. subst m'. apply H6.
-  destruct H2 as [c' [H2a H2b]]; exists c'; split; auto.
-  hnf in H2b.
-  specialize (H2b (Some (ghost_PCM.ext_ref z', compcert_rmaps.RML.R.NoneP) :: nil)).
-  spec H2b. apply join_sub_refl.
-  spec H2b.
-  { rewrite Hg'.
-    eexists (Some (ghost_PCM.ext_both z', compcert_rmaps.RML.R.NoneP) :: _);
-      repeat constructor.  }
-  destruct H2b as [jm'' [? [? ?]]].
-  destruct H7 as [? [? ?]].
-  subst m'. rewrite <- H7.
-  specialize (IHn  z' jm'' c').
-  subst n'. rewrite <- H9.
-  change (level (m_phi jm'')) with (level  jm'') in IHn.
-  apply IHn. omega.
-  auto.
-  rewrite H9; auto.
- - eapply safeN_halted; eauto.
-    apply JDE. auto.
- Unshelve. simpl. split; [apply Share.nontrivial | hnf]. exists None; constructor.
-all: fail.
-Qed.
-
-(* In this version, the program starts with knowledge of the external state. *)
 Lemma whole_program_sequential_safety_ext:
    forall {CS: compspecs} {Espec: OracleKind} (initial_oracle: OK_ty) 
+   (EXIT: forall (v : val) (ora : OK_ty) (jm : juicy_mem),
+       ext_spec_exit OK_spec (Some v) ora jm)
      (dryspec: ext_spec OK_ty)
      (dessicate : forall (ef : external_function) jm,
                ext_spec_type OK_spec ef ->
@@ -568,9 +403,8 @@ Lemma whole_program_sequential_safety_ext:
        initial_core  (cl_core_sem (globalenv prog))
            0 m q m' (Vptr b Ptrofs.zero) nil /\
        forall n,
-        @dry_safeN _ _ _ OK_ty (genv_symb_injective)
-            (coresem_extract_cenv  (cl_core_sem (globalenv prog))
-                (prog_comp_env prog)) 
+        @dry_safeN _ _ _ OK_ty (semax.genv_symb_injective)
+            (cl_core_sem (globalenv prog))
             (*(dryspec  OK_ty)*) dryspec
             (Build_genv (Genv.globalenv prog) (prog_comp_env prog)) 
              n initial_oracle q m'.
@@ -578,7 +412,7 @@ Proof.
  intros.
  destruct (@semax_prog_rule_ext (*NullExtension.*)Espec CS _ _ _ _ 
      0 (*additional temporary argument - TODO (Santiago): FIXME*)
-     initial_oracle H H0) as [b [q [[H1 H2] H3]]].
+     initial_oracle EXIT H H0) as [b [q [[H1 H2] H3]]].
  destruct (H3 O) as [jmx [H4x [H5x [H6x [H7x _]]]]].
  destruct (H2 jmx H4x) as [jmx' [H8x H8y]].
  exists b, q, (m_dry jmx').
@@ -737,12 +571,12 @@ Lemma module_sequential_safety : (*TODO*)
      Genv.find_symbol ge f_id = Some f_b ->
      Genv.find_funct  ge (Vptr f_b Ptrofs.zero) = Some f_body ->
      forall x : ext_spec_type (@OK_spec spec) f,
-     ext_spec_pre (@OK_spec spec) f x (genv_symb_injective ge) tys args ora m ->
+     ext_spec_pre (@OK_spec spec) f x (semax.genv_symb_injective ge) tys args ora m ->
      exists q,
        initial_core sem 
          0 (*additional temporary argument - TODO (Santiago): FIXME*)
              m q m
               (Vptr f_b Ptrofs.zero) args /\
-       forall n, safeN_(genv_symb := @genv_symb_injective _ _)(Hrel := juicy_extspec.Hrel) (coresem_extract_cenv sem (prog_comp_env prog))
-(upd_exit (@OK_spec spec) x (genv_symb_injective ge)) ge n ora q m.
+       forall n, safeN_(genv_symb := @semax.genv_symb_injective _ _)(Hrel := juicy_extspec.Hrel) sem
+(upd_exit (@OK_spec spec) x (semax.genv_symb_injective ge)) ge n ora q m.
 Abort.

--- a/veric/SequentialClight2.v
+++ b/veric/SequentialClight2.v
@@ -1,7 +1,7 @@
 Require Import VST.sepcomp.semantics.
 
 Require Import VST.veric.Clight_base.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.veric.Clight_lemmas.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.sepcomp.event_semantics.
@@ -9,7 +9,7 @@ Require Import VST.veric.SeparationLogic.
 Require Import VST.veric.juicy_extspec.
 Require Import VST.veric.juicy_mem.
 Require VST.veric.NullExtension.
-Require Import VST.veric.Clight_sim.
+(*Require Import VST.veric.Clight_sim.*)
 Require Import VST.veric.SeparationLogicSoundness.
 Require Import VST.sepcomp.extspec.
 Require Import VST.msl.msl_standard.

--- a/veric/initialize.v
+++ b/veric/initialize.v
@@ -5,7 +5,7 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.veric.tycontext.
 Require Import VST.veric.expr2.
 Require Import VST.veric.expr_lemmas.

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -90,6 +90,8 @@ Definition assert_safe'_
        match ctl with
        | Cont (Kseq s ctl') => 
              jsafeN (@OK_spec Espec) ge (level w) ora (State f s ctl' ve te) jm
+       | Cont (Kloop1 body incr ctl') =>
+             jsafeN (@OK_spec Espec) ge (level w) ora (State f Sskip (Kloop1 body incr ctl') ve te) jm
        | Cont _ => False
        | Ret None ctl' =>
                 jsafeN (@OK_spec Espec) ge (level w) ora (State f (Sreturn None) ctl' ve te) jm
@@ -118,6 +120,7 @@ Next Obligation.
   change (level (m_phi jm)) with (level jm).
   change (level (m_phi jm0)) with (level jm0) in *.
   destruct ctl. destruct c; try contradiction.
+  eapply age_safe; eauto.
   eapply age_safe; eauto.
   destruct o; intros.
   eapply age_safe; eauto. apply (H0 e v'); auto.

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -131,9 +131,6 @@ Definition guard (Espec : OracleKind)
     (gx: genv) (Delta: tycontext) f (P : assert)  (ctl: cont) : pred nat :=
   _guard Espec gx Delta f P ctl.
 
-Definition zap_fn_return (f: function) : function :=
- mkfunction Tvoid f.(fn_callconv) f.(fn_params) f.(fn_vars) f.(fn_temps) f.(fn_body).
-
 Fixpoint break_cont (k: cont) :=
 match k with
 | Kseq _ k' => break_cont k'
@@ -159,7 +156,7 @@ Definition exit_cont (ek: exitkind) (vl: option val) (k: cont) : cont :=
   | EK_return =>
          match vl, call_cont k with
          | Some v, Kcall (Some x) f ve te k' =>
-                    Kseq (Sreturn None) (Kcall None (zap_fn_return f) ve (PTree.set x v te) k')
+                    Kseq (Sreturn None) (Kcall None f ve (PTree.set x v te) k')
          | _,_ => Kseq (Sreturn None) (call_cont k)
          end
    end.

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -92,6 +92,8 @@ Definition assert_safe'_
              jsafeN (@OK_spec Espec) ge (level w) ora (State f s ctl' ve te) jm
        | Cont (Kloop1 body incr ctl') =>
              jsafeN (@OK_spec Espec) ge (level w) ora (State f Sskip (Kloop1 body incr ctl') ve te) jm
+       | Cont (Kloop2 body incr ctl') =>
+             jsafeN (@OK_spec Espec) ge (level w) ora (State f (Sloop body incr) ctl' ve te) jm
        | Cont _ => False
        | Ret None ctl' =>
                 jsafeN (@OK_spec Espec) ge (level w) ora (State f (Sreturn None) ctl' ve te) jm
@@ -120,6 +122,7 @@ Next Obligation.
   change (level (m_phi jm)) with (level jm).
   change (level (m_phi jm0)) with (level jm0) in *.
   destruct ctl. destruct c; try contradiction.
+  eapply age_safe; eauto.
   eapply age_safe; eauto.
   eapply age_safe; eauto.
   destruct o; intros.
@@ -171,7 +174,7 @@ match k with
 | Kseq _ k' => continue_cont k'
 | Kloop1 s1 s2 k' => Kseq s2 (Kloop2 s1 s2 k')
 | Kswitch k' => continue_cont k'
-| _ => k (* oops! *)
+| _ => Kstop (* oops! *)
 end.
 
 Definition exit_cont (ek: exitkind) (vl: option val) (k: cont) : contx :=

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -4,7 +4,7 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.veric.Clight_lemmas.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
@@ -15,7 +15,7 @@ Require Import VST.veric.expr2.
 Require Import VST.veric.expr_lemmas.
 Require Import VST.veric.own.
 
-Import Ctypes Clight_new.
+Import Ctypes Clight_core.
 
 Local Open Scope nat_scope.
 Local Open Scope pred.
@@ -75,24 +75,31 @@ Qed.
 
 Program Definition assert_safe
      (Espec : OracleKind)
-     (ge: genv) ve te (ctl: cont) : assert :=
-  fun rho => bupd (fun w => forall ora (jm:juicy_mem),
+     (ge: genv) f ve te (ctl: cont) : assert :=
+  fun rho =>
+       bupd (fun w => 
+       forall ora (jm:juicy_mem),
        ext_compat ora w ->
        rho = construct_rho (filter_genv ge) ve te ->
        m_phi jm = w ->
-             jsafeN (@OK_spec Espec) ge (level w) ora (State ve te ctl) jm).
+       forall (LW: level w > O),
+       exists s ctl', ctl = Kseq s ctl' /\
+             jsafeN (@OK_spec Espec) ge (level w) ora (State f s ctl' ve te) jm).
  Next Obligation.
   intro; intros.
-  subst.
+   subst.
    destruct (oracle_unage _ _ H) as [jm0 [? ?]].
    subst.
    specialize (H0 ora jm0); spec H0.
    { erewrite age1_ghost_of in H1 by eauto.
       eapply ext_join_unapprox; eauto. }
    specialize (H0 (eq_refl _) (eq_refl _)).
-   forget (State ve te ctl) as c. clear H ve te ctl.
+   spec H0. apply age_level in H. omega.
+   destruct H0 as [s [ctl' [? ?]]]. subst ctl. exists s, ctl'.
+   split; auto; intros.
+   forget (State f s ctl' ve te) as c. clear ve te s ctl'.
   change (level (m_phi jm)) with (level jm).
-  change (level (m_phi jm0)) with (level jm0) in H0.
+  change (level (m_phi jm0)) with (level jm0) in *.
   eapply age_safe; eauto.
 Qed.
 
@@ -102,13 +109,10 @@ Definition list2opt {T: Type} (vl: list T) : option T :=
 Definition match_venv (ve: venviron) (vars: list (ident * type)) :=
  forall id, match ve id with Some (b,t) => In (id,t) vars | _ => True end.
 
-Definition guard_environ (Delta: tycontext) (f: option function) (rho: environ) : Prop :=
+Definition guard_environ (Delta: tycontext) (f: function) (rho: environ) : Prop :=
    typecheck_environ Delta rho /\
-  match f with
-  | Some f' => match_venv (ve_of rho) (fn_vars f')
-                /\ ret_type Delta = fn_return f'
-  | None => True
-  end.
+    match_venv (ve_of rho) (fn_vars f)
+   /\ ret_type Delta = fn_return f.
 
 Lemma guard_environ_e1:
    forall Delta f rho, guard_environ Delta f rho ->
@@ -116,19 +120,36 @@ Lemma guard_environ_e1:
 Proof. intros. destruct H; auto. Qed.
 
 Definition _guard (Espec : OracleKind)
-    (gx: genv) (Delta: tycontext) (P : assert) (f: option function) (ctl: cont) : pred nat :=
+    (gx: genv) (Delta: tycontext) (f: function) (P : assert) (ctl: cont) : pred nat :=
      ALL tx : Clight.temp_env, ALL vx : env,
           let rho := construct_rho (filter_genv gx) vx tx in
           !! guard_environ Delta f rho
                   && P rho && funassert Delta rho
-             >=> assert_safe Espec gx vx tx ctl rho.
+             >=> assert_safe Espec gx f vx tx ctl rho.
 
 Definition guard (Espec : OracleKind)
-    (gx: genv) (Delta: tycontext) (P : assert)  (ctl: cont) : pred nat :=
-  _guard Espec gx Delta P (current_function ctl) ctl.
+    (gx: genv) (Delta: tycontext) f (P : assert)  (ctl: cont) : pred nat :=
+  _guard Espec gx Delta f P ctl.
 
 Definition zap_fn_return (f: function) : function :=
  mkfunction Tvoid f.(fn_callconv) f.(fn_params) f.(fn_vars) f.(fn_temps) f.(fn_body).
+
+Fixpoint break_cont (k: cont) :=
+match k with
+| Kseq _ k' => break_cont k'
+| Kloop1 _ _ k' => k'
+| Kloop2 _ _ k' => k'
+| Kswitch k' => k'
+| _ => k (* oops! *)
+end.
+
+Fixpoint continue_cont (k: cont) :=
+match k with
+| Kseq _ k' => continue_cont k'
+| Kloop1 s1 s2 k' => Kseq s2 (Kloop2 s1 s2 k')
+| Kswitch k' => continue_cont k'
+| _ => k (* oops! *)
+end.
 
 Definition exit_cont (ek: exitkind) (vl: option val) (k: cont) : cont :=
   match ek with
@@ -137,16 +158,16 @@ Definition exit_cont (ek: exitkind) (vl: option val) (k: cont) : cont :=
   | EK_continue => continue_cont k
   | EK_return =>
          match vl, call_cont k with
-         | Some v, Kcall (Some x) f ve te :: k' =>
-                    Kseq (Sreturn None) :: Kcall None (zap_fn_return f) ve (PTree.set x v te) :: k'
-         | _,_ => Kseq (Sreturn None) :: call_cont k
+         | Some v, Kcall (Some x) f ve te k' =>
+                    Kseq (Sreturn None) (Kcall None (zap_fn_return f) ve (PTree.set x v te) k')
+         | _,_ => Kseq (Sreturn None) (call_cont k)
          end
    end.
 
 Definition rguard (Espec : OracleKind)
-    (gx: genv) (Delta: tycontext)  (R : ret_assert) (ctl: cont) : pred nat :=
+    (gx: genv) (Delta: tycontext) (f: function) (R : ret_assert) (ctl: cont) : pred nat :=
   ALL ek: exitkind, ALL vl: option val,
-    _guard Espec gx Delta (proj_ret_assert R ek vl) (current_function ctl) (exit_cont ek vl ctl).
+    _guard Espec gx Delta f (proj_ret_assert R ek vl)  (exit_cont ek vl ctl).
 
 Record semaxArg :Type := SemaxArg {
  sa_cs: compspecs;
@@ -278,7 +299,7 @@ Definition believe_internal_ CS
                          (fun rho => (bind_args (fst fsig) (f.(fn_params)) (P ts x) rho 
                                               * stackframe_of' (@cenv_cs CS') f rho)
                                         && funassert (func_tycontext' f Delta') rho)
-                          (Ssequence f.(fn_body) (Sreturn None))
+                          (f.(fn_body))
            (frame_ret_assert (function_body_ret_assert (fn_return f) (Q ts x)) 
               (stackframe_of' (@cenv_cs CS') f)))) )).
 
@@ -306,10 +327,10 @@ Definition semax_ (Espec: OracleKind)
             /\ cenv_sub (@cenv_cs CS) (@cenv_cs CS') 
             /\ cenv_sub (@cenv_cs CS') (genv_cenv gx)) -->
       (believepred CS' Espec semax Delta' gx Delta') -->
-     ALL k: cont, ALL F: assert,
+     ALL k: cont, ALL F: assert, ALL f:function,
        (!! (closed_wrt_modvars c F) &&
-              rguard Espec gx Delta' (frame_ret_assert R F) k) -->
-        guard Espec gx Delta' (fun rho => F rho * P rho) (Kseq c :: k)
+              rguard Espec gx Delta' f (frame_ret_assert R F) k) -->
+        guard Espec gx Delta' f (fun rho => F rho * P rho) (Kseq c k)
   end.
 
 Definition semax'  {CS: compspecs} (Espec: OracleKind) Delta P c R : pred nat :=
@@ -338,7 +359,7 @@ Definition believe_internal {CS: compspecs} (Espec:  OracleKind)
      |> @semax' CS' Espec (func_tycontext' f Delta')
                                 (fun rho => (bind_args (fst fsig) (f.(fn_params)) (P ts x) rho * stackframe_of' (@cenv_cs CS') f rho)
                                              && funassert (func_tycontext' f Delta') rho)
-                               (Ssequence f.(fn_body) (Sreturn None))
+                               (f.(fn_body))
            (frame_ret_assert (function_body_ret_assert (fn_return f) (Q ts x)) (stackframe_of' (@cenv_cs CS') f))))).
 
 Definition believe {CS: compspecs} (Espec:OracleKind)
@@ -358,9 +379,9 @@ Lemma semax_fold_unfold : forall {CS: compspecs} (Espec : OracleKind),
            /\ cenv_sub (@cenv_cs CS) (@cenv_cs CS')
            /\ cenv_sub (@cenv_cs CS') (genv_cenv gx)) -->
        @believe CS' Espec Delta' gx Delta' -->
-     ALL k: cont, ALL F: assert,
-        (!! (closed_wrt_modvars c F) && rguard Espec gx Delta' (frame_ret_assert R F) k) -->
-        guard Espec gx Delta' (fun rho => F rho * P rho) (Kseq c :: k).
+     ALL k: cont, ALL F: assert, ALL f: function,
+        (!! (closed_wrt_modvars c F) && rguard Espec gx Delta' f (frame_ret_assert R F) k) -->
+        guard Espec gx Delta' f (fun rho => F rho * P rho) (Kseq c k).
 Proof.
 intros ? ?.
 extensionality G P. extensionality c R.
@@ -412,12 +433,12 @@ Definition weakest_pre {CS: compspecs} (Espec: OracleKind) (Delta: tycontext) c 
   ALL gx: genv, ALL Delta': tycontext,
        !! (tycontext_sub Delta Delta' /\ genv_cenv gx = cenv_cs) -->
        unfash (believe Espec Delta' gx Delta') -->
-     ALL k: cont, ALL F: assert,
-        unfash (!! (closed_wrt_modvars c F) && rguard Espec gx Delta' (frame_ret_assert Q F) k) -->
+     ALL k: cont, ALL F: assert, ALL f: function, 
+        unfash (!! (closed_wrt_modvars c F) && rguard Espec gx Delta' f (frame_ret_assert Q F) k) -->
         ALL tx : Clight.temp_env, ALL vx : env,
           (!! (rho = construct_rho (filter_genv gx) vx tx)) -->
-          ((!! guard_environ Delta' (current_function (Kseq c :: k)) rho && funassert Delta' rho) -->
-             (F rho -* assert_safe Espec gx vx tx (Kseq c :: k) rho)).
+          ((!! guard_environ Delta' f rho && funassert Delta' rho) -->
+             (F rho -* assert_safe Espec gx f vx tx (Kseq c k) rho)).
 
 Opaque semax'.
 
@@ -657,7 +678,7 @@ Qed.
 Section believe_monotonicity.
 Context {CS: compspecs} {Espec: OracleKind}.
 
-Lemma guard_mono gx Delta Gamma (P Q:assert) ctl
+Lemma guard_mono gx Delta Gamma f (P Q:assert) ctl
   (GD1: forall e te, typecheck_environ Gamma (construct_rho (filter_genv gx) e te) ->
                      typecheck_environ Delta (construct_rho (filter_genv gx) e te))
   (GD2: ret_type Delta = ret_type Gamma)
@@ -665,8 +686,8 @@ Lemma guard_mono gx Delta Gamma (P Q:assert) ctl
                         P (construct_rho (filter_genv gx) e te))
   (GD4: forall e te, (funassert Gamma (construct_rho (filter_genv gx) e te)) |--
                      (funassert Delta (construct_rho (filter_genv gx) e te))):
-  @guard Espec gx Delta P ctl |--
-  @guard Espec gx Gamma Q ctl.
+  @guard Espec gx Delta f P ctl |--
+  @guard Espec gx Gamma f Q ctl.
 Proof. intros n G te e r R a' A' [[[X1 X2] X3] X4].
   apply (G te e r R a' A').
   split; [split; [split;[auto | rewrite GD2; trivial] | apply GD3; trivial] | apply GD4; trivial].

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -215,13 +215,6 @@ Program Definition ext_spec_post' (Espec: OracleKind)
 Definition juicy_mem_pred (P : pred rmap) (jm: juicy_mem): pred nat :=
      # diamond fashionM (exactly (m_phi jm) && P).
 
-Fixpoint make_ext_args (gx: genviron) (ids: list ident) (vl: list val)  :=
-  match ids, vl with
-  | id::ids', v::vl' => env_set (make_ext_args gx ids' vl') id v
-  | _, v::vl' => env_set (make_ext_args gx ids vl') 1%positive v
-  | _, _ => mkEnviron gx (Map.empty _) (Map.empty _)
- end.
-
 Definition make_ext_rval  (gx: genviron) (v: option val):=
   match v with
   | Some v' =>  mkEnviron gx (Map.empty _)
@@ -239,7 +232,7 @@ Definition semax_external
    |>  ALL F: pred rmap, ALL ts: list typ,
    ALL args: list val,
    !!Val.has_type_list args (sig_args (ef_sig ef)) &&
-   juicy_mem_op (P Ts x (make_ext_args (filter_genv gx) ids args) * F) >=>
+   juicy_mem_op (P Ts x (make_args ids args (tycontext.empty_environ gx)) * F) >=>
    EX x': ext_spec_type OK_spec ef,
     (ALL z:_, juicy_mem_op (ext_compat z) -->
      ext_spec_pre' Hspec ef x' (genv_symb_injective gx) ts args z) &&

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -593,9 +593,7 @@ Lemma semax_call_typecheck_environ:
         func_at b0 (b1,0) a')
    (TC8 : tc_vals (snd (split (fn_params f))) args)
    (H21 : bind_parameter_temps (fn_params f) args
-              (create_undef_temps (fn_temps f)) = Some te')
-   (TE : typecheck_environ
-        Delta (mkEnviron (filter_genv psi) (make_venv vx) (make_tenv tx))),
+              (create_undef_temps (fn_temps f)) = Some te'),
    typecheck_environ
     (mk_tycontext
       (make_tycontext_t (fn_params f) (fn_temps f))
@@ -603,7 +601,7 @@ Lemma semax_call_typecheck_environ:
       (fn_return f)  (glob_types Delta) (glob_specs Delta) (annotations Delta))
      (mkEnviron (filter_genv psi) (make_venv ve') (make_tenv te')).
 Proof. assert (H1:= True).
- intros. 
+ intros.
  pose (rho3 := mkEnviron (filter_genv psi) (make_venv ve') (make_tenv te')).
 
 unfold typecheck_environ. repeat rewrite andb_true_iff.
@@ -613,7 +611,7 @@ clear H H1 H15.
 unfold typecheck_temp_environ in *. intros. simpl.
 unfold temp_types in *. simpl in *.
 apply func_tycontext_t_sound in H; auto.
- clear - H21 H TC8 TC3 H17 TE.
+ clear - H21 H TC8 TC3 H17.
 
 destruct H. (*in params*)
 forget (create_undef_temps (fn_temps f)) as temps.
@@ -1373,7 +1371,7 @@ spec H15; [ clear; omega | ].
 specialize (H15 _ (necR_refl _)).
 spec H15. { clear H15.
 assert (app_pred ((P ts x
-      (make_ext_args (filter_genv psi) (map fst params) args) *
+      (make_args (map fst params) args (tycontext.empty_environ psi)) *
     (F0 (construct_rho (filter_genv psi) vx tx) *
      F (construct_rho (filter_genv psi) vx tx)))) (m_phi jm)). {
 rewrite sepcon_comm.
@@ -2811,7 +2809,6 @@ spec H19; [clear H19|]. {
   unfold rho3 in *. simpl in *. destruct H23.
   destruct rho. inv H0. simpl in *.
   remember (split (fn_params f)). destruct p.
-  assert (TE := proj1 TC3). 
   simpl in *. if_tac in H16; try congruence.
   destruct TC3 as [TC3 TC3'].
   destruct TC3 as [TC3 [TC4 TC5]].

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -2737,11 +2737,12 @@ clear a bl TC0.
 clear Q HR H11; rename HR' into HR; rename Q' into Q; assert (H11 := I).
 rename NEQ' into NEQ.
 
+(*** cut here *****)
 
-(*************************************************)
 assert (Prog_OK' := Prog_OK).
-specialize (Prog_OK' (Vptr b Ptrofs.zero) (params,retty) cc A P Q _ (necR_refl _)). 
-(*************************************************)
+specialize (Prog_OK' (Vptr b Ptrofs.zero)
+    (params,retty) cc A P Q _ (necR_refl _)). 
+
 spec Prog_OK'.
 { hnf. exists id, NEP, NEQ; split; auto.
   exists b; split; auto.
@@ -2771,11 +2772,11 @@ rewrite H16 in H3b. injection H3b; clear H3b; intros; subst ff.
 destruct H3 as [COMPLETE [H17 [H17' [Hvars [H18 H18']]]]].
 pose proof I.
 
-assert (HDelta: forall f : function, tycontext_sub (func_tycontext' f Delta) (func_tycontext' f Delta))
-   by (intro; apply tycontext_sub_refl).
-specialize (H19 Delta CS (level (m_phi jm)) (necR_refl _) HDelta _ (necR_refl _) (cenv_sub_refl) ts x).
+specialize (H19 Delta CS _ (necR_refl _)).
+spec H19. { intro; apply tycontext_sub_refl. }
+specialize (H19 _ (necR_refl _) (cenv_sub_refl) ts x).
 red in H19.
-clear HDelta.
+
 change (level (m_phi jm)) with (level jm) in *.
 clear H2. destruct (level jm) eqn:H2; [constructor |].
 destruct (levelS_age1 _ _ H2) as [jm2 H13]. change (age jm jm2) in H13.

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -1870,6 +1870,12 @@ spec Hsafe. {
   eapply jsafeN_local_step. constructor.
   intros.
   eapply age_safe; eauto.
+  eapply jsafeN_local_step. constructor.
+  intros.
+  eapply age_safe; eauto.
+  eapply jsafeN_local_step. constructor.
+  intros.
+  eapply age_safe; eauto.
 Qed.
 
 Lemma alloc_juicy_variables_age:

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -1867,6 +1867,9 @@ spec Hsafe. {
   eapply jsafeN_local_step. constructor.
   intros.
   eapply age_safe; eauto.
+  eapply jsafeN_local_step. constructor.
+  intros.
+  eapply age_safe; eauto.
 Qed.
 
 Lemma alloc_juicy_variables_age:

--- a/veric/semax_conj_disj.v
+++ b/veric/semax_conj_disj.v
@@ -4,7 +4,7 @@ Require Import VST.VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.tycontext.

--- a/veric/semax_conseq.v
+++ b/veric/semax_conseq.v
@@ -263,7 +263,7 @@ Proof.
       split; auto.
       split; auto.
       simpl.
-      intros. omega.
+      hnf; intros. omega.
     - apply H.
       destruct H2 as [[? ?] ?].
       split; [split |]; auto.
@@ -339,8 +339,7 @@ Proof.
       split; auto.
       split; auto.
       simpl.
-      intros.
-      hnf. omega.
+      hnf; intros. omega.
     - apply H.
       destruct H2 as [[? ?] ?].
       split; [split |]; auto.

--- a/veric/semax_conseq.v
+++ b/veric/semax_conseq.v
@@ -4,7 +4,7 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.tycontext.
@@ -24,9 +24,9 @@ Local Open Scope pred.
 
 (* Part 1: Proof of semax_conseq *)
 
-Lemma _guard_mono: forall Espec ge Delta (P Q: assert) f k,
+Lemma _guard_mono: forall Espec ge Delta f (P Q: assert) k,
   (forall rho, P rho |-- Q rho) ->
-  _guard Espec ge Delta Q f k |-- _guard Espec ge Delta P f k.
+  _guard Espec ge Delta f Q k |-- _guard Espec ge Delta f P k.
 Proof.
   intros.
   unfold _guard.
@@ -36,18 +36,18 @@ Proof.
   apply imp_derives; auto.
 Qed.
 
-Lemma guard_mono: forall Espec ge Delta (P Q: assert) k,
+Lemma guard_mono: forall Espec ge Delta f (P Q: assert) k,
   (forall rho, P rho |-- Q rho) ->
-  guard Espec ge Delta Q k |-- guard Espec ge Delta P k.
+  guard Espec ge Delta f Q k |-- guard Espec ge Delta f P k.
 Proof.
   intros.
   unfold guard.
   apply _guard_mono; auto.
 Qed.
 
-Lemma rguard_mono: forall Espec ge Delta (P Q: ret_assert) k,
+Lemma rguard_mono: forall Espec ge Delta f (P Q: ret_assert) k,
   (forall rk vl rho, proj_ret_assert P rk vl rho |-- proj_ret_assert Q rk vl rho) ->
-  rguard Espec ge Delta Q k |-- rguard Espec ge Delta P k.
+  rguard Espec ge Delta f Q k |-- rguard Espec ge Delta f P k.
 Proof.
   intros.
   unfold rguard.
@@ -79,9 +79,9 @@ Lemma assert_safe_bupd':
     let PP1 := !! guard_environ Delta f rho in
     let PP2 := funassert Delta rho in
     PP1 && (P rho) && PP2 >=>
-    assert_safe Espec gx vx tx k rho =
+    assert_safe Espec gx f vx tx k rho =
     PP1 && (bupd (P rho)) && PP2 >=>
-    assert_safe Espec gx vx tx k rho.
+    assert_safe Espec gx f vx tx k rho.
 Proof.
   intros.
   apply pred_ext.
@@ -96,7 +96,7 @@ Proof.
     destruct H3 as [b [? [m' [? [? [? ?]]]]]].
     exists b; split; auto.
     exists m'; split; [| split; [| split]]; auto.
-    change (assert_safe Espec gx vx tx k rho m').
+    change (assert_safe Espec gx f vx tx k rho m').
     specialize (H m' ltac: (apply necR_level in H1; omega)).
     specialize (H m' ltac: (apply necR_refl)).
     apply H.
@@ -117,7 +117,7 @@ Qed.
 
 Lemma _guard_bupd':
   forall {Espec: OracleKind} ge Delta (P: environ -> pred rmap) f k,
-    _guard Espec ge Delta P f k = _guard Espec ge Delta (fun rho => bupd (P rho)) f k.
+    _guard Espec ge Delta f P k = _guard Espec ge Delta f (fun rho => bupd (P rho)) k.
 Proof.
   intros.
   unfold _guard.
@@ -127,16 +127,16 @@ Proof.
 Qed.
   
 Lemma guard_bupd':
-  forall {Espec: OracleKind} ge Delta (P: environ -> pred rmap) k,
-    guard Espec ge Delta P k = guard Espec ge Delta (fun rho => bupd (P rho)) k.
+  forall {Espec: OracleKind} ge Delta f (P: environ -> pred rmap) k,
+    guard Espec ge Delta f P k = guard Espec ge Delta f (fun rho => bupd (P rho)) k.
 Proof.
   intros.
   apply _guard_bupd'.
 Qed.
 
 Lemma rguard_bupd':
-  forall {Espec: OracleKind} ge Delta (P: ret_assert) k,
-    rguard Espec ge Delta P k = rguard Espec ge Delta (bupd_ret_assert P) k.
+  forall {Espec: OracleKind} ge Delta f (P: ret_assert) k,
+    rguard Espec ge Delta f P k = rguard Espec ge Delta f (bupd_ret_assert P) k.
 Proof.
   intros.
   unfold rguard.
@@ -151,9 +151,9 @@ Lemma assert_safe_bupd:
     let PP1 := !! guard_environ Delta f rho in
     let PP2 := funassert Delta rho in
     PP1 && (F rho * P rho) && PP2 >=>
-    assert_safe Espec gx vx tx k rho =
+    assert_safe Espec gx f vx tx k rho =
     PP1 && (F rho * bupd (P rho)) && PP2 >=>
-    assert_safe Espec gx vx tx k rho.
+    assert_safe Espec gx f vx tx k rho.
 Proof.
   intros.
   apply pred_ext.
@@ -169,7 +169,7 @@ Proof.
     destruct H3 as [b [? [m' [? [? [? ?]]]]]].
     exists b; split; auto.
     exists m'; split; [| split; [| split]]; auto.
-    change (assert_safe Espec gx vx tx k rho m').
+    change (assert_safe Espec gx f vx tx k rho m').
     specialize (H m' ltac: (apply necR_level in H1; omega)).
     specialize (H m' ltac: (apply necR_refl)).
     apply H.
@@ -191,8 +191,8 @@ Proof.
 Qed.
 
 Lemma _guard_bupd:
-  forall {Espec: OracleKind} ge Delta (F P: environ -> pred rmap) f k,
-    _guard Espec ge Delta (fun rho => F rho * P rho) f k = _guard Espec ge Delta (fun rho => F rho * bupd (P rho)) f k.
+  forall {Espec: OracleKind} ge Delta f (F P: environ -> pred rmap) k,
+    _guard Espec ge Delta f (fun rho => F rho * P rho) k = _guard Espec ge Delta f (fun rho => F rho * bupd (P rho)) k.
 Proof.
   intros.
   unfold _guard.
@@ -202,16 +202,16 @@ Proof.
 Qed.
   
 Lemma guard_bupd:
-  forall {Espec: OracleKind} ge Delta (F P: environ -> pred rmap) k,
-    guard Espec ge Delta (fun rho => F rho * P rho) k = guard Espec ge Delta (fun rho => F rho * bupd (P rho)) k.
+  forall {Espec: OracleKind} ge Delta f (F P: environ -> pred rmap) k,
+    guard Espec ge Delta f (fun rho => F rho * P rho) k = guard Espec ge Delta f (fun rho => F rho * bupd (P rho)) k.
 Proof.
   intros.
   apply _guard_bupd.
 Qed.
 
 Lemma rguard_bupd:
-  forall {Espec: OracleKind} ge Delta F (P: ret_assert) k,
-    rguard Espec ge Delta (frame_ret_assert P F) k = rguard Espec ge Delta (frame_ret_assert (bupd_ret_assert P) F) k.
+  forall {Espec: OracleKind} ge Delta F f (P: ret_assert) k,
+    rguard Espec ge Delta f (frame_ret_assert P F) k = rguard Espec ge Delta f (frame_ret_assert (bupd_ret_assert P) F) k.
 Proof.
   intros.
   unfold rguard.
@@ -241,11 +241,11 @@ ported, the frame does not need to be quantified in the semantic definition of s
 these two lemmas can replace the other two afterwards. *)
 
 Lemma assert_safe_except_0':
-  forall {Espec: OracleKind} gx vx tx PP1 PP2 rho (P: environ -> pred rmap) k,
+  forall {Espec: OracleKind} gx f vx tx PP1 PP2 rho (P: environ -> pred rmap) k,
     PP1 && (P rho) && PP2 >=>
-    assert_safe Espec gx vx tx k rho =
+    assert_safe Espec gx f vx tx k rho =
     PP1 && ((|> FF || P rho)) && PP2 >=>
-    assert_safe Espec gx vx tx k rho.
+    assert_safe Espec gx f vx tx k rho.
 Proof.
   intros.
   apply pred_ext.
@@ -263,9 +263,7 @@ Proof.
       split; auto.
       split; auto.
       simpl.
-      intros.
-      hnf.
-      rewrite H0; constructor.
+      intros. omega.
     - apply H.
       destruct H2 as [[? ?] ?].
       split; [split |]; auto.
@@ -289,7 +287,7 @@ Qed.
 
 Lemma _guard_except_0':
   forall {Espec: OracleKind} ge Delta (P: environ -> pred rmap) f k,
-    _guard Espec ge Delta P f k = _guard Espec ge Delta (fun rho => |> FF || P rho) f k.
+    _guard Espec ge Delta f P k = _guard Espec ge Delta f (fun rho => |> FF || P rho) k.
 Proof.
   intros.
   unfold _guard.
@@ -299,16 +297,16 @@ Proof.
 Qed.
   
 Lemma guard_except_0':
-  forall {Espec: OracleKind} ge Delta (P: environ -> pred rmap) k,
-    guard Espec ge Delta P k = guard Espec ge Delta (fun rho => |> FF || P rho) k.
+  forall {Espec: OracleKind} ge Delta f (P: environ -> pred rmap) k,
+    guard Espec ge Delta f P k = guard Espec ge Delta f (fun rho => |> FF || P rho) k.
 Proof.
   intros.
   apply _guard_except_0'.
 Qed.
 
 Lemma rguard_except_0':
-  forall {Espec: OracleKind} ge Delta (P: ret_assert) k,
-    rguard Espec ge Delta P k = rguard Espec ge Delta (except_0_ret_assert P) k.
+  forall {Espec: OracleKind} ge Delta (P: ret_assert) f k,
+    rguard Espec ge Delta f P k = rguard Espec ge Delta f (except_0_ret_assert P) k.
 Proof.
   intros.
   unfold rguard.
@@ -319,11 +317,11 @@ Proof.
 Qed.
 
 Lemma assert_safe_except_0:
-  forall {Espec: OracleKind} gx vx tx PP1 PP2 rho (F P: environ -> pred rmap) k,
+  forall {Espec: OracleKind} gx f vx tx PP1 PP2 rho (F P: environ -> pred rmap) k,
     PP1 && (F rho * P rho) && PP2 >=>
-    assert_safe Espec gx vx tx k rho =
+    assert_safe Espec gx f vx tx k rho =
     PP1 && (F rho * (|> FF || P rho)) && PP2 >=>
-    assert_safe Espec gx vx tx k rho.
+    assert_safe Espec gx f vx tx k rho.
 Proof.
   intros.
   apply pred_ext.
@@ -342,8 +340,7 @@ Proof.
       split; auto.
       simpl.
       intros.
-      hnf.
-      rewrite H0; constructor.
+      hnf. omega.
     - apply H.
       destruct H2 as [[? ?] ?].
       split; [split |]; auto.
@@ -375,7 +372,7 @@ Qed.
 
 Lemma _guard_except_0:
   forall {Espec: OracleKind} ge Delta (F P: environ -> pred rmap) f k,
-    _guard Espec ge Delta (fun rho => F rho * P rho) f k = _guard Espec ge Delta (fun rho => F rho * (|> FF || P rho)) f k.
+    _guard Espec ge Delta f (fun rho => F rho * P rho) k = _guard Espec ge Delta f (fun rho => F rho * (|> FF || P rho)) k.
 Proof.
   intros.
   unfold _guard.
@@ -385,18 +382,18 @@ Proof.
 Qed.
 
 Lemma guard_except_0: 
-  forall {Espec: OracleKind} ge Delta (F P: environ -> pred rmap) k,
-    guard Espec ge Delta (fun rho => F rho * P rho) k =
-    guard Espec ge Delta (fun rho => F rho * (|> FF || P rho)) k.
+  forall {Espec: OracleKind} ge Delta f (F P: environ -> pred rmap) k,
+    guard Espec ge Delta f (fun rho => F rho * P rho) k =
+    guard Espec ge Delta f (fun rho => F rho * (|> FF || P rho)) k.
 Proof.
   intros.
   apply _guard_except_0.
 Qed.
 
 Lemma rguard_except_0:
-  forall {Espec: OracleKind} ge Delta (F: environ -> pred rmap) Q k,
-    rguard Espec ge Delta (frame_ret_assert Q F) k =
-    rguard Espec ge Delta (frame_ret_assert (except_0_ret_assert Q) F) k.
+  forall {Espec: OracleKind} ge Delta f (F: environ -> pred rmap) Q k,
+    rguard Espec ge Delta f (frame_ret_assert Q F) k =
+    rguard Espec ge Delta f (frame_ret_assert (except_0_ret_assert Q) F) k.
 Proof.
   intros.
   unfold rguard.
@@ -408,9 +405,9 @@ Proof.
 Qed.
 
 Lemma _guard_allp_fun_id:
-  forall {Espec: OracleKind} ge Delta' Delta (F P: environ -> pred rmap) f k,
+  forall {Espec: OracleKind} ge Delta' Delta f (F P: environ -> pred rmap) k,
     tycontext_sub Delta Delta' ->
-    _guard Espec ge Delta' (fun rho => F rho * P rho) f k = _guard Espec ge Delta' (fun rho => F rho * (allp_fun_id Delta rho && P rho)) f k.
+    _guard Espec ge Delta' f (fun rho => F rho * P rho) k = _guard Espec ge Delta' f (fun rho => F rho * (allp_fun_id Delta rho && P rho)) k.
 Proof.
   intros.
   unfold _guard.
@@ -428,17 +425,17 @@ Proof.
   eapply funassert_allp_fun_id_sub; eauto.
 Qed.
 
-Lemma guard_allp_fun_id: forall {Espec: OracleKind} ge Delta' Delta (F P: environ -> pred rmap) k,
+Lemma guard_allp_fun_id: forall {Espec: OracleKind} ge Delta' Delta f (F P: environ -> pred rmap) k,
   tycontext_sub Delta Delta' ->
-  guard Espec ge Delta' (fun rho => F rho * P rho) k = guard Espec ge Delta' (fun rho => F rho * (allp_fun_id Delta rho && P rho)) k.
+  guard Espec ge Delta' f (fun rho => F rho * P rho) k = guard Espec ge Delta' f (fun rho => F rho * (allp_fun_id Delta rho && P rho)) k.
 Proof.
   intros.
   apply _guard_allp_fun_id; auto.
 Qed.
 
-Lemma rguard_allp_fun_id: forall {Espec: OracleKind} ge Delta' Delta (F: environ -> pred rmap) P k,
+Lemma rguard_allp_fun_id: forall {Espec: OracleKind} ge Delta' Delta f (F: environ -> pred rmap) P k,
   tycontext_sub Delta Delta' ->
-  rguard Espec ge Delta' (frame_ret_assert P F) k = rguard Espec ge Delta' (frame_ret_assert (conj_ret_assert P (allp_fun_id Delta)) F) k.
+  rguard Espec ge Delta' f (frame_ret_assert P F) k = rguard Espec ge Delta' f (frame_ret_assert (conj_ret_assert P (allp_fun_id Delta)) F) k.
 Proof.
   intros.
   unfold rguard.
@@ -450,9 +447,10 @@ Proof.
 Qed. 
 
 Lemma _guard_tc_environ:
-  forall {Espec: OracleKind} ge Delta' Delta (F P: environ -> pred rmap) f k,
+  forall {Espec: OracleKind} ge Delta' Delta f (F P: environ -> pred rmap) k,
     tycontext_sub Delta Delta' ->
-    _guard Espec ge Delta' (fun rho => F rho * P rho) f k = _guard Espec ge Delta' (fun rho => F rho * (!! typecheck_environ Delta rho && P rho)) f k.
+    _guard Espec ge Delta' f (fun rho => F rho * P rho) k = 
+    _guard Espec ge Delta' f (fun rho => F rho * (!! typecheck_environ Delta rho && P rho)) k.
 Proof.
   intros.
   unfold _guard.
@@ -470,17 +468,17 @@ Proof.
   eapply typecheck_environ_sub; eauto.
 Qed.
 
-Lemma guard_tc_environ: forall {Espec: OracleKind} ge Delta' Delta (F P: environ -> pred rmap) k,
+Lemma guard_tc_environ: forall {Espec: OracleKind} ge Delta' Delta f (F P: environ -> pred rmap) k,
   tycontext_sub Delta Delta' ->
-  guard Espec ge Delta' (fun rho => F rho * P rho) k = guard Espec ge Delta' (fun rho => F rho * (!! typecheck_environ Delta rho && P rho)) k.
+  guard Espec ge Delta' f (fun rho => F rho * P rho) k = guard Espec ge Delta' f (fun rho => F rho * (!! typecheck_environ Delta rho && P rho)) k.
 Proof.
   intros.
   apply _guard_tc_environ; auto.
 Qed.
 
-Lemma rguard_tc_environ: forall {Espec: OracleKind} ge Delta' Delta (F: environ -> pred rmap) P k,
+Lemma rguard_tc_environ: forall {Espec: OracleKind} ge Delta' Delta f (F: environ -> pred rmap) P k,
   tycontext_sub Delta Delta' ->
-  rguard Espec ge Delta' (frame_ret_assert P F) k = rguard Espec ge Delta' (frame_ret_assert (conj_ret_assert P (fun rho => !! typecheck_environ Delta rho)) F) k.
+  rguard Espec ge Delta' f (frame_ret_assert P F) k = rguard Espec ge Delta'  f (frame_ret_assert (conj_ret_assert P (fun rho => !! typecheck_environ Delta rho)) F) k.
 Proof.
   intros.
   unfold rguard.
@@ -515,22 +513,23 @@ Proof.
   apply prop_imp_derives; intros [? _].
   apply imp_derives; auto.
   apply allp_derives; intros k.
+  apply allp_derives; intros F.
   apply allp_derives; intros f.
   apply imp_derives; [apply andp_derives; auto |].
-  + erewrite (rguard_allp_fun_id _ _ _ _ R') by eauto.
-    erewrite (rguard_tc_environ _ _ _ _ (conj_ret_assert R' _)) by eauto.
-    rewrite (rguard_except_0 _ _ _ R).
-    rewrite (rguard_bupd _ _ _ (except_0_ret_assert _)).
+  + erewrite (rguard_allp_fun_id _ _ _ _ _ R') by eauto.
+    erewrite (rguard_tc_environ _ _ _ _ _ (conj_ret_assert R' _)) by eauto.
+    rewrite (rguard_except_0 _ _ _ _ R).
+    rewrite (rguard_bupd _ _ _ _ (except_0_ret_assert _)).
     apply rguard_mono.
     intros.
     rewrite proj_frame, proj_conj, proj_conj.
     rewrite proj_frame, proj_bupd_ret_assert, proj_except_0_ret_assert.
     apply sepcon_derives; auto.
     destruct rk; unfold proj_ret_assert; auto.
-  + erewrite (guard_allp_fun_id _ _ _ _ P) by eauto.
-    erewrite (guard_tc_environ _ _ _ _ (fun rho => allp_fun_id Delta rho && P rho)) by eauto.
-    rewrite (guard_except_0 _ _ _ P').
-    rewrite (guard_bupd _ _ _ (fun rho => |> FF || P' rho)).
+  + erewrite (guard_allp_fun_id _ _ _ _ _ P) by eauto.
+    erewrite (guard_tc_environ _ _ _ _ _ (fun rho => allp_fun_id Delta rho && P rho)) by eauto.
+    rewrite (guard_except_0 _ _ _ _ P').
+    rewrite (guard_bupd _ _ _ _ (fun rho => |> FF || P' rho)).
     apply guard_mono.
     intros.
     apply sepcon_derives; auto.
@@ -553,6 +552,7 @@ apply prop_imp_derives; intros [TS HGG].
 apply imp_derives; auto.
 apply allp_derives; intro k.
 apply allp_derives; intro F.
+apply allp_derives; intro f.
 apply imp_derives; auto.
 unfold rguard, guard.
 apply andp_derives; auto.
@@ -585,7 +585,7 @@ assert (bupd (proj_ret_assert (frame_ret_assert R F) ek vl
     apply bupd_frame_r in HFP.
     destruct R; auto.
   * destruct H3; eapply typecheck_environ_sub; eauto. }
-assert ((bupd (assert_safe Espec psi ve te (exit_cont ek vl k)
+assert ((bupd (assert_safe Espec psi f ve te (exit_cont ek vl k)
   (construct_rho (filter_genv psi) ve te))) a') as Hsafe.
 { intros ? J.
   destruct (HFP' _ J) as (b & ? & m' & ? & ? & ? & ?).
@@ -624,6 +624,7 @@ apply prop_imp_derives; intros [TS HGG].
 apply imp_derives; auto.
 apply allp_derives; intro k.
 apply allp_derives; intro F.
+apply allp_derives; intro f.
 apply imp_derives; auto.
 unfold guard.
 apply allp_derives; intro te.

--- a/veric/semax_ext.v
+++ b/veric/semax_ext.v
@@ -95,7 +95,8 @@ Definition funspec2pre (ext_link: Strings.String.string -> ident) (A : TypeTree)
   with
     | left _ => fun x' => Val.has_type_list args (sig_args (ef_sig ef)) /\
                       exists phi0 phi1, join phi0 phi1 (m_phi m)
-                       /\ P (projT1 (snd x')) (projT2 (snd x')) (make_ext_args (filter_genv (symb2genv ge_s)) ids args) phi0
+                       /\ P (projT1 (snd x')) (projT2 (snd x')) 
+     (seplog.make_args ids args (empty_environ (symb2genv ge_s)) ) phi0
                        /\ necR (fst x') phi1 /\ joins (ghost_of (m_phi m)) (Some (ghost_PCM.ext_ref z, NoneP) :: nil)
     | right n => fun x' => ext_spec_pre Espec ef x' ge_s tys args z m
   end x.
@@ -131,18 +132,18 @@ Definition wf_funspec (f : funspec) :=
     | mk_funspec sig cc A P Q _ _ =>
         forall ts a (ge ge': genv) n args,
           Genv.genv_symb ge = Genv.genv_symb ge' ->
-          P ts a (make_ext_args (filter_genv ge) n args) |-- P ts a (make_ext_args (filter_genv ge') n args)
+          P ts a (seplog.make_args n args (empty_environ ge)) 
+         |-- P ts a (seplog.make_args n args (empty_environ ge'))
   end.
 
 Lemma make_ext_args_symb (ge ge' : genv)
       (H: Genv.genv_symb ge = Genv.genv_symb ge') n args :
-  make_ext_args (filter_genv ge) n args = make_ext_args (filter_genv ge') n args.
+  (seplog.make_args n args (empty_environ ge)) = (seplog.make_args n args (empty_environ ge')).
 Proof.
-revert ge ge' n H; induction args.
-* simpl; unfold filter_genv, Genv.find_symbol. intros ? ? ? ->; auto.
-* intros ge ge' n H. simpl. destruct n; auto.
-  erewrite IHargs; eauto.
-  erewrite IHargs; eauto.
+intros.
+f_equal.
+unfold empty_environ, filter_genv, Genv.find_symbol.
+rewrite H; auto.
 Qed.
 
 Lemma all_funspecs_wf f : wf_funspec f.
@@ -218,7 +219,7 @@ Lemma add_funspecs_pre  (ext_link: Strings.String.string -> ident)
   In (ext_link id, (mk_funspec sig cc A P Q NEP NEQ)) fs ->
   join phi0 phi1 (m_phi m) ->
   Val.has_type_list args (sig_args (ef_sig ef)) ->
-  P (projT1 x) (projT2 x) (make_ext_args (filter_genv (symb2genv ge_s)) (fst (split (fst sig))) args) phi0 ->
+  P (projT1 x) (projT2 x) (seplog.make_args (fst (split (fst sig))) args (empty_environ (symb2genv ge_s))) phi0 ->
   exists x' : ext_spec_type (JE_spec _ (add_funspecs_rec ext_link Z Espec fs)) ef,
     JMeq (phi1, x) x'
     /\ forall z, joins (ghost_of (m_phi m)) (Some (ghost_PCM.ext_ref z, NoneP) :: nil) ->
@@ -262,7 +263,7 @@ Lemma add_funspecs_pre_void  (ext_link: Strings.String.string -> ident)
   In (ext_link id, (mk_funspec (sig, tvoid) cc A P Q NEP NEQ)) fs ->
   join phi0 phi1 (m_phi m) ->
   Val.has_type_list args (sig_args (ef_sig ef)) ->
-  P (projT1 x) (projT2 x) (make_ext_args (filter_genv (symb2genv ge_s)) (fst (split sig)) args) phi0 ->
+  P (projT1 x) (projT2 x) (seplog.make_args (fst (split sig)) args (empty_environ (symb2genv ge_s)) ) phi0 ->
   exists x' : ext_spec_type (JE_spec _ (add_funspecs_rec ext_link Z Espec fs)) ef,
     JMeq (phi1, x) x'
     /\ forall z, joins (ghost_of (m_phi m)) (Some (ghost_PCM.ext_ref z, NoneP) :: nil) ->
@@ -408,8 +409,9 @@ intros n ge Ts x n0 Hlater F ts args jm H jm' H2 [Hargsty H3].
 destruct H3 as [s [t [Hjoin [Hp Hf]]]].
 destruct Espec.
 
-assert (Hp'': P Ts x (make_ext_args (filter_genv (symb2genv (genv_symb_injective ge)))
-                                 (fst (split (fst sig))) args) s).
+assert (Hp'': P Ts x (seplog.make_args (fst (split (fst sig))) args
+                                (empty_environ (symb2genv (genv_symb_injective ge))))
+                    s).
 { generalize (all_funspecs_wf f) as Hwf2; intro.
   specialize (Hwf2 Ts x ge (symb2genv (genv_symb_injective ge)) (fst (split (fst sig))) args).
   spec Hwf2.
@@ -467,8 +469,7 @@ unfold semax_external.
 intros n ge Ts x n0 Hlater F ts args jm H jm' H2 [Hargsty H3].
 destruct H3 as [s [t [Hjoin [Hp Hf]]]].
 destruct Espec.
-assert (Hp'': P Ts x (make_ext_args (filter_genv (symb2genv (genv_symb_injective ge)))
-                                 (fst (split sig)) args) s).
+assert (Hp'': P Ts x (seplog.make_args (fst (split sig)) args (empty_environ (symb2genv (genv_symb_injective ge)))) s).
 { generalize (all_funspecs_wf f) as Hwf2; intro.
   specialize (Hwf2 Ts x ge (symb2genv (genv_symb_injective ge)) (fst (split sig)) args).
   spec Hwf2.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -321,7 +321,10 @@ Proof.
   { eapply juicy_core_sem_preserves_corestep_fun with (csem := cl_core_sem ge); eauto. }
   inv H0; auto.
   setoid_rewrite (semantics.corestep_not_at_external (juicy_core_sem _)) in H2; eauto; congruence.
-  contradiction.
+  destruct H.
+  elimtype False.
+  eapply cl_corestep_not_halted. apply Int.zero.
+  simpl in H. apply H. apply H1. 
 Qed.
 
 Lemma semax_unfold {CS: compspecs} {Espec: OracleKind}:
@@ -856,20 +859,6 @@ simpl in *; congruence.
 contradiction.
 Qed.
 *)
-
-Lemma safe_step_forward {Espec: OracleKind}:
-  forall psi n ora st m,
-   cl_at_external st = None ->
-   jsafeN (@OK_spec Espec) psi (S n) ora st m ->
- exists st', exists m',
-   jstep (cl_core_sem psi) st m st' m' /\ jm_bupd ora (jsafeN (@OK_spec Espec) psi n ora  st') m'.
-Proof.
- intros.
- inv H0.
- eexists; eexists; split; eauto.
- simpl in H2; rewrite H2 in H; congruence.
- contradiction.
-Qed.
 
 Local Open Scope nat_scope.
 

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -4,7 +4,7 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.tycontext.
@@ -196,9 +196,67 @@ Proof.
     eapply necR_PURE' in H as [? ->]; simpl; eauto.
 Qed.
 
+Lemma cl_corestep_fun: forall ge m q m1 q1 m2 q2,
+    cl_step ge q m q1 m1 ->
+    cl_step ge q m q2 m2 ->
+    (q1,m1)=(q2,m2).
+Proof.
+intros.
+inv H; inv H0; repeat fun_tac; auto;
+repeat match goal with H: _ = _ \/ _ = _ |- _ => destruct H; try discriminate end;
+try contradiction.
+inversion2 H1 H16; fun_tac; auto.
+inv H1. inv H8.
+fun_tac.
+pose proof (alloc_variables_fun H3 H7). inv H8. auto.
+Qed.
+
 Lemma cl_corestep_fun': forall ge, corestep_fun (cl_core_sem ge).
 Proof.  repeat intro. eapply cl_corestep_fun; simpl in *; eauto. Qed.
 Hint Resolve cl_corestep_fun'.
+
+Lemma age1_resource_decay:
+  forall jm jm', age jm jm' -> resource_decay (nextblock (m_dry jm)) (m_phi jm) (m_phi jm').
+Proof.
+ intros. split.
+ apply age_level in H.
+ change (level (m_phi jm)) with (level jm).
+ change (level (m_phi jm')) with (level jm').
+ omega.
+ intro l. split. apply juicy_mem_alloc_cohere. left.
+ symmetry; apply age1_resource_at with (m_phi jm); eauto.
+  destruct (age1_juicy_mem_unpack _ _ H); auto.
+ symmetry; apply resource_at_approx.
+Qed.
+
+Lemma jsafeN_local_step:
+  forall {Espec: OracleKind} ge ora s1 m s2,
+  cl_step  ge s1 (m_dry m) s2 (m_dry m) ->
+  (forall m', age m m' -> 
+    jsafeN (@OK_spec Espec) ge (level m') ora s2 m') ->
+  jsafeN (@OK_spec Espec) ge (level m) ora s1 m.
+Proof.
+intros.
+  rename H into Hstep.
+  remember (level m) as N.
+  destruct N; [constructor|].
+  case_eq (age1 m); [intros m' H |  intro; apply age1_level0 in H; omegaContradiction].
+  eapply jsafeN_step with
+   (* (c' := State f Sskip (Kseq Scontinue (Kloop1 Sskip Sskip k)) ve te)*)
+    (m'0 := m').
+  split3.
+  replace (m_dry m') with (m_dry m) by (destruct (age1_juicy_mem_unpack _ _ H); auto).
+  apply Hstep.
+  apply age1_resource_decay; auto. split; [apply age_level; auto|].
+  apply age_jm_phi in H.
+  erewrite (age1_ghost_of _ _ H) by (symmetry; apply ghost_of_approx).
+  unfold level at 1; simpl.
+  repeat intro; auto.
+  assert (N = level m')%nat.
+  apply age_level in H; omega.
+  apply jm_bupd_intro.
+  subst. apply H0. auto.
+Qed.
 
 Lemma derives_skip:
   forall {CS: compspecs} {Espec: OracleKind} p Delta (R: ret_assert),
@@ -212,7 +270,7 @@ intros psi Delta' CS'.
 apply prop_imp_i; intros [? HGG].
 clear H0 Delta. rename Delta' into Delta.
 intros ?w _ _. clear n.
-intros k F.
+intros k F f.
 intros ?w _ ?.
 clear w. rename w0 into n.
 intros te ve w ?.
@@ -231,20 +289,19 @@ rewrite sepcon_comm.
 eapply sepcon_derives; try apply H0; auto.
 
 repeat intro.
-destruct (H0 _ H1) as (b & ? & m' & ? & ? & ? & HP).
+destruct (H0 _ H1) as (b & ? & m' & ? & ? & ? & HP); clear H0.
 exists b; split; auto; exists m'; repeat split; auto.
 repeat intro.
-specialize (HP ora jm H6 H7 H8).
-destruct (@level rmap _ m').
-constructor.
-apply convergent_controls_jsafe with (State ve te k); auto.
-simpl.
-
+specialize (HP ora jm H0 H6 H7 LW).
+destruct HP as [s [ctl' [? HP]]].
+subst k.
+exists Sskip, (Kseq s ctl'); split; auto.
+rewrite <- H7 in HP|-*.
+change (level (m_phi jm)) with (level jm) in HP|-*.
+eapply jsafeN_local_step. constructor.
 intros.
-destruct H9 as [? [? ?]].
-split3; auto.
-
-econstructor; eauto.
+eapply age_safe in HP; try apply H8.
+auto.
 Qed.
 
 Lemma jsafe_corestep_forward:
@@ -266,10 +323,10 @@ Lemma semax_unfold {CS: compspecs} {Espec: OracleKind}:
     forall (psi: Clight.genv) Delta' CS' (w: nat)
           (TS: tycontext_sub Delta Delta')
           (HGG: (*genv_cenv psi = cenv_cs*)cenv_sub (@cenv_cs CS) (@cenv_cs CS') /\ cenv_sub (@cenv_cs CS') (genv_cenv psi))
-           (Prog_OK: @believe CS' Espec Delta' psi Delta' w) (k: cont) (F: assert),
+           (Prog_OK: @believe CS' Espec Delta' psi Delta' w) (k: cont) (F: assert) f,
         closed_wrt_modvars c F ->
-       rguard Espec psi Delta' (frame_ret_assert R F) k w ->
-       guard Espec psi Delta' (fun rho => F rho * P rho) (Kseq c :: k) w.
+       rguard Espec psi Delta' f (frame_ret_assert R F) k w ->
+       guard Espec psi Delta' f (fun rho => F rho * P rho) (Kseq c k) w.
 Proof.
 unfold semax; rewrite semax_fold_unfold.
 extensionality Delta P c R.
@@ -279,7 +336,7 @@ apply prop_ext; split; intros.
   - split; trivial.
 + intros psi Delta' CS'.
   apply prop_imp_i; intros [? HGG].
-  intros w' ? ? k F w'' ? [? ?].
+  intros w' ? ? k F f w'' ? [? ?].
   apply (H psi Delta' CS' w'' H0 HGG); trivial. 
   eapply pred_nec_hereditary; eauto.
 Qed.
@@ -289,13 +346,15 @@ Fixpoint list_drop (A: Type) (n: nat) (l: list A) {struct n} : list A :=
 Arguments list_drop [A] _ _.
 
 Definition straightline (c: Clight.statement) :=
- forall ge ve te k m ve' te' k' m',
-        cl_step ge (State ve te (Kseq c :: k)) m (State ve' te' k') m' ->  k=k'.
+ forall ge f ve te k m f' ve' te' c' k' m',
+        cl_step ge (State f c k ve te) m (State f' c' k' ve' te') m' ->  (c'=Sskip /\ k=k').
 
 Lemma straightline_assign: forall e0 e, straightline (Clight.Sassign e0 e).
 Proof.
 unfold straightline; intros.
 inv H; auto.
+destruct H13; inv H; auto.
+destruct H13; inv H; auto.
 Qed.
 
 Lemma extract_exists_pre_later {CS: compspecs} {Espec: OracleKind}:
@@ -317,7 +376,7 @@ destruct (@age1_join _ _ _ _ _ _ _ _ H6 Heqo)
 hnf in H8.
 specialize (H8 _ (age_laterR H10)).
 destruct H8 as [x H8].
-specialize (H x psi Delta' CS' w TS HGG Prog_OK k F H0 H1).
+specialize (H x psi Delta' CS' w TS HGG Prog_OK k F f H0 H1).
 unfold guard, _guard in H.
 specialize (H te ve).
 cbv beta in H.
@@ -343,6 +402,7 @@ apply H10.
 exists w1.
 split3; auto. split; auto.
 simpl.
+exists c,k; split; auto.
 intros.
 rewrite H9.
 constructor.
@@ -361,7 +421,7 @@ rewrite exp_sepcon2 in H4.
 destruct H4 as [[TC [x H5]] ?].
 (*destruct H4 as [[[TC [x H5]] ?] ?].*)
 specialize (H x).
-specialize (H psi Delta' CS' w TS HGG Prog_OK k F H0).
+specialize (H psi Delta' CS' w TS HGG Prog_OK k F f H0).
 spec H. {
  clear - H1.
  unfold rguard in *.
@@ -395,8 +455,8 @@ inv H1.
 Qed.
 
 Definition all_assertions_computable  :=
-  forall (Espec: OracleKind) psi tx vx (Q: assert), 
-     exists k,  assert_safe Espec psi tx vx k = Q.
+  forall (Espec: OracleKind) psi f tx vx (Q: assert), 
+     exists k,  assert_safe Espec psi f tx vx k = Q.
 (* This is not generally true, but could be made true by adding an "assert" operator
   to the programming language
 *)
@@ -435,17 +495,6 @@ destruct f; auto.
 destruct H1; split; auto.
 destruct H as [? [? [? ?]]]. rewrite H4; auto.
 Qed.
-(*not needed
-Lemma guard_environ_eqv:
-  forall Delta Delta' f rho,
-  tycontext_eqv Delta Delta' ->
-  guard_environ Delta f rho -> guard_environ Delta' f rho.
-Proof.
-  intros.
-  rewrite tycontext_eqv_spec in H.
-  eapply guard_environ_sub; eauto.
-  tauto.
-Qed.*)
 
 Lemma proj_frame_ret_assert:
  forall (R: ret_assert) (F: assert) ek vl,
@@ -478,9 +527,9 @@ specialize (H5 gx Delta'' CS' _ (necR_refl _)
  (conj (tycontext_sub_trans _ _ _ H2 TS) HGG)
                   _ H6 H7).
 
-intros k F w4 Hw4 [? ?].
-specialize (H5 k F w4 Hw4).
-assert ((rguard Espec gx Delta'' (frame_ret_assert R F) k) w4).
+intros k F f w4 Hw4 [? ?].
+specialize (H5 k F f w4 Hw4).
+assert ((rguard Espec gx Delta'' f (frame_ret_assert R F) k) w4).
 do 9 intro.
 apply (H9 b b0 b1 b2 y H10 a' H11).
 destruct H12; split; auto; clear H13.
@@ -539,7 +588,7 @@ rewrite semax_unfold.
 rewrite semax_unfold in H.
 intros.
 pose (F0F := fun rho => F0 rho * F rho).
-specialize (H psi Delta' CS' w TS HGG Prog_OK k F0F).
+specialize (H psi Delta' CS' w TS HGG Prog_OK k F0F f).
 spec H. {
  unfold F0F.
  clear - H0 CL.
@@ -573,17 +622,15 @@ f_equal. apply sepcon_comm.
 Qed.
 
 Lemma assert_safe_last:
-  forall {Espec: OracleKind} ge ve te st rho w,
-   (forall w', age w w' -> assert_safe Espec ge ve te st rho w) ->
-    assert_safe Espec ge ve te st rho w.
+  forall {Espec: OracleKind} f ge ve te c k rho w,
+   (forall w', age w w' -> assert_safe Espec f ge ve te (Kseq c k) rho w) ->
+    assert_safe Espec f ge ve te (Kseq c k) rho w.
 Proof.
 intros.
 case_eq (age1 w). auto.
 clear H.
 intro; apply bupd_intro; repeat intro.
-rewrite (af_level1 age_facts) in H.
-rewrite H.
-constructor.
+apply age1_level0 in H. omega. 
 Qed.
 
 Lemma pred_sub_later' {A} `{H: ageable A}:
@@ -597,12 +644,12 @@ auto.
 Qed.
 
 Lemma later_strengthen_safe1:
-  forall {Espec: OracleKind} (P: pred rmap) ge ve te k rho,
-              ((|> P) >=> assert_safe Espec ge ve te k rho) |--   |>  (P >=> assert_safe Espec ge ve te k rho).
+  forall {Espec: OracleKind} (P: pred rmap) f ge ve te k rho,
+              ((|> P) >=> assert_safe Espec f ge ve te k rho) |--   |>  (P >=> assert_safe Espec f ge ve te k rho).
 Proof.
 intros.
 intros w ?.
-apply (@pred_sub_later' _ _ P  (assert_safe Espec ge ve te k rho)); auto.
+apply (@pred_sub_later' _ _ P  (assert_safe Espec f ge ve te k rho)); auto.
 eapply subp_trans'; try apply H.
 apply derives_subp; clear.
 apply now_later.
@@ -612,35 +659,60 @@ End SemaxContext.
 
 Hint Resolve @age_laterR.
 
-
 Fixpoint filter_seq (k: cont) : cont :=
  match k with
-  | Kseq s :: k1 => filter_seq k1
+  | Kseq s  k1 => filter_seq k1
   | _ => k
   end.
 
-Lemma cons_app: forall A (x: A) (y: list A), x::y = (x::nil)++y.
+Fixpoint app_cont (k1 k2: cont) : cont :=
+ match k1 with
+ | Kstop => k2
+ | Kseq c k1' => Kseq c (app_cont k1' k2)
+ | Kloop1 c1 c2 k1' => Kloop1 c1 c2 (app_cont k1' k2)
+ | Kloop2 c1 c2 k1' => Kloop2 c1 c2 (app_cont k1' k2)
+ | Kswitch k1' => Kswitch (app_cont k1' k2)
+ | Kcall i f ve te k1' => Kcall i f ve te (app_cont k1' k2)
+ end.
+
+Lemma cons_app: forall x y, 
+  Kseq x y = app_cont (Kseq x Kstop) y.
 Proof. auto. Qed.
 
-Lemma cons_app': forall A (x:A) y z,
-      x::y++z = (x::y)++z.
+Lemma cons_app': forall x y z,
+      Kseq x (app_cont y z) = app_cont (Kseq x y) z.
 Proof. auto. Qed.
+
+Fixpoint length_cont (k: cont) :=
+match k with
+| Kstop => O
+| Kseq _ k' => S (length_cont k')
+| Kloop1 _ _ k' =>  S (length_cont k')
+| Kloop2 _ _ k' =>  S (length_cont k')
+| Kswitch k' =>  S (length_cont k')
+| Kcall _ _ _ _ k' =>  S (length_cont k')
+end.
+
+Lemma app_cont_length: forall k1 k2, 
+  length_cont (app_cont k1 k2) = (length_cont k1 + length_cont k2)%nat.
+Proof.
+induction k1; simpl; intros; auto.
+Qed.
 
 Lemma cat_prefix_empty:
-   forall {A} prefix (ctl: list A), ctl =  prefix ++ ctl -> prefix = nil.
+   forall prefix ctl, ctl =  app_cont prefix ctl -> prefix = Kstop.
 Proof.
-do 3 intro.
-destruct prefix; auto; intro; elimtype False.
-assert (length ctl = length ((a::prefix) ++ ctl)).
-f_equal; auto.
-simpl in H0.
-rewrite app_length in H0.
-omega.
+intros.
+pose proof (app_cont_length prefix ctl).
+rewrite <- H in H0.
+assert (length_cont prefix = O) by omega.
+clear - H1. 
+destruct prefix; inv H1; auto.
 Qed.
 
 Definition true_expr : Clight.expr := Clight.Econst_int Int.one (Tint I32 Signed noattr).
 
-
+(*
 (* BEGIN Lemmas duplicated from Clight_sim. v *)
 Lemma dec_skip: forall s, {s=Sskip}+{s<>Sskip}.
 Proof.
@@ -687,7 +759,6 @@ Proof. intros. revert k H;  induction k; intros. inv H.
  destruct s; inv H; simpl; auto.
 Qed.
 
-
 Lemma filter_seq_current_function:
   forall ctl1 ctl2, filter_seq ctl1 = filter_seq ctl2 ->
        current_function ctl1 = current_function ctl2.
@@ -696,26 +767,28 @@ Proof.
   revert H0; induction ctl2; simpl; intros; try destruct a; try congruence; auto.
   destruct a; auto; revert H0; induction ctl2; simpl; intros; try destruct a; try congruence; auto.
 Qed.
+*)
 
 Lemma filter_seq_call_cont:
   forall ctl1 ctl2, filter_seq ctl1 = filter_seq ctl2 -> call_cont ctl1 = call_cont ctl2.
 Proof.
-  intros ? ? H0. revert ctl2 H0; induction ctl1; simpl; intros.
+  intros ? ? H0.
+  revert ctl2 H0; induction ctl1; simpl; intros; auto;
   revert H0; induction ctl2; simpl; intros; try destruct a; try congruence; auto.
-  destruct a; auto; revert H0; induction ctl2; simpl; intros; try destruct a; try congruence; auto.
 Qed.
 
 Lemma call_cont_app_nil:
-  forall l k, call_cont l = nil -> call_cont (l++k) = call_cont k.
+  forall l k, call_cont l = Kstop -> call_cont (app_cont l k) = call_cont k.
 Proof.
  intros l k; revert k; induction l; simpl; intros;
    try destruct a; simpl in *; try congruence; auto.
 Qed.
+
 Lemma call_cont_app_cons:
-  forall l c l', call_cont l = c::l' -> forall k, call_cont (l++k) = c::l' ++ k.
+  forall l, call_cont l <> Kstop -> 
+    forall k, call_cont (app_cont l k) = app_cont (call_cont l)  k.
 Proof.
-  intros; revert c l' k H; induction l; simpl; intros;
-   try destruct a; simpl in *; try congruence; auto.
+  induction l; simpl; intros; try congruence; auto.
 Qed.
 
 Lemma and_FF : forall {A} `{ageable A} (P:pred A),
@@ -732,63 +805,30 @@ Qed.
 
 Section extensions.
 
-Lemma age1_resource_decay:
-  forall jm jm', age jm jm' -> resource_decay (nextblock (m_dry jm)) (m_phi jm) (m_phi jm').
-Proof.
- intros. split.
- apply age_level in H.
- change (level (m_phi jm)) with (level jm).
- change (level (m_phi jm')) with (level jm').
- omega.
- intro l. split. apply juicy_mem_alloc_cohere. left.
- symmetry; apply age1_resource_at with (m_phi jm); eauto.
-  destruct (age1_juicy_mem_unpack _ _ H); auto.
- symmetry; apply resource_at_approx.
-Qed.
-
 Lemma safe_loop_skip:
   forall {Espec: OracleKind}
-    ge ora ve te k m,
+    ge ora f ve te k m,
     jsafeN (@OK_spec Espec) ge (level m) ora
-           (State ve te (Kseq (Sloop Clight.Sskip Clight.Sskip) :: k)) m.
+           (State f (Sloop Clight.Sskip Clight.Sskip) k ve te ) m.
 Proof.
   intros.
-  remember (level m)%nat as N.
-  destruct N; [constructor|].
-  case_eq (age1 m); [intros m' ? |  intro; apply age1_level0 in H; omegaContradiction].
-  apply jsafeN_step with
-    (c' := State ve te (Kseq Sskip :: Kseq Scontinue :: Kloop1 Sskip Sskip :: k))
-    (m'0 := m').
-  split3.
-  replace (m_dry m') with (m_dry m) by (destruct (age1_juicy_mem_unpack _ _ H); auto).
-  repeat econstructor.
-  apply age1_resource_decay; auto. split; [apply age_level; auto|].
-  apply age_jm_phi in H.
-  erewrite (age1_ghost_of _ _ H) by (symmetry; apply ghost_of_approx).
-  unfold level at 1; simpl.
-  repeat intro; auto.
-  assert (N = level m')%nat.
-  apply age_level in H; omega.
-  clear HeqN m H. rename m' into m.
-  intros; eexists; repeat split; eauto.
-  clear H H1; revert m H0; induction N; intros; simpl; [constructor|].
-  case_eq (age1 m); [intros m' ? |  intro; apply age1_level0 in H; omegaContradiction].
-  apply jsafeN_step
-    with (c' := State ve te (Kseq Sskip :: Kseq Scontinue :: Kloop1 Sskip Sskip :: k))
-         (m'0 := m').
-  split3.
-  replace (m_dry m') with (m_dry m) by (destruct (age1_juicy_mem_unpack _ _ H); auto).
-  repeat constructor.
- apply age1_resource_decay; auto. split; [apply age_level; auto|].
-  apply age_jm_phi in H.
-  erewrite (age1_ghost_of _ _ H) by (symmetry; apply ghost_of_approx).
-  unfold level at 1; simpl.
-  repeat intro; auto.
-  intros; eexists; repeat split; eauto.
-  eapply IHN; eauto.
-  apply age_level in H. omega.
-Qed.
+  pose (M := level m).
+  assert (Hge: (M >= level m)%nat) by omega.
+  clearbody M.
+  revert m Hge; induction M; intros.
+  assert (level m = O) by omega. rewrite H.
+  constructor.
+  eapply jsafeN_local_step. constructor.
+  intros.
+  eapply jsafeN_local_step. constructor. auto.
+  intros.
+  eapply jsafeN_local_step. constructor.
+  intros.
+  apply IHM.
+  apply age_level in H. apply age_level in H0. apply age_level in H1. omega.
+Qed.  
 
+(*
 Lemma safe_seq_skip {Espec: OracleKind} ge n ora ve te k m :
   jsafeN OK_spec ge n ora (State ve te k) m ->
   jsafeN OK_spec ge n ora (State ve te (Kseq Sskip :: k)) m.
@@ -810,6 +850,7 @@ inv H0; auto.
 simpl in *; congruence.
 contradiction.
 Qed.
+*)
 
 Lemma safe_step_forward {Espec: OracleKind}:
   forall psi n ora st m,
@@ -825,6 +866,7 @@ Proof.
  contradiction.
 Qed.
 
+(*
 Lemma safeN_strip {Espec: OracleKind}:
   forall ge n ora ve te k m,
      jsafeN (@OK_spec Espec) ge n ora (State ve te (strip_skip k)) m =
@@ -843,64 +885,106 @@ Proof.
    simpl in *. apply IHk. apply safe_seq_skip'; auto.
    destruct s; simpl in *; congruence. }
 Qed.
+*)
 
 Local Open Scope nat_scope.
 
+(*
 Definition control_as_safe {Espec: OracleKind} ge n ctl1 ctl2 :=
- forall (ora : OK_ty) (ve : env) (te : temp_env) (m : juicy_mem) (n' : nat),
+ (exists c1 k1, ctl1 = Kseq c1 k1 /\
+  exists c2 k2, ctl2 = Kseq c2 k2 /\
+  forall (ora : OK_ty) f (ve : env) (te : temp_env) (m : juicy_mem) (n' : nat),
      n' <= n ->
-     jsafeN (@OK_spec Espec) ge n' ora (State ve te ctl1) m ->
-     jsafeN (@OK_spec Espec) ge n' ora (State ve te ctl2) m.
+     jsafeN (@OK_spec Espec) ge n' ora (State f c1 k1 ve te) m ->
+     jsafeN (@OK_spec Espec) ge n' ora (State f c2 k2 ve te) m)
+ /\ 
+    (forall ora f args m n',
+     jsafeN (@OK_spec Espec) ge n' ora (Callstate f args ctl1) m ->
+     jsafeN (@OK_spec Espec) ge n' ora (Callstate f args ctl2) m)
+ /\ 
+    (forall ora res m n',
+     jsafeN (@OK_spec Espec) ge n' ora (Returnstate res ctl1) m ->
+     jsafeN (@OK_spec Espec) ge n' ora (Returnstate res ctl2) m).
+*)
+
+Definition control_as_safe {Espec: OracleKind} ge n ctl1 ctl2 :=
+ exists c1 k1, ctl1 = Kseq c1 k1 /\
+ exists c2 k2, ctl2 = Kseq c2 k2 /\
+ forall (ora : OK_ty) f (ve : env) (te : temp_env) (m : juicy_mem) (n' : nat),
+     n' <= n ->
+     jsafeN (@OK_spec Espec) ge n' ora (State f c1 k1 ve te) m ->
+     jsafeN (@OK_spec Espec) ge n' ora (State f c2 k2 ve te) m.
+
+Definition control_as_safe' {Espec: OracleKind} ge n c1 ctl1 c2 ctl2 :=
+ forall (ora : OK_ty) f (ve : env) (te : temp_env) (m : juicy_mem) (n' : nat),
+     n' <= n ->
+     jsafeN (@OK_spec Espec) ge n' ora (State f c1 ctl1 ve te) m ->
+     jsafeN (@OK_spec Espec) ge n' ora (State f c2 ctl2 ve te) m.
 
 Fixpoint prebreak_cont (k: cont) : cont :=
   match k with
-  | Kloop1 s e3 :: k' => k
-  | Kseq s :: k' => prebreak_cont k'
-  | Kloop2 s e3 :: k' => k
-  | Kswitch :: k' => k
-  | _ =>  nil (* stuck *)
+  | Kloop1 s e3 k' => k
+  | Kseq s k' => prebreak_cont k'
+  | Kloop2 s e3 k' => k
+  | Kswitch k' => k
+  | _ =>  Kstop (* stuck *)
   end.
 
 Lemma prebreak_cont_is: forall k,
   match (prebreak_cont k) with
-  | Kloop1 _ _ :: _ => True
-  | Kloop2 _ _ :: _ => True
-  | Kswitch :: _ => True
-  | nil => True
+  | Kloop1 _ _ _ => True
+  | Kloop2 _ _ _ => True
+  | Kswitch _ => True
+  | Kstop => True
   | _ => False
   end.
 Proof.
 induction k; simpl; auto.
-destruct (prebreak_cont k); try contradiction; destruct a; auto.
+Qed.
+
+Lemma app_cont_ass: forall j k l,
+  app_cont (app_cont j k) l = app_cont j (app_cont k l).
+Proof.
+intros.
+induction j; simpl; f_equal; auto.
 Qed.
 
 Lemma find_label_prefix:
-  forall lbl s ctl k, find_label lbl s ctl = Some k -> exists j, k = j++ctl
+  forall lbl s ctl s' k, find_label lbl s ctl = Some (s',k) -> 
+     exists j, Kseq s' k = app_cont j ctl
 with
   find_label_ls_prefix:
-  forall lbl s ctl k, find_label_ls lbl s ctl = Some k -> exists j, k = j++ctl.
+  forall lbl s ctl s' k, find_label_ls lbl s ctl = Some (s',k) -> 
+     exists j, Kseq s' k = app_cont j ctl.
 Proof.
+-
  intros.
   clear find_label_prefix.
   revert ctl k H; induction s; simpl; intros; try congruence.
-  revert H; case_eq (find_label lbl s1 (Kseq s2 :: ctl)); intros; [inv H0 | auto ].
-  destruct (IHs1 _ _ H) as [j ?]. exists (j++ (Kseq s2::nil)); rewrite app_ass; auto.
-  revert H; case_eq (find_label lbl s1 ctl); intros; [inv H0 | auto ]; auto.
-  revert H; case_eq (find_label lbl s1 (Kseq Scontinue :: Kloop1 s1 s2 :: ctl)); intros; [inv H0 | auto ].
-  destruct (IHs1 _ _ H) as [j ?]. exists (j++ (Kseq Scontinue :: Kloop1 s1 s2::nil)); rewrite app_ass; auto.
-  destruct (IHs2 _ _ H0) as [j ?]. exists (j++ (Kloop2 s1 s2::nil)); rewrite app_ass; auto.
-  destruct (find_label_ls_prefix _ _ _ _ H) as [j ?]. exists (j++(Kswitch :: nil)); rewrite app_ass; auto.
+ + revert H; case_eq (find_label lbl s1 (Kseq s2 ctl)); intros; [inv H0 | auto ].
+    destruct (IHs1 _ _ H) as [j ?]. 
+    exists (app_cont j (Kseq s2 Kstop)); rewrite app_cont_ass; auto.
+  + revert H; case_eq (find_label lbl s1 ctl); intros; [inv H0 | auto ]; auto.
+  + destruct (find_label lbl s1 (Kloop1 s1 s2 ctl)) eqn:H0; inv H.
+      apply IHs1 in H0. destruct H0 as [j ?]. exists (app_cont j (Kloop1 s1 s2 Kstop)).
+      rewrite app_cont_ass. auto.
+      apply IHs2 in H2. destruct H2 as [j ?].
+      exists (app_cont j (Kloop2 s1 s2 Kstop)). rewrite app_cont_ass; auto.
+  + destruct (find_label_ls_prefix _ _ _ _ _ H) as [j ?].
+      exists (app_cont j (Kswitch Kstop)); rewrite app_cont_ass; auto.
+  +
   if_tac in H. subst l. inv H.
-  exists (Kseq s :: nil); auto.
+  exists (Kseq s' Kstop); auto.
   apply IHs; auto.
-
+-
  induction s; simpl; intros. inv H.
- revert H; case_eq (find_label lbl s (Kseq (seq_of_labeled_statement s0) :: ctl)); intros.
- inv H0.
- destruct (find_label_prefix _ _ _ _ H) as [j ?]; exists (j++Kseq (seq_of_labeled_statement s0) ::nil); rewrite app_ass; auto.
+ destruct (find_label lbl s (Kseq (seq_of_labeled_statement s0) ctl)) eqn:?H.
+ inv H.
+ destruct (find_label_prefix _ _ _ _ _ H0) as [j ?].
+ exists (app_cont j (Kseq (seq_of_labeled_statement s0) Kstop)).
+ rewrite app_cont_ass; auto.
  auto.
 Qed.
-
 
 Lemma find_label_None:
   forall lbl s ctl, find_label lbl s ctl = None -> forall ctl', find_label lbl s ctl' = None
@@ -925,9 +1009,10 @@ clear find_label_ls_None; induction s; simpl; intros; try congruence;
  rewrite (find_label_None _ _ _ H). eauto.
 Qed.
 
+(*
 Lemma find_label_prefix2':
- forall lbl s k1 pre, find_label lbl s k1 = Some (pre++k1) ->
-               forall k2, find_label lbl s k2 = Some (pre++k2)
+ forall lbl s k1 pre, find_label lbl s k1 = Some (app_cont pre k1) ->
+               forall k2, find_label lbl s k2 = Some (app_cont pre k2)
 with find_label_ls_prefix2':
  forall lbl s k1 pre, find_label_ls lbl s k1 = Some (pre++k1) ->
                forall k2, find_label_ls lbl s k2 = Some (pre++k2) .
@@ -995,382 +1080,95 @@ intros.
  eapply find_label_prefix2'; eauto.
 Qed.
 
-Lemma control_as_safe_bupd {Espec: OracleKind}: forall ge n ctl1 ctl2, control_as_safe ge n ctl1 ctl2 ->
- forall (ora : OK_ty) (ve : env) (te : temp_env) (m : juicy_mem) (n' : nat),
-     n' <= n ->
-     jm_bupd ora (jsafeN (@OK_spec Espec) ge n' ora (State ve te ctl1)) m ->
-     jm_bupd ora (jsafeN (@OK_spec Espec) ge n' ora (State ve te ctl2)) m.
-Proof.
-  repeat intro.
-  destruct (H1 _ H2) as (? & ? & ? & ?); eauto.
-Qed.
-
-Lemma corestep_preservation_lemma {Espec: OracleKind}:
-   forall ge ctl1 ctl2 ora ve te m n c l c' m',
-       filter_seq ctl1 = filter_seq ctl2 ->
-      (forall k : list cont', control_as_safe ge n (k ++ ctl1) (k ++ ctl2)) ->
-      control_as_safe ge (S n) ctl1 ctl2 ->
-      jstep (cl_core_sem ge) (State ve te (c :: l ++ ctl1)) m c' m' ->
-      jm_bupd ora (jsafeN (@OK_spec Espec) ge n ora c') m' ->
-   exists c2 : corestate,
-     exists m2 : juicy_mem,
-       jstep (cl_core_sem ge) (State ve te (c :: l ++ ctl2)) m c2 m2 /\
-       jm_bupd ora (jsafeN (@OK_spec Espec) ge n ora c2) m2.
-Proof. intros until m'. intros H0 H4 CS0 H H1.
-  remember (State ve te (c :: l ++ ctl1)) as q. rename c' into q'.
-  destruct H as [H [Hb [Hc Hg]]].
-  remember (m_dry m) as dm; remember (m_dry m') as dm'.
-  revert c l m Heqdm m' Heqdm' Hb Hc Hg H1 Heqq; induction H; intros; try inv Heqq.
-  (* assign *)
-  do 2 eexists; split; [split3; [econstructor; eauto | auto | auto ] | eapply control_as_safe_bupd; auto ].
-  (* set *)
-  do 2 eexists; split; [split3; [ | eassumption | auto ] | ].
-  rewrite <- Heqdm'; econstructor; eauto.
-  eapply control_as_safe_bupd; auto.
-  (* call_internal *)
-  do 2 eexists; split; [split3; [econstructor; eauto | auto | auto ] |  ].
-  do 3 rewrite cons_app'. eapply control_as_safe_bupd; auto.
-  (* call_external *)
-{ do 2 eexists; split; [split3; [ | eassumption | auto ] | ].
-  rewrite <- Heqdm';  eapply step_call_external; eauto.
-  intros ? HC J; specialize (H5 _ HC J) as (m'' & J' & Hupd & H5).
-  exists m''; split; auto; split; auto.
-  destruct n; [constructor|].
-  inv H5.
-  { destruct H7 as (?&?&?). inv H5. }
-  { eapply jsafeN_external; eauto.
-    intros ret m'0 z'' n'' Hargsty Hretty Hle H10 H11; specialize (H9 ret m'0 z'' n'' Hargsty Hretty Hle H10 H11).
-    destruct H9 as [c' [? ?]]. simpl in H5. unfold cl_after_external in *.
-    destruct ret as [ret|]. destruct optid.
-    exists (State ve (PTree.set i ret te) (l ++ ctl2)); split; auto.
-    inv H5. eapply control_as_safe_bupd; auto.
-    destruct H10 as (?&?&?). inv H5.
-    exists (State ve te (l ++ ctl2)); split; auto. eapply control_as_safe_bupd; auto.
-    destruct optid; auto.
-    exists (State ve (PTree.set i Vundef te) (l ++ ctl2)); split; auto.  inv H5. eapply control_as_safe_bupd; auto.
-    exists (State ve te (l ++ ctl2)); split; auto. eapply control_as_safe_bupd; auto.
-    inv H5. auto. }
-   contradiction. }
-  (* sequence  *)
-  { destruct (IHcl_step (Kseq s1) (Kseq s2 :: l)
-            _ (eq_refl _) _ (eq_refl _) Hb Hc Hg H1 (eq_refl _))
-      as [c2 [m2 [? ?]]]; clear IHcl_step.
-    destruct H2 as [H2 [H2b H2c]].
-    exists c2, m2; split; auto. split3; auto. constructor. apply H2. }
-  (* skip *)
-  { destruct l.
-    simpl in H.
-   assert (jsafeN (@OK_spec Espec) ge (S n) ora (State ve te ctl1) m0).
-   { econstructor; eauto; split3; eauto. }
-   apply CS0 in H2; auto.
-    eapply safe_step_forward in H2; auto.
-   destruct H2 as [st2 [m2 [? ?]]]; exists st2; exists m2; split; auto.
-   simpl.
-     destruct H2 as [H2 [H2b H2c]].
-    split3; auto.
-    simpl; rewrite <- strip_step. simpl. rewrite strip_step; auto.
-    destruct (IHcl_step c l _ (eq_refl _) _ (eq_refl _) Hb Hc Hg H1 (eq_refl _))
-      as [c2 [m2 [? ?]]]; clear IHcl_step.
-    exists c2; exists m2; split; auto.
-    destruct H2 as [H2 [H2b H2c]].
-   simpl.
-   split3; auto.
-   simpl; rewrite <- strip_step.
-   change (strip_skip (Kseq Sskip :: c :: l ++ ctl2)) with (strip_skip (c::l++ctl2)).
-   rewrite strip_step; auto. }
-  (* continue *)
-  case_eq (continue_cont l); intros.
-  assert (continue_cont (l++ctl1) = continue_cont (l++ctl2)).
-  clear - H0 H2.
-  induction l; simpl in *.
- revert ctl2 H0; induction ctl1; simpl; intros.
- revert H0; induction ctl2; simpl; intros; auto.
- destruct a; simpl in *; auto. inv H0. inv H0.
- destruct a; auto.
- revert H0; induction ctl2; simpl; intros. inv H0.
- destruct a; try congruence. rewrite <- (IHctl2 H0).
- f_equal.
- revert H0; induction ctl2; simpl; intros; try destruct a; try congruence.
- auto.
- revert H0; induction ctl2; simpl; intros; try destruct a; try congruence.
- auto.
- revert H0; induction ctl2; simpl; intros; try destruct a; try congruence.
- auto.
- destruct a; try congruence. auto. auto.
-  rewrite H3 in H.
-  exists st', m'0; split; auto.
-  split3; auto.
-  constructor. auto.
-  assert (forall k, continue_cont (l++k) = c::l0++k).
-  clear - H2. revert H2; induction l; intros; try destruct a; simpl in *; auto; try discriminate.
-  repeat rewrite cons_app'. f_equal; auto.
-  rewrite H3 in H, IHcl_step.
-  destruct (IHcl_step _ _ _ (eq_refl _) _ (eq_refl _) Hb Hc Hg H1 (eq_refl _)) as [c2 [m2 [? ?]]]; clear IHcl_step.
-  exists c2,m2; split; auto.
-   destruct H5 as [H5 [H5b H5c]].
- split3; auto.
- constructor. rewrite H3; auto.
-  (* break *)
-{
-  case_eq (prebreak_cont l); intros.
-  {
-  assert (break_cont (l++ctl1) = break_cont (l++ctl2)).
-  clear - H0 H2.
-  revert H2; induction l; simpl; intros; try destruct a; try congruence.
-  revert ctl2 H0; induction ctl1; simpl; intros.
- revert H0; induction ctl2; simpl; intros; try destruct a; try congruence. auto.
- destruct a. auto.
- revert H0; induction ctl2; try destruct a; simpl; intros; try congruence; auto.
- revert H0; induction ctl2; try destruct a; simpl; intros; try congruence; auto.
- revert H0; induction ctl2; try destruct a; simpl; intros; try congruence; auto.
- revert H0; induction ctl2; try destruct a; simpl; intros; try congruence; auto.
- destruct s; auto.
-  rewrite H3 in H.
-  exists st', m'0; split; auto.
-  split3; auto.
-  constructor. auto.
-  }
-  {
-  assert (PB:= prebreak_cont_is l); rewrite H2 in PB.
-  destruct c; try contradiction.
-  {
-  assert (forall k, break_cont (l++k) = l0++k).
-  clear - H2.
-  revert H2; induction l; intros; try destruct a; simpl in *; auto; congruence.
-  rewrite H3 in H.
-  destruct l0; simpl in *.
-  hnf in CS0.
-  specialize (CS0 ora ve te m0 (S n)).
-  assert (semantics.corestep (juicy_core_sem (cl_core_sem ge)) (State ve te ctl1) m0 st' m'0).
-  split3; auto.
-  pose proof (@jsafeN_step genv _ _ genv_symb_injective (cl_core_sem ge) OK_spec ge _ _ _ _ _ _ H5 H1).
-  apply CS0 in H6; auto.
-  destruct (safe_step_forward ge n ora (State ve te ctl2) m0) as [c2 [m2 [? ?]]]; auto.
-  exists c2; exists m2; split; auto.
-  destruct H7;  constructor; auto. constructor; auto. rewrite H3. auto.
-  destruct (IHcl_step c l0 m0 (eq_refl _) m'0 (eq_refl _)) as [c2 [m2 [? ?]]]; auto.
-  rewrite H3; auto.
-  exists c2,m2; split; auto.
-  destruct H5; split; auto. constructor; auto. rewrite H3; auto.
-  }
-  {
-  assert (forall k, break_cont (l++k) = l0++k).
-  clear - H2.
-  revert H2; induction l; intros; try destruct a; simpl in *; auto; congruence.
-  rewrite H3 in H.
-  destruct l0; simpl in *.
-  hnf in CS0.
-  specialize (CS0 ora ve te m0 (S n)).
-  assert (semantics.corestep (juicy_core_sem (cl_core_sem ge)) (State ve te ctl1) m0 st' m'0).
-  split3; auto.
-  pose proof (@jsafeN_step genv _ _ genv_symb_injective  (cl_core_sem ge) OK_spec ge _ _ _ _ _ _ H5 H1).
-  apply CS0 in H6; auto.
-  destruct (safe_step_forward ge n ora (State ve te ctl2) m0) as [c2 [m2 [? ?]]]; auto.
-  exists c2; exists m2; split; auto.
-  destruct H7;  constructor; auto. constructor; auto. rewrite H3. auto.
-  destruct (IHcl_step c l0 m0 (eq_refl _) m'0 (eq_refl _)) as [c2 [m2 [? ?]]]; auto.
-  rewrite H3; auto.
-  exists c2,m2; split; auto.
-  destruct H5; split; auto. constructor; auto. rewrite H3; auto.
-  }
-  {
-  assert (forall k, break_cont (l++k) = l0++k).
-  clear - H2.
-  revert H2; induction l; intros; try destruct a; simpl in *; auto; congruence.
-  rewrite H3 in H.
-  destruct l0; simpl in *.
-  hnf in CS0.
-  specialize (CS0 ora ve te m0 (S n)).
-  assert (semantics.corestep (juicy_core_sem (cl_core_sem ge)) (State ve te ctl1) m0 st' m'0).
-  split3; auto.
-  pose proof (@jsafeN_step genv _ _ genv_symb_injective  (cl_core_sem ge) OK_spec ge _ _ _ _ _ _ H5 H1).
-  apply CS0 in H6; auto.
-  destruct (safe_step_forward ge n ora (State ve te ctl2) m0) as [c2 [m2 [? ?]]]; auto.
-  exists c2; exists m2; split; auto.
-  destruct H7;  constructor; auto. constructor; auto. rewrite H3. auto.
-  destruct (IHcl_step c l0 m0 (eq_refl _) m'0 (eq_refl _)) as [c2 [m2 [? ?]]]; auto.
-  rewrite H3; auto.
-  exists c2,m2; split; auto.
-  destruct H5; split; auto. constructor; auto. rewrite H3; auto.
-  }
-  }
-}
-  (* ifthenelse *)
-  exists (State ve te (Kseq (if b then s1 else s2) :: l ++ ctl2)), m'.
-  split. split3; auto. rewrite <- Heqdm'. econstructor; eauto.
-  rewrite cons_app. rewrite <- app_ass.
-  eapply control_as_safe_bupd; auto.
-  (* loop *)
-  change (Kseq s1 :: Kseq Scontinue :: Kloop1 s1 s2 :: l ++ ctl1) with
-               ((Kseq s1 :: Kseq Scontinue :: Kloop1 s1 s2 :: l) ++ ctl1) in H1.
-  eapply control_as_safe_bupd in H1; eauto.
-  do 2 eexists; split; eauto.
-   split3; eauto. rewrite <- Heqdm'.
-  econstructor; eauto.
-  (* loop2 *)
-  change (Kseq s :: Kseq Scontinue :: Kloop1 s a3 :: l ++ ctl1) with
-              ((Kseq s :: Kseq Scontinue :: Kloop1 s a3 :: l) ++ ctl1) in H1.
-  eapply control_as_safe_bupd in H1; eauto.
-  do 2 eexists; split; eauto.   split3; eauto. rewrite <- Heqdm'.  econstructor; eauto.
- (* return *)
-  case_eq (call_cont l); intros.
-  rewrite call_cont_app_nil in * by auto.
-  exists (State ve' te'' k'), m'0; split; auto.
-  split3; auto.
-  econstructor; try eassumption. rewrite call_cont_app_nil; auto.
-  rewrite <- (filter_seq_call_cont _ _ H0); auto.
-  rewrite (call_cont_app_cons _ _ _ H6) in H. inv H.
-  do 2 eexists; split.
-  split3; eauto.
-  econstructor; try eassumption.
- rewrite (call_cont_app_cons _ _ _ H6). reflexivity.
-  eapply control_as_safe_bupd; auto.
- (* switch *)
-  do 2 eexists; split; [split3; [| eauto | eauto] | ].
-  rewrite <- Heqdm'. econstructor; eauto.
-  do 2 rewrite cons_app'. eapply control_as_safe_bupd; auto.
- (* label *)
-  destruct (IHcl_step _ _  _ (eq_refl _) _ (eq_refl _) Hb Hc Hg H1 (eq_refl _)) as [c2 [m2 [? ?]]]; clear IHcl_step.
-  exists c2, m2; split; auto.
-   destruct H2 as [H2 [H2b H2c]].
-  split3; auto.
-  constructor; auto.
- (* goto *)
-  case_eq (call_cont l); intros.
-  do 2 eexists; split; [ | apply H1].
-  split3; auto.
-  rewrite <- Heqdm'; econstructor. 2: rewrite call_cont_app_nil; auto.
-  instantiate (1:=f).
-  generalize (filter_seq_current_function ctl1 ctl2 H0); intro.
-  clear - H3 H2 CUR.
-  revert l H3 H2 CUR; induction l; simpl; try destruct a; intros; auto; try congruence.
-  rewrite call_cont_app_nil in H by auto.
-  rewrite <- (filter_seq_call_cont ctl1 ctl2 H0); eauto.
-  rewrite (call_cont_app_cons _ _ _ H2) in H.
-  assert (exists j, k' = j ++ ctl1).
-  clear - H2 H.
-  assert (exists id, exists f, exists ve, exists te, c =  Kcall id f ve te).
-  clear - H2; induction l; [inv H2 | ].
-  destruct a; simpl in H2; auto. inv H2; do 4 eexists; reflexivity.
-  destruct H0 as [id [ff [ve [te ?]]]]. clear H2; subst c.
-  change (find_label lbl (fn_body f)
-      ((Kseq (Sreturn None) :: Kcall id ff ve te :: l0) ++ ctl1) = Some k') in H.
-  forget (Kseq (Sreturn None) :: Kcall id ff ve te :: l0) as pre.
-  assert (exists j, k' = j++ (pre++ctl1));
-   [ | destruct H0 as [j H0]; exists (j++pre); rewrite app_ass; auto ].
-  forget (pre++ctl1) as ctl. forget (fn_body f) as s;  clear - H.
- eapply find_label_prefix; eauto.
-  destruct H3 as [j ?].
-  subst k'.
-  exists (State ve te (j++ctl2)), m'; split; [ | eapply control_as_safe_bupd; eauto].
-  split3; auto.
-  rewrite <- Heqdm'; econstructor.
-  instantiate (1:=f).
-  clear - CUR H2.
-  revert f c l0 CUR H2; induction l; simpl; intros. inv H2.
-  destruct a; simpl in *; eauto.
-  rewrite (call_cont_app_cons _ _ _ H2).
-  clear - H2 H.
-  change (Kseq (Sreturn None) :: c :: l0 ++ ctl1) with ((Kseq (Sreturn None) :: c :: l0) ++ ctl1) in H.
-  change (Kseq (Sreturn None) :: c :: l0 ++ ctl2) with ((Kseq (Sreturn None) :: c :: l0) ++ ctl2).
-  forget (Kseq (Sreturn None) :: c :: l0)  as pre.
-clear - H.
- eapply find_label_prefix2; eauto.
-Qed.
+*)
 
 Lemma control_as_safe_le {Espec: OracleKind}:
   forall n' n ge ctl1 ctl2, n' <= n -> control_as_safe ge n ctl1 ctl2 -> control_as_safe ge n' ctl1 ctl2.
 Proof.
- intros. intro; intros. eapply H0; auto; omega.
-Qed.
-
-Lemma control_suffix_safe {Espec: OracleKind}:
-    forall
-      ge n ctl1 ctl2 k,
-      filter_seq ctl1 = filter_seq ctl2 ->
-      control_as_safe ge n ctl1 ctl2 ->
-      control_as_safe ge n (k ++ ctl1) (k ++ ctl2).
-  Proof.
-    intro ge. induction n using (well_founded_induction lt_wf).
-    intros. hnf; intros.
-    destruct n'; [ constructor | ].
-    assert (forall k, control_as_safe ge n' (k ++ ctl1) (k ++ ctl2)).
-    intro; apply H; auto. apply control_as_safe_le with n; eauto. omega.
-   case_eq (strip_skip k); intros.
-    rewrite <- safeN_strip in H3|-*.  rewrite strip_skip_app in H3|-* by auto.
-   rewrite safeN_strip in H3|-*.
-    auto.
-   assert (ZZ: forall k, strip_skip (c::l++k) = c::l++k)
-    by (clear - H5; intros; rewrite <- (strip_skip_app_cons H5); rewrite strip_strip; auto).
-  rewrite <- safeN_strip in H3|-*.
-  rewrite (strip_skip_app_cons H5) in H3|-* by auto.
-  inv H3.
-  apply corestep_preservation_lemma
-    with (c0 := c) (l0 := l) (ve0 := ve) (te0 := te) (m0 := m)
-         (ctl3:=ctl1) (ctl4:=ctl2) (n0 := n') in H8; auto.
-   destruct H8 as [? [? [? ?]]].
-   econstructor; eauto.
-   eapply control_as_safe_le; eauto.
-  simpl in H7. congruence.
-  simpl in H6. unfold cl_halted in H6. contradiction.
+ intros.
+ destruct H0 as [? [? [? [? [? [? ?]]]]]].
+  subst.
+  do 2 eexists; split; eauto.
+  do 2 eexists; split; eauto.
+ intros.
+ eapply H2; auto; omega.
 Qed.
 
 Lemma guard_safe_adj {Espec: OracleKind}:
  forall
-   psi Delta P k1 k2,
-   current_function k1 = current_function k2 ->
+   psi Delta f P c1 k1 c2 k2,
   (forall ora m ve te n,
-     jsafeN (@OK_spec Espec) psi n ora (State ve te k1) m ->
-     jsafeN (@OK_spec Espec) psi n ora (State ve te k2) m) ->
-  guard Espec psi Delta P k1 |-- guard Espec psi Delta P k2.
+     jsafeN (@OK_spec Espec) psi n ora (State f c1 k1 ve te) m ->
+     jsafeN (@OK_spec Espec) psi n ora (State f c2 k2 ve te) m) ->
+  guard Espec psi Delta f P (Kseq c1 k1) |-- guard Espec psi Delta f P (Kseq c2 k2).
 Proof.
 intros.
 unfold guard.
 apply allp_derives. intros tx.
 apply allp_derives. intros vx.
-rewrite H; apply subp_derives; auto.
+apply subp_derives; auto.
 apply bupd_mono.
-intros w ? ? ? ? ? ?.
-apply H0.
-eapply H1; eauto.
+intros w ? ? ? ? .
+simpl in H0.
+specialize (H0 ora jm H1).
+intros.
+destruct H0 as [? [? [? ?]]]; auto.
+do 2 eexists; split; eauto.
+inv H0.
+apply H.
+eapply H4; eauto.
+Qed.
+
+Lemma guard_safe_adj' {Espec: OracleKind}:
+ forall
+   psi Delta f P c1 k1 c2 k2,
+  (forall ora m ve te,
+     jsafeN (@OK_spec Espec) psi (level m) ora (State f c1 k1 ve te) m ->
+     jsafeN (@OK_spec Espec) psi (level m) ora (State f c2 k2 ve te) m) ->
+  guard Espec psi Delta f P (Kseq c1 k1) |-- guard Espec psi Delta f P (Kseq c2 k2).
+Proof.
+intros.
+unfold guard.
+apply allp_derives. intros tx.
+apply allp_derives. intros vx.
+apply subp_derives; auto.
+apply bupd_mono.
+do 2 eexists; split; eauto.
+specialize (H0 ora jm).
+destruct H0 as [? [? [? ?]]]; auto. symmetry in H0; inv H0.
+apply H.
+eapply H4; eauto.
 Qed.
 
 Lemma assert_safe_adj:
-  forall {Espec: OracleKind} ge ve te k k' rho,
+  forall {Espec: OracleKind} ge f ve te k k' rho,
       (forall n, control_as_safe ge n k k') ->
-     assert_safe Espec ge ve te k rho |-- assert_safe Espec ge ve te k' rho.
+     assert_safe Espec ge f ve te k rho |-- assert_safe Espec ge f ve te k' rho.
 Proof.
- intros. apply bupd_mono. intros w ? ? ? ? ? ?. specialize (H0 ora jm H1 H2 H3).
- eapply H; try apply H0. apply le_refl.
+ intros. apply bupd_mono.
+ intros w ? ? ?. specialize (H0 ora jm).
+ intros.
+ destruct H0 as [? [? [? ?]]]; auto. subst k.
+ specialize (H (level w)). hnf in H.
+ destruct H as [c1 [k1 [? ?]]]. inv H.
+ destruct H0 as [c2 [k2 [? ?]]]. 
+ do 2 eexists; split; eauto.
 Qed.
 
 Lemma assert_safe_adj':
-  forall {Espec: OracleKind} ge ve te k k' rho P w,
+  forall {Espec: OracleKind} ge f ve te k k' rho P w,
       (forall n, control_as_safe ge n k k') ->
-     app_pred (P >=> assert_safe Espec ge ve te k rho) w ->
-     app_pred (P >=> assert_safe Espec ge ve te k' rho) w.
+     app_pred (P >=> assert_safe Espec ge f ve te k rho) w ->
+     app_pred (P >=> assert_safe Espec ge f ve te k' rho) w.
 Proof.
  intros.
  eapply subp_trans'; [ | apply derives_subp; eapply assert_safe_adj; try eassumption; eauto].
  auto.
 Qed.
 
-Lemma rguard_adj:
-  forall {Espec: OracleKind} ge Delta R k k',
-      current_function k = current_function k' ->
-      (forall ek vl n, control_as_safe ge n (exit_cont ek vl k) (exit_cont ek vl k')) ->
-      rguard Espec ge Delta R k |-- rguard Espec ge Delta R k'.
-Proof.
- intros.
- intros n H1;  hnf in H1|-*.
- intros ek vl te ve; specialize (H1 ek vl te ve).
- rewrite <- H.
- eapply assert_safe_adj'; eauto.
-Qed.
-
-Lemma assert_safe_last': forall {Espec: OracleKind} ge ve te ctl rho w,
-            (age1 w <> None -> assert_safe Espec ge ve te ctl rho w) ->
-             assert_safe Espec ge ve te ctl rho w.
+Lemma assert_safe_last': forall {Espec: OracleKind} ge f ve te c k rho w,
+            (age1 w <> None -> assert_safe Espec ge f ve te (Kseq c k) rho w) ->
+             assert_safe Espec ge f ve te (Kseq c k) rho w.
 Proof.
  intros. apply assert_safe_last; intros. apply H. rewrite H0. congruence.
 Qed.
@@ -1743,10 +1541,10 @@ Lemma semax_eq:
                                           cenv_sub (@cenv_cs CS') (genv_cenv psi)) -->
          @believe CS' Espec Delta' psi Delta' -->
          ALL k : cont ,
-         ALL F : assert ,
+         ALL F : assert , ALL f: function,
          !! closed_wrt_modvars c F &&
-         rguard Espec psi Delta' (frame_ret_assert R F) k -->
-         guard Espec psi Delta' (fun rho : environ => F rho * P rho) (Kseq c :: k))).
+         rguard Espec psi Delta' f (frame_ret_assert R F) k -->
+         guard Espec psi Delta' f (fun rho : environ => F rho * P rho) (Kseq c k))).
 Proof.
 intros.
 extensionality w.
@@ -1754,9 +1552,10 @@ rewrite semax_fold_unfold.
 apply prop_ext; intuition.
 Qed.
 
-Lemma safe_kseq_Slabel {Espec: OracleKind} psi n ora ve te l c k m :
+(*
+Lemma safe_kseq_Slabel {Espec: OracleKind} psi n ora f ve te l c k m :
   @jsafeN (@OK_ty Espec) (@OK_spec Espec) psi n ora
-      (State ve te (@cons cont' (Kseq c) k)) m ->
+      (State f ve te (@cons cont' (Kseq c) k)) m ->
 @jsafeN (@OK_ty Espec) (@OK_spec Espec) psi n ora
   (State ve te (@cons cont' (Kseq (Slabel l c)) k)) m.
 Proof.
@@ -1767,6 +1566,7 @@ inversion 1; subst.
 + simpl in *; congruence.
 + simpl in *. unfold cl_halted in H0. contradiction.
 Qed.
+*)
 
 Lemma semax_Slabel {cs:compspecs} {Espec: OracleKind}
        (Gamma:tycontext) (P:environ -> mpred) (c:statement) (Q:ret_assert) l:
@@ -1781,9 +1581,15 @@ apply prop_imp_derives; intros TC.
 apply imp_derives; [ apply derives_refl | ].
 apply allp_derives; intros k.
 apply allp_derives; intros F.
+apply allp_derives; intros f.
 apply imp_derives; [ apply derives_refl | ].
-apply guard_safe_adj; [ trivial | intros].
-apply safe_kseq_Slabel; trivial.
+apply guard_safe_adj'.
+intros.
+clear - H.
+eapply jsafeN_local_step.
+constructor.
+intros.
+eapply age_safe; eauto.
 Qed.
 
 Lemma denote_tc_resource: forall {cs: compspecs} rho a a' t, resource_at a = resource_at a' ->
@@ -1847,20 +1653,62 @@ Proof.
   eapply denote_tc_resource; [|eauto]; auto.
 Qed.
 
-Lemma assert_safe_jsafe: forall {Espec: OracleKind} ge ve te ctl ora jm,
-  assert_safe Espec ge ve te ctl (construct_rho (filter_genv ge) ve te) (m_phi jm) ->
-  jm_bupd ora (jsafeN OK_spec ge (level jm) ora (State ve te ctl)) jm.
+Lemma assert_safe_jsafe: forall {Espec: OracleKind} ge f ve te c k ora jm,
+  assert_safe Espec ge f ve te (Kseq c k) (construct_rho (filter_genv ge) ve te) (m_phi jm) ->
+  jm_bupd ora (jsafeN OK_spec ge (level jm) ora (State f c k ve te)) jm.
 Proof.
   repeat intro.
   destruct (H _ H1) as (? & ? & ? & Hl & Hr & ? & Hsafe); subst.
   destruct (juicy_mem_resource _ _ Hr) as (jm' & ? & ?); subst.
   exists jm'; repeat split; auto.
   rewrite level_juice_level_phi, <- Hl.
-  apply Hsafe; auto.
+  specialize (Hsafe ora jm').
+  destruct (gt_dec (level (m_phi jm')) O).
+  destruct Hsafe as [c1 [k1 [? Hsafe]]]; auto.
   simpl.
   eapply joins_comm, join_sub_joins_trans, joins_comm, H2.
   destruct H0.
   change (Some (ghost_PCM.ext_ref ora, NoneP) :: nil) with
     (ghost_approx (m_phi jm) (Some (ghost_PCM.ext_ref ora, NoneP) :: nil)).
   eexists; apply ghost_fmap_join; eauto.
+  inv H3. auto. 
+  replace (level (m_phi jm')) with O by omega. constructor.
 Qed.
+
+Lemma assert_safe_jsafe': forall {Espec: OracleKind} ge f ve te k ora jm,
+  assert_safe Espec ge f ve te k (construct_rho (filter_genv ge) ve te) (m_phi jm) ->
+  jm_bupd ora (jsafeN OK_spec ge (level jm) ora (State f Sskip k ve te)) jm.
+Proof.
+  intros.
+  repeat intro.
+  destruct (H _ H1) as (? & ? & ? & Hl & Hr & ? & Hsafe); subst.
+  destruct (juicy_mem_resource _ _ Hr) as (jm' & ? & ?); subst.
+  exists jm'; repeat split; auto.
+  rewrite level_juice_level_phi, <- Hl.
+  specialize (Hsafe ora jm').
+  destruct (gt_dec (level (m_phi jm')) O).
+2:   replace (level (m_phi jm')) with O by omega; constructor.
+  destruct Hsafe as [c1 [k1 [? Hsafe]]]; auto.
+  simpl.
+  eapply joins_comm, join_sub_joins_trans, joins_comm, H2.
+  destruct H0.
+  change (Some (ghost_PCM.ext_ref ora, NoneP) :: nil) with
+    (ghost_approx (m_phi jm) (Some (ghost_PCM.ext_ref ora, NoneP) :: nil)).
+  eexists; apply ghost_fmap_join; eauto.
+  inv H3.
+  eapply jsafeN_local_step. constructor.
+  intros.
+  eapply age_safe; eauto.
+Qed.
+
+Lemma jm_bupd_local_step
+     : forall {Espec: OracleKind} (ge : genv) (ora : OK_ty) (s1 : CC_core)
+         (m : juicy_mem) (s2 : CC_core),
+       cl_step ge s1 (m_dry m) s2 (m_dry m) ->
+       (forall m' : juicy_mem,
+        age m m' -> jm_bupd ora (jsafeN (@OK_spec Espec) ge (level m') ora s2) m') ->
+       jm_bupd ora (jsafeN (@OK_spec Espec) ge (level m) ora s1) m.
+Proof.
+intros.
+destruct (age1 m) as [m' | ] eqn:?H.
+Abort.  

--- a/veric/semax_loop.v
+++ b/veric/semax_loop.v
@@ -5,7 +5,7 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.juicy_extspec.

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -4,7 +4,7 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.juicy_extspec.
@@ -1525,7 +1525,7 @@ Proof.
       hnf in H10', H11.
       destruct H9.
       subst a.
-      change Clight_new.true_expr with true_expr.
+      change Clight_core.true_expr with true_expr.
       change (level (m_phi jm)) with (level jm).
       apply safe_loop_skip.
 (*    +rewrite HGG. apply cenv_sub_refl.*)
@@ -1760,7 +1760,7 @@ eapply (semax_call_aux (Delta1 V G) (ConstType (ident->val))
   hnf in H10', H11.
   destruct H9.
   subst a.
-  change Clight_new.true_expr with true_expr.
+  change Clight_core.true_expr with true_expr.
   change (level (m_phi jm)) with (level jm).
   apply safe_loop_skip.
 + unfold glob_types, Delta1. simpl @snd.

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -79,10 +79,10 @@ specialize (Hsafe _ (necR_refl _)).
 destruct H4.
 spec Hsafe; [clear Hsafe| ].
 split; auto.
+simpl proj_ret_assert.
+rewrite (prop_true_andp (None=None)) by auto.
 split; auto.
 subst rho'; auto.
-rewrite proj_frame_ret_assert.
-simpl seplog.sepcon.
 rewrite sepcon_comm; subst rho'; auto.
 subst rho'.
 replace (level jm1) with (level jm').

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -5,7 +5,7 @@ Require Import VST.veric.res_predicates.
 Require Import VST.veric.extend_tc.
 Require Import VST.veric.Clight_seplog.
 Require Import VST.veric.Clight_assert_lemmas.
-Require Import VST.veric.Clight_new.
+Require Import VST.veric.Clight_core.
 Require Import VST.sepcomp.extspec.
 Require Import VST.sepcomp.step_lemmas.
 Require Import VST.veric.juicy_extspec.

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -27,10 +27,10 @@ Section extensions.
 Lemma semax_straight_simple:
  forall Delta (B: assert) P c Q,
   (forall rho, boxy extendM (B rho)) ->
-  (forall jm jm1 Delta' ge ve te rho k F,
+  (forall jm jm1 Delta' ge ve te rho k F f,
               tycontext_sub Delta Delta' ->
               app_pred (B rho) (m_phi jm) ->
-              guard_environ Delta' (current_function k) rho ->
+              guard_environ Delta' f rho ->
               closed_wrt_modvars c F ->
               rho = construct_rho (filter_genv ge) ve te  ->
               age jm jm1 ->
@@ -39,15 +39,15 @@ Lemma semax_straight_simple:
               exists jm', exists te', exists rho',
                 rho' = mkEnviron (ge_of rho) (ve_of rho) (make_tenv te') /\
                 level jm = S (level jm') /\
-                guard_environ Delta' (current_function k) rho'  /\
-                jstep (cl_core_sem ge) (State ve te (Kseq c :: k)) jm
-                                 (State ve te' k) jm' /\
+                guard_environ Delta' f rho'  /\
+                jstep (cl_core_sem ge) (State f c k ve te) jm
+                                 (State f Sskip k ve te') jm' /\
               ((F rho' * Q rho') && funassert Delta' rho) (m_phi jm')) ->
   semax Espec Delta (fun rho => B rho && |> P rho) c (normal_ret_assert Q).
 Proof.
 intros until Q; intros EB Hc.
 rewrite semax_unfold.
-intros psi Delta' CS' n TS [CSUB HGG'] _ k F Hcl Hsafe te ve w Hx w0 H Hglob.
+intros psi Delta' CS' n TS [CSUB HGG'] _ k F f Hcl Hsafe te ve w Hx w0 H Hglob.
 specialize (cenv_sub_trans CSUB HGG'); intros HGG.
 apply nec_nat in Hx.
 apply (pred_nec_hereditary _ _ _ Hx) in Hsafe.
@@ -62,7 +62,7 @@ destruct Hglob as [[TC' Hglob] Hglob'].
 apply can_age_jm in Hage; destruct Hage as [jm1 Hage].
 apply extend_sepcon_andp in Hglob; auto.
 destruct Hglob as [TC2 Hglob].
-specialize (Hc jm jm1 Delta' psi ve te _ k F TS TC2 TC' Hcl (eq_refl _) Hage).
+specialize (Hc jm jm1 Delta' psi ve te _ k F f TS TC2 TC' Hcl (eq_refl _) Hage).
 specialize (Hc (conj Hglob Hglob') HGG); clear Hglob Hglob'.
 destruct Hc as [jm' [te' [rho' [H9 [H2 [TC'' [H3 H4]]]]]]].
 change (@level rmap _  (m_phi jm) = S (level (m_phi jm'))) in H2.
@@ -86,7 +86,8 @@ simpl seplog.sepcon.
 rewrite sepcon_comm; subst rho'; auto.
 subst rho'.
 replace (level jm1) with (level jm').
-apply assert_safe_jsafe; auto.
+simpl exit_cont in Hsafe.
+apply assert_safe_jsafe'; auto.
 rewrite <- !level_juice_level_phi in H2.
 apply age_level in Hage; omega.
 Qed.
@@ -392,7 +393,7 @@ Proof.
   intros CMP TC2.
   apply semax_straight_simple; auto.
   intros; repeat apply boxy_andp; auto;  apply extend_later'; apply extend_sepcon_TT.
-  intros jm jm' Delta' ge vx tx rho k F TS [[[[TC3 TC1]  TC4] MT1] MT2] TC' Hcl Hge ? ? HGG.
+  intros jm jm' Delta' ge vx tx rho k F f TS [[[[TC3 TC1]  TC4] MT1] MT2] TC' Hcl Hge ? ? HGG.
   specialize (TC3 (m_phi jm') (age_laterR (age_jm_phi H))).
   specialize (TC1 (m_phi jm') (age_laterR (age_jm_phi H))).
   specialize (TC4 (m_phi jm') (age_laterR (age_jm_phi H))).
@@ -551,7 +552,7 @@ Proof.
         |> P rho))
     by (extensionality rho;  repeat rewrite later_andp; auto).
   apply semax_straight_simple; auto.
-  intros jm jm' Delta' ge vx tx rho k F TS [TC3 TC2] TC' Hcl Hge ? ? HGG'.
+  intros jm jm' Delta' ge vx tx rho k F f TS [TC3 TC2] TC' Hcl Hge ? ? HGG'.
   specialize (TC3 (m_phi jm') (age_laterR (age_jm_phi H))).
   specialize (TC2 (m_phi jm') (age_laterR (age_jm_phi H))).
   assert (typecheck_environ Delta rho) as TC.
@@ -673,7 +674,7 @@ replace (fun rho : environ =>
      (|> tc_expr Delta e rho && |> P rho))
   by (extensionality rho;  repeat rewrite later_andp; auto).
 apply semax_straight_simple; auto.
-intros jm jm' Delta' ge vx tx rho k F TS TC3 TC' Hcl Hge ? ? HGG'.
+intros jm jm' Delta' ge vx tx rho k F f TS TC3 TC' Hcl Hge ? ? HGG'.
 specialize (TC3 (m_phi jm') (age_laterR (age_jm_phi H))).
 assert (typecheck_environ Delta rho) as TC.
 {
@@ -797,7 +798,7 @@ replace (fun rho : environ =>
      (|> tc_expr Delta (Ecast e t) rho && |> P rho))
   by (extensionality rho;  repeat rewrite later_andp; auto).
 apply semax_straight_simple; auto.
-intros jm jm' Delta' ge vx tx rho k F TS TC3 TC' Hcl Hge ? ? HGG'.
+intros jm jm' Delta' ge vx tx rho k F f TS TC3 TC' Hcl Hge ? ? HGG'.
 specialize (TC3 (m_phi jm') (age_laterR (age_jm_phi H))).
 assert (typecheck_environ Delta rho) as TC.
 {
@@ -961,7 +962,7 @@ repeat rewrite andp_assoc.
 unfold mapsto.
 apply semax_straight_simple.
 intro. apply boxy_andp; auto.
-intros jm jm1 Delta' ge ve te rho k F TS [TC2 TC3] TC' Hcl Hge ? ? HGG'.
+intros jm jm1 Delta' ge ve te rho k F f TS [TC2 TC3] TC' Hcl Hge ? ? HGG'.
 specialize (TC2 (m_phi jm1) (age_laterR (age_jm_phi H))).
 specialize (TC3 (m_phi jm1) (age_laterR (age_jm_phi H))).
 assert (typecheck_environ Delta rho) as TC.
@@ -1102,7 +1103,7 @@ repeat rewrite andp_assoc.
 unfold mapsto.
 apply semax_straight_simple.
 intro. apply boxy_andp; auto.
-intros jm jm1 Delta' ge ve te rho k F TS [TC2 TC3] TC' Hcl Hge ? ? HGG'.
+intros jm jm1 Delta' ge ve te rho k F f TS [TC2 TC3] TC' Hcl Hge ? ? HGG'.
 specialize (TC2 (m_phi jm1) (age_laterR (age_jm_phi H))).
 specialize (TC3 (m_phi jm1) (age_laterR (age_jm_phi H))).
 assert (typecheck_environ Delta rho) as TC.
@@ -1429,7 +1430,7 @@ apply exp_right with Vundef.
 repeat rewrite later_andp; auto.
 apply extract_exists_pre; intro v3.
 apply semax_straight_simple; auto.
-intros jm jm1 Delta' ge ve te rho k F TS [TC1 TC2] TC4 Hcl Hge Hage [H0 H0'] HGG'.
+intros jm jm1 Delta' ge ve te rho k F f TS [TC1 TC2] TC4 Hcl Hge Hage [H0 H0'] HGG'.
 specialize (TC1 (m_phi jm1) (age_laterR (age_jm_phi Hage))).
 specialize (TC2 (m_phi jm1) (age_laterR (age_jm_phi Hage))).
 assert (typecheck_environ Delta rho) as TC.

--- a/veric/semax_switch.v
+++ b/veric/semax_switch.v
@@ -279,8 +279,16 @@ apply allp_right; intro vx'.
  rewrite !proj_frame_ret_assert.
  simpl.
  apply fash_derives.
- destruct R as [?R ?R ?R ?R]; destruct ek; subst ek' vl'; simpl; auto.
- apply imp_right. normalize.
+ destruct R as [?R ?R ?R ?R]; destruct ek eqn:?H; subst ek' vl'; simpl; auto.
+ apply imp_right; normalize; apply imp_derives; auto.
+ apply imp_derives; normalize.
+ rewrite !andp_assoc.
+ repeat apply andp_derives; auto.
+ repeat intro; hnf; auto.
+ apply imp_derives; normalize.
+ rewrite !andp_assoc.
+ repeat apply andp_derives; auto.
+ repeat intro; hnf; auto.
 Qed.
 
 Lemma unfash_fash_imp:

--- a/veric/semax_switch.v
+++ b/veric/semax_switch.v
@@ -301,9 +301,9 @@ Lemma assert_safe_step_nostore:
     app_pred (tc_expr Delta e rho) (m_phi jm) ->
      cl_step psi (State f c1 k1 vx tx)
       (m_dry jm) (State f c2 k2 vx2 tx2) (m_dry jm)) ->
-  assert_safe Espec psi f vx2 tx2 (Kseq c2 k2) (construct_rho (filter_genv psi) vx2 tx2)
+  assert_safe Espec psi f vx2 tx2 (Cont (Kseq c2 k2)) (construct_rho (filter_genv psi) vx2 tx2)
  && tc_expr Delta e rho
-|-- assert_safe Espec psi f vx tx (Kseq c1 k1) (construct_rho (filter_genv psi) vx tx).
+|-- assert_safe Espec psi f vx tx (Cont (Kseq c1 k1)) (construct_rho (filter_genv psi) vx tx).
 Proof.
 intros.
 intros w [Hw Hw'] ? J.
@@ -313,7 +313,7 @@ destruct (level (m_phi jm)) eqn:?; try omega. clear LW.
 destruct (levelS_age1 _ _ Heqn) as [phi' H1].
 destruct (can_age1_juicy_mem _ _ H1) as [jm' H9].
 clear phi' H1.
-do 2 eexists; split; eauto.
+simpl.
 econstructor 2 with (m' := jm').
 econstructor.
 rewrite <- (age_jm_dry H9).


### PR DESCRIPTION
Soundness of VST is now proved directly on CompCert Clight semantics, rather than veric/Clight_new.  Therefore there's no longer a need for the simulation proof between Clight_new and Clight.