### PR TITLE
Add compcert/_CoqProject

### DIFF
--- a/compcert/_CoqProject
+++ b/compcert/_CoqProject
@@ -1,0 +1,2 @@
+-R lib compcert.lib -R common compcert.common -R x86 compcert.x86 -R backend compcert.backend -R cfrontend compcert.cfrontend -R driver compcert.driver -R flocq compcert.flocq -R exportclight compcert.exportclight -R cparser compcert.cparser -R MenhirLib compcert.MenhirLib
+-R x86_32 compcert.x86_32


### PR DESCRIPTION
Add compcert/_CoqProject so that CoqIDE / Proof-general can load compcert's .v files correctly.

The settings have been tested on CoqIDE for windows and Proof-general in Mac.