### PR TITLE
Consequence of fixing an ltac inconsistency of intro wrt intros (Coq PR #11721)

### DIFF
--- a/veric/align_mem.v
+++ b/veric/align_mem.v
@@ -393,7 +393,7 @@ Proof.
       erewrite hardware_alignof_by_value in H0 by eauto.
       apply Z.divide_add_r; auto.
   } 
-  intro t; type_induction t cenv CENV_CONS; intros.
+  intros t; type_induction t cenv CENV_CONS; intros.
   + split; intros; inv H1; inv H2.
   + eapply BY_VALUE; auto.
     destruct s, i; eexists; reflexivity.
@@ -406,11 +406,11 @@ Proof.
   + simpl in H0.
     split; intros; apply align_compatible_rec_Tarray; intros;
     eapply align_compatible_rec_Tarray_inv in H1; eauto.
-    - specialize (IH (z1 + sizeof cenv t0 * i) (z2 + sizeof cenv t0 * i)).
-      replace (z1 + sizeof cenv t0 * i - (z2 + sizeof cenv t0 * i)) with (z1 - z2) in IH by omega.
+    - specialize (IH (z1 + sizeof cenv t * i) (z2 + sizeof cenv t * i)).
+      replace (z1 + sizeof cenv t * i - (z2 + sizeof cenv t * i)) with (z1 - z2) in IH by omega.
       tauto.
-    - specialize (IH (z1 + sizeof cenv t0 * i) (z2 + sizeof cenv t0 * i)).
-      replace (z1 + sizeof cenv t0 * i - (z2 + sizeof cenv t0 * i)) with (z1 - z2) in IH by omega.
+    - specialize (IH (z1 + sizeof cenv t * i) (z2 + sizeof cenv t * i)).
+      replace (z1 + sizeof cenv t * i - (z2 + sizeof cenv t * i)) with (z1 - z2) in IH by omega.
       tauto.
   + split; intros; inv H1; inv H2; econstructor.
   + simpl in H, H0.


### PR DESCRIPTION
Hi, this PR is to propose a backward compatible fix so that VST continues to compile after coq/coq#11721 is merged.

The issue is that names introduced by `intros` behaved as binders for the continuation of the tactic, but that was not the case of `intro`. As a consequence, in `align_mem.v`, in a call to `intro t; type_induction t`, the second `t` was considered as a fresh name rather than as a bound name, later impacting a call to `fresh "t"` in the body of the Ltac definition for `type_induction`.

As a result, a generated name `t0` is now simply `t`.

The name would have been `t` if `intro` had been replaced by `intros`. This is what this PR does, so as to maintain backward compatibility (In particular, the PR can be merged at once, without waiting for coq/coq#11721. Keeping `intro` would otherwise be ok, but only once coq/coq#11721 is merged. I suspect that you have no reason to particularly prefer `intro` to `intros` though.)