### PR TITLE
Adapting to Coq PR #11885 (fixing swapped names Sorted/LocallySorted).

### DIFF
--- a/floyd/VSU.v
+++ b/floyd/VSU.v
@@ -3142,7 +3142,7 @@ Qed.
 Definition SortComponent {Espec V cs Externs Imports p Exports G} 
            (C:@Component Espec V cs Externs Imports p Exports G):
            @SortedComponent Espec V cs Externs Imports p Exports (SortFunspec.sort G).
-constructor; [ | apply SortFunspec.Sorted_sort].
+constructor; [ | apply SortFunspec.Sorted_sort || apply SortFunspec.LocallySorted_sort ].
 specialize (Comp_ctx_LNR C); intros DISJ.
 (*destruct C;*) unfold Comp_G in DISJ.
 constructor; trivial; try apply C; clear - C DISJ.


### PR DESCRIPTION
Hi,

It was noticed last week that the strings `LocallySorted` and `Sorted` were swapped in the name of the theorems `LocallySorted_sort` and `Sorted_sort` of the file `Mergesort.v` of the Coq standard library (coq/coq#11885). Continuous Integration told that it was not used in the developments that we are testing, but, meanwhile, we discovered that file `Floyd/VSU.v` of VST just added proofs referring to `LocallySorted` and `Sorted`, finally resulting in a failure of VST on Continuous Integration.

Are you ok with the change made in coq/coq#11885 (it swaps the names of `LocallySorted_sort` and `Sorted_sort` so that the former name proves `LocallySorted` and the second `Sorted` as expected).

In the urgency, for the CI, the attached patch is one possible way to adapt `VSU.v` which remains compatible with 8.11, trying to use one or the other lemma names, assuming that at least of the names will do the job in either 8.11 or Coq master.

