### PR TITLE
overlay for coq/coq#12162

### DIFF
--- a/progs/ghosts.v
+++ b/progs/ghosts.v
@@ -625,7 +625,7 @@ Next Obligation.
   auto.
 Defined.
 
-Global Instance max_order : PCM_order le.
+Global Instance max_order : PCM_order Peano.le.
 Proof.
   constructor; auto; intros.
   - intros ???; lia.

--- a/sepcomp/step_lemmas.v
+++ b/sepcomp/step_lemmas.v
@@ -92,7 +92,7 @@ Qed.
 
   Lemma safe_downward :
     forall n n' c m z,
-      le n' n ->
+      Peano.le n' n ->
       safeN_ n z c m -> safeN_ n' z c m.
   Proof.
     do 6 intro. revert c m z. induction H; auto.
@@ -110,7 +110,7 @@ Qed.
     revert c m c' m' n H0 H1.
     induction n0; intros; auto.
     simpl in H0; inv H0.
-    eapply safe_downward in H1; eauto. omega.
+    eapply safe_downward in H1; eauto. apply Nat.le_add_r.
     simpl in H0. destruct H0 as [c2 [m2 [STEP STEPN]]].
     apply (IHn0 _ _ _ _ n STEPN).
     assert (Heq: (n + S (S n0) = S (n + S n0))%nat) by omega.
@@ -147,7 +147,7 @@ Qed.
     solve[assert (Heq: (n = n - 0)%nat) by omega; rewrite Heq; auto].
     simpl in H. destruct H as [c2 [m2 [STEP STEPN]]].
     assert (H: safeN_ (n - 1 - n0) z c' m').
-    eapply safe_downward in H0; eauto. omega.
+    eapply safe_downward in H0; eauto. now rewrite <- Nat.sub_add_distr.
     specialize (IHn0 _ _ _ _ (n - 1)%nat STEPN H).
     solve[eapply safe_step'_back2; eauto].
   Qed.

--- a/veric/Clight_aging_lemmas.v
+++ b/veric/Clight_aging_lemmas.v
@@ -18,14 +18,14 @@ Set Bullet Behavior "Strict Subproofs".
 Lemma jsafeN_age Z Jspec ge ora q n jm jmaged :
   ext_spec_stable age (JE_spec _ Jspec) ->
   age jm jmaged ->
-  le n (level jmaged) ->
+  Peano.le n (level jmaged) ->
   @jsafeN Z Jspec ge n ora q jm ->
   @jsafeN Z Jspec ge n ora q jmaged.
 Proof. intros. eapply jsafeN__age; eauto. Qed.
 
 Lemma jsafeN_age_to Z Jspec ge ora q n l jm :
   ext_spec_stable age (JE_spec _ Jspec) ->
-  le n l ->
+  Peano.le n l ->
   @jsafeN Z Jspec ge n ora q jm ->
   @jsafeN Z Jspec ge n ora q (age_to l jm).
 Proof. intros. eapply jsafeN__age_to; eauto. Qed.

--- a/veric/aging_lemmas.v
+++ b/veric/aging_lemmas.v
@@ -115,7 +115,7 @@ Qed.
 Lemma jsafeN__age {G C Z HH Sem Jspec ge ora q n} jm jmaged :
   ext_spec_stable age (JE_spec _ Jspec) ->
   age jm jmaged ->
-  le n (level jmaged) ->
+  Peano.le n (level jmaged) ->
   @jsafeN_ G Z C HH Sem Jspec ge n ora q jm ->
   @jsafeN_ G Z C HH Sem Jspec ge n ora q jmaged.
 Proof.
@@ -162,7 +162,7 @@ Qed.
 
 Lemma jsafeN__age_to {G C Z HH Sem Jspec ge ora q n} l jm :
   ext_spec_stable age (JE_spec _ Jspec) ->
-  le n l ->
+  Peano.le n l ->
   @jsafeN_ G Z C HH Sem Jspec ge n ora q jm ->
   @jsafeN_ G Z C HH Sem Jspec ge n ora q (age_to l jm).
 Proof.

--- a/veric/juicy_extspec.v
+++ b/veric/juicy_extspec.v
@@ -344,7 +344,7 @@ Section juicy_safety.
 
   Lemma jsafe_downward :
     forall n n' c m z,
-      le n' n ->
+      Peano.le n' n ->
       jsafeN_ n z c m -> jsafeN_ n' z c m.
   Proof.
     do 6 intro. revert c m z. induction H; auto.

--- a/veric/rmaps_lemmas.v
+++ b/veric/rmaps_lemmas.v
@@ -492,7 +492,7 @@ Proof.
   apply H0, ghost_of_join; auto.
 Qed.
 
-  Lemma ageN_squash : forall d n rm, le d n ->
+  Lemma ageN_squash : forall d n rm, Peano.le d n ->
     ageN d (squash (n, rm)) = Some (squash ((n - d)%nat, rm)).
   Proof.
     induction d; simpl; intros.


### PR DESCRIPTION
The PR coq/coq#12162 renames `Bool.leb` into `Bool.le` which is more coherent with the rest of the standard library since it has type `bool -> bool -> Prop`. This generates possible clashes with `Nat.le` or  `Peano.le` so that additional qualification is required. `omega` also sometimes gets lost.
