### PR TITLE
In do_compute_expr1, avoid simpl-ifying the user's definitions.

### DIFF
--- a/hmacdrbg/verif_hmac_drbg_generate.v
+++ b/hmacdrbg/verif_hmac_drbg_generate.v
@@ -928,7 +928,7 @@ Proof.
        forward. entailer!. unfold Vzero. f_equal. 
        apply negb_false_iff in Hrv. apply int_eq_e in Hrv. trivial.
      }
- 
+     simpl.
      forward. subst I after_reseed_add_len. rewrite Hshould_reseed in *. clear Hshould_reseed should_reseed.
      entailer!. simpl in *. (*
      Exists  ss KK (mc1, (mc2, mc3),
@@ -966,8 +966,15 @@ Proof.
        destruct ENT_GenErrAx as [X _]. elim X; trivial.
   }
   { (*Case should_reseed = false*)
-    forward. subst after_reseed_add_len. rewrite H (*, Hinitial_state*) in *. clear H (*Hinitial_state*).
-    Exists s key initial_state. go_lower; simpl. entailer!. thaw FR2; cancel.
+    simpl.
+   subst should_reseed. rewrite H.
+    simpl.
+    forward. subst after_reseed_add_len.
+   (*  rewrite H (*, Hinitial_state*) in *. clear H (*Hinitial_state*). *)
+    Exists s key initial_state. go_lower; simpl. entailer!.
+   rewrite H. split; auto.
+    hnf; auto.
+    thaw FR2; cancel.
   }
   clear FR2. Intros stream1 key1 ctx1. rename H into PRS. 
 
@@ -1018,7 +1025,7 @@ Proof.
    da_emp sha (tarray tuchar (Zlength contents)) (map Vubyte contents) additional;
     data_at shc t_struct_hmac256drbg_context_st ctx2 (Vptr b i) *
     md_full key2 (mc1, (mc2, mc3))))).
-   { rewrite H in *. subst na.
+   { change (na = true) in H. subst na.
      destruct should_reseed; simpl in PRS, H. rewrite andb_false_r in H; discriminate.
      destruct (initial_world.EqDec_Z (Zlength contents) 0); simpl in H.
      { rewrite andb_false_r in H; discriminate. }
@@ -1053,7 +1060,7 @@ Proof.
          split; [| repeat split; trivial].
          exists b0, i0, VV. repeat split; trivial. }  
      }
-     { clear - H. forward. rewrite H in *. 
+     { clear - H.  change (na=false) in H. forward. rewrite H in *. 
        Exists ctx1 key1. entailer!. simpl; auto. }
   Intros ctx2 key2. rename H into PUPD.
 

--- a/hmacdrbg/verif_hmac_drbg_generate_abs.v
+++ b/hmacdrbg/verif_hmac_drbg_generate_abs.v
@@ -339,7 +339,12 @@ Proof.
        destruct ENT_GenErrAx as [X _]. elim X; trivial.
   }
   { (*Case should_reseed = false*)
-    forward. subst after_reseed_add_len. rewrite H (*, Haaa*) in *. clear H (*Haaa*).
+    simpl.
+   subst should_reseed. rewrite H.
+    simpl.
+    forward. subst after_reseed_add_len.
+   (*  rewrite H (*, Hinitial_state*) in *. clear H (*Hinitial_state*). *)
+   rewrite H.  clear H (*Haaa*).
     Exists s key aaa. go_lower; simpl; entailer!. thaw FR2; cancel.
   }
   clear FR2. Intros stream1 key1 ctx1. rename H into PRS. 
@@ -391,7 +396,7 @@ Proof.
    da_emp sha (tarray tuchar add_len) (map Vubyte contents) additional;
     data_at shc t_struct_hmac256drbg_context_st ctx2 (Vptr b i) *
     md_full key2 (mc1, (mc2, mc3))))).
-  { rewrite H in *. subst na.
+  { change (na = true) in H. rewrite H in *. subst na.
      destruct should_reseed; simpl in PRS, H. rewrite andb_false_r in H; discriminate.
      destruct (initial_world.EqDec_Z (Zlength contents) 0); simpl in H.
      { rewrite andb_false_r in H; discriminate. }
@@ -426,7 +431,7 @@ Proof.
          split; [| repeat split; trivial].
          exists b0, i0, VV. repeat split; trivial. }  
      }
-     { clear - H. forward. rewrite H in *. 
+     { clear - H.  change (na=false) in H. forward. rewrite H in *. 
        Exists ctx1 key1. entailer!. simpl; auto. }
   Intros ctx2 key2. rename H into PUPD.
 

--- a/mailbox/verif_mailbox_write.v
+++ b/mailbox/verif_mailbox_write.v
@@ -156,7 +156,9 @@ Proof.
       { subst available.
         match goal with H : typed_true _ _ |- _ => setoid_rewrite Znth_map in H; [rewrite Znth_upto in H|];
           try assumption; rewrite ?Zlength_upto, ?Z2Nat.id; try omega; unfold typed_true in H; simpl in H; inv H end.
-        destruct (eq_dec i b0); [|destruct (in_dec eq_dec i lasts)]; auto; discriminate. }
+        destruct (eq_dec i b0); [|destruct (in_dec eq_dec i lasts)]; auto; discriminate.
+        all: change B with 5 in * ; lia.
+ }
       unfold data_at_, field_at_; entailer!. }
     { forward.
       entailer!.
@@ -165,7 +167,8 @@ Proof.
       match goal with H : typed_false _ _ |- _ => setoid_rewrite Znth_map in H; [rewrite Znth_upto in H|];
         try assumption; rewrite ?Zlength_upto, ?Z2Nat.id; try omega; unfold typed_true in H; simpl in H; inv H end.
       destruct (eq_dec _ _); auto.
-      destruct (in_dec _ _ _); auto; discriminate. }
+      destruct (in_dec _ _ _); auto; discriminate. 
+        all: change B with 5 in * ; lia. }
     instantiate (1 := EX i : Z, PROP (0 <= i < B; Znth i available = vint 0;
       forall j : Z, 0 <= j < i -> Znth j available = vint 0)
       LOCAL (temp _i__1 (vint i); lvar _available (tarray tint B) v_available; gvars gv)
@@ -958,8 +961,9 @@ Proof.
       forward_if (PROP () (LOCALx Q (SEPx (data_at Ews (tarray tint N)
         (upd_Znth i l (vint (if eq_dec (vint b') Empty then b0 else Znth i lasts))) (gv _last_taken) :: R)))) end.
     + forward.
-      subst. apply ENTAIL_refl.
-    + forward.
+      subst. rewrite (if_true (vint b' = Empty)) by (rewrite H18; reflexivity).
+     apply ENTAIL_refl.
+    + forward. rewrite neg_repr in H18.
       rename H18 into n1.
       erewrite upd_Znth_triv with (i0 := i).
       apply ENTAIL_refl.
@@ -967,8 +971,7 @@ Proof.
       * rewrite !Znth_map, Znth_upto; try (simpl; unfold N in *; omega).
         rewrite Znth_overflow by omega.
         rewrite if_false. rewrite if_false; auto.
-        clear - H20 n1. unfold Empty. contradict n1. apply Vint_inj in n1.
-        apply repr_inj_signed in n1; rep_lia.
+        clear - H20 n1. unfold Empty. contradict n1. apply Vint_inj in n1. auto.
         intro Hx; inv Hx.
         change (Zlength (upto 3)) with 3. unfold N in *; omega.
         autorewrite with sublist.     change (Zlength (upto 3)) with 3. unfold N in *; omega.

--- a/sha/verif_sha_update.v
+++ b/sha/verif_sha_update.v
@@ -259,6 +259,7 @@ hnf.  unfold s256_h, s256_data, s256_num, s256_Nh, s256_Nl, s256a_regs, fst, snd
  cancel.
 + (* else-clause *)
  forward. (* skip; *)
+ try (fold dd in H1; fold b4d in H1; apply repr_inj_unsigned in H1; try rep_lia).
  unfold sha256state_.
  unfold data_block.
  match goal with |- context [data_at _ t_struct_SHA256state_st ?r _] => Exists r end.


### PR DESCRIPTION
That is, before doing 'simpl' to evaluate an expression, factor
out anything that might be part of the user's (temp _x USER_EXPR).
This causes some incompatibilities, and there is now an warning
message when do_compute_expr1 detects that the user's proof script
may need adjustment.  This is rare (but not extremely rare).