### PR TITLE
Notation in modules to avoid pollution

### DIFF
--- a/concurrency/semax_conc.v
+++ b/concurrency/semax_conc.v
@@ -25,6 +25,7 @@ Require Import VST.floyd.jmeq_lemmas.
 Require Import VST.floyd.funspec_old.
 Require Import VST.concurrency.lksize.
 Require Import VST.concurrency.semax_conc_pred.
+Import FashNotation.
 Import String.
 Open Scope funspec_scope.
 

--- a/msl/alg_seplog.v
+++ b/msl/alg_seplog.v
@@ -118,10 +118,12 @@ Definition HOnonexpansive {A}{NA: NatDed A}{IA: Indir A}{RA: RecIndir A}
 End SL2.
 
 
+Module FashNotation.
 Notation "'#' e" := (fash e) (at level 30, right associativity): logic.
 Notation "'!' e" := (unfash e) (at level 30, right associativity): logic.
 Notation "P '>=>' Q" := (# (P --> Q)) (at level 55, right associativity) : logic.
 Notation "P '<=>' Q" := (# (P <--> Q)) (at level 57, no associativity) : logic.
+End FashNotation.
 
 Definition algRecIndir (T: Type) {agT: ageable T}{JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_alg T}{AgeT: Age_alg T} :
          @RecIndir (pred T) (algNatDed T) (algIndir T).

--- a/msl/log_normalize.v
+++ b/msl/log_normalize.v
@@ -1288,6 +1288,7 @@ Qed.
 
 (***** subtyping and contractiveness -- should split this into a separate file ******)
 Require Import VST.msl.alg_seplog.
+Import FashNotation.
 
 Lemma later_fash1 {A} {NA: NatDed A}{IA: Indir A}{RA: RecIndir A}:
    forall P : A, |> # P |-- # |> P.

--- a/progs/conclib.v
+++ b/progs/conclib.v
@@ -5,6 +5,7 @@ Require Export VST.concurrency.semax_conc.
 Require Export VST.floyd.proofauto.
 Require Import VST.floyd.library.
 Require Export VST.floyd.sublist.
+Import FashNotation.
 Import LiftNotation.
 
 (* general list lemmas *)

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -37,6 +37,7 @@ Require Import VST.veric.valid_pointer.
 Require Import VST.veric.own.
 Require VST.veric.semax_prog.
 Require VST.veric.semax_ext.
+Import FashNotation.
 Import LiftNotation.
 Import Ctypes Clight expr.
 


### PR DESCRIPTION
Otherwise the notation conflict makes VST incompatible with coq-ext-lib:
```coq
From VST Require Import alg_seplog.
From ExtLib Require Import Monad.
Fail Import MonadNotation.
```
> The command has indeed failed with message:
Notation "_ >=> _" is already defined at level 55 with arguments constr at next level, constr at level 55
while it is now required to be at level 61 with arguments constr at next level, constr at level 61.