### PR TITLE
Fix 64bit installed file list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ endif
 
 PROGS64_FILES=$(V64_ORDINARY)
 
-INSTALL_FILES_SRC=$(shell util/calc_install_files $(PROGSDIR))
+INSTALL_FILES_SRC=$(shell BITSIZE=$(BITSIZE) ARCH=$(ARCH) util/calc_install_files $(PROGSDIR))
 INSTALL_FILES_VO=$(patsubst %.v,%.vo,$(INSTALL_FILES_SRC))
 INSTALL_FILES=$(sort $(INSTALL_FILES_SRC) $(INSTALL_FILES_VO))
 

--- a/Makefile
+++ b/Makefile
@@ -226,10 +226,10 @@ ifeq ($(ARCH),x86)
   ifeq ($(BITSIZE),32)
     INSTALLDIR ?= $(COQLIB)/user-contrib/VST
   else
-    INSTALLDIR ?= $(realpath $(COQLIB)/../coq-variant/VST64/VST)
+    INSTALLDIR ?= $(abspath $(COQLIB)/../coq-variant/VST64/VST)
   endif
 else
-  INSTALLDIR ?= $(realpath $(COQLIB)/../coq-variant/VST_$(ARCH)_$(BITSIZE)/VST
+  INSTALLDIR ?= $(abspath $(COQLIB)/../coq-variant/VST_$(ARCH)_$(BITSIZE)/VST
 endif
 
 # ########## Flags ##########


### PR DESCRIPTION
The 64 bit `make install` target did not install all files in the progs64 folder because the BITSIZE parameter has not been passed to the `calc_install_files` utility.