### PR TITLE
Avoid running git when the command does not exist

### DIFF
--- a/util/make_version
+++ b/util/make_version
@@ -3,7 +3,9 @@ F=veric/version.v
 set -e
 printf >$F 'Require Import Coq.Strings.String. Open Scope string.\n'
 printf >>$F 'Definition git_rev := "'
-git log -n 1 --pretty=format:"%H" >>$F || true
+if [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
+  git log -n 1 --pretty=format:"%H" >>$F || true
+fi
 printf >>$F '".\n'
 printf >>$F 'Definition release := "'
 tr -d '[:cntrl:]' <VERSION >>$F


### PR DESCRIPTION
When building from a .tar.gz release, git will not always be available.  Do not create a git_rev definition in such a case.