### PR TITLE
Honour the coqbench timing infrastructure flags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -655,7 +655,9 @@ INSTALL_FILES=$(sort $(INSTALL_FILES_SRC) $(INSTALL_FILES_VO))
 
 %.vo: %.v
 	@echo COQC $*.v
-ifeq ($(TIMINGS), true)
+ifneq (,$(TIMING))
+	@$(COQC) $(COQF) -time $*.v > $<.timing
+else ifeq ($(TIMINGS), true)
 #	bash -c "wc $*.v >>timings; date +'%s.%N before' >> timings; $(COQC) $(COQF) $*.v; date +'%s.%N after' >>timings" 2>>timings
 	echo true timings
 	@bash -c "/usr/bin/time --output=TIMINGS -a -f '%e real, %U user, %S sys %M mem, '\"$(shell wc $*.v)\" $(COQC) $(COQF) $*.v"


### PR DESCRIPTION
The coqbench uses the flag `TIMING` to output timing information to be processed further by our tools. Fortunately it's not the same as the flag `TIMINGS` already used by the makefile for the VST infrastructure...