### PR TITLE
fix process_cases to work with switch terms for which rep_lia fails

### DIFF
--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -2520,8 +2520,8 @@ match goal with
         unfold seq_of_labeled_statement at 1;
         apply unsigned_eq_eq in E;
         match sign with
-        | Signed => apply repr_inj_signed in E; [ | rep_lia | rep_lia]
-        | Unsigned => apply repr_inj_unsigned in E; [ | rep_lia | rep_lia]
+        | Signed => apply repr_inj_signed in E; try lia
+        | Unsigned => apply repr_inj_unsigned in E; try lia
         end;
         try match type of E with ?a = _ => is_var a; subst a end;
         repeat apply -> semax_skip_seq


### PR DESCRIPTION
`forward_if` is failing when a switch term is complex (i.e. it is a function application `(f x)`) or a variable. this is because `rep_lia` cannot solve generated goals and one has to prove `repable_(un)signed (f x)` manually. `try rep_lia` leaves the unproven goals to be solved and `process_cases` doesn't fail.

Example:

``` 
void
switch_bug () {
		int t = 0;
		switch(t) {
		case -1: 
		case 0: return;
		default: break;
		}
		return;
}  

```
```
Theorem switch_bug_correctness : 
  semax_body Vprog Gprog f_switch_bug switch_bug_spec.
Proof.
  start_function.
  forward.
  replace 0 with ((fun x => x) 0) by reflexivity.
  Fail match goal with
  | [ _ : _ |- semax _ ?Pre ?C ?Post ] =>
    forward_if Pre            
  end.
Admitted.

```

[switch_bug.zip](https://github.com/PrincetonUniversity/VST/files/5843623/switch_bug.zip)
