### PR TITLE
Clean up many deprecation warnings for Coq 8.13.0

### DIFF
--- a/floyd/SeparationLogicAsLogic.v
+++ b/floyd/SeparationLogicAsLogic.v
@@ -3081,7 +3081,7 @@ Proof.
   - unfold func_ptr, seplog.func_ptr. (* apply predicates_hered.exp_right with (x:=f). *)
     apply predicates_hered.andp_left1. 
     apply predicates_hered.exp_left; intros bb.
-    apply normalize.derives_extract_prop; intros X; inv X. trivial.
+    apply normalize.derives_extract_prop; intros X; inv X. apply predicates_hered.derives_refl.
 Qed. (*old proof:
   intros.
   eapply semax_conseq; [| intros; apply derives_full_refl .. | apply H2].

--- a/floyd/VSU.v
+++ b/floyd/VSU.v
@@ -2257,7 +2257,8 @@ assert (TypesOfFunspecs1: forall i, sub_option (make_tycontext_g V1 (Imports1 ++
   rewrite 2 semax_prog.make_context_g_char, 2 make_tycontext_s_find_id; trivial.
   specialize (SUBSUME1 i). red in SUBSUME1. destruct (find_id i (Imports1 ++ Comp_G c1)); simpl.
   + destruct SUBSUME1 as [psi2 [PHI2 Sub]]. rewrite PHI2.
-    exploit (Sub (compcert_rmaps.RML.empty_rmap 0)); [ trivial | intros FS].
+    exploit (Sub (compcert_rmaps.RML.empty_rmap 0)); [ | intros FS].
+    apply predicates_hered.TT_i.
     apply type_of_funspec_sub_si in FS; rewrite FS; trivial.
   + remember (find_id i V1) as w; symmetry in Heqw; destruct w as [phi |]; simpl; trivial.
     rewrite (@list_norepet_find_id_app_exclusive1 _ _ _ _ LNR4_V1 i phi Heqw).
@@ -2271,7 +2272,7 @@ assert (TypesOfFunspecs2: forall i, sub_option (make_tycontext_g V2 (Imports2 ++
   rewrite 2 semax_prog.make_context_g_char, 2 make_tycontext_s_find_id; trivial.
   specialize (SUBSUME2 i). red in SUBSUME2. destruct (find_id i (Imports2 ++ Comp_G c2)); simpl.
   + destruct SUBSUME2 as [psi2 [PHI2 Sub]]. rewrite PHI2.
-    exploit (Sub (compcert_rmaps.RML.empty_rmap 0)); [ trivial | intros FS].
+    exploit (Sub (compcert_rmaps.RML.empty_rmap 0)); [     apply predicates_hered.TT_i | intros FS].
     apply type_of_funspec_sub_si in FS; rewrite FS; trivial.
   + remember (find_id i V2) as w; symmetry in Heqw; destruct w as [phi |]; simpl; trivial.
     rewrite (@list_norepet_find_id_app_exclusive1 _ _ _ _ LNR4_V2 _ _ Heqw).
@@ -4471,7 +4472,7 @@ destruct (H i); auto.
 rewrite H1 in H0; contradiction.
 Qed.
 
-Hint Resolve globals_ok_isptr_headptr: core.
+#[export] Hint Resolve globals_ok_isptr_headptr: core.
 
 Lemma globals_ok_genviron2globals:
   forall g,  globals_ok (initialize.genviron2globals g).
@@ -4481,7 +4482,7 @@ destruct (Map.get g i); auto.
 left; eexists; eauto.
 Qed.
 
-Hint Resolve globals_ok_genviron2globals : core.
+#[export] Hint Resolve globals_ok_genviron2globals : core.
 
 Ltac InitGPred_tac :=
 intros;

--- a/floyd/assert_lemmas.v
+++ b/floyd/assert_lemmas.v
@@ -116,7 +116,7 @@ Hint Rewrite RA_normal_loop2_ret_assert : ret_assert.
 
 Lemma liftTrue: forall rho, `True rho.
 Proof. intro. unfold_lift; apply Coq.Init.Logic.I. Qed.
-Hint Resolve liftTrue : core.
+#[export] Hint Resolve liftTrue : core.
 
 Lemma overridePost_normal:
   forall P Q, overridePost P (normal_ret_assert Q) = normal_ret_assert P.
@@ -156,7 +156,7 @@ Qed.
 
 Hint Rewrite frame_normal frame_for1 frame_loop1
                  overridePost_normal: ret_assert.
-Hint Resolve TT_right : core.
+#[export] Hint Resolve TT_right : core.
 
 Lemma overridePost_overridePost:
  forall P Q R, overridePost P (overridePost Q R) = overridePost P R.

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -1353,7 +1353,7 @@ simpl.
 rewrite later_sepcon.
 apply sepcon_derives; auto.
 Qed.
-Hint Resolve PROP_later_derives LOCAL_later_derives SEP_later_derives : derives.
+#[export] Hint Resolve PROP_later_derives LOCAL_later_derives SEP_later_derives : derives.
 
 Lemma local_lift0: forall P, local (lift0 P) = prop P.
 Proof.
@@ -2644,4 +2644,4 @@ erewrite lvar_eval_var; eauto.
 eapply lvar_isptr; eauto.
 Qed.
 
-Hint Extern 1 (isptr (eval_var _ _ _)) => (eapply lvar_isptr_eval_var; eassumption) : norm2.
+#[export] Hint Extern 1 (isptr (eval_var _ _ _)) => (eapply lvar_isptr_eval_var; eassumption) : norm2.

--- a/floyd/client_lemmas.v
+++ b/floyd/client_lemmas.v
@@ -42,11 +42,11 @@ Arguments sem_cmp c !t1 !t2 / v1 v2.
  in Coq 8.3, but in Coq 8.4 they seem to be necessary. *)
 Definition ListClassicalSep_environ := @LiftClassicalSep environ.
 
-Hint Resolve ListClassicalSep_environ : typeclass_instances.
+#[export] Hint Resolve ListClassicalSep_environ : typeclass_instances.
 
 Definition func_ptr' f v := func_ptr f v && emp.
 
-Hint Resolve func_ptr_isptr: saturate_local.
+#[export] Hint Resolve func_ptr_isptr: saturate_local.
 
 Lemma func_ptr'_isptr: forall f v, func_ptr' f v |-- !! isptr v.
 Proof.
@@ -54,7 +54,7 @@ intros.
 unfold func_ptr'.
 apply andp_left1. apply func_ptr_isptr.
 Qed.
-Hint Resolve func_ptr'_isptr: saturate_local.
+#[export] Hint Resolve func_ptr'_isptr: saturate_local.
 
 Lemma split_func_ptr': 
  forall fs p, func_ptr' fs p = func_ptr' fs p * func_ptr' fs p.
@@ -946,7 +946,7 @@ Lemma sepcon_later_derives {A} {NA: NatDed A}{SL: SepLog A}{IA: Indir A}{SI: Sep
 Proof.
 intros. rewrite later_sepcon. apply sepcon_derives; auto. Qed.
 
-Hint Resolve andp_later_derives sepcon_later_derives sepcon_derives
+#[export] Hint Resolve andp_later_derives sepcon_later_derives sepcon_derives
               andp_derives imp_derives now_later derives_refl: derives.
 
 (* Definitions of convertPre and NDmk_funspec' are to support

--- a/floyd/closed_lemmas.v
+++ b/floyd/closed_lemmas.v
@@ -13,7 +13,7 @@ destruct (ve_of rho i) as [[? ?]|] eqn:?; try contradiction.
 unfold globals_only.
 simpl. auto.
 Qed.
-Hint Resolve gvar_globals_only.
+#[export] Hint Resolve gvar_globals_only.
 *)
 
 Ltac safe_auto_with_closed :=
@@ -205,7 +205,7 @@ Qed.
 Hint Rewrite @closed_wrt_subst_eval_expr using solve [auto 50 with closed] : subst.
 Hint Rewrite @closed_wrt_subst_eval_lvalue using solve [auto 50 with closed] : subst.
 
-Hint Unfold closed_wrt_modvars : closed.
+#[export] Hint Unfold closed_wrt_modvars : closed.
 
 Lemma closed_wrt_local: forall S P, closed_wrt_vars S P -> closed_wrt_vars S (local P).
 Proof.
@@ -224,7 +224,7 @@ specialize (H _ _ H0).
 unfold local, lift1.
 f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_local closed_wrtl_local : closed.
+#[export] Hint Resolve closed_wrt_local closed_wrtl_local : closed.
 
 Lemma closed_wrt_lift0: forall {A} S (Q: A), closed_wrt_vars S (lift0 Q).
 Proof.
@@ -238,7 +238,7 @@ intros.
 intros ? ? ?.
 unfold lift0; auto.
 Qed.
-Hint Resolve closed_wrt_lift0 closed_wrtl_lift0 : closed.
+#[export] Hint Resolve closed_wrt_lift0 closed_wrtl_lift0 : closed.
 
 Lemma closed_wrt_lift0C: forall {B} S (Q: B),
    closed_wrt_vars S (@liftx (LiftEnviron B) Q).
@@ -254,7 +254,7 @@ intros.
 intros ? ? ?.
 unfold_lift; auto.
 Qed.
-Hint Resolve closed_wrt_lift0C closed_wrtl_lift0C: closed.
+#[export] Hint Resolve closed_wrt_lift0C closed_wrtl_lift0C: closed.
 
 Lemma closed_wrt_lift1: forall {A}{B} S (f: A -> B) P,
         closed_wrt_vars S P ->
@@ -272,7 +272,7 @@ intros.
 intros ? ? ?. specialize (H _ _ H0).
 unfold lift1; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_lift1 closed_wrtl_lift1 : closed.
+#[export] Hint Resolve closed_wrt_lift1 closed_wrtl_lift1 : closed.
 
 Lemma closed_wrt_lift1C: forall {A}{B} S (f: A -> B) P,
         closed_wrt_vars S P ->
@@ -290,7 +290,7 @@ intros.
 intros ? ? ?. specialize (H _ _ H0).
 unfold_lift; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_lift1C closed_wrtl_lift1C : closed.
+#[export] Hint Resolve closed_wrt_lift1C closed_wrtl_lift1C : closed.
 
 Lemma closed_wrt_lift2: forall {A1 A2}{B} S (f: A1 -> A2 -> B) P1 P2,
         closed_wrt_vars S P1 ->
@@ -314,7 +314,7 @@ specialize (H _ _ H1).
 specialize (H0 _ _ H1).
 unfold lift2; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_lift2 closed_wrtl_lift2 : closed.
+#[export] Hint Resolve closed_wrt_lift2 closed_wrtl_lift2 : closed.
 
 Lemma closed_wrt_lift2C: forall {A1 A2}{B} S (f: A1 -> A2 -> B) P1 P2,
         closed_wrt_vars S P1 ->
@@ -338,7 +338,7 @@ specialize (H _ _ H1).
 specialize (H0 _ _ H1).
 unfold_lift; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_lift2C closed_wrtl_lift2C : closed.
+#[export] Hint Resolve closed_wrt_lift2C closed_wrtl_lift2C : closed.
 
 Lemma closed_wrt_lift3: forall {A1 A2 A3}{B} S (f: A1 -> A2 -> A3 -> B) P1 P2 P3,
         closed_wrt_vars S P1 ->
@@ -366,7 +366,7 @@ specialize (H0 _ _ H2).
 specialize (H1 _ _ H2).
 unfold lift3; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_lift3 closed_wrtl_lift3 : closed.
+#[export] Hint Resolve closed_wrt_lift3 closed_wrtl_lift3 : closed.
 
 Lemma closed_wrt_lift3C: forall {A1 A2 A3}{B} S (f: A1 -> A2 -> A3 -> B) P1 P2 P3,
         closed_wrt_vars S P1 ->
@@ -395,7 +395,7 @@ specialize (H0 _ _ H2).
 specialize (H1 _ _ H2).
 unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_lift3C closed_wrtl_lift3C : closed.
+#[export] Hint Resolve closed_wrt_lift3C closed_wrtl_lift3C : closed.
 
 Lemma closed_wrt_lift4: forall {A1 A2 A3 A4}{B} S (f: A1 -> A2 -> A3 -> A4 -> B)
        P1 P2 P3 P4,
@@ -429,7 +429,7 @@ specialize (H1 _ _ H3).
 specialize (H2 _ _ H3).
 unfold lift4; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_lift4  closed_wrtl_lift4 : closed.
+#[export] Hint Resolve closed_wrt_lift4  closed_wrtl_lift4 : closed.
 
 Lemma closed_wrt_lift4C: forall {A1 A2 A3 A4}{B} S (f: A1 -> A2 -> A3 -> A4 -> B) P1 P2 P3 P4,
         closed_wrt_vars S P1 ->
@@ -463,7 +463,7 @@ specialize (H2 _ _ H3).
 unfold liftx; simpl.
 unfold lift. f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_lift4C closed_wrtl_lift4C : closed.
+#[export] Hint Resolve closed_wrt_lift4C closed_wrtl_lift4C : closed.
 
 Lemma closed_wrt_const:
  forall A (P: A) S, closed_wrt_vars S (fun rho: environ => P).
@@ -477,7 +477,7 @@ Proof.
 intros. hnf; intros.
 simpl. auto.
 Qed.
-Hint Resolve closed_wrt_const closed_wrtl_const : closed.
+#[export] Hint Resolve closed_wrt_const closed_wrtl_const : closed.
 
 Lemma closed_wrt_eval_var:
   forall S id t, closed_wrt_vars S (eval_var id t).
@@ -486,7 +486,7 @@ unfold closed_wrt_vars, eval_var; intros.
 simpl.
 auto.
 Qed.
-Hint Resolve closed_wrt_eval_var : closed.
+#[export] Hint Resolve closed_wrt_eval_var : closed.
 Lemma closed_wrtl_eval_var:
   forall S id t, ~ S id -> closed_wrt_lvars S (eval_var id t).
 Proof.
@@ -495,7 +495,7 @@ simpl.
 destruct (H0 id); [contradiction | ].
 rewrite <- H1; auto.
 Qed.
-Hint Resolve closed_wrtl_eval_var : closed.
+#[export] Hint Resolve closed_wrtl_eval_var : closed.
 
 (*
 Lemma closed_wrt_var:
@@ -504,14 +504,14 @@ Proof.
 unfold var; intros.
 auto with closed.
 Qed.
-Hint Resolve closed_wrt_var : closed.
+#[export] Hint Resolve closed_wrt_var : closed.
 
 Lemma closed_wrtl_var:
  forall S id t v, ~ S id -> closed_wrt_lvars S (var id t v).
 Proof.
 unfold var; intros; auto with closed.
 Qed.
-Hint Resolve closed_wrtl_var : closed.
+#[export] Hint Resolve closed_wrtl_var : closed.
 *)
 
 Lemma closed_wrt_lvar:
@@ -521,7 +521,7 @@ intros.
 hnf; intros; simpl.
 destruct (Map.get (ve_of rho) id); auto.
 Qed.
-Hint Resolve closed_wrt_lvar : closed.
+#[export] Hint Resolve closed_wrt_lvar : closed.
 
 Lemma closed_wrt_gvars:
   forall S gv, closed_wrt_vars S (locald_denote (gvars gv)).
@@ -529,7 +529,7 @@ Proof.
 intros.
 hnf; intros; simpl. reflexivity.
 Qed.
-Hint Resolve closed_wrt_gvars : closed.
+#[export] Hint Resolve closed_wrt_gvars : closed.
 
 Lemma closed_wrtl_gvars:
   forall S gv, closed_wrt_lvars S (locald_denote (gvars gv)).
@@ -537,7 +537,7 @@ Proof.
 intros.
 hnf; intros; simpl. reflexivity.
 Qed.
-Hint Resolve closed_wrtl_gvars : closed.
+#[export] Hint Resolve closed_wrtl_gvars : closed.
 
 Lemma closed_wrtl_lvar:
  forall  {cs: compspecs} S id t v,
@@ -549,7 +549,7 @@ unfold lvar_denote.
 destruct (H0 id); try contradiction.
 rewrite H1; auto.
 Qed.
-Hint Resolve closed_wrtl_lvar : closed.
+#[export] Hint Resolve closed_wrtl_lvar : closed.
 
 Definition expr_closed_wrt_lvars (S: ident -> Prop) (e: expr) : Prop :=
   forall (cs: compspecs) rho ve',
@@ -589,7 +589,7 @@ specialize (H0 cs rho ve' H1).
 unfold cmp_ptr_no_mem. rewrite H0. rewrite H.
 reflexivity.
 Qed.
-Hint Resolve closed_wrt_cmp_ptr closed_wrtl_cmp_ptr: closed.
+#[export] Hint Resolve closed_wrt_cmp_ptr closed_wrtl_cmp_ptr: closed.
 
 Lemma closed_wrt_eval_id: forall S i,
     ~ S i -> closed_wrt_vars S (eval_id i).
@@ -610,7 +610,7 @@ intros ? ? ?.
 unfold eval_id, force_val.
 simpl. auto.
 Qed.
-Hint Resolve closed_wrt_eval_id closed_wrtl_eval_id : closed.
+#[export] Hint Resolve closed_wrt_eval_id closed_wrtl_eval_id : closed.
 
 Lemma closed_wrt_temp: forall S i v,
     ~ S i -> closed_wrt_vars S (locald_denote (temp i v)).
@@ -632,7 +632,7 @@ unfold locald_denote.
 hnf; intros. simpl.
 unfold eval_id; simpl. auto.
 Qed.
-Hint Resolve closed_wrt_temp closed_wrtl_temp : closed.
+#[export] Hint Resolve closed_wrt_temp closed_wrtl_temp : closed.
 
 Lemma closed_wrt_get_result1 :
   forall (S: ident -> Prop) i , ~ S i -> closed_wrt_vars S (get_result1 i).
@@ -649,7 +649,7 @@ intros. unfold get_result1. simpl.
  hnf; intros.
  simpl. f_equal.
 Qed.
-Hint Resolve closed_wrt_get_result1 closed_wrtl_get_result1 : closed.
+#[export] Hint Resolve closed_wrt_get_result1 closed_wrtl_get_result1 : closed.
 
 Lemma closed_wrt_tc_FF:
  forall {cs: compspecs} S e, closed_wrt_vars S (denote_tc_assert (tc_FF e)).
@@ -661,7 +661,7 @@ Lemma closed_wrtl_tc_FF:
 Proof.
  intros. hnf; intros. reflexivity.
 Qed.
-Hint Resolve closed_wrt_tc_FF closed_wrtl_tc_FF : closed.
+#[export] Hint Resolve closed_wrt_tc_FF closed_wrtl_tc_FF : closed.
 
 Lemma closed_wrt_tc_TT:
  forall {cs: compspecs} S, closed_wrt_vars S (denote_tc_assert (tc_TT)).
@@ -673,7 +673,7 @@ Lemma closed_wrtl_tc_TT:
 Proof.
  intros. hnf; intros. reflexivity.
 Qed.
-Hint Resolve closed_wrt_tc_TT closed_wrtl_tc_TT : closed.
+#[export] Hint Resolve closed_wrt_tc_TT closed_wrtl_tc_TT : closed.
 
 Lemma closed_wrt_andp: forall S (P Q: environ->mpred),
   closed_wrt_vars S P -> closed_wrt_vars S Q ->
@@ -689,7 +689,7 @@ Proof.
 intros; hnf in *; intros.
 simpl. f_equal; eauto.
 Qed.
-Hint Resolve closed_wrt_andp closed_wrtl_andp : closed.
+#[export] Hint Resolve closed_wrt_andp closed_wrtl_andp : closed.
 
 Lemma closed_wrt_exp: forall {A} S (P: A -> environ->mpred),
   (forall a, closed_wrt_vars S (P a)) ->
@@ -712,7 +712,7 @@ specialize (H a).
 hnf in H.
 eauto.
 Qed.
-Hint Resolve closed_wrt_exp closed_wrtl_exp : closed.
+#[export] Hint Resolve closed_wrt_exp closed_wrtl_exp : closed.
 
 Lemma closed_wrt_imp: forall S (P Q: environ->mpred),
   closed_wrt_vars S P -> closed_wrt_vars S Q ->
@@ -728,7 +728,7 @@ Proof.
 intros; hnf in *; intros.
 simpl. f_equal; eauto.
 Qed.
-Hint Resolve closed_wrt_imp closed_wrtl_imp : closed.
+#[export] Hint Resolve closed_wrt_imp closed_wrtl_imp : closed.
 
 Lemma closed_wrt_sepcon: forall S (P Q: environ->mpred),
   closed_wrt_vars S P -> closed_wrt_vars S Q ->
@@ -744,7 +744,7 @@ Proof.
 intros; hnf in *; intros.
 simpl. f_equal; eauto.
 Qed.
-Hint Resolve closed_wrt_sepcon closed_wrtl_sepcon : closed.
+#[export] Hint Resolve closed_wrt_sepcon closed_wrtl_sepcon : closed.
 
 Lemma closed_wrt_emp {A} {ND: NatDed A} {SL: SepLog A}:
   forall S, closed_wrt_vars S emp.
@@ -755,7 +755,7 @@ Proof. repeat intro. reflexivity. Qed.
 
 Definition closed_wrt_emp_mpred := @closed_wrt_emp mpred Nveric Sveric.
 Definition closed_wrtl_emp_mpred := @closed_wrtl_emp mpred Nveric Sveric.
-Hint Resolve closed_wrt_emp_mpred closed_wrtl_emp_mpred  : closed.
+#[export] Hint Resolve closed_wrt_emp_mpred closed_wrtl_emp_mpred  : closed.
 
 Lemma closed_wrt_allp: forall A S P,
   (forall x: A, closed_wrt_vars S (P x)) ->
@@ -777,7 +777,7 @@ apply pred_ext; apply allp_right; intro x; apply (allp_left _ x);
 specialize (H x rho ve' H0);
 apply derives_refl'; congruence.
 Qed.
-Hint Resolve closed_wrt_allp closed_wrtl_allp : closed.
+#[export] Hint Resolve closed_wrt_allp closed_wrtl_allp : closed.
 (*DEAD CODE?
 Lemma closed_wrt_globvars:
   forall S gv v, closed_wrt_vars S (globvars2pred gv v).
@@ -810,7 +810,7 @@ forget (readonly2share (gvar_readonly g)) as sh.
 forget (gv i) as j.
 revert j; induction (gvar_init g); intros; simpl; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_globvars closed_wrtl_globvars: closed.
+#[export] Hint Resolve closed_wrt_globvars closed_wrtl_globvars: closed.
 
 
 Lemma closed_wrt_main_pre:
@@ -823,7 +823,7 @@ Lemma closed_wrtl_main_pre:
 Proof.
 intros. unfold main_pre. apply closed_wrtl_sepcon; [apply closed_wrtl_globvars | apply closed_wrtl_const].
 Qed.
-Hint Resolve closed_wrt_main_pre closed_wrtl_main_pre : closed.
+#[export] Hint Resolve closed_wrt_main_pre closed_wrtl_main_pre : closed.
 *)
 Lemma closed_wrt_not1:
   forall (i j: ident),
@@ -834,7 +834,7 @@ intros.
 hnf.
 intros; subst; congruence.
 Qed.
-Hint Resolve closed_wrt_not1 : closed.
+#[export] Hint Resolve closed_wrt_not1 : closed.
 
 Lemma closed_wrt_tc_andp:
   forall {cs: compspecs} S a b,
@@ -876,7 +876,7 @@ Proof.
  apply closed_wrt_tc_bool.
 Qed.
 
-Hint Resolve closed_wrt_tc_andp closed_wrt_tc_orp closed_wrt_tc_bool
+#[export] Hint Resolve closed_wrt_tc_andp closed_wrt_tc_orp closed_wrt_tc_bool
               closed_wrt_tc_int_or_ptr_type : closed.
 
 Lemma closed_wrtl_tc_andp:
@@ -909,7 +909,7 @@ Proof.
  hnf; intros.
  destruct b; simpl; auto.
 Qed.
-Hint Resolve closed_wrtl_tc_andp closed_wrtl_tc_orp closed_wrtl_tc_bool : closed.
+#[export] Hint Resolve closed_wrtl_tc_andp closed_wrtl_tc_orp closed_wrtl_tc_bool : closed.
 
 Lemma closed_wrt_tc_test_eq:
   forall {cs: compspecs} S e e',
@@ -937,7 +937,7 @@ hnf; intros.
 rewrite !binop_lemmas2.denote_tc_assert_test_eq'.
 simpl. unfold_lift. rewrite H, H0; auto.
 Qed.
-Hint Resolve  closed_wrt_tc_test_eq  closed_wrtl_tc_test_eq : closed.
+#[export] Hint Resolve  closed_wrt_tc_test_eq  closed_wrtl_tc_test_eq : closed.
 
 Lemma closed_wrt_tc_test_order:
   forall {cs: compspecs} S e e',
@@ -965,7 +965,7 @@ hnf; intros.
 rewrite !binop_lemmas2.denote_tc_assert_test_order'.
 simpl. unfold_lift. rewrite H, H0; auto.
 Qed.
-Hint Resolve  closed_wrt_tc_test_order  closed_wrtl_tc_test_order : closed.
+#[export] Hint Resolve  closed_wrt_tc_test_order  closed_wrtl_tc_test_order : closed.
 
 Lemma expr_closed_const_int:
   forall {cs: compspecs} S i t, expr_closed_wrt_vars S (Econst_int i t).
@@ -979,7 +979,7 @@ Proof.
 intros. unfold expr_closed_wrt_lvars. simpl; intros.
 super_unfold_lift. auto.
 Qed.
-Hint Resolve expr_closed_const_int expr_closedl_const_int : closed.
+#[export] Hint Resolve expr_closed_const_int expr_closedl_const_int : closed.
 
 
 Lemma closed_wrt_tc_iszero:
@@ -992,7 +992,7 @@ simpl.
 hnf; intros. hnf in H. specialize (H _ _ H0).
 unfold_lift. rewrite <- H. auto.
 Qed.
-Hint Resolve closed_wrt_tc_iszero : closed.
+#[export] Hint Resolve closed_wrt_tc_iszero : closed.
 
 Lemma closed_wrtl_tc_iszero:
   forall {cs: compspecs}  S e, expr_closed_wrt_lvars S e ->
@@ -1003,7 +1003,7 @@ rewrite binop_lemmas2.denote_tc_assert_iszero'.
 hnf; intros. specialize (H _ _ _ H0).
 simpl. unfold_lift; simpl. rewrite <- H; auto.
 Qed.
-Hint Resolve closed_wrtl_tc_iszero : closed.
+#[export] Hint Resolve closed_wrtl_tc_iszero : closed.
 
 Lemma closed_wrt_tc_isptr:
  forall {cs: compspecs} S e,
@@ -1015,7 +1015,7 @@ Proof.
  specialize (H _ _ H0).
  simpl. unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_tc_isptr : closed.
+#[export] Hint Resolve closed_wrt_tc_isptr : closed.
 
 Lemma closed_wrtl_tc_isptr:
  forall {cs: compspecs} S e,
@@ -1026,7 +1026,7 @@ Proof.
  hnf; intros. specialize (H _ _ _ H0).
  simpl. unfold_lift; simpl. rewrite <- H; auto.
 Qed.
-Hint Resolve closed_wrtl_tc_isptr : closed.
+#[export] Hint Resolve closed_wrtl_tc_isptr : closed.
 
 Lemma closed_wrt_tc_isint:
  forall {cs: compspecs} S e,
@@ -1038,7 +1038,7 @@ Proof.
  specialize (H _ _ H0).
  simpl. unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_tc_isint : closed.
+#[export] Hint Resolve closed_wrt_tc_isint : closed.
 
 Lemma closed_wrtl_tc_isint:
  forall {cs: compspecs} S e,
@@ -1050,7 +1050,7 @@ Proof.
  specialize (H _ _ _ H0).
  simpl. unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve closed_wrtl_tc_isint : closed.
+#[export] Hint Resolve closed_wrtl_tc_isint : closed.
 
 Lemma closed_wrt_tc_islong:
  forall {cs: compspecs} S e,
@@ -1062,7 +1062,7 @@ Proof.
  specialize (H _ _ H0).
  simpl. unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_tc_islong : closed.
+#[export] Hint Resolve closed_wrt_tc_islong : closed.
 
 Lemma closed_wrtl_tc_islong:
  forall {cs: compspecs} S e,
@@ -1074,7 +1074,7 @@ Proof.
  specialize (H _ _ _ H0).
  simpl. unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve closed_wrtl_tc_islong : closed.
+#[export] Hint Resolve closed_wrtl_tc_islong : closed.
 
 Lemma closed_wrt_isCastResultType:
   forall {cs: compspecs} S e t t0,
@@ -1111,7 +1111,7 @@ Proof.
 intros.
 hnf; intros. simpl. unfold_lift. rewrite (H _ _ _ H0). auto.
 Qed.
-Hint Resolve closed_wrtl_tc_Zge closed_wrtl_tc_Zle : closed.
+#[export] Hint Resolve closed_wrtl_tc_Zge closed_wrtl_tc_Zle : closed.
 
 Lemma closed_wrtl_isCastResultType:
   forall {cs: compspecs} S e t t0,
@@ -1133,7 +1133,7 @@ repeat simple_if_tac;  auto with closed;
  hnf; intros. reflexivity.
 Qed.
 
-Hint Resolve closed_wrt_isCastResultType closed_wrtl_isCastResultType : closed.
+#[export] Hint Resolve closed_wrt_isCastResultType closed_wrtl_isCastResultType : closed.
 
 Lemma closed_wrt_tc_temp_id :
   forall {cs: compspecs} Delta S e id t, expr_closed_wrt_vars S e ->
@@ -1157,7 +1157,7 @@ unfold typecheck_temp_id.
 destruct ( (temp_types Delta) ! id) eqn:?; try destruct p; simpl; auto with closed.
 Qed.
 
-Hint Resolve closed_wrt_tc_temp_id closed_wrtl_tc_temp_id : closed.
+#[export] Hint Resolve closed_wrt_tc_temp_id closed_wrtl_tc_temp_id : closed.
 
 Lemma expr_closed_tempvar:
  forall {cs: compspecs} S i t, ~ S i -> expr_closed_wrt_vars S (Etempvar i t).
@@ -1175,9 +1175,9 @@ intros.
 hnf; intros.
 simpl. unfold eval_id. f_equal.
 Qed.
-Hint Resolve expr_closed_tempvar expr_closedl_tempvar : closed.
+#[export] Hint Resolve expr_closed_tempvar expr_closedl_tempvar : closed.
 
-Hint Extern 1 (not (@eq ident _ _)) => (let Hx := fresh in intro Hx; inversion Hx) : closed.
+#[export] Hint Extern 1 (not (@eq ident _ _)) => (let Hx := fresh in intro Hx; inversion Hx) : closed.
 
 Lemma expr_closed_cast: forall {cs: compspecs} S e t,
      expr_closed_wrt_vars S e ->
@@ -1197,7 +1197,7 @@ Proof.
  super_unfold_lift.
  destruct (H cs rho ve' H0); auto.
 Qed.
-Hint Resolve expr_closed_cast expr_closedl_cast : closed.
+#[export] Hint Resolve expr_closed_cast expr_closedl_cast : closed.
 
 Lemma expr_closed_field: forall {cs: compspecs} S e f t,
   lvalue_closed_wrt_vars S e ->
@@ -1219,7 +1219,7 @@ Proof.
  f_equal.
  apply H.  auto.
 Qed.
-Hint Resolve expr_closed_field expr_closedl_field : closed.
+#[export] Hint Resolve expr_closed_field expr_closedl_field : closed.
 
 Lemma expr_closed_binop: forall {cs: compspecs} S op e1 e2 t,
      expr_closed_wrt_vars S e1 ->
@@ -1239,7 +1239,7 @@ Proof.
  simpl.
  super_unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve expr_closed_binop expr_closedl_binop : closed.
+#[export] Hint Resolve expr_closed_binop expr_closedl_binop : closed.
 
 Lemma expr_closed_unop: forall {cs: compspecs} S op e t,
      expr_closed_wrt_vars S e ->
@@ -1257,7 +1257,7 @@ Proof.
  simpl.
  super_unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve expr_closed_unop expr_closedl_unop : closed.
+#[export] Hint Resolve expr_closed_unop expr_closedl_unop : closed.
 
 Lemma closed_wrt_stackframe_of:
   forall {cs: compspecs} S f, closed_wrt_vars S (stackframe_of f).
@@ -1270,7 +1270,7 @@ apply closed_wrt_sepcon; [ | apply IHl].
 clear. destruct a; unfold var_block.
 hnf; intros. reflexivity.
 Qed.
-Hint Resolve closed_wrt_stackframe_of : closed.
+#[export] Hint Resolve closed_wrt_stackframe_of : closed.
 
 Definition included {U} (S S': U -> Prop) := forall x, S x -> S' x.
 
@@ -1286,7 +1286,7 @@ Lemma closed_wrtl_TT:
 Proof.
 intros. hnf; intros. reflexivity.
 Qed.
-Hint Resolve closed_wrt_TT closed_wrtl_TT : closed.
+#[export] Hint Resolve closed_wrt_TT closed_wrtl_TT : closed.
 
 Lemma closed_wrt_subset:
   forall (S S': ident -> Prop) (H: included S' S) B (f: environ -> B),
@@ -1304,7 +1304,7 @@ intros. hnf. intros. specialize (H0 rho ve').
 apply H0.
 intro i; destruct (H1 i); auto.
 Qed.
-Hint Resolve closed_wrt_subset closed_wrtl_subset : closed.
+#[export] Hint Resolve closed_wrt_subset closed_wrtl_subset : closed.
 
 Lemma closed_wrt_Forall_subset:
   forall S S' (H: included S' S) B (f: list (environ -> B)),
@@ -1345,7 +1345,7 @@ simpl; intros.
 hnf; intros.
 simpl. reflexivity.
 Qed.
-Hint Resolve lvalue_closed_tempvar lvalue_closedl_tempvar : closed.
+#[export] Hint Resolve lvalue_closed_tempvar lvalue_closedl_tempvar : closed.
 
 Lemma expr_closed_addrof: forall {cs: compspecs} S e t,
      lvalue_closed_wrt_vars S e ->
@@ -1363,7 +1363,7 @@ Proof.
  simpl.
  super_unfold_lift. apply H.  auto.
 Qed.
-Hint Resolve expr_closed_addrof expr_closedl_addrof : closed.
+#[export] Hint Resolve expr_closed_addrof expr_closedl_addrof : closed.
 
 Lemma lvalue_closed_field: forall {cs: compspecs} S e f t,
   lvalue_closed_wrt_vars S e ->
@@ -1381,7 +1381,7 @@ Proof.
  simpl.
  super_unfold_lift. f_equal; apply H.  auto.
 Qed.
-Hint Resolve lvalue_closed_field lvalue_closedl_field : closed.
+#[export] Hint Resolve lvalue_closed_field lvalue_closedl_field : closed.
 
 Lemma lvalue_closed_deref: forall {cs: compspecs} S e t,
   expr_closed_wrt_vars S e ->
@@ -1399,7 +1399,7 @@ Proof.
  simpl.
  super_unfold_lift. apply H.  auto.
 Qed.
-Hint Resolve lvalue_closed_deref lvalue_closedl_deref: closed.
+#[export] Hint Resolve lvalue_closed_deref lvalue_closedl_deref: closed.
 
 Fixpoint closed_eval_expr (j: ident) (e: expr) : bool :=
  match e with
@@ -1441,8 +1441,8 @@ auto with closed.
 intros Delta j e; clear closed_eval_lvalue_e; induction e; intros; simpl; auto with closed.
 Qed.
 
-Hint Extern 2 (closed_wrt_vars (eq _) (@eval_expr _ _)) => (apply closed_eval_expr_e; reflexivity) : closed.
-Hint Extern 2 (closed_wrt_vars (eq _) (@eval_lvalue _ _)) => (apply closed_eval_lvalue_e; reflexivity) : closed.
+#[export] Hint Extern 2 (closed_wrt_vars (eq _) (@eval_expr _ _)) => (apply closed_eval_expr_e; reflexivity) : closed.
+#[export] Hint Extern 2 (closed_wrt_vars (eq _) (@eval_lvalue _ _)) => (apply closed_eval_lvalue_e; reflexivity) : closed.
 
 Lemma closed_wrt_eval_expr: forall {cs: compspecs} S e,
   expr_closed_wrt_vars S e ->
@@ -1452,7 +1452,7 @@ unfold expr_closed_wrt_vars, closed_wrt_vars.
 intros.
 apply H; auto.
 Qed.
-(* Hint Resolve closed_wrt_eval_expr : closed. *)
+(* #[export] Hint Resolve closed_wrt_eval_expr : closed. *)
 
 Lemma closed_wrt_lvalue: forall {cs: compspecs} S e,
   access_mode (typeof e) = By_reference ->
@@ -1464,7 +1464,7 @@ unfold closed_wrt_vars in *;
 intros; specialize (H0 _ _ H1); clear H1; super_unfold_lift;
 auto.
 Qed.
-(* Hint Resolve closed_wrt_lvalue : closed. *)
+(* #[export] Hint Resolve closed_wrt_lvalue : closed. *)
 
 Lemma closed_wrt_ideq: forall {cs: compspecs} a b e,
   a <> b ->
@@ -1483,7 +1483,7 @@ eapply closed_eval_expr_e in H0.
 apply H0; auto.
 Qed.
 
-Hint Extern 2 (closed_wrt_vars (eq _) _) =>
+#[export] Hint Extern 2 (closed_wrt_vars (eq _) _) =>
       (apply closed_wrt_ideq; [solve [let Hx := fresh in (intro Hx; inv Hx)] | reflexivity]) : closed.
 
 Lemma closed_wrt_tc_nonzero:
@@ -1497,7 +1497,7 @@ Proof.
  repeat rewrite binop_lemmas2.denote_tc_assert_nonzero.
  rewrite <- H; auto.
 Qed.
-Hint Resolve closed_wrt_tc_nonzero : closed.
+#[export] Hint Resolve closed_wrt_tc_nonzero : closed.
 
 Lemma closed_wrt_binarithType:
   forall {cs: compspecs} S t1 t2 t a b,
@@ -1507,7 +1507,7 @@ Proof.
  unfold binarithType.
  destruct (Cop.classify_binarith t1 t2); simpl; auto with closed.
 Qed.
-Hint Resolve closed_wrt_binarithType : closed.
+#[export] Hint Resolve closed_wrt_binarithType : closed.
 
 Lemma closed_wrt_tc_samebase :
  forall {cs: compspecs} S e1 e2,
@@ -1517,7 +1517,7 @@ Lemma closed_wrt_tc_samebase :
 Proof.
  intros;  hnf; intros. simpl. unfold_lift. f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_tc_samebase : closed.
+#[export] Hint Resolve closed_wrt_tc_samebase : closed.
 
 Lemma closed_wrt_tc_ilt:
   forall {cs: compspecs} S e n,
@@ -1528,7 +1528,7 @@ Proof.
  repeat rewrite binop_lemmas2.denote_tc_assert_ilt'.
  simpl. unfold_lift. f_equal. auto.
 Qed.
-Hint Resolve closed_wrt_tc_ilt : closed.
+#[export] Hint Resolve closed_wrt_tc_ilt : closed.
 
 Lemma closed_wrt_tc_llt:
   forall {cs: compspecs} S e n,
@@ -1539,7 +1539,7 @@ Proof.
  repeat rewrite binop_lemmas2.denote_tc_assert_llt'.
  simpl. unfold_lift. f_equal. auto.
 Qed.
-Hint Resolve closed_wrt_tc_llt : closed.
+#[export] Hint Resolve closed_wrt_tc_llt : closed.
 
 Lemma closed_wrt_tc_Zge:
   forall {cs: compspecs} S e n,
@@ -1549,7 +1549,7 @@ Proof.
  intros; hnf; intros.
  simpl. unfold_lift; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_tc_Zge : closed.
+#[export] Hint Resolve closed_wrt_tc_Zge : closed.
 Lemma closed_wrt_tc_Zle:
   forall {cs: compspecs} S e n,
     closed_wrt_vars S (eval_expr e) ->
@@ -1558,7 +1558,7 @@ Proof.
  intros; hnf; intros.
  simpl. unfold_lift; f_equal; auto.
 Qed.
-Hint Resolve closed_wrt_tc_Zle : closed.
+#[export] Hint Resolve closed_wrt_tc_Zle : closed.
 
 Lemma closed_wrt_replace_nth:
   forall {B} S n R (R1: environ -> B),
@@ -1570,7 +1570,7 @@ intros.
 revert R H0; induction n; destruct R; simpl; intros; auto with closed;
 inv H0; constructor; auto with closed.
 Qed.
-Hint Resolve closed_wrt_replace_nth : closed.
+#[export] Hint Resolve closed_wrt_replace_nth : closed.
 
 Lemma closed_wrt_tc_nodivover :
  forall {cs: compspecs} S e1 e2,
@@ -1582,7 +1582,7 @@ Proof.
  repeat rewrite binop_lemmas2.denote_tc_assert_nodivover.
  rewrite <- H0; auto. rewrite <- H; auto.
 Qed.
-Hint Resolve closed_wrt_tc_nodivover : closed.
+#[export] Hint Resolve closed_wrt_tc_nodivover : closed.
 
 Lemma closed_wrt_tc_nosignedover:
   forall op {CS: compspecs} S e1 e2,
@@ -1595,7 +1595,7 @@ simpl. unfold_lift.
 rewrite <- H; auto.
 rewrite <- H0; auto.
 Qed.
-Hint Resolve closed_wrt_tc_nosignedover : closed.
+#[export] Hint Resolve closed_wrt_tc_nosignedover : closed.
 
 Lemma closed_wrt_tc_nobinover:
   forall op {CS: compspecs} S e1 e2,
@@ -1616,7 +1616,7 @@ destruct (eval_expr e2 any_environ); auto with closed.
 all: try destruct s; repeat simple_if_tac; auto with closed.
 Qed.
 
-Hint Resolve closed_wrt_tc_nobinover : closed.
+#[export] Hint Resolve closed_wrt_tc_nobinover : closed.
 
 Lemma closed_wrt_tc_expr:
   forall {cs: compspecs} Delta j e, closed_eval_expr j e = true ->
@@ -1718,8 +1718,8 @@ all: repeat simple_if_tac; try destruct si2; auto with closed.
  destruct (field_offset cenv_cs i (co_members c)); simpl; auto with closed.
 Qed.
 
-Hint Resolve closed_wrt_tc_expr : closed.
-Hint Resolve closed_wrt_tc_lvalue : closed.
+#[export] Hint Resolve closed_wrt_tc_expr : closed.
+#[export] Hint Resolve closed_wrt_tc_lvalue : closed.
 
 
 Lemma closed_wrt_lift1':
@@ -1732,7 +1732,7 @@ apply closed_wrt_lift1.
 hnf; intros. simpl. f_equal.
 apply H. auto.
 Qed.
-Hint Resolve closed_wrt_lift1' : closed.
+#[export] Hint Resolve closed_wrt_lift1' : closed.
 
 Lemma closed_wrt_Econst_int:
   forall {cs: compspecs} S i t, closed_wrt_vars S (eval_expr (Econst_int i t)).
@@ -1740,7 +1740,7 @@ Proof.
 simpl; intros.
 auto with closed.
 Qed.
-Hint Resolve closed_wrt_Econst_int : closed.
+#[export] Hint Resolve closed_wrt_Econst_int : closed.
 
 Lemma closed_wrt_PROPx:
  forall S P Q, closed_wrt_vars S Q -> closed_wrt_vars S (PROPx P Q).
@@ -1756,7 +1756,7 @@ intros.
 apply closed_wrtl_andp; auto.
 hnf; intros. reflexivity.
 Qed.
-Hint Resolve closed_wrt_PROPx closed_wrtl_PROPx: closed.
+#[export] Hint Resolve closed_wrt_PROPx closed_wrtl_PROPx: closed.
 
 
 Lemma closed_wrt_LOCALx:
@@ -1806,7 +1806,7 @@ apply closed_wrt_andp; auto with closed.
 Qed.
 *)
 
-Hint Resolve closed_wrt_LOCALx closed_wrtl_LOCALx: closed.
+#[export] Hint Resolve closed_wrt_LOCALx closed_wrtl_LOCALx: closed.
 
 Lemma closed_wrt_SEPx: forall S P,
      closed_wrt_vars S (SEPx P).
@@ -1823,7 +1823,7 @@ intros.
 unfold SEPx.
 auto with closed.
 Qed.
-Hint Resolve closed_wrt_SEPx closed_wrtl_SEPx: closed.
+#[export] Hint Resolve closed_wrt_SEPx closed_wrtl_SEPx: closed.
 
 Lemma not_not_a_param_i:
   forall (L: list (ident * type)) i,
@@ -1833,7 +1833,7 @@ Proof.
 intros.
 intro. apply H0; auto.
 Qed.
-Hint Resolve not_not_a_param_i : closed.
+#[export] Hint Resolve not_not_a_param_i : closed.
 
 Lemma in_map_fst1:
  forall (i: ident) (t: type) L,
@@ -1841,7 +1841,7 @@ Lemma in_map_fst1:
 Proof.
 intros. left. reflexivity.
 Qed.
-Hint Resolve in_map_fst1 : closed.
+#[export] Hint Resolve in_map_fst1 : closed.
 
 Lemma in_map_fst2:
  forall (i: ident) a (L: list (ident*type)),
@@ -1850,7 +1850,7 @@ Lemma in_map_fst2:
 Proof.
 intros; right; auto.
 Qed.
-Hint Resolve in_map_fst2 : closed.
+#[export] Hint Resolve in_map_fst2 : closed.
 
 Lemma Forall_map_cons:
   forall {A B} (F: A -> Prop) (g: B -> A) b bl,
@@ -1870,5 +1870,5 @@ simpl.
 intros.
 constructor; auto.
 Qed.
-Hint Resolve Forall_map_cons Forall_map_nil : closed.
-Hint Resolve Forall_cons Forall_nil : closed.
+#[export] Hint Resolve Forall_map_cons Forall_map_nil : closed.
+#[export] Hint Resolve Forall_cons Forall_nil : closed.

--- a/floyd/data_at_list_solver.v
+++ b/floyd/data_at_list_solver.v
@@ -28,7 +28,7 @@ Lemma data_subsume_default : forall {cs : compspecs} (t : type) (x y : reptype t
   data_subsume t x y.
 Proof. unfold data_subsume. intros. subst y. apply data_at_data_at_. Qed.
 
-Hint Resolve data_subsume_refl data_subsume_refl' data_subsume_default : core.
+#[export] Hint Resolve data_subsume_refl data_subsume_refl' data_subsume_default : core.
 
 Lemma data_subsume_array_ext : forall {cs : compspecs} (t : type) (n : Z) (al bl : list (reptype t)),
   n = Zlength al ->

--- a/floyd/entailer.v
+++ b/floyd/entailer.v
@@ -23,11 +23,11 @@ Lemma isptr_force_val_sem_cast_neutral :
 Proof.
 intros. destruct p; try contradiction; apply I.
 Qed.
-Hint Resolve isptr_force_val_sem_cast_neutral : norm.
+#[export] Hint Resolve isptr_force_val_sem_cast_neutral : norm.
 
 Lemma FF_local_facts: forall {A}{NA: NatDed A}, (FF:A) |-- !!False.
 Proof. intros. apply FF_left. Qed.
-Hint Resolve FF_local_facts: saturate_local.
+#[export] Hint Resolve FF_local_facts: saturate_local.
 
 Ltac simpl_compare :=
  match goal with
@@ -278,13 +278,13 @@ Proof.
 Qed.
 
 
-Hint Resolve sepcon_valid_pointer1 sepcon_valid_pointer2 : valid_pointer.
-Hint Resolve andp_valid_pointer1 andp_valid_pointer2 : valid_pointer.
-Hint Resolve valid_pointer_null : valid_pointer.
-Hint Resolve valid_pointer_zero32 : valid_pointer.
-Hint Resolve valid_pointer_zero64 : valid_pointer.
-Hint Resolve sepcon_weak_valid_pointer1: valid_pointer. 
-Hint Resolve sepcon_weak_valid_pointer2: valid_pointer. 
+#[export] Hint Resolve sepcon_valid_pointer1 sepcon_valid_pointer2 : valid_pointer.
+#[export] Hint Resolve andp_valid_pointer1 andp_valid_pointer2 : valid_pointer.
+#[export] Hint Resolve valid_pointer_null : valid_pointer.
+#[export] Hint Resolve valid_pointer_zero32 : valid_pointer.
+#[export] Hint Resolve valid_pointer_zero64 : valid_pointer.
+#[export] Hint Resolve sepcon_weak_valid_pointer1: valid_pointer. 
+#[export] Hint Resolve sepcon_weak_valid_pointer2: valid_pointer. 
 
 
 (* TODO: test_order need to be added *)
@@ -389,7 +389,7 @@ Proof.
 destruct x; simpl; intros; try contradiction.
 split; auto. apply Ptrofs.eq_true.
 Qed.
-Hint Resolve ptr_eq_refl : prove_it_now.
+#[export] Hint Resolve ptr_eq_refl : prove_it_now.
 
 Lemma ptr_eq_nullval: ptr_eq nullval nullval.
 Proof.
@@ -399,9 +399,9 @@ split3; auto.
 Opaque Archi.ptr64.
 Qed.
 
-Hint Resolve ptr_eq_nullval : prove_it_now.
+#[export] Hint Resolve ptr_eq_nullval : prove_it_now.
 
-Hint Extern 4 (value_fits _ _ _) =>
+#[export] Hint Extern 4 (value_fits _ _ _) =>
    (rewrite ?proj_sumbool_is_true by auto;
     rewrite ?proj_sumbool_is_false by auto;
     repeat simplify_value_fits; auto) : prove_it_now.
@@ -758,7 +758,7 @@ Proof.
   lia. 
 Qed.
 
-Hint Resolve cstring_local_facts : saturate_local.
+#[export] Hint Resolve cstring_local_facts : saturate_local.
 
 Lemma cstring_valid_pointer: forall {CS : compspecs} sh s p, 
    nonempty_share sh -> 
@@ -771,7 +771,7 @@ Proof.
   rewrite Z.max_r; lia.
 Qed.
 
-Hint Resolve cstring_valid_pointer : valid_pointer.
+#[export] Hint Resolve cstring_valid_pointer : valid_pointer.
 Definition cstringn {CS : compspecs} sh (s: list byte) n p :=
   !!(~In Byte.zero s) &&
   data_at sh (tarray tschar n) (map Vbyte (s ++ [Byte.zero]) ++
@@ -835,7 +835,7 @@ Proof.
   rep_lia.
 Qed.
 
-Hint Resolve cstringn_local_facts : saturate_local.
+#[export] Hint Resolve cstringn_local_facts : saturate_local.
 
 Lemma cstringn_valid_pointer: forall {CS : compspecs} sh s n p, 
      nonempty_share sh -> 
@@ -850,7 +850,7 @@ Proof.
   rewrite Z.max_r; lia.
 Qed.
 
-Hint Resolve cstringn_valid_pointer : valid_pointer.
+#[export] Hint Resolve cstringn_valid_pointer : valid_pointer.
 
 
 Lemma Znth_zero_zero:

--- a/floyd/field_at.v
+++ b/floyd/field_at.v
@@ -1680,7 +1680,7 @@ Qed.
 
 End CENV.
 
-Hint Extern 2 (memory_block _ _ _ |-- valid_pointer _) =>
+#[export] Hint Extern 2 (memory_block _ _ _ |-- valid_pointer _) =>
   (apply memory_block_valid_ptr; [auto with valid_pointer | rep_lia]) : valid_pointer.
 
 Lemma valid_pointer_weak:
@@ -1702,7 +1702,7 @@ eapply derives_trans; try eassumption.
 apply valid_pointer_weak.
 Qed.
 
-Hint Resolve valid_pointer_weak' : valid_pointer.
+#[export] Hint Resolve valid_pointer_weak' : valid_pointer.
 
 Lemma valid_pointer_offset_zero: forall P q, 
    P |-- valid_pointer (offset_val 0 q) ->
@@ -1723,13 +1723,13 @@ rewrite offset_val_zero_Vptr in H.
 auto.
 Qed.
 
-Hint Extern 1 (_ |-- valid_pointer ?Q) =>
+#[export] Hint Extern 1 (_ |-- valid_pointer ?Q) =>
   lazymatch Q with
   | offset_val _ _ => fail 
   | _ => apply valid_pointer_offset_zero
   end : core.
 
-Hint Extern 2 (memory_block _ _ _ |-- weak_valid_pointer _) =>
+#[export] Hint Extern 2 (memory_block _ _ _ |-- weak_valid_pointer _) =>
   (apply SeparationLogic.memory_block_weak_valid_pointer;
         [rep_lia | rep_lia | auto with valid_pointer]) : valid_pointer.
 
@@ -1838,7 +1838,7 @@ pose proof (Ptrofs.unsigned_range i).
 repeat split; simpl; auto; try lia.
 Qed.
 
-Hint Extern 2 (field_compatible _ nil _) =>
+#[export] Hint Extern 2 (field_compatible _ nil _) =>
  (apply malloc_compatible_field_compatible;
   [assumption | reflexivity | reflexivity]) : core.
 
@@ -1901,49 +1901,49 @@ end.
 Ltac data_at_valid_aux :=
  first [computable | unfold sizeof; simpl Ctypes.sizeof; rewrite ?Z.max_r by rep_lia; rep_lia | rep_lia].
 
-Hint Extern 1 (data_at _ _ _ _ |-- valid_pointer _) =>
+#[export] Hint Extern 1 (data_at _ _ _ _ |-- valid_pointer _) =>
     (simple apply data_at_valid_ptr; [now auto | data_at_valid_aux]) : valid_pointer.
 
-Hint Extern 1 (field_at _ _ _ _ _ |-- valid_pointer _) =>
+#[export] Hint Extern 1 (field_at _ _ _ _ _ |-- valid_pointer _) =>
     (simple apply field_at_valid_ptr; [now auto | data_at_valid_aux]) : valid_pointer.
 
 (*
-Hint Extern 1 (data_at_ _ _ _ |-- valid_pointer _) =>
+#[export] Hint Extern 1 (data_at_ _ _ _ |-- valid_pointer _) =>
     (unfold data_at_, field_at_; 
      simple apply field_at_valid_ptr; [now auto | data_at_valid_aux]) : valid_pointer.
 
-Hint Extern 1 (field_at_ _ _ _ _ |-- valid_pointer _) =>
+#[export] Hint Extern 1 (field_at_ _ _ _ _ |-- valid_pointer _) =>
     (unfold field_at_; simple apply field_at_valid_ptr; [now auto | data_at_valid_aux]) : valid_pointer.
 *)
 
-Hint Extern 1 (data_at_ _ _ _ |-- valid_pointer _) =>
+#[export] Hint Extern 1 (data_at_ _ _ _ |-- valid_pointer _) =>
     (simple apply data_at__valid_ptr; [now auto | data_at_valid_aux]) : valid_pointer.
 
-Hint Extern 1 (field_at_ _ _ _ _ |-- valid_pointer _) =>
+#[export] Hint Extern 1 (field_at_ _ _ _ _ |-- valid_pointer _) =>
     (apply field_at_valid_ptr; [now auto | data_at_valid_aux]) : valid_pointer.
 
-(* Hint Resolve data_at_valid_ptr field_at_valid_ptr field_at_valid_ptr0 : valid_pointer. *)
+(* #[export] Hint Resolve data_at_valid_ptr field_at_valid_ptr field_at_valid_ptr0 : valid_pointer. *)
 
-(*Hint Resolve field_at_local_facts : saturate_local.*)
-Hint Extern 1 (field_at _ _ _ _ _ |-- _) =>
+(*#[export] Hint Resolve field_at_local_facts : saturate_local.*)
+#[export] Hint Extern 1 (field_at _ _ _ _ _ |-- _) =>
  (field_at_saturate_local) : saturate_local.
 
-(* Hint Resolve data_at_local_facts : saturate_local.*)
-Hint Extern 1 (data_at _ _ _ _ |-- _) =>
+(* #[export] Hint Resolve data_at_local_facts : saturate_local.*)
+#[export] Hint Extern 1 (data_at _ _ _ _ |-- _) =>
  (field_at_saturate_local) : saturate_local.
 
-Hint Resolve array_at_local_facts array_at__local_facts : saturate_local.
+#[export] Hint Resolve array_at_local_facts array_at__local_facts : saturate_local.
 
 
-Hint Resolve field_at__local_facts : saturate_local.
-Hint Resolve data_at__local_facts : saturate_local.
-Hint Extern 0 (data_at _ (Tarray _ _ _) _ _ |-- _) =>
+#[export] Hint Resolve field_at__local_facts : saturate_local.
+#[export] Hint Resolve data_at__local_facts : saturate_local.
+#[export] Hint Extern 0 (data_at _ (Tarray _ _ _) _ _ |-- _) =>
   (apply data_array_at_local_facts'; lia) : saturate_local.
-Hint Extern 0 (data_at _ (tarray _ _) _ _ |-- _) =>
+#[export] Hint Extern 0 (data_at _ (tarray _ _) _ _ |-- _) =>
   (apply data_array_at_local_facts'; lia) : saturate_local.
-Hint Extern 1 (data_at _ (Tarray _ _ _) _ _ |-- _) =>
+#[export] Hint Extern 1 (data_at _ (Tarray _ _ _) _ _ |-- _) =>
   (apply data_array_at_local_facts) : saturate_local.
-Hint Extern 1 (data_at _ (tarray _ _) _ _ |-- _) =>
+#[export] Hint Extern 1 (data_at _ (tarray _ _) _ _ |-- _) =>
   (apply data_array_at_local_facts) : saturate_local.
 Hint Rewrite <- @field_at_offset_zero: norm1.
 Hint Rewrite <- @field_at__offset_zero: norm1.
@@ -1977,7 +1977,7 @@ Lemma field_at_data_at_cancel:
     field_at sh t nil v p |-- data_at sh t v p.
 Proof. intros. apply derives_refl. Qed.
 
-Hint Resolve data_at_cancel field_at_cancel
+#[export] Hint Resolve data_at_cancel field_at_cancel
    data_at_field_at_cancel field_at_data_at_cancel : cancel.
 
 Lemma field_at__data_at__cancel:
@@ -1989,38 +1989,38 @@ Lemma data_at__field_at__cancel:
   forall {cs: compspecs} sh t p,
    data_at_ sh t p |-- field_at_ sh t nil p.
 Proof. intros. apply derives_refl. Qed.
-Hint Resolve  field_at__data_at__cancel data_at__field_at__cancel : cancel.
+#[export] Hint Resolve  field_at__data_at__cancel data_at__field_at__cancel : cancel.
 
 
 (* We do these as Hint Extern, instead of Hint Resolve,
   to limit their application and make them fail faster *)
 
-Hint Extern 2 (field_at _ _ _ _ _ |-- field_at_ _ _ _ _) =>
+#[export] Hint Extern 2 (field_at _ _ _ _ _ |-- field_at_ _ _ _ _) =>
    (simple apply field_at_field_at_) : cancel.
 
-Hint Extern 2 (field_at _ _ _ _ _ |-- field_at _ _ _ _ _) =>
+#[export] Hint Extern 2 (field_at _ _ _ _ _ |-- field_at _ _ _ _ _) =>
   (simple apply field_at_field_at_default;
    match goal with |- _ = default_val _ => reflexivity end) : cancel.
 
-Hint Extern 1 (data_at _ _ _ _ |-- data_at_ _ _ _) =>
+#[export] Hint Extern 1 (data_at _ _ _ _ |-- data_at_ _ _ _) =>
     (simple apply data_at_data_at_) : cancel.
 
-Hint Extern 1 (data_at _ _ _ _ |-- memory_block _ _ _) =>
+#[export] Hint Extern 1 (data_at _ _ _ _ |-- memory_block _ _ _) =>
     (simple apply data_at__memory_block_cancel) : cancel.
 
-Hint Extern 2 (data_at _ _ _ _ |-- data_at _ _ _ _) =>
+#[export] Hint Extern 2 (data_at _ _ _ _ |-- data_at _ _ _ _) =>
   (simple apply data_at_data_at_default;
    match goal with |- _ = default_val _ => reflexivity end) : cancel.
 
 (* too slow this way.
-Hint Extern 2 (data_at _ _ _ _ |-- data_at _ _ _ _) =>
+#[export] Hint Extern 2 (data_at _ _ _ _ |-- data_at _ _ _ _) =>
   (apply data_at_data_at_default; reflexivity) : cancel.
 *)
 
-Hint Extern 2 (array_at _ _ _ _ _ _ _ |-- array_at_ _ _ _ _ _ _) =>
+#[export] Hint Extern 2 (array_at _ _ _ _ _ _ _ |-- array_at_ _ _ _ _ _ _) =>
   (simple apply array_at_array_at_) : cancel.
-Hint Extern 1 (isptr _) => (eapply field_compatible_offset_isptr; eassumption) : core.
-Hint Extern 1 (isptr _) => (eapply field_compatible0_offset_isptr; eassumption) : core.
+#[export] Hint Extern 1 (isptr _) => (eapply field_compatible_offset_isptr; eassumption) : core.
+#[export] Hint Extern 1 (isptr _) => (eapply field_compatible0_offset_isptr; eassumption) : core.
 Hint Rewrite @is_pointer_or_null_field_address_lemma : entailer_rewrite.
 Hint Rewrite @isptr_field_address_lemma : entailer_rewrite.
 
@@ -2723,7 +2723,7 @@ Ltac headptr_field_compatible :=
     repeat apply Forall_cons; try apply Forall_nil
   end.
 
-Hint Extern 2 (field_compatible _ _ _) => headptr_field_compatible : field_compatible.
+#[export] Hint Extern 2 (field_compatible _ _ _) => headptr_field_compatible : field_compatible.
 
 (* BEGIN New experiments *)
 
@@ -2732,7 +2732,7 @@ Lemma data_at_data_at_cancel  {cs: compspecs}: forall sh t v v' p,
   data_at sh t v p |-- data_at sh t v' p.
 Proof. intros. subst. apply derives_refl. Qed.
  
-Hint Resolve data_at_data_at_cancel : cancel.
+#[export] Hint Resolve data_at_data_at_cancel : cancel.
 
 
 Lemma field_at_field_at_cancel  {cs: compspecs}: forall sh t gfs v v' p,
@@ -2740,8 +2740,8 @@ Lemma field_at_field_at_cancel  {cs: compspecs}: forall sh t gfs v v' p,
   field_at sh t gfs v p |-- field_at sh t gfs v' p.
 Proof. intros. subst. apply derives_refl. Qed.
  
-Hint Resolve data_at_data_at_cancel : cancel.
-Hint Resolve field_at_field_at_cancel : cancel.
+#[export] Hint Resolve data_at_data_at_cancel : cancel.
+#[export] Hint Resolve field_at_field_at_cancel : cancel.
 
 Lemma data_at__data_at {cs: compspecs}:
    forall sh t v p, v = default_val t -> data_at_ sh t p |-- data_at sh t v p.
@@ -2768,18 +2768,18 @@ intros; subst; unfold field_at_; apply derives_refl.
 Qed.
 
 
-Hint Resolve data_at__data_at : cancel.
-Hint Resolve field_at__field_at : cancel.
-Hint Resolve data_at__field_at : cancel.
-Hint Resolve field_at__data_at : cancel.
+#[export] Hint Resolve data_at__data_at : cancel.
+#[export] Hint Resolve field_at__field_at : cancel.
+#[export] Hint Resolve data_at__field_at : cancel.
+#[export] Hint Resolve field_at__data_at : cancel.
 
-Hint Extern 1 (_ = @default_val _ _) =>
+#[export] Hint Extern 1 (_ = @default_val _ _) =>
  match goal with |- ?A = ?B => 
      let x := fresh "x" in set (x := B); hnf in x; subst x;
      match goal with |- ?A = ?B => constr_eq A B; reflexivity
   end end : core.
 
-Hint Extern 1 (_ = _) => 
+#[export] Hint Extern 1 (_ = _) => 
   match goal with |- ?A = ?B => constr_eq A B; reflexivity end : cancel.
 
 (* enhance cancel to solve field_at and data_at *)
@@ -2949,28 +2949,28 @@ intros.
 apply @change_compspecs_field_at_cancel3 with CCE; auto.
 Qed.
 
-Hint Extern 2 (@data_at_ ?cs1 ?sh _ ?p |-- @data_at_ ?cs2 ?sh _ ?p) =>
+#[export] Hint Extern 2 (@data_at_ ?cs1 ?sh _ ?p |-- @data_at_ ?cs2 ?sh _ ?p) =>
     (tryif constr_eq cs1 cs2 then fail
      else simple apply change_compspecs_data_at_cancel2; reflexivity) : cancel.
 
-Hint Extern 2 (@data_at ?cs1 ?sh _ _ ?p |-- @data_at_ ?cs2 ?sh _ ?p) =>
+#[export] Hint Extern 2 (@data_at ?cs1 ?sh _ _ ?p |-- @data_at_ ?cs2 ?sh _ ?p) =>
     (tryif constr_eq cs1 cs2 then fail
      else simple apply change_compspecs_data_at_cancel3; reflexivity) : cancel.
 
-Hint Extern 2 (@data_at ?cs1 ?sh _ _ ?p |-- @data_at ?cs2 ?sh _ _ ?p) =>
+#[export] Hint Extern 2 (@data_at ?cs1 ?sh _ _ ?p |-- @data_at ?cs2 ?sh _ _ ?p) =>
     (tryif constr_eq cs1 cs2 then fail
      else simple apply change_compspecs_data_at_cancel; 
        [ reflexivity | reflexivity | apply JMeq_refl]) : cancel.
 
-Hint Extern 2 (@field_at_ ?cs1 ?sh _ ?gfs ?p |-- @field_at_ ?cs2 ?sh _ ?gfs ?p) =>
+#[export] Hint Extern 2 (@field_at_ ?cs1 ?sh _ ?gfs ?p |-- @field_at_ ?cs2 ?sh _ ?gfs ?p) =>
     (tryif constr_eq cs1 cs2 then fail
      else simple apply change_compspecs_field_at_cancel2; reflexivity) : cancel.
 
-Hint Extern 2 (@field_at ?cs1 ?sh _ ?gfs _ ?p |-- @field_at_ ?cs2 ?sh _ ?gfs ?p) =>
+#[export] Hint Extern 2 (@field_at ?cs1 ?sh _ ?gfs _ ?p |-- @field_at_ ?cs2 ?sh _ ?gfs ?p) =>
     (tryif constr_eq cs1 cs2 then fail
      else simple apply change_compspecs_field_at_cancel3; reflexivity) : cancel.
 
-Hint Extern 2 (@field_at ?cs1 ?sh _ ?gfs _ ?p |-- @field_at ?cs2 ?sh _ ?gfs _ ?p) =>
+#[export] Hint Extern 2 (@field_at ?cs1 ?sh _ ?gfs _ ?p |-- @field_at ?cs2 ?sh _ ?gfs _ ?p) =>
     (tryif constr_eq cs1 cs2 then fail
      else simple apply change_compspecs_field_at_cancel; 
         [ reflexivity | reflexivity | apply JMeq_refl]) : cancel.

--- a/floyd/field_at_wand.v
+++ b/floyd/field_at_wand.v
@@ -29,7 +29,7 @@ Proof.
 intros.
 unfold array_with_hole. entailer!.
 Qed.
-Hint Resolve array_with_hole_local_facts : saturate_local.
+#[export] Hint Resolve array_with_hole_local_facts : saturate_local.
 
 Lemma wand_slice_array:
 forall {cs: compspecs} lo hi n sh t (al: list (reptype t)) p,

--- a/floyd/field_compat.v
+++ b/floyd/field_compat.v
@@ -37,11 +37,11 @@ Lemma field_address_offset:
 Proof. intros. unfold field_address; rewrite if_true by auto; reflexivity.
 Qed.
 
-Hint Extern 2 (field_compatible0 _ (ArraySubsc _ :: _) _) =>
+#[export] Hint Extern 2 (field_compatible0 _ (ArraySubsc _ :: _) _) =>
    (eapply field_compatible0_cons_Tarray; [reflexivity | | lia])
   : field_compatible.
 
-Hint Extern 2 (field_compatible _ (ArraySubsc _ :: _) _) =>
+#[export] Hint Extern 2 (field_compatible _ (ArraySubsc _ :: _) _) =>
    (eapply field_compatible_cons_Tarray; [reflexivity | | lia])
   : field_compatible.
 
@@ -102,16 +102,16 @@ lia.
 Qed.
 
 
-Hint Extern 2 (field_compatible (Tarray _ _ _) nil _) =>
+#[export] Hint Extern 2 (field_compatible (Tarray _ _ _) nil _) =>
    (eapply field_compatible_array_smaller0; [eassumption | lia]) : field_compatible.
 
-Hint Extern 2 (field_compatible (tarray _ _) nil _) =>
+#[export] Hint Extern 2 (field_compatible (tarray _ _) nil _) =>
    (eapply field_compatible_array_smaller0; [eassumption | lia]) : field_compatible.
 
-Hint Extern 2 (field_compatible0 (Tarray _ _ _) nil _) =>
+#[export] Hint Extern 2 (field_compatible0 (Tarray _ _ _) nil _) =>
    (eapply field_compatible0_array_smaller0; [eassumption | lia]) : field_compatible.
 
-Hint Extern 2 (field_compatible0 (tarray _ _) nil _) =>
+#[export] Hint Extern 2 (field_compatible0 (tarray _ _) nil _) =>
    (eapply field_compatible0_array_smaller0; [eassumption | lia]) : field_compatible.
 
 Lemma field_compatible0_array_smaller1:
@@ -146,15 +146,15 @@ lia.
    lia.
 Qed.
 
-Hint Extern 2 (field_compatible0 (Tarray _ _ _) (ArraySubsc _ :: nil) _) =>
+#[export] Hint Extern 2 (field_compatible0 (Tarray _ _ _) (ArraySubsc _ :: nil) _) =>
    (eapply field_compatible0_array_smaller1; [eassumption | lia | lia]) : field_compatible.
 
-Hint Extern 2 (field_compatible0 (tarray _ _) (ArraySubsc _ :: nil) _) =>
+#[export] Hint Extern 2 (field_compatible0 (tarray _ _) (ArraySubsc _ :: nil) _) =>
    (eapply field_compatible0_array_smaller1; [eassumption | lia | lia]) : field_compatible.
 
 Arguments nested_field_array_type {cs} t gfs lo hi / .
 
-Hint Resolve field_compatible_field_compatible0 : field_compatible.
+#[export] Hint Resolve field_compatible_field_compatible0 : field_compatible.
 
 Lemma field_compatible0_ArraySubsc0:
  forall {cs: compspecs} t gfs p,
@@ -256,11 +256,11 @@ hnf in H0,H2|-*.
 tauto.
 Qed.
 
-Hint Resolve field_compatible0_ArraySubsc0 : field_compatible.
+#[export] Hint Resolve field_compatible0_ArraySubsc0 : field_compatible.
 
-Hint Extern 2 (legal_nested_field0 _ _) =>
+#[export] Hint Extern 2 (legal_nested_field0 _ _) =>
   (apply compute_legal_nested_field0_spec'; repeat constructor; rep_lia) : field_compatible.
-Hint Extern 2 (field_compatible0 _ _ (offset_val _ _)) =>
+#[export] Hint Extern 2 (field_compatible0 _ _ (offset_val _ _)) =>
   (apply field_compatible0_nested_field_array; auto with field_compatible) : core. (*FIXME: should be field_compatible*)
 
 Lemma split2_data_at_Tarray_unfold {cs: compspecs}
@@ -454,10 +454,10 @@ intros until 1. intros NA ?H ?H Hni Hii Hp. subst p'.
 Qed.
 
 (*
-Hint Extern 2 (field_compatible0 (Tarray _ _ _) (ArraySubsc _ :: nil) _) =>
+#[export] Hint Extern 2 (field_compatible0 (Tarray _ _ _) (ArraySubsc _ :: nil) _) =>
     (eapply field_compatible0_Tarray_offset; [eassumption | lia | lia]) : field_compatible.
 
-Hint Extern 2 (field_compatible0 (tarray _ _) (ArraySubsc _ :: nil) _) =>
+#[export] Hint Extern 2 (field_compatible0 (tarray _ _) (ArraySubsc _ :: nil) _) =>
     (eapply field_compatible0_Tarray_offset; [eassumption | lia | lia]) : field_compatible.
 *)
 

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -59,7 +59,7 @@ unfold sem_add_ptr_int.
 rewrite H; simpl; auto.
 Qed.
 
-Hint Extern 2 (isptr (force_val (sem_add_ptr_int _ _ _ _))) =>
+#[export] Hint Extern 2 (isptr (force_val (sem_add_ptr_int _ _ _ _))) =>
     apply isptr_force_sem_add_ptr_int; [reflexivity | auto with prove_it_now] : core.
 
 (* Done in this tail-recursive style so that "hnf" fully reduces it *)
@@ -90,7 +90,7 @@ Ltac mk_varspecs prog :=
           in let e := eval hnf in e
           in unfold_varspecs e.
 
-Hint Resolve field_address_isptr : norm.
+#[export] Hint Resolve field_address_isptr : norm.
 
 Lemma field_address_eq_offset':
  forall {cs: compspecs} t path v ofs,
@@ -101,7 +101,7 @@ Proof.
 intros. subst. apply field_compatible_field_address; auto.
 Qed.
 
-Hint Resolve field_address_eq_offset' : prove_it_now.
+#[export] Hint Resolve field_address_eq_offset' : prove_it_now.
 
 Hint Rewrite <- @prop_and using solve [auto with typeclass_instances]: norm1.
 
@@ -2632,9 +2632,9 @@ Proof.
 intros. simpl_ret_assert. apply andp_left2; apply FF_left.
 Qed.
 
-Hint Resolve ENTAIL_break_normal ENTAIL_continue_normal ENTAIL_return_normal : core.
+#[export] Hint Resolve ENTAIL_break_normal ENTAIL_continue_normal ENTAIL_return_normal : core.
 
-Hint Extern 0 (ENTAIL _, _ |-- _) =>
+#[export] Hint Extern 0 (ENTAIL _, _ |-- _) =>
  match goal with |- ENTAIL _, ?A |-- ?B => constr_eq A B; simple apply ENTAIL_refl end : core.
 
 Ltac forward_if_tac post :=
@@ -2878,10 +2878,10 @@ Ltac sequential :=
  end.
 
 (* move these two elsewhere, perhaps entailer.v *)
-Hint Extern 1 (@sizeof _ ?A > 0) =>
+#[export] Hint Extern 1 (@sizeof _ ?A > 0) =>
    (let a := fresh in set (a:= sizeof A); hnf in a; subst a; computable)
   : valid_pointer.
-Hint Resolve denote_tc_test_eq_split : valid_pointer.
+#[export] Hint Resolve denote_tc_test_eq_split : valid_pointer.
 
 Ltac pre_entailer :=
   try match goal with

--- a/floyd/functional_base.v
+++ b/floyd/functional_base.v
@@ -63,8 +63,8 @@ Proof. destruct v; simpl; try solve [right; intros N; trivial]; left; trivial. D
 Lemma isptr_offset_val':
  forall i p, isptr p -> isptr (offset_val i p).
 Proof. intros. destruct p; try contradiction; apply Coq.Init.Logic.I. Qed.
-Hint Extern 1 (isptr (offset_val _ _)) => apply isptr_offset_val' : core.
-Hint Resolve isptr_offset_val': norm.
+#[export] Hint Extern 1 (isptr (offset_val _ _)) => apply isptr_offset_val' : core.
+#[export] Hint Resolve isptr_offset_val': norm.
 
 Lemma offset_val_force_ptr:
   offset_val 0 = force_ptr.
@@ -340,7 +340,7 @@ with putable x :=
   first [putable' x
          | tryif (try (assert (computable x) by (clear; auto 100 with computable); fail 1)) then fail else idtac ].
 
-Hint Extern 1 (computable ?x) => (putable' x; apply computable_any) : computable.
+#[export] Hint Extern 1 (computable ?x) => (putable' x; apply computable_any) : computable.
 
 Ltac computable := match goal with |- ?x =>
  no_evars x;
@@ -376,10 +376,10 @@ pose proof (Int.zero_ext_range n i H).
 lia.
 Qed.
 
-Hint Extern 3 (_ <= Int.signed (Int.sign_ext _ _) <= _) =>
+#[export] Hint Extern 3 (_ <= Int.signed (Int.sign_ext _ _) <= _) =>
     (apply sign_ext_range2; [computable | reflexivity | reflexivity]) : core.
 
-Hint Extern 3 (_ <= Int.unsigned (Int.zero_ext _ _) <= _) =>
+#[export] Hint Extern 3 (_ <= Int.unsigned (Int.zero_ext _ _) <= _) =>
     (apply zero_ext_range2; [computable | reflexivity | reflexivity]) : core.
 
 Hint Rewrite sign_ext_inrange using assumption : norm.

--- a/floyd/globals_lemmas.v
+++ b/floyd/globals_lemmas.v
@@ -1128,7 +1128,7 @@ unfold data_at_rec;  simpl.
 unfold mapsto. simpl. rewrite if_true by apply H13.
 rewrite andb_false_r.
 apply orp_right1.
-rewrite prop_true_andp by auto.
+rewrite prop_true_andp by apply mapsto_memory_block.is_pointer_or_null_nullval.
 {
 change (if Archi.ptr64 then 8 else 4) with (size_chunk Mptr).
 apply mapsto_memory_block.address_mapsto_address_mapsto_zeros; auto.

--- a/floyd/jmeq_lemmas.v
+++ b/floyd/jmeq_lemmas.v
@@ -22,7 +22,7 @@ Proof.
   rewrite <- eq_rect_eq.
   auto.
 Qed.
-Hint Resolve JMeq_refl : core.
+#[export] Hint Resolve JMeq_refl : core.
 
 Lemma JMeq_sym : forall {A: Type} {B:Type} {x:A} {y:B}, JMeq x y -> JMeq y x.
 Proof.
@@ -34,7 +34,7 @@ Proof.
   simpl.
   apply eq_refl.
 Qed.
-Hint Immediate JMeq_sym : core.
+#[export] Hint Immediate JMeq_sym : core.
 
 Lemma JMeq_trans :
  forall {A: Type} {B: Type} {C:Type} {x:A} {y:B} {z:C}, JMeq x y -> JMeq y z -> JMeq x z.

--- a/floyd/library.v
+++ b/floyd/library.v
@@ -71,7 +71,7 @@ Parameter malloc_token : forall {cs: compspecs}, share -> type -> val -> mpred.
 Parameter malloc_token_valid_pointer:
   forall {cs: compspecs} sh t p, sizeof t <= 0 -> malloc_token sh t p |-- valid_pointer p.
 
-Hint Extern 1 (malloc_token _ _ _ |-- valid_pointer _) =>
+#[export] Hint Extern 1 (malloc_token _ _ _ |-- valid_pointer _) =>
   (simple apply malloc_token_valid_pointer; data_at_valid_aux) : valid_pointer.
 
 Ltac malloc_token_data_at_valid_pointer :=
@@ -87,11 +87,11 @@ Ltac malloc_token_data_at_valid_pointer :=
    end
  end.
 
-Hint Extern 4 (_ |-- valid_pointer _) => malloc_token_data_at_valid_pointer : valid_pointer.
+#[export] Hint Extern 4 (_ |-- valid_pointer _) => malloc_token_data_at_valid_pointer : valid_pointer.
 
 Parameter malloc_token_local_facts:
   forall {cs: compspecs} sh t p, malloc_token sh t p |-- !! malloc_compatible (sizeof t) p.
-Hint Resolve malloc_token_local_facts : saturate_local.
+#[export] Hint Resolve malloc_token_local_facts : saturate_local.
 Parameter malloc_token_change_composite: forall {cs_from cs_to} {CCE : change_composite_env cs_from cs_to} sh t,
   cs_preserve_type cs_from cs_to (coeq cs_from cs_to) t = true ->
   @malloc_token cs_from sh t = @malloc_token cs_to sh t.

--- a/floyd/list_solver.v
+++ b/floyd/list_solver.v
@@ -245,9 +245,9 @@ Ltac eq_solve_with tac :=
 Tactic Notation "eq_solve" "with" tactic(tac) := eq_solve_with (tac).
 Tactic Notation "eq_solve" := eq_solve with fail.
 
-Hint Extern 1 (@eq _ _ _) => eq_solve : Znth_solve_hint.
-(* Hint Extern 1 (@eq _ _ _) => fassumption : Znth_solve_hint.
-Hint Extern 1 (@eq _ _ _) => congruence : Znth_solve_hint. *)
+#[export] Hint Extern 1 (@eq _ _ _) => eq_solve : Znth_solve_hint.
+(* #[export] Hint Extern 1 (@eq _ _ _) => fassumption : Znth_solve_hint.
+#[export] Hint Extern 1 (@eq _ _ _) => congruence : Znth_solve_hint. *)
 
 (*************** range definitions **********************)
 Definition forall_i (lo hi : Z) (P : Z -> Prop) :=

--- a/floyd/mapsto_memory_block.v
+++ b/floyd/mapsto_memory_block.v
@@ -55,7 +55,7 @@ Proof.
   eapply derives_trans; [apply mapsto_local_facts |].
   apply prop_derives; tauto.
 Qed.
-Hint Resolve mapsto_local_facts mapsto__local_facts : saturate_local.
+#[export] Hint Resolve mapsto_local_facts mapsto__local_facts : saturate_local.
 
 Lemma mapsto_offset_zero:
   forall sh t v1 v2, mapsto sh t v1 v2 = mapsto sh t (offset_val 0 v1) v2.
@@ -120,7 +120,7 @@ Proof.
   destruct p; simpl; normalize. apply prop_right;split; auto.
 Qed.
 
-Hint Resolve memory_block_local_facts : saturate_local.
+#[export] Hint Resolve memory_block_local_facts : saturate_local.
 
 Lemma memory_block_offset_zero:
   forall sh n v, memory_block sh n v = memory_block sh n (offset_val 0 v).
@@ -247,22 +247,22 @@ Lemmas about specific types
 (* We do these as Hint Extern, instead of Hint Resolve,
   to limit their application and make them fail faster *)
 
-Hint Extern 1 (mapsto _ _ _ _ |-- mapsto _ _ _ _) =>
+#[export] Hint Extern 1 (mapsto _ _ _ _ |-- mapsto _ _ _ _) =>
    (simple apply mapsto_mapsto_int32; apply Coq.Init.Logic.I)  : cancel.
 
-Hint Extern 1 (mapsto _ _ _ _ |-- mapsto_ _ _ _) =>
+#[export] Hint Extern 1 (mapsto _ _ _ _ |-- mapsto_ _ _ _) =>
    (simple apply mapsto_mapsto__int32; apply Coq.Init.Logic.I)  : cancel.
 
-Hint Extern 1 (mapsto _ _ _ _ |-- mapsto_ _ _ _) =>
+#[export] Hint Extern 1 (mapsto _ _ _ _ |-- mapsto_ _ _ _) =>
     (apply mapsto_mapsto_) : cancel.
 
-Hint Extern 1 (mapsto _ _ _ _ |-- mapsto_ _ _ _) =>
+#[export] Hint Extern 1 (mapsto _ _ _ _ |-- mapsto_ _ _ _) =>
    (apply mapsto_mapsto__int32)  : cancel.
 
-Hint Extern 1 (mapsto _ _ _ _ |-- mapsto _ _ _ _) =>
+#[export] Hint Extern 1 (mapsto _ _ _ _ |-- mapsto _ _ _ _) =>
    (apply mapsto_mapsto_int32)  : cancel.
 
-Hint Extern 0 (legal_alignas_type _ = true) => reflexivity : cancel.
+#[export] Hint Extern 0 (legal_alignas_type _ = true) => reflexivity : cancel.
 
 Lemma mapsto_force_ptr: forall sh t v v',
   mapsto sh t (force_ptr v) v' = mapsto sh t v v'.

--- a/floyd/nested_field_lemmas.v
+++ b/floyd/nested_field_lemmas.v
@@ -983,7 +983,7 @@ destruct a; auto.
 lia.
 Qed.
 
-Hint Resolve legal_nested_field0_field : core.
+Local Hint Resolve legal_nested_field0_field : core.
 (*
 Lemma nested_field_offset_type_divide: forall gfs t,
   legal_alignas_type t = true ->
@@ -1739,14 +1739,14 @@ Arguments nested_field_offset2 {cs} t gfs /.
 Arguments nested_field_type2 {cs} t gfs /.
 *)
 
-(* Hint Resolve field_address_isptr : core. *)
-Hint Resolve is_pointer_or_null_field_compatible : core.
-(* Hint Extern 1 (complete_type _ _ = true) => (eapply field_compatible_complete_type; eassumption). *)
-Hint Extern 1 (isptr _) => (eapply field_compatible_isptr; eassumption) : core.
-Hint Extern 1 (isptr _) => (eapply field_compatible0_isptr; eassumption) : core.
-Hint Extern 1 (legal_nested_field _ _) => (eapply field_compatible_legal_nested_field; eassumption) : core.
-Hint Extern 1 (legal_nested_field0 _ _) => (eapply field_compatible_legal_nested_field0; eassumption) : core.
-Hint Extern 1 (legal_nested_field0 _ _) => (eapply field_compatible0_legal_nested_field0; eassumption) : core.
+(* #[export] Hint Resolve field_address_isptr : core. *)
+#[export] Hint Resolve is_pointer_or_null_field_compatible : core.
+(* #[export] Hint Extern 1 (complete_type _ _ = true) => (eapply field_compatible_complete_type; eassumption). *)
+#[export] Hint Extern 1 (isptr _) => (eapply field_compatible_isptr; eassumption) : core.
+#[export] Hint Extern 1 (isptr _) => (eapply field_compatible0_isptr; eassumption) : core.
+#[export] Hint Extern 1 (legal_nested_field _ _) => (eapply field_compatible_legal_nested_field; eassumption) : core.
+#[export] Hint Extern 1 (legal_nested_field0 _ _) => (eapply field_compatible_legal_nested_field0; eassumption) : core.
+#[export] Hint Extern 1 (legal_nested_field0 _ _) => (eapply field_compatible0_legal_nested_field0; eassumption) : core.
 
 Lemma nested_field_type_preserves_change_composite: forall {cs_from cs_to} {CCE: change_composite_env cs_from cs_to} (t: type),
   cs_preserve_type cs_from cs_to (coeq _ _) t = true ->
@@ -1902,7 +1902,7 @@ intros.
 apply compute_in_members_true_iff. auto.
 Qed.
 
-Hint Extern 2 (field_compatible _ (StructField _ :: _) _) =>
+#[export] Hint Extern 2 (field_compatible _ (StructField _ :: _) _) =>
   (apply field_compatible_cons; split; [ apply compute_in_members_e; reflexivity | ])
       : field_compatible.
 

--- a/floyd/proofauto.v
+++ b/floyd/proofauto.v
@@ -95,14 +95,14 @@ Hint Rewrite modu_repr using rep_lia : entailer_rewrite norm.
 Hint Rewrite Vptrofs_unfold_false using reflexivity: entailer_rewrite norm.
 Hint Rewrite Vptrofs_unfold_true using reflexivity: entailer_rewrite norm.
 
-Hint Extern 1 (Vundef = default_val _) => reflexivity : cancel.
-Hint Extern 1 (default_val _ = Vundef) => reflexivity : cancel.
-Hint Extern 1 (list_repeat _ Vundef = default_val _) => reflexivity : cancel.
-Hint Extern 1 (default_val _ = list_repeat _ Vundef) => reflexivity : cancel.
-Hint Extern 1 (Vundef :: _ = default_val _) => reflexivity : cancel.
-Hint Extern 1 (default_val _ = Vundef :: _) => reflexivity : cancel.
-Hint Extern 1 (@nil _ = default_val _) => reflexivity : cancel.
-Hint Extern 1 (default_val _ = @nil _) => reflexivity : cancel.
+#[export] Hint Extern 1 (Vundef = default_val _) => reflexivity : cancel.
+#[export] Hint Extern 1 (default_val _ = Vundef) => reflexivity : cancel.
+#[export] Hint Extern 1 (list_repeat _ Vundef = default_val _) => reflexivity : cancel.
+#[export] Hint Extern 1 (default_val _ = list_repeat _ Vundef) => reflexivity : cancel.
+#[export] Hint Extern 1 (Vundef :: _ = default_val _) => reflexivity : cancel.
+#[export] Hint Extern 1 (default_val _ = Vundef :: _) => reflexivity : cancel.
+#[export] Hint Extern 1 (@nil _ = default_val _) => reflexivity : cancel.
+#[export] Hint Extern 1 (default_val _ = @nil _) => reflexivity : cancel.
 
 Instance Inhabitant_mpred : Inhabitant mpred := @FF mpred Nveric.
 Instance Inhabitant_share : Inhabitant share := Share.bot.
@@ -117,7 +117,7 @@ Arguments Z.add !x !y.
 Global Transparent peq.
 Global Transparent Archi.ptr64.
 
-Hint Resolve readable_Ers : core.
+#[export] Hint Resolve readable_Ers : core.
 
 Ltac EExists_unify1 x P :=
  match P with
@@ -231,52 +231,52 @@ Proof.
 Qed.
 Hint Rewrite sem_cast_i2bool_of_bool : norm.
 
-Hint Extern 1 (@eq Z _ _) => Zlength_solve : Zlength_solve.
-Hint Extern 1 (@eq _ _ _) => f_equal : f_equal.
+#[export] Hint Extern 1 (@eq Z _ _) => Zlength_solve : Zlength_solve.
+#[export] Hint Extern 1 (@eq _ _ _) => f_equal : f_equal.
 
 Lemma computable_sizeof: forall cs x, computable x -> computable (@sizeof cs x).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_sizeof : computable.
+#[export] Hint Resolve computable_sizeof : computable.
 
 Lemma computable_Ctypes_sizeof: forall cs x, computable x -> computable (@Ctypes.sizeof cs x).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_Ctypes_sizeof : computable.
+#[export] Hint Resolve computable_Ctypes_sizeof : computable.
 
 Lemma computable_alignof: forall cs x, computable x -> computable (@alignof cs x).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_alignof : computable.
+#[export] Hint Resolve computable_alignof : computable.
 
 Lemma computable_Ctypes_alignof: forall cs x, computable x -> computable (@Ctypes.alignof cs x).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_Ctypes_alignof : computable.
+#[export] Hint Resolve computable_Ctypes_alignof : computable.
 
 Lemma computable_Tint: forall sz s a, computable (Tint sz s a).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_Tint : computable.
+#[export] Hint Resolve computable_Tint : computable.
 
 Lemma computable_Tlong: forall s a, computable (Tlong s a).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_Tlong : computable.
+#[export] Hint Resolve computable_Tlong : computable.
 
 Lemma computable_Tarray: forall t i a, computable t -> computable i -> computable (Tarray t i a).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_Tarray : computable.
+#[export] Hint Resolve computable_Tarray : computable.
 
 Lemma computable_Tstruct: forall i a, computable i -> computable (Tstruct i a).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_Tstruct : computable.
+#[export] Hint Resolve computable_Tstruct : computable.
 
 Lemma computable_Tunion: forall i a, computable i -> computable (Tunion i a).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_Tunion : computable.
+#[export] Hint Resolve computable_Tunion : computable.
 
 Lemma computable_Tpointer: forall t a, computable t -> computable (Tpointer t a).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_Tpointer : computable.
+#[export] Hint Resolve computable_Tpointer : computable.
 
 Lemma computable_tptr: forall t, computable t -> computable (tptr t).
 Proof. intros. apply computable_any. Qed.
-Hint Resolve computable_tptr : computable.
+#[export] Hint Resolve computable_tptr : computable.
 
 
 (* a little bit of profiling infrastructure . . .

--- a/floyd/seplog_tactics.v
+++ b/floyd/seplog_tactics.v
@@ -114,12 +114,12 @@ Qed.
 
 (* These versions can sometimes take minutes,
    when A and B can't be unified
-Hint Extern 1 (_ |-- _) => (simple apply (@derives_refl mpred _) ) : cancel.
-Hint Extern 1 (_ |-- |> _) => (simple apply (@now_later mpred _ _) ) : cancel.
+#[export] Hint Extern 1 (_ |-- _) => (simple apply (@derives_refl mpred _) ) : cancel.
+#[export] Hint Extern 1 (_ |-- |> _) => (simple apply (@now_later mpred _ _) ) : cancel.
 *)
 
-Hint Extern 2 (?A |-- ?B) => (constr_eq A B; simple apply derives_refl) : cancel.
-Hint Extern 2 (?A |-- |> ?B) => (constr_eq A B; simple apply now_later) : cancel.
+#[export] Hint Extern 2 (?A |-- ?B) => (constr_eq A B; simple apply derives_refl) : cancel.
+#[export] Hint Extern 2 (?A |-- |> ?B) => (constr_eq A B; simple apply now_later) : cancel.
 
 Lemma cancel1_start:
  forall P Q : mpred,

--- a/floyd/val_lemmas.v
+++ b/floyd/val_lemmas.v
@@ -99,7 +99,7 @@ Proof.
 intros.
 hnf. auto.
 Qed.
-Hint Resolve is_int_I32_Vint : core.
+#[export] Hint Resolve is_int_I32_Vint : core.
 
 Lemma sem_cast_neutral_int: forall v,
   isVint v ->
@@ -139,12 +139,12 @@ Lemma eval_expr_unop: forall {cs: compspecs} op a1 t, eval_expr (Eunop op a1 t) 
 Proof. reflexivity. Qed.
 Hint Rewrite @eval_expr_unop : eval.
 
-Hint Resolve  eval_expr_Etempvar : core.
+#[export] Hint Resolve  eval_expr_Etempvar : core.
 
 Lemma eval_expr_Etempvar' : forall {cs: compspecs}  i t, eval_id i = eval_expr (Etempvar i t).
 Proof. intros. symmetry; auto.
 Qed.
-Hint Resolve  eval_expr_Etempvar' : core.
+#[export] Hint Resolve  eval_expr_Etempvar' : core.
 
 Hint Rewrite Int.add_zero  Int.add_zero_l Int.sub_zero_l : norm.
 Hint Rewrite Ptrofs.add_zero  Ptrofs.add_zero_l Ptrofs.sub_zero_l : norm.
@@ -186,7 +186,7 @@ Lemma isptr_is_pointer_or_null:
   forall v, isptr v -> is_pointer_or_null v.
 Proof. intros. destruct v; inv H; simpl; auto.
 Qed.
-Hint Resolve isptr_is_pointer_or_null : core.
+#[export] Hint Resolve isptr_is_pointer_or_null : core.
 
 Definition add_ptr_int  {cs: compspecs}  (ty: type) (v: val) (i: Z) : val :=
            eval_binop Cop.Oadd (tptr ty) tint v (Vint (Int.repr i)).
@@ -321,7 +321,7 @@ Proof.
   subst.
   hnf; auto.
 Qed.
-Hint Resolve headptr_isptr : core.
+#[export] Hint Resolve headptr_isptr : core.
 
 Lemma headptr_offset_zero: forall v,
   headptr (offset_val 0 v) <->
@@ -535,5 +535,5 @@ Lemma is_int_Vbyte: forall c, is_int I8 Signed (Vbyte c).
 Proof.
 intros. simpl. normalize. rewrite Int.signed_repr by rep_lia. rep_lia.
 Qed.
-Hint Resolve is_int_Vbyte : core.
+#[export] Hint Resolve is_int_Vbyte : core.
 

--- a/hmacdrbg/drbg_protocol_proofs.v
+++ b/hmacdrbg/drbg_protocol_proofs.v
@@ -830,7 +830,7 @@ Proof. start_function.
         destruct na; trivial; elim H1; trivial. }
       rewrite RNDS1 in *; clear H1 H.
       assert (NAF: na = false).
-      { destruct na; try lia. trivial. }
+      { destruct na; try lia; trivial. }
       rewrite NAF in *. clear Heqrounds.
       forward. rewrite H4, NAF.
       destruct additional; try contradiction; simpl in PNadditional.

--- a/hmacdrbg/verif_hmac_drbg_generate_common.v
+++ b/hmacdrbg/verif_hmac_drbg_generate_common.v
@@ -892,11 +892,11 @@ Opaque HMAC256_DRBG_generate_function.
            inv Heqq. inv HeqUPD.
            unfold hmac256drbgstate_md_info_pointer; simpl in *. entailer!. 
            { destruct WFI as [WFI1 [WFI2 [WFI3 WFI4]]]. red in Hreseed_interval. red in WFI3; simpl in *; repeat split; simpl; trivial; try lia.
-             apply hmac_common_lemmas.HMAC_Zlength.
-             clear - Hreseed_interval WFI3 WFI4 H0.
-             assert (reseed_counter <= reseed_interval). apply Zgt_is_gt_bool_f; trivial. lia. }
+             apply hmac_common_lemmas.HMAC_Zlength. }
+           { destruct WFI as [WFI1 [WFI2 [WFI3 WFI4]]]. red in Hreseed_interval. red in WFI3; simpl in *; repeat split; simpl; trivial; try lia.
            rewrite <- Heqp, sublist_firstn; simpl. cancel.
            unfold_data_at 1%nat. cancel.
+           }
         ++ destruct (Memory.EqDec_val additional nullval); simpl in na, HeqCONT.
            2: subst contents; elim n; apply Zlength_nil.
            subst na. simpl in *.
@@ -905,9 +905,7 @@ Opaque HMAC256_DRBG_generate_function.
            rewrite hmac_common_lemmas.HMAC_Zlength. 
            entailer!.
            { destruct WFI as [WFI1 [WFI2 [WFI3 WFI4]]]. red in Hreseed_interval. red in WFI3; simpl in *; repeat split; simpl; trivial; try lia. 
-             apply hmac_common_lemmas.HMAC_Zlength.
-             clear - Hreseed_interval WFI3 WFI4 H0.
-             assert (reseed_counter <= reseed_interval). apply Zgt_is_gt_bool_f; trivial. lia. }
+             apply hmac_common_lemmas.HMAC_Zlength. }
            rewrite sublist_firstn, <- Heqp; simpl. cancel.
            unfold_data_at 1%nat. cancel.
      * unfold contents_with_add in HeqCONT.
@@ -937,9 +935,7 @@ Opaque HMAC256_DRBG_generate_function.
        unfold HMAC_DRBG_update in Heqq. inv Heqq. simpl. entailer!.
        { destruct WFI as [WFI1 [WFI2 [WFI3 WFI4]]]. red in Hreseed_interval. red in WFI3; simpl in *; repeat split; simpl; trivial; try lia.
          apply hmac_common_lemmas.HMAC_Zlength.
-             2: apply hmac_common_lemmas.HMAC_Zlength.
-             clear - Hreseed_interval WFI3 WFI4 H0.
-             assert (reseed_counter <= reseed_interval). apply Zgt_is_gt_bool_f; trivial. lia. }
+         apply hmac_common_lemmas.HMAC_Zlength. }
        unfold_data_at 1%nat. cancel.
   - subst HLP MRES'.  
       remember  MGen as MGen'. subst MGen.
@@ -978,9 +974,7 @@ Opaque HMAC256_DRBG_generate_function.
            inv Heqq. inv HeqUPD.
            unfold hmac256drbgstate_md_info_pointer; simpl in *. entailer!. 
            { destruct WFI as [WFI1 [WFI2 [WFI3 WFI4]]]. red in Hreseed_interval. red in WFI3; simpl in *; repeat split; simpl; trivial; try lia.
-             apply hmac_common_lemmas.HMAC_Zlength.
-             clear - Hreseed_interval WFI3 WFI4 H0.
-             assert (reseed_counter <= reseed_interval). apply Zgt_is_gt_bool_f; trivial. lia. }
+             apply hmac_common_lemmas.HMAC_Zlength. }
            rewrite <- Heqp, sublist_firstn; simpl. cancel.
            unfold_data_at 1%nat. cancel.
         ++ destruct (Memory.EqDec_val additional nullval); simpl in na, HeqCONT.
@@ -991,9 +985,7 @@ Opaque HMAC256_DRBG_generate_function.
            rewrite hmac_common_lemmas.HMAC_Zlength. 
            entailer!.
            { destruct WFI as [WFI1 [WFI2 [WFI3 WFI4]]]. red in Hreseed_interval. red in WFI3; simpl in *; repeat split; simpl; trivial; try lia. 
-             apply hmac_common_lemmas.HMAC_Zlength.
-             clear - Hreseed_interval WFI3 WFI4 H0.
-             assert (reseed_counter <= reseed_interval). apply Zgt_is_gt_bool_f; trivial. lia. }
+             apply hmac_common_lemmas.HMAC_Zlength. }
            rewrite sublist_firstn, <- Heqp; simpl. cancel.
            unfold_data_at 1%nat. cancel.
      * unfold contents_with_add in HeqCONT.
@@ -1023,9 +1015,7 @@ Opaque HMAC256_DRBG_generate_function.
        unfold HMAC_DRBG_update in Heqq. inv Heqq. simpl. entailer!.
        { destruct WFI as [WFI1 [WFI2 [WFI3 WFI4]]]. red in Hreseed_interval. red in WFI3; simpl in *; repeat split; simpl; trivial; try lia. 
          apply hmac_common_lemmas.HMAC_Zlength.
-             2: apply hmac_common_lemmas.HMAC_Zlength.
-             clear - Hreseed_interval WFI3 WFI4 H0.
-             assert (reseed_counter <= reseed_interval). apply Zgt_is_gt_bool_f; trivial. lia. }
+         apply hmac_common_lemmas.HMAC_Zlength. }
        unfold_data_at 1%nat. cancel.
 Time Qed. (*laptop 11s, desktop25s*) 
 

--- a/hmacdrbg/verif_hmac_drbg_update.v
+++ b/hmacdrbg/verif_hmac_drbg_update.v
@@ -307,7 +307,7 @@ Proof. intros. do 2 pose proof I.
         destruct na; trivial; elim H6; trivial. }
       rewrite RNDS1 in *; clear H6 H4.
       assert (NAF: na = false).
-      { destruct na; try lia. trivial. }
+      { destruct na; try lia; trivial. }
       rewrite NAF in *. clear Heqrounds.
       forward. rewrite H9, NAF.
       destruct additional; try contradiction; simpl in PNadditional.

--- a/msl/ageable.v
+++ b/msl/ageable.v
@@ -185,7 +185,7 @@ Section RtRft.
   Qed.
 End RtRft.
 
-Hint Resolve rt_refl : core.
+#[export] Hint Resolve rt_refl : core.
 
 Definition laterR {A} `{ageable A} : relation A := clos_trans A age.
 Definition necR   {A} `{ageable A} : relation A := clos_refl_trans A age.
@@ -920,7 +920,7 @@ Proof.
 intros; constructor 2.
 Qed.
 
-Hint Resolve necR_refl : core.
+#[export] Hint Resolve necR_refl : core.
 
 Lemma necR_trans  {A} `{H : ageable A}:
   forall phi1 phi2 phi3, necR phi1 phi2 -> necR phi2 phi3 -> necR phi1 phi3.

--- a/msl/boolean_alg.v
+++ b/msl/boolean_alg.v
@@ -54,7 +54,7 @@ Module Type BOOLEAN_ALGEBRA.
 
   Axiom nontrivial : top <> bot.
 
-  Hint Resolve ord_refl ord_antisym lub_upper1 lub_upper2 lub_least
+  Global Hint Resolve ord_refl ord_antisym lub_upper1 lub_upper2 lub_least
          glb_lower1 glb_lower2 glb_greatest top_correct bot_correct
          ord_trans : ba.
 End BOOLEAN_ALGEBRA.

--- a/msl/cjoins.v
+++ b/msl/cjoins.v
@@ -43,7 +43,7 @@ destruct (join_ex_units x).
 exists x0. apply join_comm; apply u.
 Qed.
 
-Hint Resolve constructive_join_sub_refl : core.
+#[export] Hint Resolve constructive_join_sub_refl : core.
 Definition constructive_joins {A}  {JOIN: Join A} (w1 w2 : A) := {w3 | join w1 w2 w3}.
 
 Lemma cjoins_joins {A}  {JOIN: Join A}: forall {w1 w2}, constructive_joins w1 w2 -> joins w1 w2.

--- a/msl/contractive.v
+++ b/msl/contractive.v
@@ -331,9 +331,9 @@ Ltac sub_unfold :=
     | v: _ |- _ => destruct v
    end.
 
-Hint Extern 2 (_ |-- _ >=> _) => sub_unfold : contractive.
+#[export] Hint Extern 2 (_ |-- _ >=> _) => sub_unfold : contractive.
 
-Hint Resolve prove_HOcontractive
+#[export] Hint Resolve prove_HOcontractive
   subp_allp subp_imp subp_refl subp_exp subp_andp subp_orp subp_subp
   allp_imp2_later_e1 allp_imp2_later_e2 : contractive.
 

--- a/msl/corable.v
+++ b/msl/corable.v
@@ -144,7 +144,7 @@ Proof.
   exists n; auto.
 Qed.
 
-Hint Resolve corable_andp corable_orp corable_allp corable_exp
+#[export] Hint Resolve corable_andp corable_orp corable_allp corable_exp
                     corable_imp corable_prop corable_sepcon corable_wand corable_later : core.
 
 Lemma corable_andp_sepcon1{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:

--- a/msl/env.v
+++ b/msl/env.v
@@ -647,7 +647,7 @@ Lemma empty_env_unit' {key: Type}{A: Type}: forall rho: env key A, join empty_en
 Proof.
 intros; apply empty_env_unit.
 Qed.
-Hint Resolve empty_env_unit empty_env_unit' : core.
+#[export] Hint Resolve empty_env_unit empty_env_unit' : core.
 
 Lemma env_join_sub1 {key: Type}{A: Type}:
   forall rho1 rho2: env key A, (forall id x, env_get rho1 id = Some x -> env_get rho2 id = Some x) ->
@@ -927,7 +927,7 @@ Proof.
 rewrite emp_empty_env.
 auto.
 Qed.
-Hint Resolve emp_empty_env' : core.
+#[export] Hint Resolve emp_empty_env' : core.
 
 Lemma env_mapsto_cohere{key: Type}{A: Type}{KE: EqDec key}: forall id sh1 (v1: A) sh2 v2,
   (env_mapsto id sh1 v1 * TT) && (env_mapsto id sh2 v2 * TT)

--- a/msl/knot_shims.v
+++ b/msl/knot_shims.v
@@ -156,7 +156,7 @@ Module Type KNOT__COVARIANT_HERED_PROP_OTH_REL.
 
   Axiom expandM_refl : reflexive _ expandM.
   Axiom expandM_trans : transitive _ expandM.
-  Hint Resolve expandM_refl expandM_trans : core.
+  Global Hint Resolve expandM_refl expandM_trans : core.
 
   (* Definitions of the "ageable" operations *)
   Axiom knot_level : forall (k:knot),
@@ -677,7 +677,7 @@ Module Knot_CovariantHeredPropOthRel (KI':KNOT_INPUT__COVARIANT_HERED_PROP_OTH_R
     eapply KI.ORel_trans; eauto.
   Qed.
 
-  Hint Resolve expandM_refl expandM_trans : core.
+  Global Hint Resolve expandM_refl expandM_trans : core.
 
   Definition assert := { p:pred (K0.knot * KI.other) | boxy expandM p }.
 

--- a/msl/log_normalize.v
+++ b/msl/log_normalize.v
@@ -8,7 +8,7 @@ Create HintDb norm discriminated.
 
 Local Open Scope logic.
 
-Hint Extern 0 (_ |-- _) => match goal with |- ?A |-- ?B => constr_eq A B; simple apply derives_refl end : core.
+#[export] Hint Extern 0 (_ |-- _) => match goal with |- ?A |-- ?B => constr_eq A B; simple apply derives_refl end : core.
 (* Hint Resolve derives_refl.    too expensive sometimes when it fails . . . *)
 
 Ltac solve_andp' :=
@@ -27,8 +27,8 @@ Proof.
 intros; apply prop_left. intuition.
 Qed.
 
-Hint Resolve TT_right: norm.
-Hint Resolve FF_left : norm.
+#[export] Hint Resolve TT_right: norm.
+#[export] Hint Resolve FF_left : norm.
 
 Ltac norm := auto with norm.
 
@@ -765,7 +765,7 @@ apply @derives_trans with (P * emp).
 rewrite sepcon_emp...
 apply sepcon_derives...
 Qed.
-Hint Resolve sepcon_TT : core.
+#[export] Hint Resolve sepcon_TT : core.
 
 Lemma TT_sepcon {A} {NA: NatDed A}{SA: SepLog A}{CA: ClassicalSep A}:
    forall (P: A), P |-- (TT * P).
@@ -945,9 +945,9 @@ Proof.
 intros. rewrite sepcon_comm. rewrite andp_comm. rewrite corable_andp_sepcon1; auto. rewrite sepcon_comm; auto.
 Qed.
 
-Hint Resolve corable_andp corable_orp corable_allp corable_exp
+#[export] Hint Resolve corable_andp corable_orp corable_allp corable_exp
                     corable_imp corable_prop corable_sepcon corable_wand corable_later : core.
-Hint Resolve corable_prop : norm.
+#[export] Hint Resolve corable_prop : norm.
 
 (* The followings are not in auto-rewrite lib. *)
 
@@ -1549,9 +1549,9 @@ Ltac sub_unfold :=
     | v: _ |- _ => destruct v
    end.
 
-Hint Extern 2 (_ |-- _ >=> _) => sub_unfold : contractive.
+#[export] Hint Extern 2 (_ |-- _ >=> _) => sub_unfold : contractive.
 
-Hint Resolve prove_HOcontractive
+#[export] Hint Resolve prove_HOcontractive
   subp_allp subp_imp subp_refl subp_exp subp_andp subp_orp subp_subp
   subp_sepcon (* NOTE: This hint fails to work unless fully instantiated, for some reason;
                              so the client must re-do the subp_sepcon hint *)

--- a/msl/normalize.v
+++ b/msl/normalize.v
@@ -49,7 +49,7 @@ intros.
 apply H.
 Qed.
 
-Hint Resolve pure_e : core.
+#[export] Hint Resolve pure_e : core.
 
 Lemma sepcon_pure_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
  forall P Q, pure P -> pure Q -> ((P * Q) = (P && Q)).
@@ -82,11 +82,11 @@ Lemma pure_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{A
 Proof.
 intros. unfold pure; auto.
 Qed.
-Hint Resolve pure_emp : core.
+#[export] Hint Resolve pure_emp : core.
 
 Lemma join_equiv_refl {A}: forall x:A, @join A (Join_equiv A) x x x.
 Proof. split; auto. Qed.
-Hint Resolve join_equiv_refl : core.
+#[export] Hint Resolve join_equiv_refl : core.
 
 Lemma pure_sepcon1'' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall P Q R, pure P -> Q |-- R -> P * Q |-- R.
 Proof.
@@ -108,7 +108,7 @@ intros w [x ?].
 apply (H x); auto.
 Qed.
 
-Hint Resolve pure_existential : core.
+#[export] Hint Resolve pure_existential : core.
 
 Lemma pure_core {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall P w, pure P -> P w -> P (core w).
@@ -150,7 +150,7 @@ unfold pure in *.
 rewrite <- sepcon_emp.
 apply sepcon_derives; auto.
 Qed.
-Hint Resolve pure_con' : core.
+#[export] Hint Resolve pure_con' : core.
 
 Lemma pure_intersection1: forall {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
        (P Q: pred A), pure P -> pure (P && Q).
@@ -164,7 +164,7 @@ Proof.
 unfold pure; intros; auto.
 intros w [? ?]; auto.
 Qed.
-Hint Resolve pure_intersection1 pure_intersection2 : core.
+#[export] Hint Resolve pure_intersection1 pure_intersection2 : core.
 
 Lemma FF_andp {A} `{ageable A}:  forall P: pred A, FF && P = FF.
 Proof.
@@ -204,7 +204,7 @@ intros.
 rewrite <- (sepcon_emp P) at 1.
 eapply sepcon_derives; try apply H0; auto.
 Qed.
-Hint Resolve sepcon_TT : core.
+#[export] Hint Resolve sepcon_TT : core.
 
 Lemma imp_extract_exp_left {B A: Type} `{ageable A}:
     forall    (p : B -> pred A) (q: pred A),

--- a/msl/predicates_hered.v
+++ b/msl/predicates_hered.v
@@ -33,7 +33,7 @@ Definition pred_hereditary `{ageable} (p:pred A) := proj2_sig p.
 Coercion app_pred : pred >-> Funclass.
 Global Opaque pred.
 
-Hint Resolve pred_hereditary : core.
+#[export] Hint Resolve pred_hereditary : core.
 
 Lemma nec_hereditary {A} `{ageable A} (p: A -> Prop) : hereditary age p ->
   forall a a':A, necR a a' -> p a -> p a'.
@@ -201,8 +201,8 @@ Definition necM {A} `{ageable A} : modality
   := exist _ necR valid_rel_nec.
 *)
 
-Hint Resolve rt_refl rt_trans t_trans : core.
-Hint Unfold necR : core.
+#[export] Hint Resolve rt_refl rt_trans t_trans : core.
+#[export] Hint Unfold necR : core.
 Obligation Tactic := unfold hereditary; intuition;
     first [eapply pred_hereditary; eauto; fail | eauto ].
 
@@ -497,7 +497,7 @@ unfold necR.
 constructor 2.
 Qed.
 
-Hint Resolve necM_refl.
+#[export] Hint Resolve necM_refl.
 *)
 
 (* relationship between box and diamond *)
@@ -901,7 +901,7 @@ simpl.
 split; eapply boxy_e; eauto.
 Qed.
 
-Hint Resolve boxy_andp : core.
+#[export] Hint Resolve boxy_andp : core.
 
 Lemma boxy_disjunction {A} `{H : ageable A}:
      forall (M: modality) , reflexive _ (app_mode M) ->
@@ -916,7 +916,7 @@ left.  eapply boxy_e; eauto.
 right. eapply boxy_e; eauto.
 Qed.
 
-Hint Resolve boxy_disjunction : core.
+#[export] Hint Resolve boxy_disjunction : core.
 
 Lemma boxy_exp {A} `{agA : ageable A}:
     forall (M: modality) T (P: T -> pred A),
@@ -931,7 +931,7 @@ specialize ( H2 w' H1).
 econstructor; eauto.
 Qed.
 
-Hint Resolve boxy_exp : core.
+#[export] Hint Resolve boxy_exp : core.
 
 Lemma boxy_prop {A} `{H : ageable A}:  forall (M: modality) P, reflexive _ (app_mode M) -> boxy M (prop P).
 Proof.
@@ -950,15 +950,15 @@ Proof.
 intros; apply boxy_i; intros; auto; contradiction.
 Qed.
 
-Hint Resolve boxy_TT : core.
-Hint Resolve boxy_FF : core.
+#[export] Hint Resolve boxy_TT : core.
+#[export] Hint Resolve boxy_FF : core.
 
 Lemma TT_i  {A} `{ageable A}: forall w: A,  app_pred TT w.
 Proof.
 unfold TT, prop; simpl; auto.
 Qed.
 
-Hint Resolve TT_i : core.
+#[export] Hint Resolve TT_i : core.
 
 Lemma prop_andp_left {A}{agA: ageable A}: forall (P: Prop) Q R, (P -> Q |-- R) -> !!P && Q |-- R.
 Proof.
@@ -1023,7 +1023,7 @@ specialize ( H2 b).
 rewrite <- H0 in H2.
 apply H2; auto.
 Qed.
-Hint Resolve boxy_allp : core.
+#[export] Hint Resolve boxy_allp : core.
 
 Lemma later_allp {A} `{agA : ageable A}:
        forall B P, |> (allp P) = allp (fun x:B => |> (P x)).
@@ -1108,7 +1108,7 @@ Lemma derives_refl {A: Type} `{ageable A}:
 Proof. firstorder.
 Qed.
 
-Hint Resolve derives_refl : core.
+#[export] Hint Resolve derives_refl : core.
 
 Lemma andp_derives {A} `{ageable A}:
   forall P Q P' Q': pred A, P |-- P' -> Q |-- Q' -> P && Q |-- P' && Q'.
@@ -1160,13 +1160,13 @@ Proof.
 intros.
 intros ? ?; auto.
 Qed.
-Hint Resolve derives_TT : core.
+#[export] Hint Resolve derives_TT : core.
 
 Lemma FF_derives {A} `{ageable A}: forall P, FF |-- P.
 Proof.
 intros. intros ? ?. hnf in H0; contradiction.
 Qed.
-Hint Immediate FF_derives : core.
+#[export] Hint Immediate FF_derives : core.
 
 Lemma necR_level' {A} `{H : ageable A}: forall {w w': A}, necR w w' ->
        @necR _ ag_nat (level w) (level w').

--- a/msl/predicates_sa.v
+++ b/msl/predicates_sa.v
@@ -34,7 +34,7 @@ Proof.
 Qed.
 
 Definition prop {A: Type}  (P: Prop) : pred A := (fun _  => P).
-Hint Unfold prop : core.
+#[export] Hint Unfold prop : core.
 
 Definition TT {A}: pred A := prop True.
 Definition FF  {A}: pred A := prop False.
@@ -275,7 +275,7 @@ Proof.
 unfold TT, prop; simpl; auto.
 Qed.
 
-Hint Resolve TT_i : core.
+#[export] Hint Resolve TT_i : core.
 
 Lemma TT_and {A}: forall (Q: pred A), TT && Q = Q.
 intros; unfold andp,  TT, prop; extensionality w.
@@ -359,14 +359,14 @@ Lemma derives_refl {A: Type}:
 Proof. firstorder.
 Qed.
 
-Hint Resolve derives_refl : core.
+#[export] Hint Resolve derives_refl : core.
 
 Lemma derives_TT {A}: forall (P: pred A), P |-- TT.
 Proof.
 intros.
 intros ? ?; auto.
 Qed.
-Hint Resolve derives_TT : core.
+#[export] Hint Resolve derives_TT : core.
 
 Lemma sepcon_derives {A} {JA: Join A}{PA: Perm_alg A}:
   forall p q p' q', (p |-- p') -> (q |-- q') -> (p * q |-- p' * q').
@@ -537,14 +537,14 @@ Require Import VST.msl.cross_split.
 Lemma exactly_i {A} : forall x: A, exactly x x.
 Proof. intros. reflexivity.
 Qed.
-Hint Resolve exactly_i : core.
+#[export] Hint Resolve exactly_i : core.
 
 Lemma superprecise_exactly {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}: forall x, superprecise (exactly x).
 Proof.
 unfold exactly, superprecise; intros.
 subst; auto.
 Qed.
-Hint Resolve superprecise_exactly : core.
+#[export] Hint Resolve superprecise_exactly : core.
 
 Lemma find_overlap {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
      Cross_alg A ->

--- a/msl/predicates_sl.v
+++ b/msl/predicates_sl.v
@@ -122,8 +122,8 @@ intros; intro; simpl.
 apply comparable_refl.
 Qed.
 
-Hint Resolve extendM_refl : core.
-Hint Resolve compareM_refl : core.
+#[export] Hint Resolve extendM_refl : core.
+#[export] Hint Resolve compareM_refl : core.
 
 
 (* Rules for the BI connectives *)
@@ -359,7 +359,7 @@ Lemma extend_later' {A}{JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_al
 Proof.
 intros. unfold boxy in *. rewrite later_commute. rewrite H. auto.
 Qed.
-Hint Resolve extend_later' : core.
+#[export] Hint Resolve extend_later' : core.
 
 Lemma age_sepcon {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} :
       forall P Q, (box ageM (P * Q) = box ageM P * box ageM Q)%pred.
@@ -630,7 +630,7 @@ hnf in H,H0.
 eapply necR_linear'; eauto.
 apply comparable_fashionR; auto.
 Qed.
-Hint Resolve superprecise_exactly : core.
+#[export] Hint Resolve superprecise_exactly : core.
 
 Lemma superprecise_precise {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}: forall (P: pred A) , superprecise P -> precise P.
 Proof.

--- a/msl/psepalg.v
+++ b/msl/psepalg.v
@@ -288,7 +288,7 @@ intros. simpl. auto.
 constructor.
 Qed.
 
-Hint Resolve None_unit : core.
+#[export] Hint Resolve None_unit : core.
 
 Lemma None_identity {A} {JA: Join A}{psaA: Pos_alg A}: 
      @identity (option A) (Join_lower _) None.
@@ -297,7 +297,7 @@ intros.
 intros x y ?. inv H; auto.
 Qed.
 
-Hint Resolve None_identity : core.
+#[export] Hint Resolve None_identity : core.
 
   Lemma lower_inv: forall {A}{JA: Join A} {PA: Perm_alg A} {psa_A: Pos_alg A} (a b c : option A),
     join a b c ->
@@ -345,7 +345,7 @@ Existing Instance Sep_smash. (* Must not be inside a Section *)
 Lemma smashed_lifted_None_identity {A}`{Perm_alg A}:
   @identity (smashed A) _ None.
 Proof. intros; apply None_identity. Qed.
-Hint Resolve smashed_lifted_None_identity : core.
+#[export] Hint Resolve smashed_lifted_None_identity : core.
 (** The option separation algebra.  The bool sepalg is isomorphic
      to the option sepalg applied to units. *)
 

--- a/msl/sepalg_generators.v
+++ b/msl/sepalg_generators.v
@@ -159,10 +159,9 @@ Existing Instance Canc_equiv.
 Existing Instance Disj_equiv.
 Existing Instance Cross_equiv.
 
-Hint Extern 1 (@join _ _ _ _ _) =>
+#[export] Hint Extern 1 (@join _ _ _ _ _) =>
    match goal with |- @join _ (@Join_equiv _) _ _ _ => apply join_equiv_refl end
    : core.
-(* Hint Resolve join_equiv_refl. *)
 
 Section SepAlgProp.
   Variable A:Type.

--- a/msl/sepalg_list.v
+++ b/msl/sepalg_list.v
@@ -365,13 +365,13 @@ inv H. exists phi2'; exists phi3'; split; auto.
 Qed.
 
 
-Hint Resolve join_comparable join_comparable'  join_comparable'' join_comparable'''
+#[export] Hint Resolve join_comparable join_comparable'  join_comparable'' join_comparable'''
       join_comparable2 join_comparable2' list_join_comparable list_join_comparable'
       joins_comparable joins_comparable2 join_sub_comparable join_sub_comparable2
       eq_comparable  eq_comparable2
   : comparable.
 
-Hint Immediate comparable_refl  comparable_sym  : comparable.
+#[export] Hint Immediate comparable_refl  comparable_sym  : comparable.
 
 Ltac Comp1 phi1 phi2 :=
    solve [ eauto 3 with comparable typeclass_instances |

--- a/msl/seplog.v
+++ b/msl/seplog.v
@@ -37,8 +37,8 @@ Program Instance LiftNatDed (A B: Type) {ND: NatDed B} : NatDed (A -> B) :=
  mkNatDed (A -> B)
     (*andp*) (fun P Q x => andp (P x) (Q x))
     (*orp*) (fun P Q x => orp (P x) (Q x))
-    (*exp*) (fun {T} (F: T -> A -> B) (a: A) => exp (fun x => F x a))
-    (*allp*) (fun {T} (F: T -> A -> B) (a: A) => allp (fun x => F x a))
+    (*exp*) (fun T (F: T -> A -> B) (a: A) => exp (fun x => F x a))
+    (*allp*) (fun T (F: T -> A -> B) (a: A) => allp (fun x => F x a))
     (*imp*) (fun P Q x => imp (P x) (Q x))
     (*prop*) (fun P x => prop P)
     (*derives*) (fun P Q => forall x, derives (P x) (Q x))
@@ -98,8 +98,10 @@ Next Obligation.
  intros; eapply allp_prop_left; eauto.
 Defined.
 
+Declare Scope logic.
 Delimit Scope logic with logic.
 Local Open Scope logic.
+Declare Scope logic_derives.
 Notation "P '|--' Q" := (derives P%logic Q%logic) (at level 80, no associativity) : logic_derives.
 Open Scope logic_derives.
 Notation "'EX' x .. y , P " :=

--- a/msl/shares.v
+++ b/msl/shares.v
@@ -65,7 +65,7 @@ Proof.
   auto.
 Qed.
 
-Hint Resolve bot_identity : core.
+Global Hint Resolve bot_identity : core.
 
 Lemma identity_share_bot : forall s,
   identity s -> s = bot.
@@ -480,7 +480,7 @@ Proof.
   trivial.
 Qed.
 
-Hint Resolve bot_unit : core.
+Global Hint Resolve bot_unit : core.
 
 Lemma join_bot: join emptyshare emptyshare emptyshare.
 Proof.

--- a/msl/subtypes.v
+++ b/msl/subtypes.v
@@ -36,7 +36,7 @@ Qed.
 Definition fashionM {A} `{ageable A} : modality
   := exist _ fashionR valid_rel_fashion.
 
-Existing Instance ag_nat. Hint Resolve ag_nat : core.
+Existing Instance ag_nat.   #[export] Hint Resolve ag_nat : core.
 
 Program Definition fash {A: Type} `{NA: ageable A} (P: pred A): pred nat :=
       fun n => forall y, n >= level y -> P y.
@@ -423,7 +423,7 @@ intros.
 unfold fashionable.
 rewrite fash_fash. auto.
 Qed.
-Hint Resolve fash_subp : core.
+#[export] Hint Resolve fash_subp : core.
 
 Lemma fash_allp {A} {agA:ageable A}:
   forall  (B: Type) (F: B -> pred A),

--- a/msl/subtypes_sl.v
+++ b/msl/subtypes_sl.v
@@ -144,13 +144,13 @@ intros w' ? w'' ? ?.
 eapply H; eauto.
 Qed.
 
-Hint Resolve sepcon_subp' : core.
-Hint Resolve subp_refl' : core.
-Hint Resolve andp_subp' : core.
-Hint Resolve allp_subp' : core.
-Hint Resolve derives_subp : core.
-Hint Resolve pred_eq_e1 : core.
-Hint Resolve pred_eq_e2 : core.
+#[export] Hint Resolve sepcon_subp' : core.
+#[export] Hint Resolve subp_refl' : core.
+#[export] Hint Resolve andp_subp' : core.
+#[export] Hint Resolve allp_subp' : core.
+#[export] Hint Resolve derives_subp : core.
+#[export] Hint Resolve pred_eq_e1 : core.
+#[export] Hint Resolve pred_eq_e2 : core.
 
 
 Lemma allp_imp2_later_e2 {B}{A}{agA: ageable A}:
@@ -189,7 +189,7 @@ apply comparable_fashionR.
 eapply join_comparable; eauto.
 Qed.
 
-Hint Resolve extend_unfash : core.
+#[export] Hint Resolve extend_unfash : core.
 
 Lemma subp_unfash {A} `{Age_alg A}:
   forall (P Q : pred nat) (n: nat), (P >=> Q) n -> ( ! P >=> ! Q) n.
@@ -199,7 +199,7 @@ intros w ?. specialize (H0 _ H1).
 intros w' ? ?. apply (H0 _ (necR_level' H2)).
 auto.
 Qed.
-Hint Resolve subp_unfash : core.
+#[export] Hint Resolve subp_unfash : core.
 
 
 Lemma unfash_sepcon_distrib:

--- a/msl/tree_shares.v
+++ b/msl/tree_shares.v
@@ -134,11 +134,11 @@ Module Share <: SHARE_MODEL.
        shareTreeOrd r1 r2 ->
        shareTreeOrd (Node l1 r1) (Node l2 r2)
   .
-  Hint Constructors shareTreeOrd : core.
+  Global Hint Constructors shareTreeOrd : core.
 
   Definition shareTreeEq (x y:ShareTree) :=
       shareTreeOrd x y /\ shareTreeOrd y x.
-  Hint Unfold shareTreeEq : core.
+  Global Hint Unfold shareTreeEq : core.
 
   Ltac destruct_bool :=
     repeat (match goal with [ b:bool |- _ ] => destruct b end).
@@ -202,7 +202,7 @@ Module Share <: SHARE_MODEL.
     induction x; destruct_bool; auto.
   Qed.
 
-  Hint Resolve geTrueFull leFalseEmpty emptyLeFalse fullGeTrue
+  Global Hint Resolve geTrueFull leFalseEmpty emptyLeFalse fullGeTrue
      falseLeaf_bottom trueLeaf_top : core.
 
   Lemma eqFalseLeaf_empty : forall x,
@@ -234,7 +234,7 @@ Module Share <: SHARE_MODEL.
     induction x; simpl; intros; invert_ord; destruct_bool; intuition.
   Qed.
 
-  Hint Resolve eqFalseLeaf_empty eqTrueLeaf_full emptyTree_canonical_falseLeaf
+  Global Hint Resolve eqFalseLeaf_empty eqTrueLeaf_full emptyTree_canonical_falseLeaf
     fullTree_canonical_trueLeaf : core.
 
   (* Show that shareTreeOrd is a preorder (reflexive and transitive). *)
@@ -340,7 +340,7 @@ Module Share <: SHARE_MODEL.
     destruct (bool_dec b b0); subst; intuition; simpl; auto.
   Qed.
 
-  Hint Resolve mkCanon_nonEmpty mkCanon_correct mkCanon_eq : core.
+  Global Hint Resolve mkCanon_nonEmpty mkCanon_correct mkCanon_eq : core.
 
   (* Show that union and intersection are the LUB and GLB
      for the lattice, respectively. *)
@@ -747,7 +747,7 @@ Module Share <: SHARE_MODEL.
     rewrite IHa1; rewrite IHa2; auto.
   Qed.
 
-  Hint Resolve relativ_empty relativ_empty1 relativ_empty2
+  Global Hint Resolve relativ_empty relativ_empty1 relativ_empty2
     relativ_full relativ_full1 relativ_full2 relativ_inv : core.
 
   Lemma relativ_almost_canon : forall a x,
@@ -1079,7 +1079,7 @@ Module Share <: SHARE_MODEL.
     intro x; induction x; simpl; intros; destruct_bool; intuition.
   Qed.
 
-  Hint Resolve comp_full_empty comp_empty_full : core.
+  Global Hint Resolve comp_full_empty comp_empty_full : core.
 
   Lemma comp_canonical : forall x,
     canonicalTree x -> canonicalTree (comp_tree x).

--- a/progs/conc_queue_specs.v
+++ b/progs/conc_queue_specs.v
@@ -503,7 +503,7 @@ Proof.
   apply positive_andp2.
   do 7 apply positive_sepcon1; apply positive_sepcon2; auto.
 Qed.
-Hint Resolve q_inv_precise q_inv_positive.
+#[export] Hint Resolve q_inv_precise q_inv_positive.
 
 Lemma lqueue_precise : forall lsh t P p lock gsh1 gsh2,
   precise (EX h : hist (reptype t), lqueue lsh t P p lock gsh1 gsh2 h).
@@ -516,7 +516,7 @@ Proof.
   - repeat apply precise_sepcon; auto.
     apply ghost_precise.
 Qed.
-Hint Resolve lqueue_precise.
+#[export] Hint Resolve lqueue_precise.
 
 Lemma lqueue_isptr : forall lsh t P p lock gsh1 gsh2 h, lqueue lsh t P p lock gsh1 gsh2 h =
   !!isptr p && lqueue lsh t P p lock gsh1 gsh2 h.
@@ -529,7 +529,7 @@ Lemma list_incl_refl : forall {A} (l : list A), list_incl l l.
 Proof.
   induction l; auto.
 Qed.
-Hint Resolve list_incl_refl.
+#[export] Hint Resolve list_incl_refl.
 
 Lemma consistent_inj : forall {t} (h : hist t) a b b' (Hb : consistent h a b) (Hb' : consistent h a b'), b = b'.
 Proof.

--- a/progs/conclib.v
+++ b/progs/conclib.v
@@ -67,7 +67,7 @@ Lemma repable_0 : repable_signed 0.
 Proof.
   split; computable.
 Qed.
-Hint Resolve repable_0 : core.
+#[export] Hint Resolve repable_0 : core.
 
 Definition complete MAX l := l ++ Zrepeat (vptrofs 0) (MAX - Zlength l).
 
@@ -809,7 +809,7 @@ Lemma incl_nil : forall {A} (l : list A), incl [] l.
 Proof.
   repeat intro; contradiction.
 Qed.
-Hint Resolve incl_nil : core.
+#[export] Hint Resolve incl_nil : core.
 
 Lemma incl_cons_out : forall {A} (a : A) l1 l2, incl l1 (a :: l2) -> ~In a l1 -> incl l1 l2.
 Proof.
@@ -2054,7 +2054,7 @@ Lemma cond_var_isptr : forall {cs} sh v, @cond_var cs sh v = !! isptr v && cond_
 Proof.
   intros; apply data_at__isptr.
 Qed.
-Hint Resolve lock_inv_isptr cond_var_isptr : saturate_local.
+#[export] Hint Resolve lock_inv_isptr cond_var_isptr : saturate_local.
 
 Lemma cond_var_share_join : forall {cs} sh1 sh2 sh v (Hjoin : sepalg.join sh1 sh2 sh),
   @cond_var cs sh1 v * cond_var sh2 v = cond_var sh v.
@@ -2239,7 +2239,7 @@ Proof.
     split; [eapply sepalg.join_eq|]; auto.
 Qed. *)
 
-Hint Resolve lock_inv_exclusive selflock_exclusive cond_var_exclusive data_at_exclusive
+#[export] Hint Resolve lock_inv_exclusive selflock_exclusive cond_var_exclusive data_at_exclusive
   data_at__exclusive field_at_exclusive field_at__exclusive selflock_rec : core.
 
 Lemma eq_dec_refl : forall {A B} {A_eq : EqDec A} (a : A) (b c : B), (if eq_dec a a then b else c) = b.
@@ -2302,7 +2302,7 @@ Proof.
   unfold readable_share, nonempty_share, sepalg.nonidentity.
   rewrite Share.glb_bot; auto.
 Qed.
-Hint Resolve unreadable_bot : core.
+#[export] Hint Resolve unreadable_bot : core.
 
 Definition join_Bot := join_Bot.
 
@@ -2332,7 +2332,7 @@ Proof.
   apply slice.cleave_join; unfold gsh1, gsh2; destruct (slice.cleave Tsh); auto.
 Qed.
 
-Hint Resolve readable_gsh1 readable_gsh2 gsh1_gsh2_join : core.
+#[export] Hint Resolve readable_gsh1 readable_gsh2 gsh1_gsh2_join : core.
 
 Lemma gsh1_not_bot : gsh1 <> Share.bot.
 Proof.
@@ -2343,7 +2343,7 @@ Lemma gsh2_not_bot : gsh2 <> Share.bot.
 Proof.
   intro X; contradiction unreadable_bot; rewrite <- X; auto.
 Qed.
-Hint Resolve gsh1_not_bot gsh2_not_bot : core.
+#[export] Hint Resolve gsh1_not_bot gsh2_not_bot : core.
 
 (*
 Lemma data_at_Tsh_conflict : forall {cs : compspecs} sh t v v' p, sepalg.nonidentity sh -> 0 < sizeof t ->
@@ -2891,7 +2891,7 @@ Transparent predicates_hered.pred.
 Opaque mpred. Opaque predicates_hered.pred.
 Qed.
 
-Hint Resolve valid_pointer_isptr : saturate_local.
+#[export] Hint Resolve valid_pointer_isptr : saturate_local.
 
 Lemma approx_imp : forall n P Q, compcert_rmaps.RML.R.approx n (predicates_hered.imp P Q) =
   compcert_rmaps.RML.R.approx n (predicates_hered.imp (compcert_rmaps.RML.R.approx n P)

--- a/progs/ghosts.v
+++ b/progs/ghosts.v
@@ -9,7 +9,7 @@ Import List.
 (* Lemmas about ghost state and common instances *)
 (* Where should this sit? *)
 
-Hint Resolve Share.nontrivial : core.
+#[export] Hint Resolve Share.nontrivial : core.
 
 Definition gname := own.gname.
 
@@ -521,7 +521,7 @@ Qed.
 
 End Reference.
 
-Hint Resolve self_completable : init.
+#[export] Hint Resolve self_completable : init.
 
 Section Discrete.
 
@@ -1193,7 +1193,7 @@ End Maps.
 
 Notation maps_add l := (fold_right map_add empty_map l).
 
-Hint Resolve empty_map_incl empty_map_disjoint all_disjoint_nil : core.
+#[export] Hint Resolve empty_map_incl empty_map_disjoint all_disjoint_nil : core.
 
 Section GHist.
 
@@ -1503,7 +1503,7 @@ Inductive hist_list' : hist_part -> list hist_el -> Prop :=
 | hist_list'_nil : hist_list' empty_map []
 | hist_list'_snoc : forall h l t e (Hlast : newer h t) (Hrest : hist_list' h l),
     hist_list' (map_upd h t e) (l ++ [e]).
-Hint Resolve hist_list'_nil : core.
+Local Hint Resolve hist_list'_nil : core.
 
 Lemma hist_list'_in : forall h l (Hl : hist_list' h l) e, (exists t, h t = Some e) <-> In e l.
 Proof.
@@ -1619,7 +1619,7 @@ Inductive add_events h : list hist_el -> hist_part -> Prop :=
 | add_events_nil : add_events h [] h
 | add_events_snoc : forall le h' t e (Hh' : add_events h le h') (Ht : newer h' t),
     add_events h (le ++ [e]) (map_upd h' t e).
-Hint Resolve add_events_nil : core.
+Local Hint Resolve add_events_nil : core.
 
 Lemma add_events_1 : forall h t e (Ht : newer h t), add_events h [e] (map_upd h t e).
 Proof.
@@ -1698,9 +1698,9 @@ Qed.
 
 End GHist.
 
-Hint Resolve hist_incl_nil hist_list_nil hist_list'_nil add_events_nil : core.
-(*Hint Resolve ghost_var_precise ghost_var_precise'.*)
-Hint Resolve (*ghost_var_init*) master_init (*ghost_map_init*) ghost_hist_init : init.
+#[export] Hint Resolve hist_incl_nil hist_list_nil hist_list'_nil add_events_nil : core.
+(*#[export] Hint Resolve ghost_var_precise ghost_var_precise'.*)
+#[export] Hint Resolve (*ghost_var_init*) master_init (*ghost_map_init*) ghost_hist_init : init.
 
 Ltac ghost_alloc G :=
   match goal with |-semax _ (PROPx ?P (LOCALx ?Q (SEPx ?R))) _ _ =>

--- a/progs/invariants.v
+++ b/progs/invariants.v
@@ -25,7 +25,7 @@ Lemma Included_Full : forall {A} E, Included E (Full_set A).
 Proof.
   repeat intro; constructor.
 Qed.
-Hint Resolve Included_Full.
+#[export] Hint Resolve Included_Full.
 
 Notation cored := own.cored.
 

--- a/progs/list_dt.v
+++ b/progs/list_dt.v
@@ -1126,6 +1126,7 @@ intros.
 destruct l'.
 rewrite lseg_nil_eq.
 normalize.
+rewrite prop_true_andp by apply ptr_eq_nullval.
 apply lseg_cons_right_null.
 rewrite lseg_cons_eq.
 Intros u. Exists u. subst z.
@@ -1263,7 +1264,7 @@ Hint Rewrite @lseg_nil_eq : norm.
 
 Hint Rewrite @lseg_eq using reflexivity: norm.
 
-Hint Resolve lseg_local_facts : saturate_local.
+#[export] Hint Resolve lseg_local_facts : saturate_local.
 End LsegGeneral.
 
 Module LsegSpecial.
@@ -1667,6 +1668,7 @@ intros.
 destruct l'.
 rewrite lseg_nil_eq.
 normalize.
+rewrite prop_true_andp by apply ptr_eq_nullval.
 apply lseg_cons_right_null.
 rewrite lseg_cons_eq.
 Intros u.
@@ -1807,7 +1809,7 @@ End LIST.
 
 Hint Rewrite @lseg_nil_eq : norm.
 Hint Rewrite @lseg_eq using reflexivity: norm.
-Hint Resolve lseg_local_facts : saturate_local.
+#[export] Hint Resolve lseg_local_facts : saturate_local.
 
 Ltac resolve_lseg_valid_pointer :=
 match goal with
@@ -1820,7 +1822,7 @@ match goal with
    end
  end.
 
-Hint Extern 10 (_ |-- valid_pointer _) =>
+#[export] Hint Extern 10 (_ |-- valid_pointer _) =>
    resolve_lseg_valid_pointer : valid_pointer.
 
 Lemma list_cell_local_facts:
@@ -1832,7 +1834,7 @@ intros.
 unfold list_cell.
 normalize.
 Qed.
-Hint Resolve list_cell_local_facts : saturate_local.
+#[export] Hint Resolve list_cell_local_facts : saturate_local.
 
 End LsegSpecial.
 
@@ -2348,7 +2350,7 @@ apply ptr_eq_e in H. subst y.
 entailer!.
 destruct H. contradiction H.
 rewrite prop_true_andp by reflexivity.
-rewrite prop_true_andp by normalize.
+rewrite prop_true_andp by apply ptr_eq_nullval.
 normalize.
 apply derives_refl'; f_equal. f_equal.
 apply nonreadable_list_cell_eq; auto.
@@ -2364,7 +2366,7 @@ apply andp_right; [ | apply prop_right; auto].
 apply not_prop_right; intro.
 apply ptr_eq_e in H0. subst x.
 entailer.
-destruct H3; contradiction H3.
+destruct H2; contradiction H2.
 eapply derives_trans.
 2: apply sepcon_derives; [ | eassumption]; apply derives_refl.
 clear IHl.
@@ -2384,6 +2386,7 @@ intros.
 destruct l'.
 rewrite lseg_nil_eq.
 normalize.
+rewrite prop_true_andp by apply ptr_eq_nullval.
 apply lseg_cons_right_null; auto.
 rewrite lseg_cons_eq; auto.
 Intros u. Exists u. subst.
@@ -2587,15 +2590,15 @@ End LIST2.
 Lemma join_sub_Tsh:
   forall sh, sepalg.join_sub sh Tsh.
 Admitted. (* easy *)
-Hint Resolve join_sub_Tsh: valid_pointer.
+#[export] Hint Resolve join_sub_Tsh: valid_pointer.
 
 Hint Rewrite @lseg_nil_eq : norm.
 
 Hint Rewrite @lseg_eq using reflexivity: norm.
 
-Hint Resolve lseg_local_facts : saturate_local.
+#[export] Hint Resolve lseg_local_facts : saturate_local.
 
-Hint Resolve denote_tc_test_eq_split : valid_pointer.
+#[export] Hint Resolve denote_tc_test_eq_split : valid_pointer.
 
 Ltac resolve_lseg_valid_pointer :=
 match goal with
@@ -2608,7 +2611,7 @@ match goal with
    end
  end.
 
-Hint Extern 10 (_ |-- valid_pointer _) =>
+#[export] Hint Extern 10 (_ |-- valid_pointer _) =>
        resolve_lseg_valid_pointer : valid_pointer.
 
 Ltac resolve_list_cell_valid_pointer :=
@@ -2625,7 +2628,7 @@ Ltac resolve_list_cell_valid_pointer :=
   end
  end.
 
-Hint Extern 10 (_ |-- valid_pointer _) =>
+#[export] Hint Extern 10 (_ |-- valid_pointer _) =>
    resolve_list_cell_valid_pointer : valid_pointer.
 
 End Links.

--- a/progs/reify_example.v
+++ b/progs/reify_example.v
@@ -249,7 +249,7 @@ Proof.
  simpl. intuition.
 Qed.
 
-Hint Resolve link_local_facts : saturate_local.
+#[export] Hint Resolve link_local_facts : saturate_local.
 
 Lemma link__local_facts:
  forall x, link_ x |-- !! isptr x.
@@ -260,7 +260,7 @@ eapply derives_trans; [eapply field_at__local_facts; reflexivity | ].
 apply prop_derives; intuition.
 Qed.
 
-Hint Resolve link__local_facts : saturate_local.
+#[export] Hint Resolve link__local_facts : saturate_local.
 
 
 Definition Delta :=

--- a/progs/verif_append2.v
+++ b/progs/verif_append2.v
@@ -29,7 +29,7 @@ Intros y. entailer!.
 split; intro. subst p. destruct H; contradiction. inv H2.
 Qed.
 
-Hint Resolve listrep_local_facts : saturate_local.
+#[export] Hint Resolve listrep_local_facts : saturate_local.
 
 Lemma listrep_valid_pointer:
   forall sh contents p,
@@ -44,7 +44,7 @@ Proof.
  simpl;  computable.
 Qed.
 
-Hint Resolve listrep_valid_pointer : valid_pointer.
+#[export] Hint Resolve listrep_valid_pointer : valid_pointer.
 
 Lemma listrep_null: forall sh contents,
     listrep sh contents nullval = !! (contents=nil) && emp.
@@ -245,7 +245,7 @@ entailer!.
 intuition congruence.
 Qed.
 
-Hint Resolve lseg_local_facts : saturate_local.
+#[export] Hint Resolve lseg_local_facts : saturate_local.
 
 Lemma lseg_valid_pointer:
   forall sh contents p ,
@@ -257,7 +257,7 @@ Proof.
  auto with valid_pointer.
 Qed.
 
-Hint Resolve lseg_valid_pointer : valid_pointer.
+#[export] Hint Resolve lseg_valid_pointer : valid_pointer.
 
 Lemma lseg_eq: forall sh contents x,
     lseg sh contents x x = !! (contents=nil /\ is_pointer_or_null x) && emp.

--- a/progs/verif_bst.v
+++ b/progs/verif_bst.v
@@ -249,7 +249,7 @@ entailer!.
 Intros pa pb. entailer!.
 Qed.
 
-Hint Resolve tree_rep_saturate_local: saturate_local.
+#[export] Hint Resolve tree_rep_saturate_local: saturate_local.
 
 Lemma tree_rep_valid_pointer:
   forall t p, tree_rep t p |-- valid_pointer p.
@@ -257,7 +257,7 @@ Proof.
 intros.
 destruct t; simpl; Intros; try Intros pa pb; subst; auto with valid_pointer.
 Qed.
-Hint Resolve tree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve tree_rep_valid_pointer: valid_pointer.
 
 Lemma treebox_rep_saturate_local:
    forall t b, treebox_rep t b |-- !! field_compatible (tptr t_struct_tree) [] b.
@@ -268,7 +268,7 @@ Intros p.
 entailer!.
 Qed.
 
-Hint Resolve treebox_rep_saturate_local: saturate_local.
+#[export] Hint Resolve treebox_rep_saturate_local: saturate_local.
 
 Definition insert_inv (b0: val) (t0: tree val) (x: Z) (v: val): environ -> mpred :=
   EX b: val, EX t: tree val,
@@ -296,7 +296,7 @@ Proof.
   Intros pa pb. entailer!.
 Qed.
 
-Hint Resolve tree_rep_nullval: saturate_local.
+#[export] Hint Resolve tree_rep_nullval: saturate_local.
 
 Lemma treebox_rep_leaf: forall x p b (v: val),
   is_pointer_or_null v ->

--- a/progs/verif_bst_conc.v
+++ b/progs/verif_bst_conc.v
@@ -390,7 +390,7 @@ entailer!.
 Intros pa pb locka lockb. entailer!.
 Qed.
 
-Hint Resolve tree_rep_saturate_local: saturate_local.
+#[export] Hint Resolve tree_rep_saturate_local: saturate_local.
 
 Lemma tree_rep_valid_pointer:
   forall tl lsh t p, node_rep tl lsh t p |-- valid_pointer p.
@@ -398,7 +398,7 @@ Proof.
 intros.
 destruct t; simpl; normalize; auto with valid_pointer.
 Qed.
-Hint Resolve tree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve tree_rep_valid_pointer: valid_pointer.
 
 (*Lemma treebox_rep_saturate_local:
    forall t b, treebox_rep t b |-- !! field_compatible (tptr t_struct_tree_t) [] b.
@@ -409,7 +409,7 @@ Intros p.
 entailer!.
 Qed.
 
-Hint Resolve treebox_rep_saturate_local: saturate_local.
+#[export] Hint Resolve treebox_rep_saturate_local: saturate_local.
 
 Definition insert_inv (b0: val) (t0: tree val) (x: Z) (v: val): environ -> mpred :=
   EX b: val, EX t: tree val,
@@ -448,7 +448,7 @@ Proof.
   Intros pa pb locka lockb. entailer!.
 Qed.
 
-Hint Resolve tree_rep_nullval: saturate_local.
+#[export] Hint Resolve tree_rep_nullval: saturate_local.
 
 (*Lemma treebox_rep_leaf: forall x p b (v: val),
   is_pointer_or_null v ->
@@ -548,7 +548,7 @@ Proof.
     auto. 
     simpl. lia.
 Qed.
-(*Hint Resolve t_lock_exclusive.*)
+(*#[export] Hint Resolve t_lock_exclusive.*)
 
 Lemma body_insert: semax_body Vprog Gprog f_insert insert_spec.
 Proof.

--- a/progs/verif_bst_oo.v
+++ b/progs/verif_bst_oo.v
@@ -269,7 +269,7 @@ destruct t.
   entailer!.
 Qed.
 
-Hint Resolve treebox_rep_saturate_local: saturate_local.
+#[export] Hint Resolve treebox_rep_saturate_local: saturate_local.
 
 (*
 Lemma tree_rep_saturate_local:
@@ -280,7 +280,7 @@ entailer!.
 Intros pa pb. entailer!.
 Qed.
 
-Hint Resolve tree_rep_saturate_local: saturate_local.
+#[export] Hint Resolve tree_rep_saturate_local: saturate_local.
 
 Lemma tree_rep_valid_pointer:
   forall t p, tree_rep t p |-- valid_pointer p.
@@ -288,7 +288,7 @@ Proof.
 intros.
 destruct t; simpl; normalize; auto with valid_pointer.
 Qed.
-Hint Resolve tree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve tree_rep_valid_pointer: valid_pointer.
 
 *)
 Lemma modus_ponens_wand' {A}{ND: NatDed A}{SL: SepLog A}:

--- a/progs/verif_cond.v
+++ b/progs/verif_cond.v
@@ -53,7 +53,7 @@ Proof.
   unfold dlock_inv.
   Intros i; cancel.
 Qed.
-Hint Resolve inv_exclusive : core.
+#[export] Hint Resolve inv_exclusive : core.
 
 Lemma body_thread_func : semax_body Vprog Gprog f_thread_func thread_func_spec.
 Proof.

--- a/progs/verif_example.v
+++ b/progs/verif_example.v
@@ -72,7 +72,7 @@ Proof.
   intro; apply positive_sepcon2.
   rewrite field_at_data_at; auto.
 Qed.
-Hint Resolve inv_precise inv_positive.
+#[export] Hint Resolve inv_precise inv_positive.
 
 Lemma body_g : semax_body Vprog Gprog f_g g_spec.
 Proof.

--- a/progs/verif_incr.v
+++ b/progs/verif_incr.v
@@ -80,7 +80,7 @@ Proof.
   Intro z; apply sepcon_derives; [cancel|].
   Intros x y; Exists x y; apply derives_refl.
 Qed.
-Hint Resolve ctr_inv_exclusive : core.
+#[export] Hint Resolve ctr_inv_exclusive : core.
 
 Lemma thread_inv_exclusive : forall sh g1 g2 ctr lock lockt,
   exclusive_mpred (thread_lock_inv sh g1 g2 ctr lock lockt).
@@ -89,7 +89,7 @@ Proof.
   unfold thread_lock_R.
   apply exclusive_sepcon1; auto.
 Qed.
-Hint Resolve thread_inv_exclusive : core.
+#[export] Hint Resolve thread_inv_exclusive : core.
 
 Lemma body_incr: semax_body Vprog Gprog f_incr incr_spec.
 Proof.

--- a/progs/verif_incrN.v
+++ b/progs/verif_incrN.v
@@ -99,7 +99,7 @@ Proof.
   Intro z; apply sepcon_derives; [cancel|].
   Intros lv; Exists lv; apply derives_refl.
 Qed.
-Hint Resolve ctr_inv_exclusive.
+#[export] Hint Resolve ctr_inv_exclusive.
 
 Lemma thread_inv_exclusive : forall tsh sh lg i ctr lock lockt,
   exclusive_mpred (thread_lock_inv tsh sh lg i ctr lock lockt).
@@ -108,7 +108,7 @@ Proof.
   unfold thread_lock_R.
   apply exclusive_sepcon1; auto.
 Qed.
-Hint Resolve thread_inv_exclusive.
+#[export] Hint Resolve thread_inv_exclusive.
 
 Lemma sum_repeat: forall i n, sum (repeat i n) = (i * Z.of_nat n)%Z.
 Proof.

--- a/progs/verif_incr_gen.v
+++ b/progs/verif_incr_gen.v
@@ -126,7 +126,7 @@ Proof.
   Intro z; apply sepcon_derives; [cancel|].
   Exists z; apply derives_refl.
 Qed.
-Hint Resolve ctr_inv_exclusive.
+#[export] Hint Resolve ctr_inv_exclusive.
 
 Lemma thread_inv_exclusive : forall tsh sh gsh g ctr lock lockt,
   exclusive_mpred (thread_lock_inv tsh sh gsh g ctr lock lockt).
@@ -135,7 +135,7 @@ Proof.
   unfold thread_lock_R.
   apply exclusive_sepcon1; auto.
 Qed.
-Hint Resolve thread_inv_exclusive.
+#[export] Hint Resolve thread_inv_exclusive.
 
 Lemma body_init_ctr: semax_body Vprog Gprog f_init_ctr init_ctr_spec.
 Proof.

--- a/progs/verif_incr_simple.v
+++ b/progs/verif_incr_simple.v
@@ -75,7 +75,7 @@ Proof.
   eapply derives_exclusive, data_at__exclusive with (sh := Ews)(t := tuint); auto; simpl; try lia.
   Intro z; cancel.
 Qed.
-Hint Resolve ctr_inv_exclusive.
+#[export] Hint Resolve ctr_inv_exclusive.
 
 Lemma thread_inv_exclusive : forall sh ctr lock lockt,
   exclusive_mpred (thread_lock_inv sh ctr lock lockt).
@@ -83,7 +83,7 @@ Proof.
   intros; apply selflock_exclusive.
   unfold thread_lock_R; auto.
 Qed.
-Hint Resolve thread_inv_exclusive.
+#[export] Hint Resolve thread_inv_exclusive.
 
 Lemma body_incr: semax_body Vprog Gprog f_incr incr_spec.
 Proof.

--- a/progs/verif_int_or_ptr.v
+++ b/progs/verif_int_or_ptr.v
@@ -97,7 +97,7 @@ entailer!.
 apply field_compatible_valid_int_or_ptr; auto.
 Qed.
 
-Hint Resolve treerep_local_facts : saturate_local.
+#[export] Hint Resolve treerep_local_facts : saturate_local.
 
 Definition test_int_or_ptr_spec :=
  DECLARE _test_int_or_ptr

--- a/progs/verif_lock_coupling.v
+++ b/progs/verif_lock_coupling.v
@@ -233,14 +233,14 @@ Proof.
   intro; eapply derives_precise, data_at__precise with (sh := Ews)(t := tint); auto.
   intros ? (? & H); apply data_at_data_at_ in H; eauto.
 Qed.
-Hint Resolve ctr_inv_precise.
+#[export] Hint Resolve ctr_inv_precise.
 
 Lemma ctr_inv_positive : forall ctr,
   positive_mpred (cptr_lock_inv ctr).
 Proof.
   intro; apply ex_positive; auto.
 Qed.
-Hint Resolve ctr_inv_positive.
+#[export] Hint Resolve ctr_inv_positive.
 
 Lemma body_incr: semax_body Vprog Gprog f_incr incr_spec.
 Proof.

--- a/progs/verif_logical_compare.v
+++ b/progs/verif_logical_compare.v
@@ -18,7 +18,7 @@ match s with
      s2 => match quick_shortcut_logical s2 with None => None | Some id2 =>
                  if ident_eq id id2 then Some id else None
                 end
-| Sifthenelse e1 s2
+| Sifthenelse _ s2
      (Sset id (Econst_int _ (Tint I32 Signed {| attr_volatile := false; attr_alignas := None |})))
       => match quick_shortcut_logical s2 with None => None | Some id2 =>
                  if ident_eq id id2 then Some id else None

--- a/progs/verif_message.v
+++ b/progs/verif_message.v
@@ -43,7 +43,7 @@ eapply derives_trans;[ apply mf_bufprop | ].
 entailer!.
 Qed.
 
-Hint Resolve mf_assert_local_facts : saturate_local.
+#[export] Hint Resolve mf_assert_local_facts : saturate_local.
 
 
 Definition t_struct_intpair := Tstruct _intpair noattr.

--- a/progs/verif_min.v
+++ b/progs/verif_min.v
@@ -74,7 +74,7 @@ Lemma is_int_I32_Znth_map_Vint:
 Proof.
 intros. rewrite Znth_map; auto.
 Qed.
-Hint Extern 3 (is_int I32 _ (Znth _ (map Vint _))) =>
+#[export] Hint Extern 3 (is_int I32 _ (Znth _ (map Vint _))) =>
   (apply  is_int_I32_Znth_map_Vint; rewrite ?Zlength_map; lia) : core.
 
 Definition minimum_spec :=

--- a/progs/verif_min64.v
+++ b/progs/verif_min64.v
@@ -71,7 +71,7 @@ Lemma is_int_I32_Znth_map_Vint:
 Proof.
 intros. rewrite Znth_map; auto.
 Qed.
-Hint Extern 3 (is_int I32 _ (Znth _ (map Vint _))) =>
+#[export] Hint Extern 3 (is_int I32 _ (Znth _ (map Vint _))) =>
   (apply  is_int_I32_Znth_map_Vint; rewrite ?Zlength_map; lia) : core.
 
 Definition minimum_spec :=

--- a/progs/verif_object.v
+++ b/progs/verif_object.v
@@ -49,7 +49,7 @@ unfold object_methods.
 Intros sh reset twiddle.
 entailer!.
 Qed.
-Hint Resolve object_methods_local_facts : saturate_local.
+#[export] Hint Resolve object_methods_local_facts : saturate_local.
 
 Definition object_mpred (history: list Z) (self: val) : mpred :=
   EX instance: object_invariant, EX mtable: val, 

--- a/progs/verif_objectSelf.v
+++ b/progs/verif_objectSelf.v
@@ -71,7 +71,7 @@ unfold object_methods.
 Intros sh reset twiddle twiddleR.
 entailer!.
 Qed.
-Hint Resolve object_methods_local_facts : saturate_local.
+#[export] Hint Resolve object_methods_local_facts : saturate_local.
 
 (*Andrew's definition
 Definition object_mpred (history: list Z) (self: val) : mpred :=

--- a/progs/verif_objectSelfFancy.v
+++ b/progs/verif_objectSelfFancy.v
@@ -64,7 +64,7 @@ unfold object_methods.
 Intros sh reset twiddle twiddleR.
 entailer!.
 Qed.
-Hint Resolve object_methods_local_facts : saturate_local.
+Local Hint Resolve object_methods_local_facts : saturate_local.
 
 (*Moved here from further below, and added twiddleR*)
 Lemma make_object_methods:
@@ -718,7 +718,7 @@ unfold fobject_methods.
 Intros sh reset twiddle twiddleR setcol getcol.
 entailer!.
 Qed.
-Hint Resolve fobject_methods_local_facts : saturate_local.
+Local Hint Resolve fobject_methods_local_facts : saturate_local.
 
 Lemma make_fobject_methods:
   forall sh instance reset twiddle twiddleR setcol getcol mtable,

--- a/progs/verif_objectSelfFancyOverriding.v
+++ b/progs/verif_objectSelfFancyOverriding.v
@@ -64,7 +64,7 @@ unfold object_methods.
 Intros sh reset twiddle twiddleR.
 entailer!.
 Qed.
-Hint Resolve object_methods_local_facts : saturate_local.
+Local Hint Resolve object_methods_local_facts : saturate_local.
 
 (*Moved here from further below, and added twiddleR*)
 Lemma make_object_methods:
@@ -719,7 +719,7 @@ unfold fobject_methods.
 Intros sh reset twiddle twiddleR setcol getcol.
 entailer!.
 Qed.
-Hint Resolve fobject_methods_local_facts : saturate_local.
+Local Hint Resolve fobject_methods_local_facts : saturate_local.
 
 Lemma make_fobject_methods:
   forall sh instance reset twiddle twiddleR setcol getcol mtable,

--- a/progs/verif_queue.v
+++ b/progs/verif_queue.v
@@ -94,7 +94,7 @@ apply sepalg.join_comm.
 apply Qsh_Qsh'.
 Qed.
 
-Hint Resolve Qsh_not_readable : core.
+#[export] Hint Resolve Qsh_not_readable : core.
 
 
 Lemma Qsh_nonempty: Qsh <> Share.bot.
@@ -143,7 +143,7 @@ rewrite Share.glb_absorb in H0.
 contradiction.
 Qed.
 
-Hint Resolve Qsh_nonempty : valid_pointer.
+#[export] Hint Resolve Qsh_nonempty : valid_pointer.
 
 Lemma Qsh_nonidentity: sepalg.nonidentity Qsh.
 Proof.
@@ -153,7 +153,7 @@ Proof.
   auto.
 Qed.
 
-Hint Resolve Qsh_nonidentity : valid_pointer.
+#[export] Hint Resolve Qsh_nonidentity : valid_pointer.
 
 Lemma sub_Qsh_Ews: sepalg.join_sub Qsh Ews.
 Proof.
@@ -165,7 +165,7 @@ apply leq_join_sub.
 apply Share.lub_upper1.
 Qed.
 
-Hint Resolve sub_Qsh_Ews: valid_pointer.
+#[export] Hint Resolve sub_Qsh_Ews: valid_pointer.
 
 Lemma field_at_list_cell_weak:
   forall sh i j p,
@@ -368,7 +368,7 @@ intros.
  Intros ht; destruct ht; if_tac; entailer!.
 Qed.
 
-Hint Resolve fifo_isptr : saturate_local.
+#[export] Hint Resolve fifo_isptr : saturate_local.
 
 Lemma body_fifo_empty: semax_body Vprog Gprog f_fifo_empty fifo_empty_spec.
 Proof.
@@ -528,7 +528,7 @@ forward_call (*  p = surely_malloc(sizeof ( *p));  *)
   apply derives_refl.
 Qed.
 
-Hint Resolve readable_share_Qsh' : core.
+#[export] Hint Resolve readable_share_Qsh' : core.
 
 Lemma body_main:  semax_body Vprog Gprog f_main main_spec.
 Proof.

--- a/progs/verif_queue.v
+++ b/progs/verif_queue.v
@@ -448,10 +448,10 @@ forward_if
    + Intros prefix.
       destruct prefix;
       entailer!.
-      contradiction (field_compatible_isptr _ _ _ H7).
+      contradiction (field_compatible_isptr _ _ _ H6).
       rewrite lseg_cons_eq by auto. simpl.
       Intros y. saturate_local.
-      contradiction (field_compatible_isptr _ _ _ H11).
+      contradiction (field_compatible_isptr _ _ _ H9).
 * (* else clause *)
   forward. (*  t = Q->tail; *)
   unfold fifo_body.

--- a/progs/verif_queue2.v
+++ b/progs/verif_queue2.v
@@ -165,7 +165,7 @@ intros.
  if_tac.  entailer!.  Intros prefix; entailer!.
 Qed.
 
-Hint Resolve fifo_isptr : saturate_local.
+#[export] Hint Resolve fifo_isptr : saturate_local.
 
 Lemma body_fifo_empty: semax_body Vprog Gprog f_fifo_empty fifo_empty_spec.
 Proof.

--- a/progs/verif_queue_ex.v
+++ b/progs/verif_queue_ex.v
@@ -82,7 +82,7 @@ Proof.
   do 3 apply positive_sepcon1.
   apply data_at_positive; auto.
 Qed.
-Hint Resolve f_inv_precise f_inv_positive.
+#[export] Hint Resolve f_inv_precise f_inv_positive.
 
 Lemma lock_struct_array : forall sh z (v : list val) p,
   data_at sh (tarray (tptr (Tstruct _lock_t noattr)) z) v p =

--- a/progs/verif_revarray.v
+++ b/progs/verif_revarray.v
@@ -246,7 +246,7 @@ Ltac calc_Zlength_extra l ::=
 
 Hint Rewrite Zlength_rev : Zlength.
 Hint Rewrite @Znth_rev using Zlength_solve : Znth.
-Hint Unfold flip_ends : list_solve_unfold.
+#[export] Hint Unfold flip_ends : list_solve_unfold.
 
 Lemma body_reverse: semax_body Vprog Gprog f_reverse reverse_spec.
 Proof.

--- a/progs/verif_reverse.v
+++ b/progs/verif_reverse.v
@@ -260,7 +260,7 @@ Proof.
   rewrite (sepcon_emp (lseg _ _ _ _ _)).
   rewrite sepcon_emp.
 
-  repeat
+ repeat
   match goal with |- _ * (mapsto _ _ _ ?q * _) |-- lseg _ _ _ (offset_val ?n _) _ =>
     assert (FC': field_compatible t_struct_list [] (offset_val n (gv _three)));
       [apply (@field_compatible_nested_field CompSpecs (tarray t_struct_list 3)
@@ -271,11 +271,11 @@ Proof.
        tauto
       |];
     apply @lseg_unroll_nonempty1 with q;
-      [destruct (gv _three); try contradiction; intro Hx; inv Hx | floyd.seplog_tactics.normalize | ];
+      [destruct (gv _three); try contradiction; intro Hx; inv Hx | normalize; try reflexivity | ];
     rewrite list_cell_eq by auto;
     do 2 (apply sepcon_derives;
       [ unfold field_at; rewrite prop_true_andp by auto with field_compatible;
-        unfold data_at_rec, at_offset; simpl; floyd.seplog_tactics.normalize; try apply derives_refl | ]);
+        unfold data_at_rec, at_offset; simpl; normalize; try apply derives_refl | ]);
     clear FC'
     end.
   rewrite mapsto_tuint_tptr_nullval; auto. apply derives_refl.

--- a/progs/verif_reverse2.v
+++ b/progs/verif_reverse2.v
@@ -58,7 +58,7 @@ Intros y. entailer!.
 split; intro. subst p. destruct H; contradiction. inv H2.
 Qed.
 
-Hint Resolve listrep_local_facts : saturate_local.
+#[export] Hint Resolve listrep_local_facts : saturate_local.
 
 Lemma listrep_valid_pointer:
   forall sigma p,
@@ -72,7 +72,7 @@ Proof.
  simpl;  computable.
 Qed.
 
-Hint Resolve listrep_valid_pointer : valid_pointer.
+#[export] Hint Resolve listrep_valid_pointer : valid_pointer.
 
 (** Specification of the [reverse] function.  It characterizes
  ** the precondition required for calling the function,

--- a/progs/verif_reverse_client.v
+++ b/progs/verif_reverse_client.v
@@ -27,7 +27,7 @@ Intros y. entailer!.
 split; intro. subst p. destruct H; contradiction. inv H2.
 Qed.
 
-Hint Resolve listrep_local_facts : saturate_local.
+#[export] Hint Resolve listrep_local_facts : saturate_local.
 
 Lemma listrep_valid_pointer:
   forall sigma p,
@@ -41,7 +41,7 @@ Proof.
  simpl;  computable.
 Qed.
 
-Hint Resolve listrep_valid_pointer : valid_pointer.
+#[export] Hint Resolve listrep_valid_pointer : valid_pointer.
 
 Definition reverse_spec :=
  DECLARE _reverse

--- a/progs/verif_tree.v
+++ b/progs/verif_tree.v
@@ -203,7 +203,7 @@ Proof.
 intros.
 destruct t; simpl; Intros; try Intros q; subst; auto with valid_pointer.
 Qed.
-Hint Resolve xtree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve xtree_rep_valid_pointer: valid_pointer.
 
 Lemma xtree_rep_local_facts:
   forall t p, xtree_rep t p |-- !! (is_pointer_or_null p /\ (p = nullval <-> t = XLeaf)).
@@ -214,7 +214,7 @@ destruct t; simpl; Intros; try Intros q;  entailer!.
 + split; intros; try congruence.
   subst; destruct H as [? _]; inv H.
 Qed.
-Hint Resolve xtree_rep_local_facts: saturate_local.
+#[export] Hint Resolve xtree_rep_local_facts: saturate_local.
 
 Lemma list_rep_Xlist_valid_pointer:
   forall (r: list val) (q: val),
@@ -225,7 +225,7 @@ Proof.
   intros.
   auto with valid_pointer.
 Qed.
-Hint Resolve list_rep_Xlist_valid_pointer: valid_pointer.
+#[export] Hint Resolve list_rep_Xlist_valid_pointer: valid_pointer.
 
 Lemma list_rep_Xlist_local_facts:
   forall (r: list val) (q: val),
@@ -236,7 +236,7 @@ Proof.
   intros.
   entailer!.
 Qed.
-Hint Resolve list_rep_Xlist_local_facts: saturate_local.
+#[export] Hint Resolve list_rep_Xlist_local_facts: saturate_local.
 
 Lemma xtree_rep_nullval: forall t,
   xtree_rep t nullval |-- !! (t = XLeaf).
@@ -246,7 +246,7 @@ Proof.
   simpl xtree_rep.
   Intros q r. entailer!.
 Qed.
-Hint Resolve xtree_rep_nullval: saturate_local.
+#[export] Hint Resolve xtree_rep_nullval: saturate_local.
 
 (* X_DEFS ends. *)
 
@@ -302,14 +302,14 @@ Proof.
   apply list_rep_valid_pointer.
   intros; auto with valid_pointer.
 Qed.
-Hint Resolve y_list_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve y_list_rep_valid_pointer: valid_pointer.
 
 Lemma y_list_rep_local_facts: forall t p, y_list_rep t p |-- !! (is_pointer_or_null p /\ (p = nullval <-> t = nil)).
 Proof.
   apply list_rep_local_facts.
   intros; entailer!.
 Qed.
-Hint Resolve y_list_rep_local_facts: saturate_local.
+#[export] Hint Resolve y_list_rep_local_facts: saturate_local.
 
 Lemma y_tree_rep_valid_pointer: forall t p, y_tree_rep t p |-- valid_pointer p.
 Proof.
@@ -317,14 +317,14 @@ Proof.
   apply tree_rep_valid_pointer.
   intros; auto with valid_pointer.
 Qed.
-Hint Resolve y_tree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve y_tree_rep_valid_pointer: valid_pointer.
 
 Lemma y_tree_rep_local_facts: forall t p, y_tree_rep t p |-- !! (is_pointer_or_null p /\ (p = nullval <-> t = E)).
 Proof.
   apply tree_rep_local_facts.
   intros; entailer!.
 Qed.
-Hint Resolve y_tree_rep_local_facts: saturate_local.
+#[export] Hint Resolve y_tree_rep_local_facts: saturate_local.
 
 Lemma ytree_rep_valid_pointer:
   forall t p, ytree_rep t p |-- valid_pointer p.
@@ -332,7 +332,7 @@ Proof.
 intros.
 destruct t; simpl; Intros; try Intros q; subst; auto with valid_pointer.
 Qed.
-Hint Resolve ytree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve ytree_rep_valid_pointer: valid_pointer.
 
 Lemma ytree_rep_local_facts:
   forall t p, ytree_rep t p |-- !! (is_pointer_or_null p /\ (p = nullval <-> t = YLeaf)).
@@ -343,7 +343,7 @@ destruct t; simpl; Intros; try Intros q; entailer!.
 + split; intros; try congruence.
   subst; destruct H as [? _]; inv H.
 Qed.
-Hint Resolve ytree_rep_local_facts: saturate_local.
+#[export] Hint Resolve ytree_rep_local_facts: saturate_local.
 
 Lemma lt_ytree_rep_valid_pointer: forall t p, lt_ytree_rep t p |-- valid_pointer p.
 Proof.
@@ -352,7 +352,7 @@ Proof.
   Intros r.
   auto with valid_pointer.
 Qed.
-Hint Resolve lt_ytree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve lt_ytree_rep_valid_pointer: valid_pointer.
 
 Lemma lt_ytree_rep_local_facts: forall t p, lt_ytree_rep t p |-- !! (is_pointer_or_null p /\ (p = nullval <-> t = nil)).
 Proof.
@@ -366,7 +366,7 @@ Proof.
   rewrite H.
   destruct l; simpl; split; intros; congruence.
 Qed.
-Hint Resolve lt_ytree_rep_local_facts: saturate_local.
+#[export] Hint Resolve lt_ytree_rep_local_facts: saturate_local.
 
 Lemma t_ytree_rep_valid_pointer: forall t p, t_ytree_rep t p |-- valid_pointer p.
 Proof.
@@ -375,7 +375,7 @@ Proof.
   Intros s.
   auto with valid_pointer.
 Qed.
-Hint Resolve t_ytree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve t_ytree_rep_valid_pointer: valid_pointer.
 
 Lemma t_ytree_rep_local_facts: forall t p, t_ytree_rep t p |-- !! (is_pointer_or_null p /\ (p = nullval <-> t = E)).
 Proof.
@@ -389,7 +389,7 @@ Proof.
   rewrite H.
   destruct tl; simpl; split; intros; congruence.
 Qed.
-Hint Resolve t_ytree_rep_local_facts: saturate_local.
+#[export] Hint Resolve t_ytree_rep_local_facts: saturate_local.
 
 (* Y_DEFS ends. *)
 

--- a/progs64/verif_append2.v
+++ b/progs64/verif_append2.v
@@ -30,7 +30,7 @@ Intros y. entailer!.
 split; intro. subst p. destruct H; contradiction. inv H2.
 Qed.
 
-Hint Resolve listrep_local_facts : saturate_local.
+#[export] Hint Resolve listrep_local_facts : saturate_local.
 
 Lemma listrep_valid_pointer:
   forall sh contents p,
@@ -45,7 +45,7 @@ Proof.
  simpl;  computable.
 Qed.
 
-Hint Resolve listrep_valid_pointer : valid_pointer.
+#[export] Hint Resolve listrep_valid_pointer : valid_pointer.
 
 Lemma listrep_null: forall sh contents,
     listrep sh contents nullval = !! (contents=nil) && emp.
@@ -246,7 +246,7 @@ entailer!.
 intuition congruence.
 Qed.
 
-Hint Resolve lseg_local_facts : saturate_local.
+#[export] Hint Resolve lseg_local_facts : saturate_local.
 
 Lemma lseg_valid_pointer:
   forall sh contents p ,
@@ -258,7 +258,7 @@ Proof.
  auto with valid_pointer.
 Qed.
 
-Hint Resolve lseg_valid_pointer : valid_pointer.
+#[export] Hint Resolve lseg_valid_pointer : valid_pointer.
 
 Lemma lseg_eq: forall sh contents x,
     lseg sh contents x x = !! (contents=nil /\ is_pointer_or_null x) && emp.

--- a/progs64/verif_bst.v
+++ b/progs64/verif_bst.v
@@ -250,7 +250,7 @@ entailer!.
 Intros pa pb. entailer!.
 Qed.
 
-Hint Resolve tree_rep_saturate_local: saturate_local.
+#[export] Hint Resolve tree_rep_saturate_local: saturate_local.
 
 Lemma tree_rep_valid_pointer:
   forall t p, tree_rep t p |-- valid_pointer p.
@@ -258,7 +258,7 @@ Proof.
 intros.
 destruct t; simpl; Intros; try Intros pa pb; subst; auto with valid_pointer.
 Qed.
-Hint Resolve tree_rep_valid_pointer: valid_pointer.
+#[export] Hint Resolve tree_rep_valid_pointer: valid_pointer.
 
 Lemma treebox_rep_saturate_local:
    forall t b, treebox_rep t b |-- !! field_compatible (tptr t_struct_tree) [] b.
@@ -269,7 +269,7 @@ Intros p.
 entailer!.
 Qed.
 
-Hint Resolve treebox_rep_saturate_local: saturate_local.
+#[export] Hint Resolve treebox_rep_saturate_local: saturate_local.
 
 Definition insert_inv (b0: val) (t0: tree val) (x: Z) (v: val): environ -> mpred :=
   EX b: val, EX t: tree val,
@@ -297,7 +297,7 @@ Proof.
   Intros pa pb. entailer!.
 Qed.
 
-Hint Resolve tree_rep_nullval: saturate_local.
+#[export] Hint Resolve tree_rep_nullval: saturate_local.
 
 Lemma treebox_rep_leaf: forall x p b (v: val),
   is_pointer_or_null v ->

--- a/progs64/verif_logical_compare.v
+++ b/progs64/verif_logical_compare.v
@@ -19,7 +19,7 @@ match s with
      s2 => match quick_shortcut_logical s2 with None => None | Some id2 =>
                  if ident_eq id id2 then Some id else None
                 end
-| Sifthenelse e1 s2
+| Sifthenelse _ s2
      (Sset id (Econst_int _ (Tint I32 Signed {| attr_volatile := false; attr_alignas := None |})))
       => match quick_shortcut_logical s2 with None => None | Some id2 =>
                  if ident_eq id id2 then Some id else None

--- a/progs64/verif_message.v
+++ b/progs64/verif_message.v
@@ -44,7 +44,7 @@ eapply derives_trans;[ apply mf_bufprop | ].
 entailer!.
 Qed.
 
-Hint Resolve mf_assert_local_facts : saturate_local.
+#[export] Hint Resolve mf_assert_local_facts : saturate_local.
 
 
 Definition t_struct_intpair := Tstruct _intpair noattr.

--- a/progs64/verif_min.v
+++ b/progs64/verif_min.v
@@ -75,7 +75,7 @@ Lemma is_int_I32_Znth_map_Vint:
 Proof.
 intros. rewrite Znth_map; auto.
 Qed.
-Hint Extern 3 (is_int I32 _ (Znth _ (map Vint _))) =>
+#[export] Hint Extern 3 (is_int I32 _ (Znth _ (map Vint _))) =>
   (apply  is_int_I32_Znth_map_Vint; rewrite ?Zlength_map; lia) : core.
 
 Definition minimum_spec :=

--- a/progs64/verif_min64.v
+++ b/progs64/verif_min64.v
@@ -72,7 +72,7 @@ Lemma is_int_I32_Znth_map_Vint:
 Proof.
 intros. rewrite Znth_map; auto.
 Qed.
-Hint Extern 3 (is_int I32 _ (Znth _ (map Vint _))) =>
+#[export] Hint Extern 3 (is_int I32 _ (Znth _ (map Vint _))) =>
   (apply  is_int_I32_Znth_map_Vint; rewrite ?Zlength_map; lia) : core.
 
 Definition minimum_spec :=

--- a/progs64/verif_object.v
+++ b/progs64/verif_object.v
@@ -50,7 +50,7 @@ unfold object_methods.
 Intros sh reset twiddle.
 entailer!.
 Qed.
-Hint Resolve object_methods_local_facts : saturate_local.
+#[export] Hint Resolve object_methods_local_facts : saturate_local.
 
 Definition object_mpred (history: list Z) (self: val) : mpred :=
   EX instance: object_invariant, EX mtable: val, 

--- a/progs64/verif_revarray.v
+++ b/progs64/verif_revarray.v
@@ -267,17 +267,8 @@ Time repeat step!.
 Time repeat step!.
 (* Finished transaction in 32.154 secs (32.031u,0.s) (successful) *)
 (* solved in step! *)
-(* + unfold flip_ends. list_solve2.
-+ unfold flip_ends. list_solve2.
-+ list_solve2.
-+ list_solve2. (* a better way is eq_solve *)
-+ simpl. unfold flip_ends. Time list_solve!. *)
-(* Finished transaction in 29.44 secs (29.25u,0.171s) (successful) *)
 * (* after the loop *)
 repeat step!.
-(* simpl.
-forward. (* return; *)
-unfold flip_ends. Time list_solve!. *)
 (* Finished transaction in 2.587 secs (2.593u,0.s) (successful) *) 
 Time Qed.
 (* Finished transaction in 6.801 secs (6.796u,0.015s) (successful) *)
@@ -297,16 +288,6 @@ forward_call  (*  revarray(four,4); *)
    split; [computable | auto].
 rewrite rev_involutive.
 forward. (* return s; *)
-Qed.
-
-Existing Instance NullExtension.Espec.
-
-Lemma prog_correct:
-  semax_prog prog tt Vprog Gprog.
-Proof.
-prove_semax_prog.
-semax_func_cons body_reverse.
-semax_func_cons body_main.
 Qed.
 
 End Alternate.

--- a/progs64/verif_revarray.v
+++ b/progs64/verif_revarray.v
@@ -247,7 +247,7 @@ Ltac calc_Zlength_extra l ::=
 
 Hint Rewrite Zlength_rev : Zlength.
 Hint Rewrite @Znth_rev using Zlength_solve : Znth.
-Hint Unfold flip_ends : list_solve_unfold.
+#[export] Hint Unfold flip_ends : list_solve_unfold.
 
 Lemma body_reverse: semax_body Vprog Gprog f_reverse reverse_spec.
 Proof.

--- a/progs64/verif_reverse2.v
+++ b/progs64/verif_reverse2.v
@@ -59,7 +59,7 @@ Intros y. entailer!.
 split; intro. subst p. destruct H; contradiction. inv H2.
 Qed.
 
-Hint Resolve listrep_local_facts : saturate_local.
+#[export] Hint Resolve listrep_local_facts : saturate_local.
 
 Lemma listrep_valid_pointer:
   forall sigma p,
@@ -73,7 +73,7 @@ Proof.
  simpl;  computable.
 Qed.
 
-Hint Resolve listrep_valid_pointer : valid_pointer.
+#[export] Hint Resolve listrep_valid_pointer : valid_pointer.
 
 (** Specification of the [reverse] function.  It characterizes
  ** the precondition required for calling the function,

--- a/progs64/verif_strlib.v
+++ b/progs64/verif_strlib.v
@@ -548,8 +548,8 @@ forward_loop (EX i : Z,
   {
   repeat step!.
   (* - list_prop_solve.
-  - list_solve2.
-  - fold_Vbyte. list_solve2. *)
+  - list_solve.
+  - fold_Vbyte. list_solve. *)
   }
 Qed.
 
@@ -620,7 +620,7 @@ forward_loop (EX i : Z,
   repeat step.
 -
   repeat step!.
-  (* + fold_Vbyte. list_solve2. *)
+  (* + fold_Vbyte. list_solve. *)
 Qed.
 
 End Alternate.

--- a/progs64/verif_union.v
+++ b/progs64/verif_union.v
@@ -75,12 +75,218 @@ unfold decode_val in H.
 simpl in H. inversion H.
 Qed.
 
+Module FABS_STUFF.
+
+Lemma shift_pos_succ:
+  forall k j, (shift_pos (Pos.succ k) j = (shift_pos k j)~0)%positive.
+Proof.
+intros.
+change ((shift_pos k j)~0)%positive
+with (2 * (shift_pos k j))%positive.
+apply Pos2Z.inj.
+rewrite Pos2Z.inj_mul.
+rewrite !shift_pos_correct.
+rewrite Z.mul_assoc.
+f_equal.
+rewrite <- !two_power_pos_correct.
+rewrite <- Pos.add_1_l.
+rewrite two_power_pos_is_exp.
+reflexivity.
+Qed.
+
+Lemma nan_pl_range:
+ forall k p, Binary.nan_pl k p = true ->
+ Z.pos p < 2 ^ (k-1).
+Proof.
+intros.
+unfold Binary.nan_pl in H.
+apply Z.ltb_lt in H.
+revert k H; induction p; simpl; intros.
+-
+rewrite Pos2Z.inj_succ in H.
+specialize (IHp (k-1)).
+spec IHp; [lia | ].
+replace (2^(k-1)) with (2^1 * 2^(k-1-1)).
+2:{ rewrite <- Z.pow_add_r by lia. f_equal. lia. }
+rewrite Pos2Z.inj_xI.
+lia.
+-
+rewrite Pos2Z.inj_succ in H.
+specialize (IHp (k-1)).
+spec IHp; [lia | ].
+replace (2^(k-1)) with (2^1 * 2^(k-1-1)).
+2:{ rewrite <- Z.pow_add_r by lia. f_equal. lia. }
+rewrite Pos2Z.inj_xO.
+lia.
+-
+replace (2^(k-1)) with (2^1 * 2^(k-1-1)).
+2:{ rewrite <- Z.pow_add_r by lia. f_equal. lia. }
+change (2^1) with 2.
+assert (0 < 2 ^ (k-1-1)).
+apply Z.pow_pos_nonneg; lia.
+lia.
+Qed.
+
+
+Definition abs_nan (any_nan: {x : Bits.binary32 | Binary.is_nan 24 128 x = true}) (f: Binary.binary_float 24 128)   :=
+match f with
+| @Binary.B754_nan _ _ _ p H =>
+    exist (fun x : Binary.binary_float 24 128 => Binary.is_nan 24 128 x = true)
+      (Binary.B754_nan 24 128 false p H) eq_refl
+| _ => any_nan
+end.
+
+Lemma bounded_mantissa:
+  forall prec emax m e, Binary.bounded prec emax m e = true ->
+    Z.pos m < 2 ^ prec.
+Proof.
+intros.
+unfold Binary.bounded in H.
+rewrite andb_true_iff in H.
+destruct H as [H H0].
+apply Z.leb_le in H0.
+unfold Binary.canonical_mantissa in H.
+apply Zeq_bool_eq in H.
+unfold FLT.FLT_exp in H.
+rewrite Digits.Zpos_digits2_pos in H.
+pose proof (Z.max_lub_l (Digits.Zdigits Zaux.radix2 (Z.pos m) + e - prec)
+      (3 - emax - prec) e).
+spec H1; [ lia | ].
+clear H.
+assert (Digits.Zdigits Zaux.radix2 (Z.pos m) <= prec) by lia.
+clear - H.
+apply Digits.Zpower_gt_Zdigits in H.
+apply H.
+Qed.
+
+Lemma binary32_abs_lemma:
+ forall (x : Bits.binary32)
+      (any_nan : {x : Bits.binary32 | Binary.is_nan 24 128 x = true}),
+  Bits.b32_of_bits (Bits.bits_of_b32 x mod 2 ^ 31) =
+  Binary.Babs 24 128 (abs_nan any_nan) x.
+Proof.
+intros.
+destruct x.
+- (* B754_zero *)
+destruct s; reflexivity.
+- (* B754_infinity *)
+destruct s; reflexivity.
+- (* B754_nan *)
+assert (Hpl := nan_pl_range _ _ e).
+unfold Bits.b32_of_bits, Binary.Babs, Bits.bits_of_b32, Bits.bits_of_binary_float.
+assert (Bits.join_bits 23 8 s (Z.pos pl) (2 ^ 8 - 1) mod 2 ^ 31 =
+            Bits.join_bits 23 8 false (Z.pos pl) (2 ^ 8 - 1)).  {
+ unfold Bits.join_bits.
+rewrite !Z.shiftl_mul_pow2 by computable.
+rewrite Z.add_0_l.
+rewrite Z.mul_add_distr_r.
+rewrite <- Z.add_assoc.
+rewrite Z.add_mod by (compute; lia).
+replace (((if s then 2 ^ 8 else 0) * 2 ^ 23) mod 2 ^ 31) with 0
+  by (destruct s; reflexivity).
+rewrite Z.add_0_l.
+rewrite Z.mod_mod by lia.
+apply Z.mod_small.
+lia.
+}
+rewrite H; clear H.
+transitivity (Binary.B754_nan 24 128 false pl e); [ | reflexivity].
+clear.
+replace (Bits.join_bits 23 8 false (Z.pos pl) (2 ^ 8 - 1))
+   with (Bits.bits_of_binary_float 23 8 (Binary.B754_nan 24 128 false pl e)).
+apply (Bits.binary_float_of_bits_of_binary_float 23 8 eq_refl eq_refl eq_refl).
+reflexivity.
+- (* B754_finite *)
+unfold Binary.Babs.
+clear.
+unfold Bits.b32_of_bits, Binary.Babs, Bits.bits_of_b32, Bits.bits_of_binary_float.
+pose proof (bounded_mantissa _ _ _ _ e0).
+destruct (0 <=? Z.pos m - 2 ^ 23) eqn:?H.
++
+apply Z.leb_le in H0.
+assert (Z.pos m - 2^23 < 2^23) by lia.
+replace (Bits.join_bits 23 8 s (Z.pos m - 2 ^ 23)
+                 (e - (3 - 2 ^ (8 - 1) - (23 + 1)) + 1) mod  2 ^ 31)
+   with (Bits.bits_of_binary_float 23 8 (Binary.B754_finite 24 128 false m e e0)).
+apply (Bits.binary_float_of_bits_of_binary_float 23 8 eq_refl eq_refl eq_refl).
+unfold Bits.bits_of_binary_float.
+pose proof H0.
+apply Z.leb_le in H2. rewrite H2. clear H2.
+forget (Z.pos m - 2^23)  as i.
+unfold Binary.bounded in e0.
+rewrite andb_true_iff in e0.
+destruct e0 as [H' ?H].
+assert (-149 <= e). {
+ clear - H'.
+ unfold Binary.canonical_mantissa in H'.
+apply Zeq_bool_eq in H'.
+unfold FLT.FLT_exp in H'.
+rewrite Digits.Zpos_digits2_pos in H'.
+pose proof (Z.max_lub_r (Digits.Zdigits Zaux.radix2 (Z.pos m) + e - 24)
+      (3 - 128 - 24) e).
+spec H; lia.
+}
+clear H'.
+apply Z.leb_le in H2.
+simpl Z.sub.
+replace (e - -149 + 1) with (e+150) by lia.
+unfold Bits.join_bits.
+rewrite !Z.shiftl_mul_pow2 by lia.
+rewrite Z.add_0_l.
+set (e' := e+150).
+rewrite Z.mul_add_distr_r.
+rewrite <- Z.add_assoc.
+rewrite Z.add_mod by (compute; lia).
+replace (((if s then 2 ^ 8 else 0) * 2 ^ 23) mod 2 ^ 31)
+  with 0 by (destruct s; reflexivity).
+rewrite Z.add_0_l.
+rewrite Z.mod_mod by lia.
+rewrite (Z.mod_small); auto.
+subst e'.
+lia.
++
+replace (Bits.join_bits 23 8 s (Z.pos m) 0 mod 2 ^ 31)
+ with (Bits.join_bits 23 8 false (Z.pos m) 0).
+replace (Bits.join_bits 23 8 false (Z.pos m) 0)
+   with (Bits.bits_of_binary_float 23 8 (Binary.B754_finite 24 128 false m e e0)).
+apply (Bits.binary_float_of_bits_of_binary_float 23 8 eq_refl eq_refl eq_refl).
+unfold Bits.bits_of_binary_float.
+rewrite H0. auto.
+clear H0.
+unfold Bits.join_bits.
+rewrite Z.add_mod by (compute; lia).
+rewrite (Z.mod_small (Z.pos m)) by lia.
+rewrite !Z.add_0_r.
+replace (Z.shiftl (if s then 2 ^ 8 else 0) 23 mod 2 ^ 31) with 0 by (destruct s; reflexivity).
+simpl Z.shiftl.
+symmetry.
+apply Z.mod_small.
+lia.
+Qed.
+
+
 Lemma fabs_float32_lemma:
   forall x: float32,
   Float32.of_bits (Int.and (Float32.to_bits x) (Int.repr 2147483647)) =
   Float32.abs x.
 Proof.
-Admitted.  (* Provable in the Flocq theory, we hope *)
+intros.
+Transparent Float32.of_bits.
+Transparent Float32.to_bits.
+Transparent Float32.abs.
+unfold Float32.of_bits, Float32.to_bits, Float32.abs.
+Opaque Float32.of_bits.
+Opaque Float32.to_bits.
+Opaque Float32.abs.
+rewrite and_repr.
+change 2147483647 with (Z.ones 31).
+rewrite Z.land_ones by computable.
+rewrite Int.unsigned_repr
+ by (pose proof (Z_mod_lt (Bits.bits_of_b32 x) (2 ^ 31) (eq_refl _)); rep_lia).
+apply binary32_abs_lemma.
+Qed.
+
+End FABS_STUFF.
 
 Module Single.
 
@@ -118,7 +324,7 @@ forward.
 forward.
 entailer!.
 f_equal.
-apply fabs_float32_lemma.
+apply FABS_STUFF.fabs_float32_lemma.
 Qed.
 End Single.
 

--- a/sepcomp/Address.v
+++ b/sepcomp/Address.v
@@ -78,7 +78,7 @@ Proof.
   intros; generalize (size_chunk_pos ch); lia.
 Qed.
 
-Hint Resolve zero_in_chunk : mem.
+#[export] Hint Resolve zero_in_chunk : mem.
 
 Definition range_overlap (base1: address) (sz1: Z) (base2: address) (sz2: Z) : Prop :=
   exists loc, adr_range base1 sz1 loc /\ adr_range base2 sz2 loc.

--- a/sepcomp/event_semantics.v
+++ b/sepcomp/event_semantics.v
@@ -6,6 +6,7 @@ Require Import compcert.common.Memory.
 Require Import compcert.common.Events.
 Require Import compcert.common.AST.
 Require Import compcert.common.Globalenvs.
+Require Import Lia.
 
 Require Import VST.msl.Extensionality.
 Require Import VST.sepcomp.mem_lemmas.
@@ -87,7 +88,7 @@ induction T; simpl; intros.
      destruct (zlt ofs (ofs0 + Zlength bytes)); simpl in *; try discriminate.
      rewrite Zlength_correct in *.
      apply Mem.storebytes_range_perm in SB.
-     exploit (SB ofs); try omega.
+     exploit (SB ofs); try lia.
      intros; subst; assumption.
   - (*Load*)
      destruct H as [LB EV]. specialize (IHT _ _ EV); clear EV.
@@ -98,7 +99,7 @@ induction T; simpl; intros.
      destruct (zle ofs0 ofs); simpl in *; try discriminate.
      destruct (zlt ofs (ofs0 + n)); simpl in *; try discriminate.
      apply Mem.loadbytes_range_perm in LB.
-     exploit (LB ofs); try omega.
+     exploit (LB ofs); try lia.
      intros; subst; assumption.
   - (*Alloc*)
      destruct H as [m'' [ALLOC EV]]. specialize (IHT _ _ EV); clear EV.
@@ -124,7 +125,7 @@ induction T; simpl; intros.
          destruct (eq_block bb b); simpl in Heqd; inv Heqd.
          exploit (Heqp ofs); clear Heqp; trivial.
          destruct (zle lo ofs); try discriminate.
-         destruct (zlt ofs hi); try discriminate. omega. }
+         destruct (zlt ofs hi); try discriminate. lia. }
        { eapply po_trans; try eassumption. clear - Heqp.
          remember ((Mem.mem_access m0) !! b ofs Cur) as perm2.
          destruct perm2; try solve [apply po_None].
@@ -273,7 +274,7 @@ Proof. intros l FL. destruct FL as [[[? ?] ?] [? [? ?]]]; subst b0.
            ++ exploit freelist_mem_access_1. eassumption. eassumption. intros XX.
               exfalso. apply Mem.free_result in H. subst m0. simpl in XX.
               rewrite PMap.gss in XX. case_eq (zle z ofs && zlt ofs z0); intros; rewrite H in *; try discriminate.
-              destruct (zle z ofs); try omega; simpl  in *. destruct ( zlt ofs z0); try omega. inv H.
+              destruct (zle z ofs); try lia; simpl  in *. destruct ( zlt ofs z0); try lia. inv H.
            ++ split; trivial. eapply freelist_forward; eauto.
               exploit Mem.free_range_perm. eassumption. eassumption. intros.
               eapply Mem.valid_block_free_1; try eassumption. eapply Mem.perm_valid_block; eauto.
@@ -306,7 +307,7 @@ Proof.  induction ev; simpl; intros. subst; trivial.
         - destruct EV as [? [? EV]].
           apply (IHev _ _ EV); clear IHev EV.
           + Transparent Mem.alloc.
-            unfold Mem.alloc in H. Opaque Mem.alloc.  inv H. simpl. rewrite PMap.gso; trivial. unfold Mem.valid_block in VB. xomega.
+            unfold Mem.alloc in H. Opaque Mem.alloc.  inv H. simpl. rewrite PMap.gso; trivial. unfold Mem.valid_block in VB. apply Plt_ne; auto.
           + eapply Mem.valid_block_alloc; eauto.
         - destruct EV as [? [? EV]]. apply (IHev _ _ EV); clear IHev.
           2: eapply freelist_forward; eauto.
@@ -418,10 +419,10 @@ Proof. unfold in_free_list.
        - destruct (zle z ofs).
          * destruct (zlt ofs z0). -- left. exists (b, z, z0). split; eauto.
            -- right. intros [[[? ?] ?] [? [? ?]]]. subst b0.
-              destruct H. inv H. omega. apply n; clear n.
+              destruct H. inv H. lia. apply n; clear n.
               exists (b, z1, z2). split; eauto.
          * right. intros [[[? ?] ?] [? [? ?]]]. subst b0.
-           destruct H. inv H. omega. apply n; clear n.
+           destruct H. inv H. lia. apply n; clear n.
            exists (b, z1, z2). split; eauto.
        - right. intros [[[? ?] ?] [? [? ?]]]. subst b1.
          destruct H. inv H. congruence.
@@ -519,7 +520,7 @@ Proof.
     + destruct (zle lo ofs); simpl in *; try solve [right; trivial].
       destruct (zlt ofs hi); simpl in *; try solve [right; trivial].
       rewrite <- H; clear H.
-      assert (A: lo <= ofs < hi) by omega.
+      assert (A: lo <= ofs < hi) by lia.
       specialize (r _ A). unfold Mem.perm, Mem.perm_order' in r.
       remember ((Mem.mem_access m) !! bb ofs Cur) as q. destruct q; try contradiction.
       left; split; trivial. destruct p; simpl in *; trivial; inv r.
@@ -544,7 +545,7 @@ Proof.
       etransitivity.
       * eapply Mem.nextblock_alloc in H.
         instantiate(1:=  Mem.nextblock x); rewrite H.
-        xomega.
+        lia.
       * eapply IHev; eauto.
     + destruct H as (?&?&?).
       etransitivity.

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -71,7 +71,7 @@ Definition local:  (environ -> Prop) -> environ->mpred :=  lift1 prop.
 
 Global Opaque mpred Nveric Sveric Cveric Iveric Rveric Sveric SIveric CSLveric CIveric SRveric Bveric.
 
-Hint Resolve any_environ : typeclass_instances.
+#[export] Hint Resolve any_environ : typeclass_instances.
 
 Local Open Scope logic.
 
@@ -1304,7 +1304,7 @@ Global Opaque mpred Nveric Sveric Cveric Iveric Rveric Sveric SIveric SRveric Bv
    perhaps because one needs both "contractive" and "typeclass_instances"
    Hint databases if this next line is not added. *)
 Definition subp_sepcon_mpred := @subp_sepcon mpred Nveric Iveric Sveric SIveric Rveric SRveric.
-Hint Resolve subp_sepcon_mpred: contractive.
+#[export] Hint Resolve subp_sepcon_mpred: contractive.
 
 Fixpoint unfold_Ssequence c :=
   match c with

--- a/veric/align_mem.v
+++ b/veric/align_mem.v
@@ -354,10 +354,10 @@ Proof.
     eexists; reflexivity.
 Qed.
 
-Hint Resolve alignof_two_p: align.
-Hint Resolve align_chunk_two_p: align.
-Hint Extern 10 (exists n: nat, hardware_alignof _ _ = two_power_nat n) => (eapply hardware_alignof_two_p; eassumption): align.
-Hint Extern 10 (exists n: nat, hardware_alignof_composite _ _ = two_power_nat n) => (eapply hardware_alignof_composite_two_p; eassumption): align.
+#[export] Hint Resolve alignof_two_p: align.
+#[export] Hint Resolve align_chunk_two_p: align.
+#[export] Hint Extern 10 (exists n: nat, hardware_alignof _ _ = two_power_nat n) => (eapply hardware_alignof_two_p; eassumption): align.
+#[export] Hint Extern 10 (exists n: nat, hardware_alignof_composite _ _ = two_power_nat n) => (eapply hardware_alignof_composite_two_p; eassumption): align.
 
 Lemma hardware_alignof_by_value: forall ha_env t ch,
   access_mode t = By_value ch ->

--- a/veric/assert_lemmas.v
+++ b/veric/assert_lemmas.v
@@ -158,7 +158,7 @@ Qed.
    forall {A} `{ageable A} (P: pred A), P |-- !!(is_true Vtrue) && P.
   Proof.  intros. apply assert_truth. apply Val_is_true_Vtrue. Qed.
 
-Hint Resolve Val_is_true_Vtrue  @assert_Val_is_true : core.
+#[export] Hint Resolve Val_is_true_Vtrue  assert_Val_is_true : core.
 *)
 
 (****************** stuff moved from semax_prog  *****************)
@@ -327,7 +327,7 @@ Proof.
   apply corable_func_at.
 Qed.
 
-Hint Resolve corable_func_ptr corable_func_ptr_si (*corable_func_ptr_early*) : core.
+#[export] Hint Resolve corable_func_ptr corable_func_ptr_si (*corable_func_ptr_early*) : core.
 
 Lemma corable_funspecs_assert:
   forall FS rho, corable (funspecs_assert FS rho).
@@ -346,7 +346,7 @@ Proof.
 (* + apply corable_pureat.*)
 Qed.
 
-Hint Resolve corable_funspecs_assert : core.
+#[export] Hint Resolve corable_funspecs_assert : core.
 
 Lemma corable_jam: forall {B} {S': B -> Prop} (S: forall l, {S' l}+{~ S' l}) (P Q: B -> pred rmap),
     (forall loc, corable (P loc)) ->
@@ -377,7 +377,7 @@ apply corable_pureat.
 intro w. unfold TTat. apply prop_ext; split; intros; hnf in H|-*; auto.
 Qed.
 
-Hint Resolve corable_fun_assert : normalize.
+#[export] Hint Resolve corable_fun_assert : normalize.
 *)
 Lemma prop_derives {A}{H: ageable A}:
  forall (P Q: Prop), (P -> Q) -> prop P |-- prop Q.

--- a/veric/compcert_rmaps.v
+++ b/veric/compcert_rmaps.v
@@ -43,7 +43,7 @@ Definition isFUN (k: kind) := match k with | FUN _ _ => True | _ => False end.
 
 Lemma isVAL_i: forall v, isVAL (VAL v).
 Proof. intros; simpl; auto. Qed.
-Hint Resolve isVAL_i : core.
+#[export] Hint Resolve isVAL_i : core.
 
 Lemma isVAL_dec: forall k, {isVAL k}+{~isVAL k}.
 Proof.
@@ -822,7 +822,7 @@ unfold bytes_writable, bytes_readable; intros.
 apply writable_readable; auto.
 Qed.
 
-Hint Resolve bytes_writable_readable : mem.
+#[export] Hint Resolve bytes_writable_readable : mem.
 
 Lemma rmap_age_i:
  forall w w' : rmap,

--- a/veric/coqlib4.v
+++ b/veric/coqlib4.v
@@ -134,7 +134,7 @@ Hint Rewrite power_nat_divide_le using (auto with align): align.
 Hint Rewrite Z.mod_divide using (apply two_power_nat_0; auto with align): align.
 Hint Rewrite two_p_max_divide using (auto with align): align.
 Hint Rewrite two_p_max_1 using (auto with align): align.
-Hint Resolve Z_max_two_p: align.
+#[export] Hint Resolve Z_max_two_p: align.
 
 Lemma Z_of_nat_ge_O: forall n, Z.of_nat n >= 0.
 Proof. intros.

--- a/veric/mapsto_memory_block.v
+++ b/veric/mapsto_memory_block.v
@@ -881,6 +881,7 @@ Proof.
   pose proof Ptrofs.unsigned_range z.
   assert (Ptrofs.unsigned z + n < Ptrofs.modulus) by lia.
   apply pred_ext; normalize.
+   apply andp_left2; auto.
   apply andp_right; auto.
   intros ? _; simpl; auto.
 Qed.
@@ -1061,7 +1062,7 @@ Proof.
 unfold is_pointer_or_null, nullval.
 simple_if_tac; auto.
 Qed.
-Hint Resolve is_pointer_or_null_nullval : core.
+#[export] Hint Resolve is_pointer_or_null_nullval : core.
 
 Lemma tc_val_pointer_nullval':
  forall t a, tc_val (Tpointer t a) nullval.
@@ -1070,7 +1071,7 @@ Proof.
  simple_if_tac; hnf;
  simple_if_tac; auto.
 Qed.
-Hint Resolve tc_val_pointer_nullval' : core.
+#[export] Hint Resolve tc_val_pointer_nullval' : core.
 
 Arguments type_is_volatile ty / .
 
@@ -1123,7 +1124,7 @@ Proof.
  rewrite andb_false_r.
  hnf. simple_if_tac; auto.
 Qed.
-Hint Resolve tc_val_pointer_nullval : core.
+#[export] Hint Resolve tc_val_pointer_nullval : core.
 
 Lemma mapsto_tuint_tptr_nullval:
   forall sh p t, mapsto sh (Tpointer t noattr) p nullval = mapsto sh size_t p nullval.

--- a/veric/res_predicates.v
+++ b/veric/res_predicates.v
@@ -1527,7 +1527,7 @@ Proof.
    destruct loc, b; intros [? ?]; simpl in *; lia.
    apply ghost_of_identity; auto.
 Qed.
-Hint Resolve VALspec_range_0: normalize.
+#[export] Hint Resolve VALspec_range_0: normalize.
 
 Lemma nonlock_permission_bytes_0: forall sh a, nonlock_permission_bytes sh a 0 = emp.
 Proof.

--- a/veric/rmaps.v
+++ b/veric/rmaps.v
@@ -384,7 +384,7 @@ Module StratModel (AV' : ADR_VAL) : STRAT_MODEL with Module AV:=AV'.
   | ghost_join_nil_r m: ghost_join PRED m nil m
   | ghost_join_cons a1 a2 m1 m2 a3 m3: join a1 a2 a3 -> ghost_join PRED m1 m2 m3 ->
       ghost_join PRED (a1 :: m1) (a2 :: m2) (a3 :: m3).
-  Hint Constructors ghost_join : core.
+  Global Hint Constructors ghost_join : core.
   Existing Instance ghost_join.
 
   Lemma elem_join_inv: forall a1 a2 a3, ghost_elem_join a1 a2 a3 ->

--- a/veric/rmaps_lemmas.v
+++ b/veric/rmaps_lemmas.v
@@ -10,7 +10,7 @@ Module R := R0.
 Import R.
 
 Definition subp_sepcon_rmap := @subp_sepcon _ Join_rmap Perm_rmap Sep_rmap.
-Hint Resolve subp_sepcon_rmap : contractive.
+Global Hint Resolve subp_sepcon_rmap : contractive.
 
  Lemma approx_p  : forall (p:pred rmap) n w, approx n p w -> p w.
  Proof. unfold approx; simpl; intuition. Qed.

--- a/veric/semax_conj_disj.v
+++ b/veric/semax_conj_disj.v
@@ -17,7 +17,7 @@ Require Import VST.veric.Clight_lemmas.
 
 Open Local Scope pred.
 
-Hint Resolve @now_later @andp_derives @sepcon_derives.
+Hint Resolve now_later andp_derives sepcon_derives.
 
 (*
 Definition rmap_chain := {c: nat -> rmap | forall n, level (c n) = n /\ age (c (S n)) (c n)}.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -19,7 +19,7 @@ Import Ctypes.
 
 Local Open Scope pred.
 
-Hint Resolve @now_later @andp_derives @sepcon_derives : core.
+#[export] Hint Resolve now_later andp_derives sepcon_derives : core.
 
 Lemma no_dups_swap:
   forall F V a b c, @no_dups F V (a++b) c -> @no_dups F V (b++a) c.
@@ -117,7 +117,7 @@ Lemma age_laterR {A} `{ageable A}: forall {x y}, age x y -> laterR x y.
 Proof.
 intros. constructor 1; auto.
 Qed.
-Hint Resolve @age_laterR : core.
+Local Hint Resolve age_laterR : core.
 
 Lemma typecheck_environ_sub:
   forall Delta Delta', tycontext_sub Delta Delta' ->
@@ -648,7 +648,7 @@ Qed.
 
 End SemaxContext.
 
-Hint Resolve @age_laterR : core.
+#[export] Hint Resolve age_laterR : core.
 
 Fixpoint filter_seq (k: cont) : cont :=
  match k with

--- a/veric/shares.v
+++ b/veric/shares.v
@@ -232,7 +232,7 @@ apply identity_share_bot in Heqp.
 apply Share.nontrivial; auto.
 simpl in H; auto.
 Qed.
-Hint Resolve writable_readable : core.
+#[export] Hint Resolve writable_readable : core.
 
 Lemma top_pfullshare: forall psh, pshare_sh psh = Share.top -> psh = pfullshare.
 Proof.
@@ -299,14 +299,14 @@ unfold Share.Lsh, Share.Rsh, Tsh.
 destruct (Share.split Share.top) eqn:?. simpl.
 apply split_join; auto.
 Qed.
-Hint Resolve writable_share_top : core.
+#[export] Hint Resolve writable_share_top : core.
 
 Lemma writable_readable_share:
  forall sh, writable_share sh -> readable_share sh.
 Proof.
 apply writable_readable; auto.
 Qed.
-Hint Resolve writable_readable_share : core.
+#[export] Hint Resolve writable_readable_share : core.
 
 Definition extern_retainer := fst (Share.split Share.Lsh).
 
@@ -346,7 +346,7 @@ Proof.
   unfold writable_share.
 Abort.  (* Not true any more *)
 
-Hint Resolve writable_Ews : core.
+#[export] Hint Resolve writable_Ews : core.
 
 Definition Ers (* Extern read share *) := 
   Share.lub extern_retainer (fst (Share.split Share.Rsh)).
@@ -361,7 +361,7 @@ rewrite Share.glb_bot.
 apply bot_identity.
 Qed.
 
-Hint Resolve readable_nonidentity : core.
+#[export] Hint Resolve readable_nonidentity : core.
 
 Lemma sub_glb_bot:
   forall r a c : share,
@@ -1027,7 +1027,7 @@ Proof.
 intros.
 destruct H. auto.
 Qed.
-Hint Resolve writable_writable0 : core.
+#[export] Hint Resolve writable_writable0 : core.
 
 Lemma writable0_readable: forall sh,
   writable0_share sh -> readable_share sh.
@@ -1044,7 +1044,7 @@ destruct (Share.split Share.top) eqn:?. simpl in H0.
 apply split_nontrivial' in Heqp; auto.
 apply top_share_nonidentity in Heqp. auto.
 Qed.
-Hint Resolve writable0_readable : core.
+#[export] Hint Resolve writable0_readable : core.
 
 Lemma writable0_Rsh: writable0_share Share.Rsh.
 Proof.


### PR DESCRIPTION
Many deprecation warnings removed.  Most are about Hint locality, new in Coq 8.13.0, but some are others left over from Coq 8.12.

Not quite done yet; almost everything in msl/veric/floyd is done, and "make travis" builds, but I haven't #[export]-labelled the Hints in progs/, mailbox/, sha/, etc.,  and I haven't yet copied progs into progs64 and adjusted those.