### PR TITLE
Added several lemmas on pointers & an example and fixed Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ COQLIB=$(shell $(COQC) -where | tr -d '\r' | tr '\\' '/')
 
 # Check Coq version
 
-COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13.0
+COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13.0 or-else 8.13.1
 
 COQV=$(shell $(COQC) -v)
 ifneq ($(IGNORECOQVERSION),true)

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -1728,6 +1728,126 @@ destruct (Int.eq i Int.zero) eqn:?; inv H1.
 apply int_eq_e in Heqb. subst; reflexivity.
 Qed.
 
+Lemma true_Cne_neq: 
+  forall x y, 
+    typed_true tint (force_val (sem_cmp_pp Cne x y)) -> x <> y.
+Proof.
+  intros. hnf in H. destruct x, y; try inversion H.
+  - clear H1.
+    unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    destruct Archi.ptr64 eqn:Hp; simpl in H; 
+    destruct (Int64.eq i i0) eqn:?; simpl in H; try inversion H.
+    intro. 
+    inversion H0. subst i. pose proof (Int64.eq_spec i0 i0). 
+    rewrite Heqb in H1.
+    contradiction.
+  - intro. inversion H0.
+  - intro. inversion H0.
+  - unfold sem_cmp_pp in H. simpl in H.
+    destruct (eq_block b b0).
+    + destruct (Ptrofs.eq i i0) eqn:? .
+      * simpl in H. pose proof (Ptrofs.eq_spec i i0). rewrite Heqb1 in H0.
+        subst b i. inversion H.  
+      * intro. inversion H0.
+        subst i.
+        pose proof (Ptrofs.eq_spec i0 i0). rewrite Heqb1 in H2.
+        contradiction.  
+    + intro. inversion H0. subst b. contradiction.
+Qed.
+
+Lemma true_Ceq_eq: 
+  forall x y, 
+    typed_true tint (force_val (sem_cmp_pp Ceq x y)) -> x = y.
+Proof.
+  intros. hnf in H. destruct x, y; try inversion H.
+  - clear H1.
+    unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    destruct Archi.ptr64 eqn:Hp; simpl in H; 
+    destruct (Int64.eq i i0) eqn:?; simpl in H; try inversion H.
+    f_equal.
+    pose proof (Int64.eq_spec i i0).
+    rewrite Heqb in H0. auto.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    destruct Archi.ptr64 eqn:Hp; simpl in H;
+    destruct (Int64.eq i Int64.zero) eqn:?; simpl in H; try inversion H.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    destruct Archi.ptr64 eqn:Hp; simpl in H;
+    destruct (Int64.eq i0 Int64.zero) eqn:?; simpl in H; try inversion H.
+  - unfold sem_cmp_pp in H. simpl in H.
+    destruct (eq_block b b0) eqn:E.
+    + subst b. 
+      destruct (Ptrofs.eq i i0) eqn:E'.
+      * pose proof (Ptrofs.eq_spec i i0). rewrite E' in H0. subst i.
+        reflexivity.
+      * simpl in H. inversion H.
+    + simpl in H. inversion H.
+Qed.
+
+Lemma false_Cne_neq: 
+  forall x y, 
+    typed_false tint (force_val (sem_cmp_pp Cne x y)) -> x = y.
+Proof.
+  intros. hnf in H. destruct x, y; try inversion H. 
+  - clear H1.
+    unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    destruct Archi.ptr64 eqn:Hp; simpl in H; 
+    destruct (Int64.eq i i0) eqn:?; simpl in H; try inversion H.
+    f_equal.
+    pose proof (Int64.eq_spec i i0).
+    rewrite Heqb in H0. auto.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    destruct Archi.ptr64 eqn:Hp; simpl in H;
+    destruct (Int64.eq i Int64.zero) eqn:?; simpl in H; try inversion H.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    destruct Archi.ptr64 eqn:Hp; simpl in H;
+    destruct (Int64.eq i0 Int64.zero) eqn:?; simpl in H; try inversion H.
+  - unfold sem_cmp_pp in H. simpl in H.
+    destruct (eq_block b b0).
+    + destruct (Ptrofs.eq i i0) eqn:? .
+      * simpl in H. pose proof (Ptrofs.eq_spec i i0). rewrite Heqb1 in H0.
+        subst b i. reflexivity.  
+      * simpl in H. inversion H.
+    + simpl in H. inversion H.
+Qed.
+
+Lemma false_Ceq_eq: 
+  forall x y, 
+    typed_false tint (force_val (sem_cmp_pp Ceq x y)) -> x <> y.
+Proof.
+  intros. hnf in H. destruct x, y; try inversion H.
+  - clear H1.
+    unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    destruct Archi.ptr64 eqn:Hp; simpl in H; 
+    destruct (Int64.eq i i0) eqn:?; simpl in H; try inversion H.
+    intro. 
+    inversion H0. subst i. pose proof (Int64.eq_spec i0 i0). 
+    rewrite Heqb in H1.
+    contradiction.
+  - intro. inversion H0.
+  - intro. inversion H0.
+  - unfold sem_cmp_pp in H. simpl in H.
+    destruct (eq_block b b0).
+    + destruct (Ptrofs.eq i i0) eqn:? .
+      * simpl in H. pose proof (Ptrofs.eq_spec i i0). rewrite Heqb1 in H0.
+        subst b i. inversion H.
+      * intro. inversion H0. subst b i. pose proof (Ptrofs.eq_spec i0 i0). 
+        rewrite Heqb1 in H2. contradiction.
+    + intro. inversion H0. contradiction. 
+Qed.
+
+Ltac pointer_destructor :=
+  repeat match goal with
+  | x : typed_false tint (force_val (sem_cmp_pp Ceq ?Y ?Z)) |- _  =>
+    try apply false_Ceq_eq in x; try contradiction
+  | x : typed_true tint (force_val (sem_cmp_pp Ceq ?Y ?Z)) |- _ =>
+    try apply true_Ceq_eq in x; try subst Y; try (assert_PROP False; entailer!)
+  | x : typed_true tint (force_val (sem_cmp_pp Cne ?Y ?Z)) |- _ =>
+    try apply true_Cne_neq in x; try contradiction
+  | x : typed_false tint (force_val (sem_cmp_pp Cne ?Y ?Z)) |- _ =>
+    try apply false_Cne_neq in x; try subst Y; try (assert_PROP False; entailer!)
+  | _   => idtac
+  end.
+
 Ltac cleanup_repr H :=
 rewrite ?mul_repr, ?add_repr, ?sub_repr in H;
 match type of H with
@@ -2614,7 +2734,7 @@ match goal with
        try rewrite Int.signed_repr in HRE by rep_lia;
        repeat apply -> semax_skip_seq;
        abbreviate_semax
-     ]
+     ]; pointer_destructor   (* add it here *)
 | |- semax ?Delta (PROPx ?P (LOCALx ?Q (SEPx ?R))) (Ssequence (Sifthenelse ?e ?c1 ?c2) _) _ =>
     tryif (unify (orb (quickflow c1 nofallthrough) (quickflow c2 nofallthrough)) true)
     then (apply semax_if_seq; forward_if'_new)

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -1853,16 +1853,16 @@ Proof.
     + intro. inversion H0. contradiction. 
 Qed.
 
-Ltac pointer_destructor :=
-  repeat match goal with
-  | x : typed_false tint (force_val (sem_cmp_pp Ceq ?Y ?Z)) |- _  =>
-    try apply false_Ceq_eq in x; try contradiction
-  | x : typed_true tint (force_val (sem_cmp_pp Ceq ?Y ?Z)) |- _ =>
-    try apply true_Ceq_eq in x; try subst Y; try (assert_PROP False; entailer!)
-  | x : typed_true tint (force_val (sem_cmp_pp Cne ?Y ?Z)) |- _ =>
-    try apply true_Cne_neq in x; try contradiction
-  | x : typed_false tint (force_val (sem_cmp_pp Cne ?Y ?Z)) |- _ =>
-    try apply false_Cne_neq in x; try subst Y; try (assert_PROP False; entailer!)
+Ltac pointer_destructor H :=
+  repeat match type of H with
+  | typed_false tint (force_val (sem_cmp_pp Ceq ?Y ?Z)) =>
+    try apply false_Ceq_eq in H; try contradiction
+  | typed_true tint (force_val (sem_cmp_pp Ceq ?Y ?Z)) =>
+    try apply true_Ceq_eq in H; try subst Y; try (assert_PROP False; entailer!)
+  | typed_true tint (force_val (sem_cmp_pp Cne ?Y ?Z)) =>
+    try apply true_Cne_neq in H; try contradiction
+  | typed_false tint (force_val (sem_cmp_pp Cne ?Y ?Z)) =>
+    try apply false_Cne_neq in H; try subst Y; try (assert_PROP False; entailer!)
   | _   => idtac
   end.
 
@@ -2072,7 +2072,8 @@ Ltac do_repr_inj H :=
          ];
     rewrite ?Byte_signed_lem, ?Byte_signed_lem',
                  ?int_repr_byte_signed_eq0, ?int_repr_byte_signed_eq0
-      in H.
+      in H; 
+      pointer_destructor H.
 
 Ltac simpl_fst_snd :=
 repeat match goal with
@@ -2752,7 +2753,7 @@ match goal with
        try rewrite Int.signed_repr in HRE by rep_lia;
        repeat apply -> semax_skip_seq;
        abbreviate_semax
-     ]; pointer_destructor   (* add it here *)
+     ]
 | |- semax ?Delta (PROPx ?P (LOCALx ?Q (SEPx ?R))) (Ssequence (Sifthenelse ?e ?c1 ?c2) _) _ =>
     tryif (unify (orb (quickflow c1 nofallthrough) (quickflow c2 nofallthrough)) true)
     then (apply semax_if_seq; forward_if'_new)

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -2005,13 +2005,17 @@ Ltac do_repr_inj H :=
          | simple apply repr_inj_unsigned' in H; [ | rep_lia | rep_lia ]
          | match type of H with
             | typed_true _  (force_val (sem_cmp_pp Ceq _ _)) =>
-                                    apply typed_true_Ceq_eq in H
+                                    try apply typed_true_nullptr3 in H;
+                                    try apply typed_true_Ceq_eq in H
             | typed_true _  (force_val (sem_cmp_pp Cne _ _)) =>
-                                    apply typed_true_Cne_neq in H
+                                    try apply typed_true_nullptr4 in H;
+                                    try apply typed_true_Cne_neq in H
             | typed_false _  (force_val (sem_cmp_pp Ceq _ _)) =>
-                                    apply typed_false_Ceq_neq in H
+                                    try apply typed_false_nullptr3 in H;
+                                    try apply typed_false_Ceq_neq in H
             | typed_false _  (force_val (sem_cmp_pp Cne _ _)) =>
-                                    apply typed_false_Cne_eq in H
+                                    try apply typed_false_nullptr4 in H;
+                                    try apply typed_false_Cne_eq in H
           end
          | apply typed_false_nullptr4 in H
          | simple apply ltu_repr in H; [ | rep_lia | rep_lia]

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -1733,14 +1733,17 @@ Lemma true_Cne_neq:
     typed_true tint (force_val (sem_cmp_pp Cne x y)) -> x <> y.
 Proof.
   intros. hnf in H. destruct x, y; try inversion H.
-  - clear H1.
-    unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
     destruct Archi.ptr64 eqn:Hp; simpl in H; 
-    destruct (Int64.eq i i0) eqn:?; simpl in H; try inversion H.
+    try destruct (Int64.eq i i0) eqn:?;
+    try destruct (Int.eq i i0) eqn:?;
+    simpl in H; try inversion H.
     intro. 
-    inversion H0. subst i. pose proof (Int64.eq_spec i0 i0). 
-    rewrite Heqb in H1.
-    contradiction.
+    inversion H0. subst i. 
+    try pose proof (Int64.eq_spec i0 i0). 
+    try pose proof (Int.eq_spec i0 i0). 
+    rewrite Heqb in *.
+    contradiction. 
   - intro. inversion H0.
   - intro. inversion H0.
   - unfold sem_cmp_pp in H. simpl in H.
@@ -1760,19 +1763,25 @@ Lemma true_Ceq_eq:
     typed_true tint (force_val (sem_cmp_pp Ceq x y)) -> x = y.
 Proof.
   intros. hnf in H. destruct x, y; try inversion H.
-  - clear H1.
-    unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H;
     destruct Archi.ptr64 eqn:Hp; simpl in H; 
-    destruct (Int64.eq i i0) eqn:?; simpl in H; try inversion H.
+    try destruct (Int64.eq i i0) eqn:?; 
+    try destruct (Int.eq i i0) eqn:?; 
+    simpl in H; try inversion H.
     f_equal.
-    pose proof (Int64.eq_spec i i0).
-    rewrite Heqb in H0. auto.
-  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    try pose proof (Int64.eq_spec i i0).
+    try pose proof (Int.eq_spec i i0).
+    rewrite Heqb in *. auto.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H;
     destruct Archi.ptr64 eqn:Hp; simpl in H;
-    destruct (Int64.eq i Int64.zero) eqn:?; simpl in H; try inversion H.
-  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    try destruct (Int64.eq i Int64.zero) eqn:?; 
+    try destruct (Int.eq i Int.zero) eqn:?; 
+    simpl in H; try inversion H.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H;
     destruct Archi.ptr64 eqn:Hp; simpl in H;
-    destruct (Int64.eq i0 Int64.zero) eqn:?; simpl in H; try inversion H.
+    try destruct (Int64.eq i0 Int64.zero) eqn:?; 
+    try destruct (Int.eq i0 Int.zero) eqn:?; 
+    simpl in H; try inversion H.
   - unfold sem_cmp_pp in H. simpl in H.
     destruct (eq_block b b0) eqn:E.
     + subst b. 
@@ -1787,20 +1796,26 @@ Lemma false_Cne_neq:
   forall x y, 
     typed_false tint (force_val (sem_cmp_pp Cne x y)) -> x = y.
 Proof.
-  intros. hnf in H. destruct x, y; try inversion H. 
-  - clear H1.
-    unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+  intros. hnf in H. destruct x, y; try inversion H.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H;
     destruct Archi.ptr64 eqn:Hp; simpl in H; 
-    destruct (Int64.eq i i0) eqn:?; simpl in H; try inversion H.
+    try destruct (Int64.eq i i0) eqn:?; 
+    try destruct (Int.eq i i0) eqn:?; 
+    simpl in H; try inversion H.
     f_equal.
-    pose proof (Int64.eq_spec i i0).
-    rewrite Heqb in H0. auto.
-  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    try pose proof (Int64.eq_spec i i0).
+    try pose proof (Int.eq_spec i i0).
+    rewrite Heqb in *. auto.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H;
     destruct Archi.ptr64 eqn:Hp; simpl in H;
-    destruct (Int64.eq i Int64.zero) eqn:?; simpl in H; try inversion H.
-  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+    try destruct (Int64.eq i Int64.zero) eqn:?; 
+    try destruct (Int.eq i Int.zero) eqn:?; 
+    simpl in H; try inversion H.
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H;
     destruct Archi.ptr64 eqn:Hp; simpl in H;
-    destruct (Int64.eq i0 Int64.zero) eqn:?; simpl in H; try inversion H.
+    try destruct (Int64.eq i0 Int64.zero) eqn:?; 
+    try destruct (Int.eq i0 Int.zero) eqn:?; 
+    simpl in H; try inversion H.
   - unfold sem_cmp_pp in H. simpl in H.
     destruct (eq_block b b0).
     + destruct (Ptrofs.eq i i0) eqn:? .
@@ -1814,15 +1829,18 @@ Lemma false_Ceq_eq:
   forall x y, 
     typed_false tint (force_val (sem_cmp_pp Ceq x y)) -> x <> y.
 Proof.
-  intros. hnf in H. destruct x, y; try inversion H.
-  - clear H1.
-    unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
+  intros. hnf in H. destruct x, y; try inversion H. 
+  - unfold sem_cmp_pp, strict_bool_val, Val.cmplu_bool, Val.cmpu_bool in H.
     destruct Archi.ptr64 eqn:Hp; simpl in H; 
-    destruct (Int64.eq i i0) eqn:?; simpl in H; try inversion H.
+    try destruct (Int64.eq i i0) eqn:?;
+    try destruct (Int.eq i i0) eqn:?;
+    simpl in H; try inversion H.
     intro. 
-    inversion H0. subst i. pose proof (Int64.eq_spec i0 i0). 
-    rewrite Heqb in H1.
-    contradiction.
+    inversion H0. subst i. 
+    try pose proof (Int64.eq_spec i0 i0). 
+    try pose proof (Int.eq_spec i0 i0). 
+    rewrite Heqb in *.
+    contradiction. 
   - intro. inversion H0.
   - intro. inversion H0.
   - unfold sem_cmp_pp in H. simpl in H.

--- a/progs64/ptr_cmp.c
+++ b/progs64/ptr_cmp.c
@@ -1,0 +1,14 @@
+#include <stddef.h>
+
+struct tree {
+    unsigned int k;
+    struct tree *left, *right;
+};
+
+int get_branch (struct tree * p, struct tree * p_fa){
+    if (p == p_fa->left){
+        return 1;
+    } else {
+        return 0;
+    }
+}

--- a/progs64/ptr_cmp.v
+++ b/progs64/ptr_cmp.v
@@ -1,0 +1,387 @@
+From Coq Require Import String List ZArith.
+From compcert Require Import Coqlib Integers Floats AST Ctypes Cop Clight Clightdefs.
+Local Open Scope Z_scope.
+Local Open Scope string_scope.
+
+Module Info.
+  Definition version := "3.8".
+  Definition build_number := "".
+  Definition build_tag := "".
+  Definition build_branch := "".
+  Definition arch := "x86".
+  Definition model := "32sse2".
+  Definition abi := "standard".
+  Definition bitsize := 64.
+  Definition big_endian := false.
+  Definition source_file := "progs64/ptr_cmp.c".
+  Definition normalized := true.
+End Info.
+
+Definition ___builtin_annot : ident := $"__builtin_annot".
+Definition ___builtin_annot_intval : ident := $"__builtin_annot_intval".
+Definition ___builtin_bswap : ident := $"__builtin_bswap".
+Definition ___builtin_bswap16 : ident := $"__builtin_bswap16".
+Definition ___builtin_bswap32 : ident := $"__builtin_bswap32".
+Definition ___builtin_bswap64 : ident := $"__builtin_bswap64".
+Definition ___builtin_clz : ident := $"__builtin_clz".
+Definition ___builtin_clzl : ident := $"__builtin_clzl".
+Definition ___builtin_clzll : ident := $"__builtin_clzll".
+Definition ___builtin_ctz : ident := $"__builtin_ctz".
+Definition ___builtin_ctzl : ident := $"__builtin_ctzl".
+Definition ___builtin_ctzll : ident := $"__builtin_ctzll".
+Definition ___builtin_debug : ident := $"__builtin_debug".
+Definition ___builtin_fabs : ident := $"__builtin_fabs".
+Definition ___builtin_fabsf : ident := $"__builtin_fabsf".
+Definition ___builtin_fmadd : ident := $"__builtin_fmadd".
+Definition ___builtin_fmax : ident := $"__builtin_fmax".
+Definition ___builtin_fmin : ident := $"__builtin_fmin".
+Definition ___builtin_fmsub : ident := $"__builtin_fmsub".
+Definition ___builtin_fnmadd : ident := $"__builtin_fnmadd".
+Definition ___builtin_fnmsub : ident := $"__builtin_fnmsub".
+Definition ___builtin_fsqrt : ident := $"__builtin_fsqrt".
+Definition ___builtin_membar : ident := $"__builtin_membar".
+Definition ___builtin_memcpy_aligned : ident := $"__builtin_memcpy_aligned".
+Definition ___builtin_read16_reversed : ident := $"__builtin_read16_reversed".
+Definition ___builtin_read32_reversed : ident := $"__builtin_read32_reversed".
+Definition ___builtin_sel : ident := $"__builtin_sel".
+Definition ___builtin_sqrt : ident := $"__builtin_sqrt".
+Definition ___builtin_va_arg : ident := $"__builtin_va_arg".
+Definition ___builtin_va_copy : ident := $"__builtin_va_copy".
+Definition ___builtin_va_end : ident := $"__builtin_va_end".
+Definition ___builtin_va_start : ident := $"__builtin_va_start".
+Definition ___builtin_write16_reversed : ident := $"__builtin_write16_reversed".
+Definition ___builtin_write32_reversed : ident := $"__builtin_write32_reversed".
+Definition ___compcert_i64_dtos : ident := $"__compcert_i64_dtos".
+Definition ___compcert_i64_dtou : ident := $"__compcert_i64_dtou".
+Definition ___compcert_i64_sar : ident := $"__compcert_i64_sar".
+Definition ___compcert_i64_sdiv : ident := $"__compcert_i64_sdiv".
+Definition ___compcert_i64_shl : ident := $"__compcert_i64_shl".
+Definition ___compcert_i64_shr : ident := $"__compcert_i64_shr".
+Definition ___compcert_i64_smod : ident := $"__compcert_i64_smod".
+Definition ___compcert_i64_smulh : ident := $"__compcert_i64_smulh".
+Definition ___compcert_i64_stod : ident := $"__compcert_i64_stod".
+Definition ___compcert_i64_stof : ident := $"__compcert_i64_stof".
+Definition ___compcert_i64_udiv : ident := $"__compcert_i64_udiv".
+Definition ___compcert_i64_umod : ident := $"__compcert_i64_umod".
+Definition ___compcert_i64_umulh : ident := $"__compcert_i64_umulh".
+Definition ___compcert_i64_utod : ident := $"__compcert_i64_utod".
+Definition ___compcert_i64_utof : ident := $"__compcert_i64_utof".
+Definition ___compcert_va_composite : ident := $"__compcert_va_composite".
+Definition ___compcert_va_float64 : ident := $"__compcert_va_float64".
+Definition ___compcert_va_int32 : ident := $"__compcert_va_int32".
+Definition ___compcert_va_int64 : ident := $"__compcert_va_int64".
+Definition _get_branch : ident := $"get_branch".
+Definition _k : ident := $"k".
+Definition _left : ident := $"left".
+Definition _main : ident := $"main".
+Definition _p : ident := $"p".
+Definition _p_fa : ident := $"p_fa".
+Definition _right : ident := $"right".
+Definition _tree : ident := $"tree".
+Definition _t'1 : ident := 128%positive.
+
+Definition f_get_branch := {|
+  fn_return := tint;
+  fn_callconv := cc_default;
+  fn_params := ((_p, (tptr (Tstruct _tree noattr))) ::
+                (_p_fa, (tptr (Tstruct _tree noattr))) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_t'1, (tptr (Tstruct _tree noattr))) :: nil);
+  fn_body :=
+(Ssequence
+  (Sset _t'1
+    (Efield
+      (Ederef (Etempvar _p_fa (tptr (Tstruct _tree noattr)))
+        (Tstruct _tree noattr)) _left (tptr (Tstruct _tree noattr))))
+  (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr (Tstruct _tree noattr)))
+                 (Etempvar _t'1 (tptr (Tstruct _tree noattr))) tint)
+    (Sreturn (Some (Econst_int (Int.repr 1) tint)))
+    (Sreturn (Some (Econst_int (Int.repr 0) tint)))))
+|}.
+
+Definition composites : list composite_definition :=
+(Composite _tree Struct
+   ((_k, tuint) :: (_left, (tptr (Tstruct _tree noattr))) ::
+    (_right, (tptr (Tstruct _tree noattr))) :: nil)
+   noattr :: nil).
+
+Definition global_definitions : list (ident * globdef fundef type) :=
+((___builtin_bswap64,
+   Gfun(External (EF_builtin "__builtin_bswap64"
+                   (mksignature (AST.Tlong :: nil) AST.Tlong cc_default))
+     (Tcons tulong Tnil) tulong cc_default)) ::
+ (___builtin_bswap,
+   Gfun(External (EF_builtin "__builtin_bswap"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap32,
+   Gfun(External (EF_builtin "__builtin_bswap32"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap16,
+   Gfun(External (EF_builtin "__builtin_bswap16"
+                   (mksignature (AST.Tint :: nil) AST.Tint16unsigned
+                     cc_default)) (Tcons tushort Tnil) tushort cc_default)) ::
+ (___builtin_clz,
+   Gfun(External (EF_builtin "__builtin_clz"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzl,
+   Gfun(External (EF_builtin "__builtin_clzl"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzll,
+   Gfun(External (EF_builtin "__builtin_clzll"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_ctz,
+   Gfun(External (EF_builtin "__builtin_ctz"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzl,
+   Gfun(External (EF_builtin "__builtin_ctzl"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzll,
+   Gfun(External (EF_builtin "__builtin_ctzll"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_fabs,
+   Gfun(External (EF_builtin "__builtin_fabs"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_fabsf,
+   Gfun(External (EF_builtin "__builtin_fabsf"
+                   (mksignature (AST.Tsingle :: nil) AST.Tsingle cc_default))
+     (Tcons tfloat Tnil) tfloat cc_default)) ::
+ (___builtin_fsqrt,
+   Gfun(External (EF_builtin "__builtin_fsqrt"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_sqrt,
+   Gfun(External (EF_builtin "__builtin_sqrt"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_memcpy_aligned,
+   Gfun(External (EF_builtin "__builtin_memcpy_aligned"
+                   (mksignature
+                     (AST.Tlong :: AST.Tlong :: AST.Tint :: AST.Tint :: nil)
+                     AST.Tvoid cc_default))
+     (Tcons (tptr tvoid)
+       (Tcons (tptr tvoid) (Tcons tuint (Tcons tuint Tnil)))) tvoid
+     cc_default)) ::
+ (___builtin_sel,
+   Gfun(External (EF_builtin "__builtin_sel"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tbool Tnil) tvoid
+     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot,
+   Gfun(External (EF_builtin "__builtin_annot"
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid
+                     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot_intval,
+   Gfun(External (EF_builtin "__builtin_annot_intval"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons (tptr tschar) (Tcons tint Tnil))
+     tint cc_default)) ::
+ (___builtin_membar,
+   Gfun(External (EF_builtin "__builtin_membar"
+                   (mksignature nil AST.Tvoid cc_default)) Tnil tvoid
+     cc_default)) ::
+ (___builtin_va_start,
+   Gfun(External (EF_builtin "__builtin_va_start"
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___builtin_va_arg,
+   Gfun(External (EF_builtin "__builtin_va_arg"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_va_copy,
+   Gfun(External (EF_builtin "__builtin_va_copy"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tvoid
+                     cc_default))
+     (Tcons (tptr tvoid) (Tcons (tptr tvoid) Tnil)) tvoid cc_default)) ::
+ (___builtin_va_end,
+   Gfun(External (EF_builtin "__builtin_va_end"
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___compcert_va_int32,
+   Gfun(External (EF_external "__compcert_va_int32"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons (tptr tvoid) Tnil) tuint cc_default)) ::
+ (___compcert_va_int64,
+   Gfun(External (EF_external "__compcert_va_int64"
+                   (mksignature (AST.Tlong :: nil) AST.Tlong cc_default))
+     (Tcons (tptr tvoid) Tnil) tulong cc_default)) ::
+ (___compcert_va_float64,
+   Gfun(External (EF_external "__compcert_va_float64"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons (tptr tvoid) Tnil) tdouble cc_default)) ::
+ (___compcert_va_composite,
+   Gfun(External (EF_external "__compcert_va_composite"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     (tptr tvoid) cc_default)) ::
+ (___compcert_i64_dtos,
+   Gfun(External (EF_runtime "__compcert_i64_dtos"
+                   (mksignature (AST.Tfloat :: nil) AST.Tlong cc_default))
+     (Tcons tdouble Tnil) tlong cc_default)) ::
+ (___compcert_i64_dtou,
+   Gfun(External (EF_runtime "__compcert_i64_dtou"
+                   (mksignature (AST.Tfloat :: nil) AST.Tlong cc_default))
+     (Tcons tdouble Tnil) tulong cc_default)) ::
+ (___compcert_i64_stod,
+   Gfun(External (EF_runtime "__compcert_i64_stod"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons tlong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_utod,
+   Gfun(External (EF_runtime "__compcert_i64_utod"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons tulong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_stof,
+   Gfun(External (EF_runtime "__compcert_i64_stof"
+                   (mksignature (AST.Tlong :: nil) AST.Tsingle cc_default))
+     (Tcons tlong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_utof,
+   Gfun(External (EF_runtime "__compcert_i64_utof"
+                   (mksignature (AST.Tlong :: nil) AST.Tsingle cc_default))
+     (Tcons tulong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_sdiv,
+   Gfun(External (EF_runtime "__compcert_i64_sdiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_udiv,
+   Gfun(External (EF_runtime "__compcert_i64_udiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_smod,
+   Gfun(External (EF_runtime "__compcert_i64_smod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_umod,
+   Gfun(External (EF_runtime "__compcert_i64_umod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_shl,
+   Gfun(External (EF_runtime "__compcert_i64_shl"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tint Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_shr,
+   Gfun(External (EF_runtime "__compcert_i64_shr"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tint Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_sar,
+   Gfun(External (EF_runtime "__compcert_i64_sar"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tint Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_smulh,
+   Gfun(External (EF_runtime "__compcert_i64_smulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_umulh,
+   Gfun(External (EF_runtime "__compcert_i64_umulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___builtin_fmax,
+   Gfun(External (EF_builtin "__builtin_fmax"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil) AST.Tfloat
+                     cc_default)) (Tcons tdouble (Tcons tdouble Tnil))
+     tdouble cc_default)) ::
+ (___builtin_fmin,
+   Gfun(External (EF_builtin "__builtin_fmin"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil) AST.Tfloat
+                     cc_default)) (Tcons tdouble (Tcons tdouble Tnil))
+     tdouble cc_default)) ::
+ (___builtin_fmadd,
+   Gfun(External (EF_builtin "__builtin_fmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fmsub,
+   Gfun(External (EF_builtin "__builtin_fmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmadd,
+   Gfun(External (EF_builtin "__builtin_fnmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmsub,
+   Gfun(External (EF_builtin "__builtin_fnmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_read16_reversed,
+   Gfun(External (EF_builtin "__builtin_read16_reversed"
+                   (mksignature (AST.Tlong :: nil) AST.Tint16unsigned
+                     cc_default)) (Tcons (tptr tushort) Tnil) tushort
+     cc_default)) ::
+ (___builtin_read32_reversed,
+   Gfun(External (EF_builtin "__builtin_read32_reversed"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons (tptr tuint) Tnil) tuint cc_default)) ::
+ (___builtin_write16_reversed,
+   Gfun(External (EF_builtin "__builtin_write16_reversed"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tushort) (Tcons tushort Tnil))
+     tvoid cc_default)) ::
+ (___builtin_write32_reversed,
+   Gfun(External (EF_builtin "__builtin_write32_reversed"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tuint) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_debug,
+   Gfun(External (EF_external "__builtin_debug"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tint Tnil) tvoid
+     {|cc_vararg:=true; cc_unproto:=false; cc_structret:=false|})) ::
+ (_get_branch, Gfun(Internal f_get_branch)) :: nil).
+
+Definition public_idents : list ident :=
+(_get_branch :: ___builtin_debug :: ___builtin_write32_reversed ::
+ ___builtin_write16_reversed :: ___builtin_read32_reversed ::
+ ___builtin_read16_reversed :: ___builtin_fnmsub :: ___builtin_fnmadd ::
+ ___builtin_fmsub :: ___builtin_fmadd :: ___builtin_fmin ::
+ ___builtin_fmax :: ___compcert_i64_umulh :: ___compcert_i64_smulh ::
+ ___compcert_i64_sar :: ___compcert_i64_shr :: ___compcert_i64_shl ::
+ ___compcert_i64_umod :: ___compcert_i64_smod :: ___compcert_i64_udiv ::
+ ___compcert_i64_sdiv :: ___compcert_i64_utof :: ___compcert_i64_stof ::
+ ___compcert_i64_utod :: ___compcert_i64_stod :: ___compcert_i64_dtou ::
+ ___compcert_i64_dtos :: ___compcert_va_composite ::
+ ___compcert_va_float64 :: ___compcert_va_int64 :: ___compcert_va_int32 ::
+ ___builtin_va_end :: ___builtin_va_copy :: ___builtin_va_arg ::
+ ___builtin_va_start :: ___builtin_membar :: ___builtin_annot_intval ::
+ ___builtin_annot :: ___builtin_sel :: ___builtin_memcpy_aligned ::
+ ___builtin_sqrt :: ___builtin_fsqrt :: ___builtin_fabsf ::
+ ___builtin_fabs :: ___builtin_ctzll :: ___builtin_ctzl :: ___builtin_ctz ::
+ ___builtin_clzll :: ___builtin_clzl :: ___builtin_clz ::
+ ___builtin_bswap16 :: ___builtin_bswap32 :: ___builtin_bswap ::
+ ___builtin_bswap64 :: nil).
+
+Definition prog : Clight.program := 
+  mkprogram composites global_definitions public_idents _main Logic.I.
+
+

--- a/progs64/verif_ptr_cmp.v
+++ b/progs64/verif_ptr_cmp.v
@@ -1,0 +1,201 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.progs64.ptr_cmp.
+
+Instance CompSpecs : compspecs. make_compspecs prog. Defined.
+Definition Vprog : varspecs. mk_varspecs prog. Defined.
+
+Definition t_struct_tree := Tstruct _tree noattr.
+
+(** Some useful lemmas about comparing two pointers. 
+    Now these lemmas has been defined in VST/floyd/forward.v. *)
+
+Inductive Tree : Type :=
+  | E
+  | T (k: Z) (lch: Tree) (rch: Tree).
+
+(** Representation of trees in memory. *)
+Fixpoint tree_rep (t: Tree) (p p_lch p_rch: val): mpred :=
+  match t with
+  | T k lch rch   =>
+    EX p_lch_l: val, EX p_lch_r: val, 
+    EX p_rch_l: val, EX p_rch_r: val, 
+    data_at Tsh t_struct_tree 
+      (Vint (Int.repr k), (p_lch, p_rch)) p
+    * tree_rep lch p_lch p_lch_l p_lch_r 
+    * tree_rep rch p_rch p_rch_l p_rch_r 
+  | E => !! (p = nullval) && emp 
+  end.
+
+(** Representation of the parent-child relationship. *)
+Definition fa_rep (d: bool) (t: Tree) (p_ch p_fa: val) : mpred :=
+  match d with
+  | true    => 
+    EX p_oppo: val, tree_rep t p_fa p_ch p_oppo
+  | false   =>
+    EX p_oppo: val, tree_rep t p_fa p_oppo p_ch
+  end.
+
+(** Some basic lemmas. *)
+Lemma tree_rep_saturate_local:
+   forall t p p_lch p_rch, tree_rep t p p_lch p_rch |-- !! is_pointer_or_null p.
+Proof.
+  destruct t; simpl; intros.
+  entailer!.
+  Intros p_lch_l p_lch_r p_rch_l p_rch_r. entailer!.
+Qed.
+#[export] Hint Resolve tree_rep_saturate_local: saturate_local.
+
+Lemma tree_rep_valid_pointer:
+  forall t p p_lch p_rch, tree_rep t p p_lch p_rch |-- valid_pointer p.
+Proof.
+  intros.
+  destruct t. 
+  - simpl. entailer!. 
+  - simpl; normalize; auto with valid_pointer.
+Qed.
+#[export] Hint Resolve tree_rep_valid_pointer: valid_pointer.
+
+Definition bool2int (d: bool) : Z :=
+  match d with
+  | true    => 1
+  | false   => 0
+  end.
+
+(** Define the specification. *)
+Definition get_branch_spec :=
+ DECLARE _get_branch
+  WITH t: Tree, d: bool, p_fa: val, p: val
+  PRE  [ tptr t_struct_tree, tptr t_struct_tree ]
+    PROP (p_fa <> nullval; p <> nullval) 
+    (** It is reasonable to assume that both p and p_fa are not null pointers. *)
+    PARAMS (p; p_fa)
+    SEP (fa_rep d t p p_fa)
+  POST [ tint ]
+    PROP ()
+    RETURN (Vint (Int.repr (bool2int d)))
+    SEP (fa_rep d t p p_fa).
+
+Definition Gprog : funspecs :=
+  ltac:(with_library prog [get_branch_spec]).
+
+(** Now try to prove this program. *)
+Theorem body_get_branch_old_fashion: semax_body Vprog Gprog f_get_branch get_branch_spec.
+Proof.
+  start_function. 
+  (* first eliminate the possibility that t is empty *)
+  destruct t.
+  { 
+    destruct d; simpl fa_rep; Intros a; apply H in H1; destruct H1.
+  } 
+  (** A meta-level discussion. Not a good solution. *)
+  destruct d.
+  {
+    (* If p is the left child of p_fa *)
+    simpl fa_rep.
+    Intros p_oppo p_lch_l p_lch_r p_rch_l p_rch_r.
+    forward.
+    forward_if.
+    {
+      (* valid case *)
+      forward.                                        (* return 1; *)
+      simpl.
+      Exists p_oppo p_lch_l p_lch_r p_rch_l p_rch_r.
+      entailer!.
+    }
+  }
+  { 
+    (* If p is the right child of p_fa *)
+    simpl fa_rep.
+    Intros p_oppo p_lch_l p_lch_r p_rch_l p_rch_r.
+    forward.
+    forward_if.
+    { 
+      (* invalid case *)
+      destruct t1. 
+      {
+        simpl.
+        Intros.
+        apply H0 in H1. destruct H1.
+      }
+      destruct t2. 
+      {
+        simpl.
+        Intros.
+        apply H0 in H1. destruct H1.
+      }
+      simpl tree_rep.
+      Intros p_lch_l0 p_lch_r0 p_rch_l0 p_rch_r0.
+      Intros p_lch_l1 p_lch_r1 p_rch_l1 p_rch_r1.
+      (** Now use data_at_conflict to solve it. *)
+      pose proof 
+      (data_at_conflict Tsh t_struct_tree 
+        (Vint (Int.repr k0), (p_lch_l, p_lch_r))
+        (Vint (Int.repr k1), (p_rch_l, p_rch_r))
+        p_oppo top_share_nonidentity).
+      sep_apply H1.
+      sep_apply FF_local_facts.
+      Intros.
+      destruct H2.
+    }
+    {
+      (* valid case *)
+      forward.                                        (* return 0; *)
+      simpl.
+      Exists p_oppo p_lch_l p_lch_r p_rch_l p_rch_r.
+      entailer!.
+    }
+  }
+Qed.
+
+(** To make the proof more concise, here we define some tactics to help us. *)
+
+Lemma tree_rep_conflict :
+  forall p t1 t2 p_ll p_lr p_rl p_rr, 
+  p <> nullval ->
+  tree_rep t1 p p_ll p_lr * tree_rep t2 p p_rl p_rr |-- !! False.
+Proof.
+  intros.
+  destruct t1. 
+  {
+    simpl.
+    Intros.
+    apply H in H0. destruct H0.
+  }
+  destruct t2. 
+  {
+    simpl.
+    Intros.
+    apply H in H0. destruct H0.
+  }
+  simpl tree_rep.
+  Intros p_lch_l0 p_lch_r0 p_rch_l0 p_rch_r0.
+  Intros p_lch_l1 p_lch_r1 p_rch_l1 p_rch_r1.
+  data_at_conflict p.
+Qed.
+
+Ltac tree_rep_conflict :=
+  try (sep_apply tree_rep_conflict; Intros; exfalso; assumption).
+
+Ltac show_the_way d := 
+  destruct d; simpl fa_rep; 
+  Intros p_oppo p_lch_l p_lch_r p_rch_l p_rch_r; 
+  forward; forward_if; 
+  try tree_rep_conflict. 
+
+Theorem body_get_branch_new_fashion: semax_body Vprog Gprog f_get_branch get_branch_spec.
+Proof.
+
+  (** Now prove the theorem again, with the new tactics. *)
+
+  start_function. 
+  (* first eliminate the possibility that t is empty *)
+  destruct t.
+  { 
+    destruct d; simpl fa_rep; Intros a; apply H in H1; destruct H1.
+  }
+  show_the_way d; 
+  (** The invalid cases are ruled out automatically. *)
+  forward; simpl;
+  Exists p_oppo p_lch_l p_lch_r p_rch_l p_rch_r;
+  entailer!.
+Qed.

--- a/progs64/verif_ptr_cmp.v
+++ b/progs64/verif_ptr_cmp.v
@@ -102,6 +102,9 @@ Proof.
       Exists p_oppo p_lch_l p_lch_r p_rch_l p_rch_r.
       entailer!.
     }
+    {
+      contradiction.
+    }
   }
   { 
     (* If p is the right child of p_fa *)
@@ -111,18 +114,11 @@ Proof.
     forward_if.
     { 
       (* invalid case *)
-      destruct t1. 
-      {
-        simpl.
-        Intros.
-        apply H0 in H1. destruct H1.
-      }
-      destruct t2. 
-      {
-        simpl.
-        Intros.
-        apply H0 in H1. destruct H1.
-      }
+      destruct t1; destruct t2;
+        simpl;
+        Intros;
+        subst;
+        try contradiction.
       simpl tree_rep.
       Intros p_lch_l0 p_lch_r0 p_rch_l0 p_rch_r0.
       Intros p_lch_l1 p_lch_r1 p_rch_l1 p_rch_r1.
@@ -180,6 +176,7 @@ Ltac show_the_way d :=
   destruct d; simpl fa_rep; 
   Intros p_oppo p_lch_l p_lch_r p_rch_l p_rch_r; 
   forward; forward_if; 
+  subst;
   try tree_rep_conflict. 
 
 Theorem body_get_branch_new_fashion: semax_body Vprog Gprog f_get_branch get_branch_spec.
@@ -193,7 +190,7 @@ Proof.
   { 
     destruct d; simpl fa_rep; Intros a; apply H in H1; destruct H1.
   }
-  show_the_way d; 
+  show_the_way d;
   (** The invalid cases are ruled out automatically. *)
   forward; simpl;
   Exists p_oppo p_lch_l p_lch_r p_rch_l p_rch_r;


### PR DESCRIPTION
- Added lemmas on pointer comparisons. Excerpt:
  ```coq
  Lemma true_Cne_neq: forall x y, 
    typed_true tint (force_val (sem_cmp_pp Cne x y)) -> x <> y.
  Lemma true_Ceq_eq: forall x y, 
    typed_true tint (force_val (sem_cmp_pp Ceq x y)) -> x = y.
  Lemma false_Cne_neq: forall x y, 
    typed_false tint (force_val (sem_cmp_pp Cne x y)) -> x = y.
  Lemma false_Ceq_eq: forall x y, 
    typed_false tint (force_val (sem_cmp_pp Ceq x y)) -> x <> y.
  ```
- Added a tactic for automatically apllying the lemmas and made it one part of `forward_if`.
- Added an example (`ptr_cmp`). Excerpt:
  ```c
  struct tree {
      unsigned int k;
      struct tree *left, *right;
  };
  
  int get_branch (struct tree * p, struct tree * p_fa){
      if (p == p_fa->left){
          return 1;
      } else {
          return 0;
      }
  }
  ```
- Added Coq 8.13.1 to version check in `Makefile`.