### PR TITLE
Fix slow forward and Qed in case of many active locals

### DIFF
--- a/floyd/client_lemmas.v
+++ b/floyd/client_lemmas.v
@@ -1512,12 +1512,13 @@ Fixpoint remove_localdef_temp (i: ident) (l: list localdef) : list localdef :=
   match l with
   | nil => nil
   | d :: l0 =>
+     let rest := remove_localdef_temp i l0 in
      match d with
      | temp j v =>
        if rlt_ident_eq i j
-       then remove_localdef_temp i l0
-       else d :: remove_localdef_temp i l0
-     | _ => d :: remove_localdef_temp i l0
+       then rest
+       else d :: rest
+     | _ => d :: rest
      end
   end.
 

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -846,7 +846,8 @@ Ltac check_typecheck :=
  end].
 
 Ltac prove_delete_temp := match goal with |- ?A = _ =>
-  let Q := fresh "Q" in set (Q:=A); hnf in Q; subst Q; reflexivity
+  (* This leads to exponential Qed blow up: let Q := fresh "Q" in set (Q:=A); hnf in Q; subst Q; reflexivity *)
+  reflexivity
 end.
 
 Ltac cancel_for_forward_call := cancel_for_evar_frame.
@@ -1121,14 +1122,23 @@ Ltac cleanup_no_post_exists :=
  end
  || unfold eq_no_post.
 
+Local Definition dummy := I.
+
 Ltac simplify_remove_localdef_temp :=
-match goal with |- context [remove_localdef_temp ?i ?L]  =>
-  let u := constr:(remove_localdef_temp i L) in
-  let u' := eval cbv [remove_localdef_temp] in u in
-  let u' := eval simpl rlt_ident_eq in u' in
-  let u' := eval cbv beta iota in u' in
-  change u with u'
-end.
+  match goal with |- context [remove_localdef_temp ?i ?L]  =>
+    let u := constr:(remove_localdef_temp i L) in
+    (* unfold remove_localdef_temp and do function and if/match conversion, 
+      but do not expand the let in remove_localdef_temp, which would lead to exponential blow up *)
+    let u' := eval lazy delta [remove_localdef_temp] beta iota in u in
+    (* now fully simplify all terms with rlt_ident_eq as head symbol *)
+    let u' := eval simpl rlt_ident_eq in u' in
+    (* do another beta iota conversion to collapse all ifs *)
+    let u' := eval lazy beta iota in u' in
+    (* now all the correct branches have been selected and we can safely expand the lets *)
+    let u' := eval lazy zeta in u' in
+    (* Note: an explicit cast with "cbv delta [dummy]" does not improve performance *)
+    change u with u'
+  end.
 
 Ltac after_forward_call :=
     check_POSTCONDITION; 


### PR DESCRIPTION
This PR fixes issue #491.

There are two situations in which many locals lead to exponentially slow proofs:

- The `eval cbv [remove_localdef_temp]` in simplify_remove_localdef_temp expands the recursive function `remove_localdef_temp`. Since the argument of the if is not yet reduced, this leads to a full binary tree with depth being the number of locals. This fixed by a let abstraction which is unfolded only after reducing the if conditions.
- During Qed time the hnf in a  hypothesis in `prove_delete_temp` leads to full expansion of the same term as above during Qed time. According to @JasonGross in a Zulip discussion on slow Qed, conversions in a hypothesis generally can lead to long Qed times, because they don't leave an annotated cast in the proof tree, which would direct the kernel into the right kind of reduction. A simple `reflexivity` seems to do the job and at least for the samples in progs64 there is no measurable speed difference by replacing the more elaborate old method with a simple reflexivity. In case there are such cases, there are alternative constructions fo rthe hnf which do not lead to Qed blowup.