### PR TITLE
Use 'repeat' instead of 'list_repeat'; make list_solve independent

### DIFF
--- a/aes/api_specs.v
+++ b/aes/api_specs.v
@@ -161,10 +161,10 @@ Definition encryption_spec_ll :=
     SEP (data_at ctx_sh (t_struct_aesctx) (
           (Vint (Int.repr Nr)),
           ((field_address t_struct_aesctx [StructField _buf] ctx),
-          (map Vint (map Int.repr (exp_key ++ (list_repeat (8%nat) 0)))))
+          (map Vint (map Int.repr (exp_key ++ (repeat 0 (8%nat))))))
           (* The following weaker precondition would also be provable, but less conveniently, and   *)
           (* since mbedtls_aes_init zeroes the whole buffer, we exploit this to simplify the proof  *)
-          (* ((map Vint (map Int.repr exp_key)) ++ (list_repeat (8%nat) Vundef))) *)
+          (* ((map Vint (map Int.repr exp_key)) ++ (repeat Vundef (8%nat)))) *)
          ) ctx;
          data_at in_sh (tarray tuchar 16) (map Vint (map Int.repr plaintext)) input;
          data_at_ out_sh (tarray tuchar 16) output;
@@ -174,12 +174,12 @@ Definition encryption_spec_ll :=
     SEP (data_at ctx_sh (t_struct_aesctx) (
           (Vint (Int.repr Nr)),
           ((field_address t_struct_aesctx [StructField _buf] ctx),
-          (map Vint (map Int.repr (exp_key ++ (list_repeat (8%nat) 0)))))
+          (map Vint (map Int.repr (exp_key ++ (repeat 0 (8%nat))))))
          ) ctx;
          data_at in_sh  (tarray tuchar 16)
                  (map Vint (map Int.repr plaintext)) input;
          data_at out_sh (tarray tuchar 16)
-                 (map Vint (mbed_tls_aes_enc plaintext (exp_key ++ (list_repeat (8%nat) 0)))) output;
+                 (map Vint (mbed_tls_aes_enc plaintext (exp_key ++ (repeat 0 (8%nat))))) output;
          tables_initialized (gv _tables)).
 
 Definition Gprog : funspecs := ltac:(with_library prog [

--- a/aes/equiv_encryption.v
+++ b/aes/equiv_encryption.v
@@ -375,7 +375,7 @@ Lemma HL_equiv_LL_encryption: forall exp_key plaintext,
   Zlength exp_key = 15 ->
   (mbed_tls_aes_enc
      (map Int.unsigned (state_to_list plaintext))
-     ((blocks_to_Zwords exp_key) ++ (list_repeat (8%nat) 0))
+     ((blocks_to_Zwords exp_key) ++ (repeat 0 (8%nat)))
   ) = output_four_ints_as_bytes (state_to_four_ints (Cipher exp_key plaintext)).
 Proof.
   intros.

--- a/aes/verif_encryption_LL.v
+++ b/aes/verif_encryption_LL.v
@@ -13,9 +13,9 @@ Proof.
                                   NOT to clearbody Delta_specs, so that the 
                                   [eapply encryption_loop_body_proof] works. *)
   start_function.
-  Opaque list_repeat.
+  Opaque repeat.
   simpl.
-  Transparent list_repeat.
+  Transparent repeat.
   reassoc_seq.
 
   (* RK = ctx->rk; *)
@@ -27,7 +27,7 @@ Proof.
     reflexivity.
   }
   rewrite Eq in *. clear Eq.
-  remember (exp_key ++ (*list_repeat 8 0*)[0; 0; 0; 0; 0; 0; 0; 0]) as buf.
+  remember (exp_key ++ (*repeat 0 8*)[0; 0; 0; 0; 0; 0; 0; 0]) as buf.
   (* TODO floyd: This is important for automatic rewriting of (Znth (map Vint ...)), and if
      it's not done, the tactics might become very slow, especially if they try to simplify complex
      terms that they would never attempt to simplify if the rewriting had succeeded.

--- a/aes/verif_encryption_LL_loop_body.v
+++ b/aes/verif_encryption_LL_loop_body.v
@@ -28,7 +28,7 @@ Definition encryption_loop_body_proof_statement :=
   (SH0 : readable_share in_sh)
   (SH1 : writable_share out_sh)
   (buf : list Z)
-  (Heqbuf : buf = exp_key ++ list_repeat 8 0)
+  (Heqbuf : buf = exp_key ++ repeat 0 8)
   (Fctx : field_compatible t_struct_aesctx [StructField _buf] ctx)
   (LenBuf : Zlength buf = 68)
   (Eq : forall i : Z,
@@ -129,7 +129,7 @@ Definition encryption_loop_body_proof_statement :=
   (SH0 : readable_share in_sh)
   (SH1 : writable_share out_sh)
   (buf : list Z)
-  (Heqbuf : buf = exp_key ++ list_repeat 8 0)
+  (Heqbuf : buf = exp_key ++ repeat 0 8)
   (Fctx : field_compatible t_struct_aesctx [StructField _buf] ctx)
   (LenBuf : Zlength buf = 68)
   (Eq : forall i : Z,

--- a/aes/verif_encryption_one_column.v
+++ b/aes/verif_encryption_one_column.v
@@ -81,7 +81,7 @@ Lemma encryption_loop_body_proof: forall
   (SH0 : readable_share in_sh)
   (SH1 : writable_share out_sh)
   (buf : list Z)
-  (Heqbuf : buf = exp_key ++ list_repeat 8 0)
+  (Heqbuf : buf = exp_key ++ repeat 0 8)
   (Fctx : field_compatible t_struct_aesctx [StructField _buf] ctx)
   (LenBuf : Zlength buf = 68)
   (Eq : forall i : Z,

--- a/aes/verif_gen_tables_LL.v
+++ b/aes/verif_gen_tables_LL.v
@@ -227,7 +227,7 @@ Proof.
          tables_uninitialized (gv _tables))).
   { (* init *)
     forward. forward. Exists 0. entailer!. do 2 Exists (repeat Vundef 256).
-    entailer!. apply derives_refl.
+    entailer!.
   }
   { (* body *)
     (* forward. TODO floyd: "forward" should tell me to use Intros instead of just failing *)

--- a/floyd/Zlength_solver.v
+++ b/floyd/Zlength_solver.v
@@ -1,9 +1,10 @@
 (* Definitions and lemmas used in list solver *)
-Require Import compcert.lib.Coqlib.
-Require Import VST.msl.Coqlib2.
-Require Import VST.floyd.sublist.
-Require Export Coq.micromega.Lia.
+Require Import ZArith Znumtheory.
+Require Import Coq.Lists.List.
+Require Import Lia.
 Import ListNotations.
+Require Import VST.floyd.sublist.
+Import SublistInternalLib.
 
 (** This file provides a almost-complete solver for list with concatenation.
   Its core symbols include:
@@ -14,7 +15,6 @@ Import ListNotations.
     sublist
     map.
   And it also interprets these symbols by convernting to core symbols:
-    list_repeat (Z.to_nat _)
     nil
     cons
     upd_Znth. *)
@@ -23,9 +23,11 @@ Import ListNotations.
 (** Zlength_solve is a tactic that solves linear arithmetic about length of lists. *)
 
 (* Auxilary lemmas for Zlength_solve. *)
+(*
 Lemma repeat_list_repeat : forall {A : Type} (n : nat) (x : A),
   repeat x n = list_repeat n x.
 Proof. intros. induction n; simpl; try f_equal; auto. Qed.
+*)
 
 Definition Zrepeat {A : Type} (x : A) (n : Z) : list A :=
   repeat x (Z.to_nat n).
@@ -33,7 +35,7 @@ Definition Zrepeat {A : Type} (x : A) (n : Z) : list A :=
 Lemma Zlength_Zrepeat : forall (A : Type) (x : A) (n : Z),
   0 <= n ->
   Zlength (Zrepeat x n) = n.
-Proof. intros *. unfold Zrepeat. rewrite repeat_list_repeat. apply @Zlength_list_repeat. Qed.
+Proof. intros *. unfold Zrepeat. apply @Zlength_repeat. Qed.
 
 Local Lemma Zlength_firstn : forall (A : Type) n (l : list A),
   Zlength (firstn n l) = Z.min (Z.max (Z.of_nat n) 0) (Zlength l).

--- a/floyd/aggregate_pred.v
+++ b/floyd/aggregate_pred.v
@@ -1308,7 +1308,7 @@ Lemma memory_block_array_pred': forall {A}{d: Inhabitant A} (a: A) sh t z b ofs,
   array_pred 0 z
      (fun i _ p =>
       memory_block sh (sizeof t) (offset_val (sizeof t * i) p))
-             (list_repeat (Z.to_nat z) a)
+             (repeat a (Z.to_nat z))
      (Vptr b (Ptrofs.repr ofs))  =
   memory_block sh (sizeof t * z) (Vptr b (Ptrofs.repr ofs)).
 Proof.
@@ -1316,7 +1316,7 @@ Proof.
   rewrite memory_block_array_pred.
   f_equal. f_equal. lia. f_equal. f_equal. rewrite Z.mul_0_r. lia.
   rewrite Z.mul_0_r. split; lia. lia.
-  rewrite Z.sub_0_r. auto. rewrite Zlength_list_repeat', Z2Nat.id by lia.
+  rewrite Z.sub_0_r. auto. rewrite Zlength_repeat', Z2Nat.id by lia.
   lia.
 Qed.
 
@@ -1327,14 +1327,14 @@ Lemma mapsto_zeros_array_pred': forall {A}{d: Inhabitant A} (a: A) sh t z b ofs,
   array_pred 0 z
      (fun i _ p =>
       mapsto_zeros (sizeof t) sh(offset_val (sizeof t * i) p))
-             (list_repeat (Z.to_nat z) a)
+             (repeat a (Z.to_nat z))
      (Vptr b (Ptrofs.repr ofs)).
 Proof.
   intros.
   eapply derives_trans; [ | apply mapsto_zeros_array_pred; try lia].
   apply derives_refl'.
   f_equal. lia. f_equal. f_equal. lia.
-  rewrite Zlength_list_repeat', Z2Nat.id by lia.
+  rewrite Zlength_repeat', Z2Nat.id by lia.
   lia.
 Qed.
 
@@ -1966,7 +1966,7 @@ Definition memory_block_array_pred:
   array_pred 0 z
      (fun i _ p =>
       memory_block sh (sizeof t)
-        (offset_val (sizeof t * i) p)) (list_repeat (Z.to_nat z) a)
+        (offset_val (sizeof t * i) p)) (repeat a (Z.to_nat z))
      (Vptr b (Ptrofs.repr ofs))  =
   memory_block sh (sizeof t * z) (Vptr b (Ptrofs.repr ofs))
 := @memory_block_array_pred'.
@@ -1979,7 +1979,7 @@ Definition mapsto_zeros_array_pred:
   array_pred 0 z
      (fun i _ p =>
       mapsto_zeros (sizeof t) sh
-        (offset_val (sizeof t * i) p)) (list_repeat (Z.to_nat z) a)
+        (offset_val (sizeof t * i) p)) (repeat a (Z.to_nat z))
      (Vptr b (Ptrofs.repr ofs))
 := @mapsto_zeros_array_pred'.
 

--- a/floyd/data_at_rec_lemmas.v
+++ b/floyd/data_at_rec_lemmas.v
@@ -495,15 +495,15 @@ Ltac AUTO_IND :=
   end.
 *)
 
-Lemma nth_list_repeat: forall A i n (x :A),
-    nth i (list_repeat n x) x = x.
+Lemma nth_repeat: forall A i n (x :A),
+    nth i (repeat x n) x = x.
 Proof.
  induction i; destruct n; simpl; auto.
 Qed.
 
-Lemma nth_list_repeat': forall A i n (x y :A),
+Lemma nth_repeat': forall A i n (x y :A),
     (i < n)%nat ->
-    nth i (list_repeat n x) y = x.
+    nth i (repeat x n) y = x.
 Proof.
  induction i; destruct n; simpl; intros; auto.
  lia. lia.
@@ -546,7 +546,7 @@ Proof.
     rewrite array_pred_ext with
      (P1 := fun i _ p => memory_block sh (sizeof t)
                           (offset_val (sizeof t * i) p))
-     (v1 := list_repeat (Z.to_nat (Z.max 0 z)) (default_val t));
+     (v1 := repeat (default_val t) (Z.to_nat (Z.max 0 z)));
      auto.
     rewrite memory_block_array_pred; auto.
     - apply Z.le_max_l.
@@ -557,7 +557,7 @@ Proof.
       rewrite at_offset_eq3.
       unfold offset_val; solve_mod_modulus.
       unfold Znth. rewrite if_false by lia.
-      rewrite nth_list_repeat.
+      rewrite nth_repeat.
       unfold expr.sizeof,  Ctypes.sizeof in H; fold @Ctypes.sizeof in H; fold (sizeof t) in H.
       pose_size_mult cs t (0 :: i :: i + 1 :: Z.max 0 z :: nil).
       assert (sizeof t = 0 -> sizeof t * i = 0)%Z by (intros HH; rewrite HH, Z.mul_0_l; auto).
@@ -719,7 +719,7 @@ Proof.
     apply array_pred_ext_derives with
      (P0 := fun i _ p => mapsto_zeros (sizeof t) sh
                           (offset_val (sizeof t * i) p))
-     (v0 := list_repeat (Z.to_nat (Z.max 0 z)) (zero_val t))];
+     (v0 := repeat (zero_val t) (Z.to_nat (Z.max 0 z)))];
      auto.
     apply mapsto_zeros_array_pred; auto.
     - apply Z.le_max_l.
@@ -731,7 +731,7 @@ Proof.
       rewrite at_offset_eq3.
       unfold offset_val; solve_mod_modulus.
       unfold Znth. rewrite if_false by lia.
-      rewrite nth_list_repeat' by lia.
+      rewrite nth_repeat' by lia.
       unfold expr.sizeof,  Ctypes.sizeof in H; fold @Ctypes.sizeof in H; fold (sizeof t) in H.
       pose_size_mult cs t (0 :: i :: i + 1 :: Z.max 0 z :: nil).
       assert (sizeof t = 0 -> sizeof t * i = 0)%Z by (intros HH; rewrite HH, Z.mul_0_l; auto).
@@ -883,7 +883,7 @@ Proof.
       rewrite unfold_fold_reptype.
       rewrite Zlength_correct in H1.
       rewrite <- Z2Nat_max0.
-      rewrite Zlength_list_repeat by lia.
+      rewrite Zlength_repeat by lia.
       lia.
     }
     rewrite default_val_eq. simpl.
@@ -897,7 +897,7 @@ Proof.
     - eapply align_compatible_rec_Tarray_inv; eauto.
       apply range_max0; auto.
     - apply derives_refl'. f_equal. unfold Znth. rewrite if_false by lia.
-      rewrite nth_list_repeat'; auto.
+      rewrite nth_repeat'; auto.
       apply Nat2Z.inj_lt. rewrite Z2Nat.id, Z2Nat_id' by lia. lia.
   + rewrite !data_at_rec_eq.
     rewrite default_val_eq, unfold_fold_reptype.
@@ -1033,8 +1033,8 @@ Proof.
   rewrite default_val_eq, unfold_fold_reptype.
   + (* Tarray *)
     split.
-    - rewrite Zlength_list_repeat', Z2Nat_id'; auto.
-    - apply Forall_list_repeat; auto.
+    - rewrite Zlength_repeat', Z2Nat_id'; auto.
+    - apply Forall_repeat; auto.
   + (* Tstruct *)
     cbv zeta in IH.
     apply struct_Prop_compact_prod_gen.
@@ -1180,11 +1180,11 @@ Proof.
     rewrite array_pred_ext with
      (P1 := fun i _ p => memory_block sh (sizeof t)
                           (offset_val (sizeof t * i) p))
-     (v1 := list_repeat (Z.to_nat (Z.max 0 z)) (default_val t)); auto.
+     (v1 := repeat (default_val t) (Z.to_nat (Z.max 0 z))); auto.
     rewrite memory_block_array_pred; auto.
     - apply Z.le_max_l.
     - rewrite (proj1 H2).
-      symmetry; apply Zlength_list_repeat; auto.
+      symmetry; apply Zlength_repeat; auto.
       apply Z.le_max_l.
     - intros.
       rewrite at_offset_eq3.

--- a/floyd/entailer.v
+++ b/floyd/entailer.v
@@ -782,7 +782,7 @@ Qed.
 Definition cstringn {CS : compspecs} sh (s: list byte) n p :=
   !!(~In Byte.zero s) &&
   data_at sh (tarray tschar n) (map Vbyte (s ++ [Byte.zero]) ++
-    list_repeat (Z.to_nat (n - (Zlength s + 1))) Vundef) p.
+    repeat Vundef (Z.to_nat (n - (Zlength s + 1)))) p.
 
 Fixpoint no_zero_bytes (s: list byte) : bool :=
  match s with

--- a/floyd/field_at.v
+++ b/floyd/field_at.v
@@ -201,7 +201,7 @@ Definition array_at (sh: Share.t) (t: type) (gfs: list gfield) (lo hi: Z)
        (nested_field_offset t (ArraySubsc i :: gfs))) v p.
 
 Definition array_at_ (sh: Share.t) (t: type) (gfs: list gfield) (lo hi: Z) : val -> mpred :=
- array_at sh t gfs lo hi (list_repeat (Z.to_nat (hi-lo)) (default_val _)).
+ array_at sh t gfs lo hi (repeat (default_val _) (Z.to_nat (hi-lo))).
 
 (************************************************
 
@@ -1094,12 +1094,12 @@ Proof.
  normalize.
   unfold array_at_.
   apply array_at_ext_derives.
-  1: rewrite Zlength_list_repeat by (rewrite Zlength_correct in H1; lia); lia.
+  1: rewrite Zlength_repeat by (rewrite Zlength_correct in H1; lia); lia.
   intros.
   destruct (field_compatible0_dec t (ArraySubsc i :: gfs) p).
   + revert u1 H5; erewrite <- nested_field_type_ArraySubsc with (i0 := i); intros.
     apply JMeq_eq in H5; rewrite H5. unfold Znth. rewrite if_false by lia.
-    rewrite nth_list_repeat.
+    rewrite nth_repeat.
     apply field_at_field_at_; auto.
   + unfold field_at.
     normalize.
@@ -2826,7 +2826,7 @@ Hint Rewrite
 Lemma data_at__Tarray:
   forall {CS: compspecs} sh t n a,
   data_at_ sh (Tarray t n a) = 
-  data_at sh (Tarray t n a) (list_repeat (Z.to_nat n) (default_val t)).
+  data_at sh (Tarray t n a) (repeat (default_val t) (Z.to_nat n)).
 Proof.
 intros.
 unfold data_at_, field_at_, data_at.
@@ -2838,12 +2838,12 @@ Qed.
 Lemma data_at__tarray:
   forall {CS: compspecs} sh t n,
   data_at_ sh (tarray t n) = 
-  data_at sh (tarray t n) (list_repeat (Z.to_nat n) (default_val t)).
+  data_at sh (tarray t n) (repeat (default_val t) (Z.to_nat n)).
 Proof. intros; apply data_at__Tarray; auto. Qed.
 
 Lemma data_at__Tarray':
   forall {CS: compspecs} sh t n a v, 
-  v = list_repeat (Z.to_nat n) (default_val t) ->
+  v = repeat (default_val t) (Z.to_nat n) ->
   data_at_ sh (Tarray t n a) = data_at sh (Tarray t n a) v.
 Proof.
 intros.
@@ -2857,7 +2857,7 @@ Qed.
 
 Lemma data_at__tarray':
   forall {CS: compspecs} sh t n v, 
-  v = list_repeat (Z.to_nat n) (default_val t) ->
+  v = repeat (default_val t) (Z.to_nat n) ->
   data_at_ sh (tarray t n) = data_at sh (tarray t n) v.
 Proof. intros; apply data_at__Tarray'; auto. Qed.
 

--- a/floyd/field_compat.v
+++ b/floyd/field_compat.v
@@ -878,12 +878,12 @@ Lemma split2_data_at__Tarray_tuchar
 Proof. intros. unfold data_at_ at 1; unfold field_at_.
 rewrite field_at_data_at.
 erewrite (@split2_data_at_Tarray cs sh tuchar n n1).
-instantiate (1:= list_repeat (Z.to_nat (n-n1)) Vundef).
-instantiate (1:= list_repeat (Z.to_nat n1) Vundef).
+instantiate (1:= repeat Vundef (Z.to_nat (n-n1))).
+instantiate (1:= repeat Vundef (Z.to_nat n1)).
 unfold field_address. simpl. 
 rewrite if_true; trivial. rewrite isptr_offset_val_zero; trivial.
 trivial.
-instantiate (1:=list_repeat (Z.to_nat n) Vundef).
+instantiate (1:=repeat Vundef (Z.to_nat n)).
 change (@reptype _ _)  with val.
 list_solve.
 unfold default_val. simpl. autorewrite with sublist. reflexivity.
@@ -901,13 +901,13 @@ Lemma split2_data_at__Tarray_tschar
 Proof. intros. unfold data_at_ at 1; unfold field_at_.
 rewrite field_at_data_at.
 erewrite (@split2_data_at_Tarray cs sh tschar n n1).
-instantiate (1:= list_repeat (Z.to_nat (n-n1)) Vundef).
-instantiate (1:= list_repeat (Z.to_nat n1) Vundef).
+instantiate (1:= repeat Vundef (Z.to_nat (n-n1))).
+instantiate (1:= repeat Vundef (Z.to_nat n1)).
 unfold field_address. simpl. 
 rewrite if_true; trivial. rewrite isptr_offset_val_zero; trivial.
 trivial.
 simpl.
-instantiate (1:=list_repeat (Z.to_nat n) Vundef).
+instantiate (1:=repeat Vundef (Z.to_nat n)).
 change (@reptype _ _)  with val.
 list_solve.
 unfold default_val. simpl. autorewrite with sublist. reflexivity.
@@ -978,14 +978,14 @@ Lemma sepconN_mapsto_array {cenv t b sh} K : forall z
     (Hz: 0 <= Ptrofs.unsigned z /\
                Z.of_nat K * size_chunk Mptr + Ptrofs.unsigned z < Ptrofs.modulus),
     sepconN K (fun p : val => mapsto sh (Tpointer t noattr) p nullval) (size_chunk Mptr) (Vptr b z)
-|-- @data_at cenv sh (tarray (Tpointer t noattr) (Z.of_nat K)) (list_repeat K nullval) (Vptr b z).
+|-- @data_at cenv sh (tarray (Tpointer t noattr) (Z.of_nat K)) (repeat nullval K) (Vptr b z).
 Proof.
   specialize (Zle_0_nat K); specialize size_chunk_range; intros SZ Kpos.
   induction K; intros.
 + rewrite data_at_zero_array_eq; simpl; trivial. (* apply derives_refl.*)
-+ rewrite (split2_data_at_Tarray_app 1 (Z.of_nat (S K)) sh (Tpointer t noattr) [nullval] (list_repeat K nullval)).
++ rewrite (split2_data_at_Tarray_app 1 (Z.of_nat (S K)) sh (Tpointer t noattr) [nullval] (repeat nullval K)).
   2: reflexivity.
-  2: rewrite Zlength_list_repeat'; lia.
+  2: rewrite Zlength_repeat'; lia.
   replace (Z.of_nat (S K) * size_chunk Mptr)%Z with 
           (Z.of_nat K * size_chunk Mptr + size_chunk Mptr)%Z in Hz by lia.
   replace  (Z.of_nat (S K) - 1) with (Z.of_nat K) by lia.
@@ -1026,7 +1026,7 @@ Lemma mapsto_zeros_data_atTarrayTptr_nullval_N {cenv} N sh t b z:
        readable_share sh ->
        (align_chunk Mptr | Ptrofs.unsigned z) ->
        mapsto_zeros (Z.of_nat N * size_chunk Mptr) sh (Vptr b z)
-       |-- @data_at cenv sh (tarray (Tpointer t noattr) (Z.of_nat N)) (list_repeat N nullval) (Vptr b z).
+       |-- @data_at cenv sh (tarray (Tpointer t noattr) (Z.of_nat N)) (repeat nullval N) (Vptr b z).
 Proof. intros. 
   eapply derives_trans.
   eapply (mapsto_zeros_mapsto_nullval_N N sh); trivial.

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -3243,7 +3243,7 @@ Ltac simple_value v :=
  | Vfloat _ => idtac
  | Vsingle _ => idtac
  | Vptr _ _ => idtac
- | list_repeat (Z.to_nat _) ?v' => simple_value v'
+ | repeat ?v' (Z.to_nat _) => simple_value v'
  end.
 
 Inductive undo_and_first__assert_PROP: Prop -> Prop := .

--- a/floyd/functional_base.v
+++ b/floyd/functional_base.v
@@ -11,6 +11,31 @@ Require Export VST.floyd.sublist.
 Require Export Lia.
 Require Export VST.floyd.list_solver.
 
+Definition Vubyte (c: Byte.int) : val :=
+  Vint (Int.repr (Byte.unsigned c)).
+Definition Vbyte (c: Byte.int) : val :=
+  Vint (Int.repr (Byte.signed c)).
+Ltac fold_Vbyte :=
+ repeat match goal with |- context [Vint (Int.repr (Byte.signed ?c))] =>
+      fold (Vbyte c)
+end.
+Ltac  customizable_list_solve_preprocess ::= fold_Vbyte.
+Instance Inhabitant_val : Inhabitant val := Vundef.
+Instance Inhabitant_int: Inhabitant int := Int.zero.
+Instance Inhabitant_byte: Inhabitant byte := Byte.zero.
+Instance Inhabitant_int64: Inhabitant Int64.int := Int64.zero.
+Instance Inhabitant_ptrofs: Inhabitant Ptrofs.int := Ptrofs.zero.
+Instance Inhabitant_float : Inhabitant float := Float.zero.
+Instance Inhabitant_float32 : Inhabitant float32 := Float32.zero.
+
+Hint Rewrite (@Znth_map _ Inhabitant_float) using Zlength_solve : Znth.
+Hint Rewrite (@Znth_map _ Inhabitant_float32) using Zlength_solve : Znth.
+Hint Rewrite (@Znth_map _ Inhabitant_ptrofs) using Zlength_solve : Znth.
+Hint Rewrite (@Znth_map _ Inhabitant_int64) using Zlength_solve : Znth.
+Hint Rewrite (@Znth_map _ Inhabitant_byte) using Zlength_solve : Znth.
+Hint Rewrite (@Znth_map _ Inhabitant_int) using Zlength_solve : Znth.
+Hint Rewrite (@Znth_map _ Inhabitant_val) using Zlength_solve : Znth.
+
 Create HintDb entailer_rewrite discriminated.
 
 Require Import VST.veric.val_lemmas.

--- a/floyd/globals_lemmas.v
+++ b/floyd/globals_lemmas.v
@@ -1060,7 +1060,7 @@ Lemma process_globvar_ptrarray_space:
        globvars_in_process gz done emp ((i,gv)::al) |--
     globvars_in_process gz
        (data_at  (readonly2share (gvar_readonly gv)) (Tarray (Tpointer t' noattr) n noattr)
-                                  (list_repeat (Z.to_nat n) nullval)  (gz i) :: done)
+                                  (repeat nullval (Z.to_nat n))  (gz i) :: done)
             emp  al.
 Proof.
 intros until n. intros Ht H3; intros.
@@ -1215,7 +1215,7 @@ rewrite Z.sub_0_r in H0. subst i.
 rewrite !Z.sub_0_r.
 rewrite Znth_pos_cons by lia.
 rewrite <- (Nat2Z.id n0).
-rewrite Znth_list_repeat_inrange by lia.
+rewrite Znth_repeat_inrange by lia.
 apply derives_refl'. f_equal. 
 simpl.
 f_equal.
@@ -1403,7 +1403,7 @@ Ltac process_idstar :=
 Create HintDb zero_val discriminated.
 
 Lemma zero_val_tarray {cs: compspecs}:
- forall t n, zero_val (tarray t n) = list_repeat (Z.to_nat n) (zero_val t).
+ forall t n, zero_val (tarray t n) = repeat (zero_val t) (Z.to_nat n).
 Proof.
 intros.
 rewrite zero_val_eq; reflexivity.

--- a/floyd/proofauto.v
+++ b/floyd/proofauto.v
@@ -97,8 +97,8 @@ Hint Rewrite Vptrofs_unfold_true using reflexivity: entailer_rewrite norm.
 
 #[export] Hint Extern 1 (Vundef = default_val _) => reflexivity : cancel.
 #[export] Hint Extern 1 (default_val _ = Vundef) => reflexivity : cancel.
-#[export] Hint Extern 1 (list_repeat _ Vundef = default_val _) => reflexivity : cancel.
-#[export] Hint Extern 1 (default_val _ = list_repeat _ Vundef) => reflexivity : cancel.
+#[export] Hint Extern 1 (repeat Vundef _ = default_val _) => reflexivity : cancel.
+#[export] Hint Extern 1 (default_val _ = list_repeat Vundef _) => reflexivity : cancel.
 #[export] Hint Extern 1 (Vundef :: _ = default_val _) => reflexivity : cancel.
 #[export] Hint Extern 1 (default_val _ = Vundef :: _) => reflexivity : cancel.
 #[export] Hint Extern 1 (@nil _ = default_val _) => reflexivity : cancel.

--- a/floyd/proofauto.v
+++ b/floyd/proofauto.v
@@ -98,7 +98,7 @@ Hint Rewrite Vptrofs_unfold_true using reflexivity: entailer_rewrite norm.
 #[export] Hint Extern 1 (Vundef = default_val _) => reflexivity : cancel.
 #[export] Hint Extern 1 (default_val _ = Vundef) => reflexivity : cancel.
 #[export] Hint Extern 1 (repeat Vundef _ = default_val _) => reflexivity : cancel.
-#[export] Hint Extern 1 (default_val _ = list_repeat Vundef _) => reflexivity : cancel.
+#[export] Hint Extern 1 (default_val _ = repeat _ Vundef) => reflexivity : cancel.
 #[export] Hint Extern 1 (Vundef :: _ = default_val _) => reflexivity : cancel.
 #[export] Hint Extern 1 (default_val _ = Vundef :: _) => reflexivity : cancel.
 #[export] Hint Extern 1 (@nil _ = default_val _) => reflexivity : cancel.

--- a/floyd/reptype_lemmas.v
+++ b/floyd/reptype_lemmas.v
@@ -147,7 +147,7 @@ Definition reptype_gen {cs: compspecs} : type -> (sigT (fun x => x)) :=
      if (type_is_by_value t)
      then existT (fun x => x) val Vundef
      else existT (fun x => x) unit tt)
-  (fun t n a TV => existT (fun x => x) (list (projT1 TV)) (list_repeat (Z.to_nat n) (projT2 TV)))
+  (fun t n a TV => existT (fun x => x) (list (projT1 TV)) (repeat (projT2 TV) (Z.to_nat n)))
   (fun id a TVs => existT (fun x => x) (compact_prod_sigT_type (decay TVs)) (compact_prod_sigT_value (decay TVs)))
   (fun id a TVs => existT (fun x => x) (compact_sum_sigT_type (decay TVs)) (compact_sum_sigT_value (decay TVs))).
 
@@ -162,7 +162,7 @@ Definition reptype_gen0 {cs: compspecs} : type -> (sigT (fun x => x)) :=
      | Tpointer _ _ => existT (fun x => x) val (Vptrofs Ptrofs.zero)
      | _ => existT (fun x => x) unit tt
      end)
-  (fun t n a TV => existT (fun x => x) (list (projT1 TV)) (list_repeat (Z.to_nat n) (projT2 TV)))
+  (fun t n a TV => existT (fun x => x) (list (projT1 TV)) (repeat (projT2 TV) (Z.to_nat n)))
   (fun id a TVs => existT (fun x => x) (compact_prod_sigT_type (decay TVs)) (compact_prod_sigT_value (decay TVs)))
   (fun id a TVs => existT (fun x => x) (compact_sum_sigT_type (decay TVs)) (compact_sum_sigT_value (decay TVs))).
 
@@ -178,7 +178,7 @@ Instance Inhabitant_reptype {cs: compspecs} (t: type) : Inhabitant (reptype t) :
 Lemma reptype_gen_eq {cs: compspecs}: forall t,
   reptype_gen t =
   match t with
-  | Tarray t0 n _ => existT (fun x => x) (list (projT1 (reptype_gen t0))) (list_repeat (Z.to_nat n) (projT2 (reptype_gen t0)))
+  | Tarray t0 n _ => existT (fun x => x) (list (projT1 (reptype_gen t0))) (repeat (projT2 (reptype_gen t0)) (Z.to_nat n))
   | Tstruct id _ => existT (fun x => x)
                      (compact_prod_sigT_type (map reptype_gen (map (fun it => field_type (fst it) (co_members (get_co id))) (co_members (get_co id)))))
                      (compact_prod_sigT_value (map reptype_gen (map (fun it => field_type (fst it) (co_members (get_co id))) (co_members (get_co id)))))
@@ -206,7 +206,7 @@ Defined.
 Lemma reptype_gen0_eq {cs: compspecs}: forall t,
   reptype_gen0 t =
   match t with
-  | Tarray t0 n _ => existT (fun x => x) (list (projT1 (reptype_gen0 t0))) (list_repeat (Z.to_nat n) (projT2 (reptype_gen0 t0)))
+  | Tarray t0 n _ => existT (fun x => x) (list (projT1 (reptype_gen0 t0))) (repeat (projT2 (reptype_gen0 t0)) (Z.to_nat n))
   | Tstruct id _ => existT (fun x => x)
                      (compact_prod_sigT_type (map reptype_gen0 (map (fun it => field_type (fst it) (co_members (get_co id))) (co_members (get_co id)))))
                      (compact_prod_sigT_value (map reptype_gen0 (map (fun it => field_type (fst it) (co_members (get_co id))) (co_members (get_co id)))))
@@ -504,7 +504,7 @@ Lemma default_val_eq: forall t,
   | Tlong _ _
   | Tfloat _ _
   | Tpointer _ _ => Vundef
-  | Tarray t0 n _ => list_repeat (Z.to_nat n) (default_val t0)
+  | Tarray t0 n _ => repeat (default_val t0) (Z.to_nat n) 
   | Tstruct id _ => struct_default_val (co_members (get_co id))
   | Tunion id _ => union_default_val (co_members (get_co id))
   end.
@@ -552,7 +552,7 @@ Lemma zero_val_eq: forall t,
   | Tfloat F32 _ => Vsingle Float32.zero
   | Tfloat F64 _ => Vfloat Float.zero
   | Tpointer _ _ => Vptrofs Ptrofs.zero
-  | Tarray t0 n _ => list_repeat (Z.to_nat n) (zero_val t0)
+  | Tarray t0 n _ => repeat (zero_val t0) (Z.to_nat n) 
   | Tstruct id _ => struct_zero_val (co_members (get_co id))
   | Tunion id _ => union_zero_val (co_members (get_co id))
   end.
@@ -571,8 +571,9 @@ Proof.
   rewrite reptype_gen0_eq.  
   destruct t; auto.
   + destruct f; auto.
-  + apply (@JMeq_trans _ _ _ _  (list_repeat (Z.to_nat z) (zero_val' t))).
+  + apply (@JMeq_trans _ _ _ _  (repeat (zero_val' t)  (Z.to_nat z))).
       apply eq_JMeq. f_equal.
+      apply JMeq_func; auto. rewrite reptype_reptype0. auto.
       apply JMeq_func; auto. rewrite reptype_reptype0. auto.
       apply JMeq_sym. apply JMeq_zero_val_zero_val'.
       rewrite reptype_reptype0. apply JMeq_refl.
@@ -1219,5 +1220,5 @@ Qed.
 
 
 Lemma Zlength_default_val_Tarray_tuchar {cs} n a (N:0<=n): Zlength (@default_val cs (Tarray tuchar n a)) = n.
-Proof. unfold default_val; simpl. rewrite Zlength_list_repeat; trivial. Qed.
+Proof. unfold default_val; simpl. rewrite Zlength_repeat; trivial. Qed.
 

--- a/floyd/sublist.v
+++ b/floyd/sublist.v
@@ -1596,6 +1596,15 @@ Hint Rewrite @upd_Znth_Zlength using old_list_solve : sublist.
 
 Hint Rewrite @sublist_nil : sublist.
 
+Lemma repeat_app  (* duplicate this from Coq standard library
+     for compatibility with Coq 8.12, where it is not present *)
+  : forall {A: Type} (x: A) (n m: nat),
+         repeat x (n + m) = repeat x n ++ repeat x m.
+Proof.
+intros.
+induction n; simpl; auto.
+f_equal; auto.
+Qed.
 
 Lemma repeat_app':
  forall {A: Type} a b (x:A), 

--- a/floyd/sublist.v
+++ b/floyd/sublist.v
@@ -1,8 +1,59 @@
-Require Import compcert.lib.Coqlib.
-Require Import VST.msl.Coqlib2.
+Require Import ZArith Znumtheory.
 Require Import Coq.Lists.List.
 Require Import Lia.
 Import ListNotations.
+
+Module SublistInternalLib.
+(* Things copied from VST, to avoid dependencies *)
+Ltac inv H := inversion H; clear H; subst.
+
+Lemma if_true: forall (A: Prop) (E: {A}+{~A}) (T: Type) (B C: T), A -> (if E then B else C) = B.
+Proof.
+intros.
+destruct E; auto.
+contradiction.
+Qed.
+
+Lemma if_false: forall (A: Prop) (E: {A}+{~A}) (T: Type) (B C: T), ~A -> (if E then B else C) = C.
+Proof.
+intros.
+destruct E; auto.
+contradiction.
+Qed.
+
+Tactic Notation "if_tac" := 
+  match goal with |- context [if ?a then _ else _] =>
+    lazymatch type of a with
+    | sumbool _ _ =>destruct a as [?H | ?H]
+    | bool => fail "Use simple_if_tac instead of if_tac, since your expression"a" has type bool"
+    | ?t => fail "Use if_tac only for sumbool; your expression"a" has type" t
+   end end.
+
+Tactic Notation "if_tac" "in" hyp(H0)
+ := match type of H0 with context [if ?a then _ else _] =>
+    lazymatch type of a with
+    | sumbool _ _ =>destruct a as [?H | ?H]
+    | bool => fail "Use simple_if_tac instead of if_tac, since your expression"a" has type bool"
+    | ?t => fail "Use if_tac only for sumbool; your expression"a" has type" t
+   end end.
+
+Tactic Notation "forget" constr(X) "as" ident(y) :=
+   set (y:=X) in *; clearbody y.
+
+Lemma Zmin_spec:
+  forall x y, Z.min x y = if Z_lt_dec x y then x else y.
+Proof.
+  intros. destruct (Zmin_spec x y); destruct H as [H H0]; rewrite H0; clear H0; destruct (Z_lt_dec x y); lia.
+Qed.
+
+Lemma Zmax_spec:
+  forall x y, Z.max x y = if Z_lt_dec y x then x else y.
+Proof.
+  intros. destruct (Zmax_spec x y); destruct H as [H H0]; rewrite H0; clear H0; destruct (Z_lt_dec y x); lia.
+Qed.
+
+End SublistInternalLib.
+Import SublistInternalLib.
 
 Class Inhabitant (A: Type) := default : A.
 
@@ -14,6 +65,7 @@ Instance Inhabitant_fun {T1 T2: Type} {H: Inhabitant T2} : Inhabitant (T1->T2) :
 Instance Inhabitant_Prop : Inhabitant Prop := False.
 Instance Inhabitant_bool : Inhabitant bool := false.
 Instance Inhabitant_pair {T1 T2 : Type} {x1: Inhabitant T1} {x2: Inhabitant T2} : Inhabitant (T1*T2)%type := (x1,x2).
+
 
 Lemma Zlength_length:
   forall A (al: list A) (n: Z),
@@ -51,8 +103,8 @@ f_equal. apply IHn.
 simpl in H; lia.
 Qed.
 
-Lemma firstn_list_repeat {A} (v:A): forall i k, (i<=k)%nat ->
-      firstn i (list_repeat k v) = list_repeat i v.
+Lemma firstn_repeat {A} (v:A): forall i k, (i<=k)%nat ->
+      firstn i (repeat v k) = repeat v i.
 Proof.
   induction i; simpl; trivial; intros.
   destruct k. lia. simpl. rewrite IHi; trivial. lia.
@@ -247,13 +299,6 @@ induction n; destruct al; intros; simpl in *; try lia; auto.
 apply IHn; lia.
 Qed.
 
-Lemma list_repeat_app: forall A a b (x:A),
-  list_repeat a x ++ list_repeat b x = list_repeat (a+b) x.
-Proof.
-intros; induction a; simpl; f_equal.
-auto.
-Qed.
-
 Lemma firstn_same:
   forall A n (b: list A), (n >= length b)%nat -> firstn n b = b.
 Proof.
@@ -305,9 +350,9 @@ rewrite firstn_app1 by lia.
 reflexivity.
 Qed.
 
-Lemma Forall_list_repeat:
+Lemma Forall_repeat:
   forall {A} (P: A -> Prop) (n: nat) (a: A),
-    P a -> Forall P (list_repeat n a).
+    P a -> Forall P (repeat a n).
 Proof.
 induction n; intros.
 constructor.
@@ -433,7 +478,7 @@ Ltac pose_Zlength_nonneg :=
 Ltac old_list_solve := autorewrite with sublist; pose_Zlength_nonneg; lia.
 
 Definition Znth {X}{d: Inhabitant X} n (xs: list X) :=
-  if (zlt n 0) then default else nth (Z.to_nat n) xs d.
+  if (Z_lt_dec n 0) then default else nth (Z.to_nat n) xs d.
 
 Lemma Znth_map:
   forall {A:Type} {da: Inhabitant A}{B:Type}{db: Inhabitant B} i (f: A -> B) (al: list A),
@@ -487,7 +532,7 @@ Qed.
 Lemma Znth_In : forall {A}{a: Inhabitant A} i l, 0 <= i < Zlength l -> In (Znth i l) l.
 Proof.
   intros; unfold Znth.
-  destruct (zlt i 0); [lia|].
+  destruct (Z_lt_dec i 0); [lia|].
   apply nth_In; rewrite Zlength_correct in *.
   apply Nat2Z.inj_lt; rewrite Z2Nat.id; lia.
 Qed.
@@ -674,7 +719,7 @@ Proof.
 intros.
 apply firstn_app1.
 apply Nat2Z.inj_le. rewrite Zlength_correct in H.
-destruct (zlt n 0).
+destruct (Z_lt_dec n 0).
 rewrite Z2Nat_neg by auto. change (Z.of_nat 0) with 0; lia.
 rewrite Z2Nat.id by lia.
 lia.
@@ -712,7 +757,7 @@ Lemma Zfirstn_firstn: forall {A} (contents: list A) n m,
   firstn (Z.to_nat n) (firstn (Z.to_nat m) contents) = firstn (Z.to_nat n) contents.
 Proof.
 intros.
-destruct (zlt n 0).
+destruct (Z_lt_dec n 0).
 rewrite (Z2Nat_neg n) by lia.
 reflexivity.
 apply firstn_firstn.
@@ -727,7 +772,7 @@ intros.
 apply skipn_app1.
 rewrite Zlength_correct in H.
 apply Nat2Z.inj_le.
-destruct (zlt n 0).
+destruct (Z_lt_dec n 0).
 rewrite (Z2Nat_neg n) by lia.
 change (Z.of_nat 0) with 0.  lia.
 rewrite Z2Nat.id by lia.
@@ -747,7 +792,7 @@ rewrite Z2Nat.inj_sub by lia.
 rewrite Nat2Z.id.
 auto.
 apply Nat2Z.inj_ge.
-destruct (zlt n 0).
+destruct (Z_lt_dec n 0).
 rewrite (Z2Nat_neg n) by lia.
 change (Z.of_nat 0) with 0.  lia.
 rewrite Z2Nat.id by lia.
@@ -840,7 +885,7 @@ Ltac unfold_sublist_old :=
   rewrite !sublist_old_sublist by lia; unfold old_sublist.
 
 Definition upd_Znth {A} (i : Z) (al : list A) (x : A) : list A :=
-  if Sumbool.sumbool_and _ _ _ _ (zle 0 i) (zlt i (Zlength al)) then
+  if Sumbool.sumbool_and _ _ _ _ (Z_le_gt_dec 0 i) (Z_lt_dec i (Zlength al)) then
     sublist 0 i al ++ x :: sublist (i+1) (Zlength al) al
   else
     al.
@@ -1092,7 +1137,7 @@ rewrite sublist_old_sublist by lia.
 rewrite sublist_old_sublist by (pose_Zmin_irreducible; pose proof (Zlength_nonneg al); lia).
 rewrite sublist_old_sublist by (apply Z.le_max_r).
 unfold old_sublist.
-destruct (zlt hi (Zlength al)).
+destruct (Z_lt_dec hi (Zlength al)).
 rewrite (Z.min_l hi (Zlength al)) by lia.
 rewrite (Z.min_l lo (Zlength al)) by lia.
 rewrite (Z.max_r (hi-Zlength al) 0) by lia.
@@ -1106,7 +1151,7 @@ rewrite Zfirstn_app1
 auto.
 rewrite (Z.min_r hi (Zlength al)) by lia.
 rewrite (Z.max_l (hi-Zlength al) 0) by lia.
-destruct (zlt lo (Zlength al)).
+destruct (Z_lt_dec lo (Zlength al)).
 rewrite (Z.min_l lo (Zlength al)) by lia.
 rewrite (Z.max_r (lo-Zlength al) 0) by lia.
 rewrite Zskipn_app1 by lia.
@@ -1222,48 +1267,49 @@ Lemma sublist_sublist00 {A} i j (l:list A): 0<=i<=j ->
   sublist 0 i (sublist 0 j l) = sublist 0 i l.
 Proof. intros. apply sublist_sublist0; lia. Qed.
 
-Lemma skipn_list_repeat:
+Lemma skipn_repeat:
    forall A k n (a: A),
-     (k <= n)%nat -> skipn k (list_repeat n a) = list_repeat (n-k) a.
+     (k <= n)%nat -> skipn k (repeat a n) = repeat a (n-k).
 Proof.
  induction k; destruct n; simpl; intros; auto.
  apply IHk; auto. lia.
 Qed.
 
-Lemma sublist_list_repeat {A} i j k (v:A) (I: 0<=i)
+Lemma sublist_repeat {A} i j k (v:A) (I: 0<=i)
           (IJK: i <= j <= k):
-      sublist i j (list_repeat (Z.to_nat k) v) = list_repeat (Z.to_nat (j-i)) v.
+      sublist i j (repeat v (Z.to_nat k)) = repeat v (Z.to_nat (j-i)).
 Proof.
   unfold_sublist_old.
-  rewrite skipn_list_repeat.
-  rewrite firstn_list_repeat.
+  rewrite skipn_repeat.
+  rewrite firstn_repeat.
   trivial.
   rewrite <- Z2Nat.inj_sub by lia.
   apply Z2Nat.inj_le; lia.
   apply Z2Nat.inj_le; lia.
 Qed.
 
-Lemma Zlength_list_repeat:
+
+Lemma Zlength_repeat:
   forall {A} n (x: A),
   0 <= n ->
-  Zlength (list_repeat (Z.to_nat n) x) = n.
+  Zlength (repeat x (Z.to_nat n)) = n.
 Proof.
 intros.
 rewrite Zlength_correct.
-rewrite length_list_repeat.
+rewrite repeat_length.
 apply Z2Nat.id; auto.
 Qed.
 
-Lemma list_repeat_0:
-  forall {A} (x:A), list_repeat (Z.to_nat 0) x = nil.
+Lemma repeat_0:
+  forall {A} (x:A), repeat x (Z.to_nat 0) = nil.
 Proof.
 simpl. auto.
 Qed.
 
-Lemma Znth_list_repeat_inrange:
+Lemma Znth_repeat_inrange:
   forall {A}{d: Inhabitant A} i n (a: A),
    (0 <= i < n)%Z ->
-   Znth i (list_repeat (Z.to_nat n) a) = a.
+   Znth i (repeat a (Z.to_nat n)) = a.
 Proof.
 intros.
 unfold Znth; rewrite if_false by lia.
@@ -1294,8 +1340,8 @@ Qed.
 Lemma sublist_In {A} lo hi data (x:A) (I:In x (sublist lo hi data)): In x data.
 Proof. eapply firstn_In. eapply skipn_In. apply I. Qed.
 
-Lemma Zlength_list_repeat' {A} n (v:A): Zlength (list_repeat n v) = Z.of_nat n.
-Proof. rewrite Zlength_correct, length_list_repeat; trivial. Qed.
+Lemma Zlength_repeat' {A} n (v:A): Zlength (repeat v n) = Z.of_nat n.
+Proof. rewrite Zlength_correct, repeat_length; trivial. Qed.
 
 Lemma sublist0_app2 {A : Type} i (al bl : list A):
   Zlength al <= i <= Zlength al + Zlength bl ->
@@ -1375,12 +1421,12 @@ Lemma upd_Znth_lookup K {A}{d: Inhabitant A}: forall l (L:Zlength l = K) i j (v:
    (i<>j /\ Znth i (upd_Znth j l v) = Znth i l).
 Proof.
   intros. unfold_upd_Znth_old.
-  destruct (zeq i j); subst.
+  destruct (Z.eq_dec i j); subst.
   + left; split; trivial.
     rewrite app_Znth2; rewrite Zlength_sublist; try rewrite Zminus_0_r; try rewrite Zminus_diag; try lia.
     rewrite Znth_0_cons. trivial.
   + right; split; trivial.
-    destruct (zlt i j).
+    destruct (Z_lt_dec i j).
     - rewrite app_Znth1; try rewrite Zlength_sublist; try lia.
       rewrite Znth_sublist; try lia. rewrite Zplus_0_r; trivial.
     - rewrite app_Znth2; rewrite Zlength_sublist; try lia.
@@ -1389,7 +1435,7 @@ Proof.
 Qed.
 
 Lemma upd_Znth_lookup' K {A}{d: Inhabitant A}: forall l (L:Zlength l = K) i (I: 0<=i<K) j (J: 0<=j<K) (v:A),
-    Znth i (upd_Znth j l v) = if zeq i j then v else Znth i l.
+    Znth i (upd_Znth j l v) = if Z.eq_dec i j then v else Znth i l.
 Proof. intros.
   destruct (upd_Znth_lookup K l L i j v I J) as [[X Y] | [X Y]]; if_tac; try lia; trivial.
 Qed.
@@ -1406,14 +1452,14 @@ Qed.
 Lemma upd_Znth_same {A}{d: Inhabitant A}: forall i l u, 0<= i< Zlength l -> Znth i (upd_Znth i l u) = u.
 Proof.
   intros. rewrite (upd_Znth_lookup' _ _ (eq_refl _)); trivial.
-  rewrite zeq_true; trivial.
+  rewrite if_true; trivial.
 Qed.
 
 Lemma upd_Znth_diff {A}{d: Inhabitant A}: forall i j l u, 0<= i< Zlength l -> 0<= j< Zlength l -> i<>j ->
       Znth i (upd_Znth j l u) = Znth i l.
 Proof.
   intros. rewrite (upd_Znth_lookup' _ _ (eq_refl _)); trivial.
-  rewrite zeq_false; trivial.
+  rewrite if_false; trivial.
 Qed.
 
 Lemma upd_Znth_app1 {A} i l1 l2 (I: 0 <= i < Zlength l1) (v:A):
@@ -1434,7 +1480,7 @@ Lemma upd_Znth_app2 {A} (l1 l2:list A) i v:
   Zlength l1 <= i <= Zlength l1 + Zlength l2 ->
   upd_Znth i (l1 ++ l2) v = l1 ++ upd_Znth (i-Zlength l1) l2 v.
 Proof. intros.
-  destruct (zlt i (Zlength l1 + Zlength l2)).
+  destruct (Z_lt_dec i (Zlength l1 + Zlength l2)).
   - unfold_upd_Znth_old.
     rewrite sublist0_app2; trivial. rewrite <- app_assoc. f_equal. f_equal. f_equal.
     rewrite sublist_app2, Zlength_app, Zminus_plus.
@@ -1521,13 +1567,13 @@ Proof.
   f_equal; [| f_equal]; f_equal; lia.
 Qed.
 
-Hint Rewrite @Znth_list_repeat_inrange : sublist.
+Hint Rewrite @Znth_repeat_inrange : sublist.
 Hint Rewrite @Zlength_cons @Zlength_nil: sublist.
-Hint Rewrite @list_repeat_0: sublist.
+Hint Rewrite @repeat_0: sublist.
 Hint Rewrite <- @app_nil_end : sublist.
 Hint Rewrite @Zlength_app: sublist.
 Hint Rewrite @Zlength_map: sublist.
-Hint Rewrite @Zlength_list_repeat using old_list_solve: sublist.
+Hint Rewrite @Zlength_repeat using old_list_solve: sublist.
 Hint Rewrite Z.sub_0_r Z.add_0_l Z.add_0_r : sublist.
 Hint Rewrite @Zlength_sublist using old_list_solve: sublist.
 Hint Rewrite Z.max_r Z.max_l using lia : sublist.
@@ -1536,7 +1582,7 @@ Hint Rewrite Z.add_simpl_r Z.sub_add Z.sub_diag : sublist.
 Hint Rewrite @sublist_sublist using old_list_solve : sublist.
 Hint Rewrite @sublist_app1 using old_list_solve : sublist.
 Hint Rewrite @sublist_app2 using old_list_solve : sublist.
-Hint Rewrite @sublist_list_repeat  using old_list_solve : sublist.
+Hint Rewrite @sublist_repeat  using old_list_solve : sublist.
 Hint Rewrite @sublist_same using old_list_solve : sublist.
 Hint Rewrite Z.add_simpl_l : sublist.
 Hint Rewrite Z.add_add_simpl_l_l Z.add_add_simpl_l_r
@@ -1551,13 +1597,13 @@ Hint Rewrite @upd_Znth_Zlength using old_list_solve : sublist.
 Hint Rewrite @sublist_nil : sublist.
 
 
-Lemma list_repeat_app':
+Lemma repeat_app':
  forall {A: Type} a b (x:A), 
     0 <= a -> 0 <= b ->
-    list_repeat (Z.to_nat a) x ++ list_repeat (Z.to_nat b) x = list_repeat (Z.to_nat (a+b)) x.
+    repeat x (Z.to_nat a) ++ repeat x (Z.to_nat b) = repeat x (Z.to_nat (a+b)).
 Proof.
  intros.
- rewrite list_repeat_app. f_equal.
+ rewrite <- repeat_app. f_equal.
   apply Nat2Z.inj. rewrite <- Z2Nat.inj_add; auto.
 Qed.
 
@@ -1651,11 +1697,11 @@ Qed.
 Hint Rewrite @upd_Znth_app1 using old_list_solve : sublist.
 Hint Rewrite @upd_Znth_app2 using old_list_solve : sublist.
 
-Lemma map_list_repeat: forall {A B} (f: A->B) n (x:A), map f (list_repeat n x) = list_repeat n (f x).
+Lemma map_repeat: forall {A B} (f: A->B) n (x:A), map f (repeat x n) = repeat (f x) n.
 Proof.
 intros. induction n; simpl; f_equal; auto.
 Qed.
-Hint Rewrite @map_list_repeat : sublist.
+Hint Rewrite @map_repeat : sublist.
 
 Lemma Zlength_sublist_correct: forall {A} (l: list A) (lo hi: Z),
   0 <= lo <= hi ->

--- a/hmacdrbg/HMAC_DRBG_algorithms.v
+++ b/hmacdrbg/HMAC_DRBG_algorithms.v
@@ -14,9 +14,9 @@ Definition HMAC_DRBG_update (HMAC: list byte -> list byte -> list byte) (provide
       (K, V)
   end.
 
-Definition initial_key: list byte := list_repeat 32 Byte.zero.
+Definition initial_key: list byte := repeat Byte.zero 32.
 
-Definition initial_value: list byte := list_repeat 32 Byte.one.
+Definition initial_value: list byte := repeat Byte.one 32.
 
 Definition HMAC_DRBG_instantiate_algorithm (HMAC: list byte -> list byte -> list byte)
            (entropy_input nonce personalization_string: list byte) (security_strength: Z): DRBG_working_state :=

--- a/hmacdrbg/drbg_protocol_proofs.v
+++ b/hmacdrbg/drbg_protocol_proofs.v
@@ -32,7 +32,7 @@ Require Import hmacdrbg.verif_hmac_drbg_seed_common.
 Opaque mbedtls_HMAC256_DRBG_reseed_function.
 Opaque initial_key. Opaque initial_value.
 Opaque mbedtls_HMAC256_DRBG_reseed_function.
-Opaque list_repeat. 
+Opaque repeat. 
 
 Require hmacdrbg.verif_hmac_drbg_seed.
 
@@ -162,7 +162,7 @@ Proof.
 
   assert (exists xx:reptype t_struct_hmac256drbg_context_st, xx =
    (((*M1*)info, (M2, p)),
-    (list_repeat (Z.to_nat 32) (Vint Int.one),
+    (repeat (Vint Int.one) (Z.to_nat 32),
      (Vint (Int.repr reseed_counter),
       (Vint (Int.repr entropy_len),
        (Val.of_bool prediction_resistance,
@@ -181,7 +181,7 @@ Proof.
     unfold field_address. rewrite if_true. 2: assumption. simpl. cancel.
   }
   clear INI. thaw OTHER.
-  set (ABS:= HMAC256DRBGabs V (list_repeat 32 Byte.one) reseed_counter entropy_len prediction_resistance reseed_interval) in *.
+  set (ABS:= HMAC256DRBGabs V (repeat Byte.one 32) reseed_counter entropy_len prediction_resistance reseed_interval) in *.
   gather_SEP 1 2.
   replace_SEP 0 (hmac256drbg_relate  ABS xx).
   { entailer!. simpl. subst ABS; unfold md_full. simpl. entailer!.
@@ -197,7 +197,7 @@ Proof.
   thaw ALLSEP.
   unfold hmac256drbgabs_common_mpreds. simpl.
   remember(HMAC256_DRBG_functional_prog.HMAC256_DRBG_update (contents_with_add data d_len Data) V
-             (list_repeat 32 Byte.one)) as HH.
+             (repeat Byte.one 32)) as HH.
   destruct HH as [KEY VALUE]. unfold hmac256drbgstate_md_info_pointer; simpl.
   Exists KEY VALUE p (M1, (M2, M3)). normalize. simpl in *.
   apply andp_right.
@@ -305,14 +305,14 @@ Proof.
 
   assert_PROP (field_compatible (tarray tuchar 384) [] seed) as Hfield by entailer!.
   replace_SEP 0 ((data_at Tsh (tarray tuchar entropy_len)
-         (list_repeat (Z.to_nat entropy_len) (Vint Int.zero)) seed) * (data_at Tsh (tarray tuchar (384 - entropy_len))
-         (list_repeat (Z.to_nat (384 - entropy_len)) (Vint Int.zero)) (offset_val entropy_len seed))).
+         (repeat (Vint Int.zero) (Z.to_nat entropy_len)) seed) * (data_at Tsh (tarray tuchar (384 - entropy_len))
+         (repeat (Vint Int.zero) (Z.to_nat (384 - entropy_len))) (offset_val entropy_len seed))).
   {
-    erewrite <- data_at_complete_split with (length:=384)(AB:=list_repeat (Z.to_nat 384) (Vint Int.zero)); 
-    repeat rewrite Zlength_list_repeat; trivial; try lia. 
+    erewrite <- data_at_complete_split with (length:=384)(AB:=repeat (Vint Int.zero) (Z.to_nat 384)); 
+    repeat rewrite Zlength_repeat; trivial; try lia. 
     solve [go_lower; apply derives_refl]. 
     solve [rewrite Zplus_minus; assumption].
-    rewrite list_repeat_app, Z2Nat.inj_sub; try lia. rewrite le_plus_minus_r; trivial. apply Z2Nat.inj_le; try lia.
+    rewrite <- repeat_app, Z2Nat.inj_sub; try lia. rewrite le_plus_minus_r; trivial. apply Z2Nat.inj_le; try lia.
   }
   flatten_sepcon_in_SEP.
 

--- a/hmacdrbg/drbg_protocol_specs.v
+++ b/hmacdrbg/drbg_protocol_specs.v
@@ -106,7 +106,7 @@ Definition drbg_seed_buf_abs_spec :=
             then seedbufREP sh gv Info info I ctx
             else match I with HMAC256DRBGabs key V RC EL PR RI =>
                  EX KEY:list byte, EX VAL:list byte, EX p:val, EX mds:mdstate,
-                 !!(hmacdrbg.HMAC256_DRBG_functional_prog.HMAC256_DRBG_update (contents_with_add data d_len Data) V (list_repeat 32 Byte.one) = (KEY, VAL))
+                 !!(hmacdrbg.HMAC256_DRBG_functional_prog.HMAC256_DRBG_update (contents_with_add data d_len Data) V (repeat Byte.one 32) = (KEY, VAL))
                  && md_full key mds *
                  REP sh gv Info (HMAC256DRBGabs KEY VAL RC EL PR RI) ctx end;
             mem_mgr gv).

--- a/hmacdrbg/spec_hmac_drbg.v
+++ b/hmacdrbg/spec_hmac_drbg.v
@@ -97,7 +97,7 @@ Definition mbedtls_zeroize_spec :=
        PARAMS (v;Vint (Int.repr n)) GLOBALS ()
        SEP (data_at_ sh (tarray tuchar n ) v)
     POST [ tvoid ]
-       PROP () LOCAL () SEP (data_block sh (list_repeat (Z.to_nat n) Byte.zero) v).
+       PROP () LOCAL () SEP (data_block sh (repeat Byte.zero (Z.to_nat n)) v).
 
 Definition drbg_memcpy_spec :=
   DECLARE _memcpy
@@ -124,7 +124,7 @@ Definition drbg_memset_spec :=
        SEP (memory_block sh n p)
     POST [ tptr tvoid ]
        PROP() LOCAL(temp ret_temp p)
-       SEP(data_at sh (tarray tuchar n) (list_repeat (Z.to_nat n) (Vint c)) p).
+       SEP(data_at sh (tarray tuchar n) (repeat (Vint c) (Z.to_nat n)) p).
 (*This results in using sha's compspecs
 Definition drbg_memset_spec := (_memset, snd spec_sha.memset_spec). 
 Definition drbg_memcpy_spec := (_memcpy, snd spec_sha.memcpy_spec). 
@@ -613,7 +613,7 @@ Definition hmac_drbg_seed_buf_spec :=
                          with (mds, (V', (RC', (EL', (PR', RI'))))),
                               HMAC256DRBGabs key V RC EL PR RI
                          => EX KEY:list byte, EX VAL:list byte, EX p:val,
-                          !!(HMAC256_DRBG_update (contents_with_add data d_len Data) V (list_repeat 32 Byte.one) = (KEY, VAL))
+                          !!(HMAC256_DRBG_update (contents_with_add data d_len Data) V (repeat Byte.one 32) = (KEY, VAL))
                              && md_full key mds *
                                 data_at shc t_struct_hmac256drbg_context_st ((info, (fst(snd mds), p)), (map Vubyte VAL, (RC', (EL', (PR', RI'))))) ctx *
                                 hmac256drbg_relate (HMAC256DRBGabs KEY VAL RC EL PR RI) ((info, (fst(snd mds), p)), (map Vubyte VAL, (RC', (EL', (PR', RI')))))
@@ -675,7 +675,7 @@ Definition hmac_drbg_init_spec :=
           PROP () 
           LOCAL ()
           SEP(data_at shc (tarray tuchar size_of_HMACDRBGCTX)
-                (list_repeat (Z.to_nat size_of_HMACDRBGCTX) (Vint Int.zero)) c).
+                (repeat (Vint Int.zero) (Z.to_nat size_of_HMACDRBGCTX)) c).
 
 Definition hmac_drbg_random_spec :=
   DECLARE _mbedtls_hmac_drbg_random
@@ -894,7 +894,7 @@ Definition hmac_drbg_free_spec :=
     POST [ tvoid ] 
       EX vret:unit, PROP ()
        LOCAL ()
-       SEP (if Val.eq ctx nullval then emp else data_block shc (list_repeat (Z.to_nat size_of_HMACDRBGCTX) Byte.zero) ctx;
+       SEP (if Val.eq ctx nullval then emp else data_block shc (repeat Byte.zero (Z.to_nat size_of_HMACDRBGCTX)) ctx;
               mem_mgr gv).
 
 Definition HmacDrbgVarSpecs : varspecs := (sha._K256, tarray tuint 64)::nil.

--- a/hmacdrbg/verif_hmac_drbg_NISTseed.v
+++ b/hmacdrbg/verif_hmac_drbg_NISTseed.v
@@ -118,7 +118,7 @@ Proof. rewrite <- instantiate256_reseed, instantiate_eq; trivial. Qed.
 Opaque mbedtls_HMAC256_DRBG_reseed_function.
 Opaque initial_key. Opaque initial_value.
 Opaque mbedtls_HMAC256_DRBG_reseed_function.
-Opaque list_repeat. 
+Opaque repeat. 
 
 (*specification for the expected case, in which 0<=len<=256.
   But use mbedtls_HMAC256_DRBG_instantiate_function PROP of PRE and assume SUCCESS*)
@@ -247,7 +247,7 @@ Proof.
     rewrite Int.unsigned_repr. reflexivity. rep_lia. }
   set (myABS := HMAC256DRBGabs initial_key initial_value rc 48 pr_flag 10000) in *.
   assert (myST: exists ST:hmac256drbgstate, ST =
-    ((info, (M2, p)), (map Vint (list_repeat 32 Int.one), (Vint (Int.repr rc),
+    ((info, (M2, p)), (map Vint (repeat Int.one 32), (Vint (Int.repr rc),
         (Vint (Int.repr 48), (Val.of_bool pr_flag, Vint (Int.repr 10000))))))). eexists; reflexivity.
   destruct myST as [ST HST].
 
@@ -381,7 +381,7 @@ Definition hmac_drbg_seed_full_spec :=
                    if (zlt 256 (Zlength Data) || (zlt 384 (48 + Zlength Data)))%bool
                    then !!(ret_value = Int.repr (-5)) &&
                      (Stream s *
-                     ( let CtxFinal:= ((info, (M2, p)), (list_repeat 32 (Vint Int.one), (Vint (Int.repr rc),
+                     ( let CtxFinal:= ((info, (M2, p)), (repeat (Vint Int.one) 32, (Vint (Int.repr rc),
                                        (Vint (Int.repr 48), (Val.of_bool pr_flag, Vint (Int.repr 10000)))))) in
                        let CTXFinal:= HMAC256DRBGabs initial_key initial_value rc 48 pr_flag 10000 in
                        data_at Ews t_struct_hmac256drbg_context_st CtxFinal ctx *
@@ -395,7 +395,7 @@ Definition hmac_drbg_seed_full_spec :=
                                | ENTROPY.generic_error => Vint ret_value = Vint (Int.repr ENT_GenErr)
                                | ENTROPY.catastrophic_error => Vint ret_value = Vint (Int.repr (-9))
                               end) && (Stream ss *
-                                       let CtxFinal:= ((info, (M2, p)), (list_repeat 32 (Vint Int.one), (Vint (Int.repr rc),
+                                       let CtxFinal:= ((info, (M2, p)), (repeat (Vint Int.one) 32, (Vint (Int.repr rc),
                                                 (Vint (Int.repr 48), (Val.of_bool pr_flag, Vint (Int.repr 10000)))))) in
                                        let CTXFinal:= HMAC256DRBGabs initial_key initial_value rc 48 pr_flag 10000 in
                                        data_at Ews t_struct_hmac256drbg_context_st CtxFinal ctx *
@@ -500,7 +500,7 @@ Proof.
     rewrite Int.unsigned_repr. reflexivity. rep_lia. }
   set (myABS := HMAC256DRBGabs initial_key initial_value rc 48 pr_flag 10000) in *.
   assert (myST: exists ST:hmac256drbgstate, ST =
-    ((info, (M2, p)), (map Vint (list_repeat 32 Int.one), (Vint (Int.repr rc),
+    ((info, (M2, p)), (map Vint (repeat Int.one 32), (Vint (Int.repr rc),
         (Vint (Int.repr 48), (Val.of_bool pr_flag, Vint (Int.repr 10000))))))). eexists; reflexivity.
   destruct myST as [ST HST].
 
@@ -673,13 +673,13 @@ Definition hmac_drbg_seed_spec :=
                    if (zlt 256 (Zlength Data) || (zlt 384 ((*hmac256drbgabs_entropy_len initial_state_abs*)48 + Zlength Data)))%bool
                    then !!(ret_value = Int.repr (-5)) &&
                      (Stream s *
-                     ( let CtxFinal:= ((info, (M2, p)), (list_repeat 32 (Vint Int.one), (Vint (Int.repr rc),
+                     ( let CtxFinal:= ((info, (M2, p)), (repeat (Vint Int.one) 32, (Vint (Int.repr rc),
                                        (Vint (Int.repr 48), (Val.of_bool pr, Vint (Int.repr 10000)))))) in
-                       let CTXFinal:= HMAC256DRBGabs VV (list_repeat 32 Byte.one) rc 48 pr 10000 in
+                       let CTXFinal:= HMAC256DRBGabs VV (repeat Byte.one 32) rc 48 pr 10000 in
                        data_at Ews t_struct_hmac256drbg_context_st CtxFinal ctx *
                                      hmac256drbg_relate CTXFinal CtxFinal))
 
-                   else let myABS := HMAC256DRBGabs VV (list_repeat 32 Byte.one) rc 48 pr 10000
+                   else let myABS := HMAC256DRBGabs VV (repeat Byte.one 32) rc 48 pr 10000
                       in match mbedtls_HMAC256_DRBG_reseed_function s myABS
                                 (contents_with_add data (Zlength Data) Data)
                          with
@@ -688,9 +688,9 @@ Definition hmac_drbg_seed_spec :=
                                | ENTROPY.generic_error => Vint ret_value = Vint (Int.repr ENT_GenErr)
                                | ENTROPY.catastrophic_error => Vint ret_value = Vint (Int.repr (-9))
                               end) && (Stream ss *
-                                       let CtxFinal:= ((info, (M2, p)), (list_repeat 32 (Vint Int.one), (Vint (Int.repr rc),
+                                       let CtxFinal:= ((info, (M2, p)), (repeat (Vint Int.one) 32, (Vint (Int.repr rc),
                                                 (Vint (Int.repr 48), (Val.of_bool pr, Vint (Int.repr 10000)))))) in
-                                       let CTXFinal:= HMAC256DRBGabs VV (list_repeat 32 Byte.one) rc 48 pr 10000 in
+                                       let CTXFinal:= HMAC256DRBGabs VV (repeat Byte.one 32) rc 48 pr 10000 in
                                        data_at Ews t_struct_hmac256drbg_context_st CtxFinal ctx *
                                        hmac256drbg_relate CTXFinal CtxFinal))
                         | ENTROPY.success handle ss => !!(ret_value = Int.zero) &&
@@ -796,9 +796,9 @@ Proof.
   { rewrite mul_repr. simpl.
     rewrite Int.unsigned_repr. reflexivity. rep_lia. }
 
-  set (myABS := HMAC256DRBGabs VV (list_repeat 32 Byte.one) rc 48 pr 10000) in *.
+  set (myABS := HMAC256DRBGabs VV (repeat Byte.one 32) rc 48 pr 10000) in *.
   assert (myST: exists ST:hmac256drbgstate, ST =
-    ((info, (M2, p)), (map Vint (list_repeat 32 Int.one), (Vint (Int.repr rc),
+    ((info, (M2, p)), (map Vint (repeat Int.one 32), (Vint (Int.repr rc),
         (Vint (Int.repr 48), (Val.of_bool pr, Vint (Int.repr 10000))))))). eexists; reflexivity.
   destruct myST as [ST HST].
 

--- a/hmacdrbg/verif_hmac_drbg_generate.v
+++ b/hmacdrbg/verif_hmac_drbg_generate.v
@@ -1181,7 +1181,7 @@ set (HLP := HMAC_DRBG_generate_helper_Z HMAC256 (*after_update_key after_update_
         initial_state (Vptr b i) Info; FRZL StreamAdd; 
       data_at sho (tarray tuchar out_len) ((map Vubyte
           (sublist 0 done (snd (HLP done)))) ++ 
-          list_repeat (Z.to_nat (out_len - done)) Vundef) output; 
+          repeat Vundef (Z.to_nat (out_len - done))) output; 
       K_vector gv)
   ).
   {
@@ -1190,7 +1190,7 @@ set (HLP := HMAC_DRBG_generate_helper_Z HMAC256 (*after_update_key after_update_
     change (sublist 0 0 (snd (HLP 0))) with (@nil byte).
     replace (out_len - 0) with out_len by lia.
     change ((map Vint (map Int.repr []) ++
-          list_repeat (Z.to_nat out_len) Vundef)) with (list_repeat (Z.to_nat out_len) Vundef).
+          repeat Vundef (Z.to_nat out_len))) with (repeat Vundef (Z.to_nat out_len)).
     assert (Hafter_update: (hmac256drbgabs_update_value after_update_state_abs(*AUSA*)
             (fst (HLP 0))) = after_update_state_abs(*AUSA*)).
     {
@@ -1240,7 +1240,7 @@ Opaque hmac256drbgabs_reseed.
   subst done.
   clear H H0.
   replace (out_len - out_len) with 0 by lia. clear HRE.
-  change (list_repeat (Z.to_nat 0) Vundef) with (@nil val).
+  change (repeat Vundef (Z.to_nat 0)) with (@nil val).
   rewrite app_nil_r.
   unfold hmac256drbgabs_common_mpreds.
   normalize. unfold hmac256drbg_relate.

--- a/hmacdrbg/verif_hmac_drbg_generate_abs.v
+++ b/hmacdrbg/verif_hmac_drbg_generate_abs.v
@@ -535,7 +535,7 @@ set (HLP := HMAC_DRBG_generate_helper_Z HMAC256 (*after_update_key after_update_
         aaa (Vptr b i) Info; FRZL StreamAdd; 
       data_at sho (tarray tuchar out_len) ((map Vubyte
           (sublist 0 done (snd (HLP done)))) ++ 
-          list_repeat (Z.to_nat (out_len - done)) Vundef) output; 
+          repeat Vundef (Z.to_nat (out_len - done))) output; 
       K_vector gv)
   ).
   {
@@ -544,7 +544,7 @@ set (HLP := HMAC_DRBG_generate_helper_Z HMAC256 (*after_update_key after_update_
     change (sublist 0 0 (snd (HLP 0))) with (@nil byte).
     replace (out_len - 0) with out_len by lia.
     change ((map Vint (map Int.repr []) ++
-          list_repeat (Z.to_nat out_len) Vundef)) with (list_repeat (Z.to_nat out_len) Vundef).
+          repeat Vundef (Z.to_nat out_len))) with (repeat Vundef (Z.to_nat out_len)).
     assert (Hafter_update: (hmac256drbgabs_update_value after_update_state_abs(*AUSA*)
             (fst (HLP 0))) = after_update_state_abs(*AUSA*)).
     {
@@ -594,7 +594,7 @@ Opaque mbedtls_HMAC256_DRBG_generate_function.
   subst done.
   clear H H0.
   replace (out_len - out_len) with 0 by lia. clear HRE.
-  change (list_repeat (Z.to_nat 0) Vundef) with (@nil val).
+  change (repeat Vundef (Z.to_nat 0)) with (@nil val).
   rewrite app_nil_r.
   unfold hmac256drbgabs_common_mpreds.
   normalize. unfold hmac256drbg_relate.

--- a/hmacdrbg/verif_hmac_drbg_generate_common.v
+++ b/hmacdrbg/verif_hmac_drbg_generate_common.v
@@ -1118,7 +1118,7 @@ Lemma loopbody_explicit (StreamAdd:list mpred) : forall (Espec : OracleKind)
              (fst (HLP done))) initial_state (Vptr b i) Info; FRZL StreamAdd;
    data_at sho (tarray tuchar out_len)
      (map Vubyte (sublist 0 done (snd (HLP done))) ++
-      list_repeat (Z.to_nat (out_len - done)) Vundef) output; K_vector gv))
+      repeat Vundef (Z.to_nat (out_len - done))) output; K_vector gv))
   (Ssequence
      (Ssequence
         (Sifthenelse
@@ -1221,7 +1221,7 @@ Lemma loopbody_explicit (StreamAdd:list mpred) : forall (Espec : OracleKind)
                 (fst (HLP a))) initial_state (Vptr b i) Info; FRZL StreamAdd;
       data_at sho (tarray tuchar out_len)
         (map Vubyte (sublist 0 a (snd (HLP a))) ++
-         list_repeat (Z.to_nat (out_len - a)) Vundef) output; K_vector gv))%assert
+         repeat Vundef (Z.to_nat (out_len - a))) output; K_vector gv))%assert
 (*
      (overridePost
         (EX a : Z,
@@ -1246,7 +1246,7 @@ Lemma loopbody_explicit (StreamAdd:list mpred) : forall (Espec : OracleKind)
          FRZL StreamAdd;
          data_at Tsh (tarray tuchar out_len)
            (map Vint (map Int.repr (sublist 0 a (snd (HLP a)))) ++
-            list_repeat (Z.to_nat (out_len - a)) Vundef) output; K_vector kv))%assert
+            repeat Vundef (Z.to_nat (out_len - a))) output; K_vector kv))%assert
         (function_body_ret_assert tint
            (fun a : environ =>
             EX x : val,
@@ -1376,7 +1376,7 @@ Proof. intros.
         Hfield_compat_output by entailer!.
     replace_SEP 5 (
         data_at sho (tarray tuchar done) (map Vubyte (sublist 0 done (snd (HLP done)))) output *
-        data_at sho (tarray tuchar (out_len - done)) (list_repeat (Z.to_nat (out_len - done)) Vundef) (offset_val done output)
+        data_at sho (tarray tuchar (out_len - done)) (repeat Vundef (Z.to_nat (out_len - done))) (offset_val done output)
     ).
     {
       entailer!.
@@ -1391,7 +1391,7 @@ Proof. intros.
         exists n; reflexivity.
       }
       
-      apply data_at_complete_split; try rewrite HZlength1; try rewrite Zlength_list_repeat; auto; try lia.
+      apply data_at_complete_split; try rewrite HZlength1; try rewrite Zlength_repeat; auto; try lia.
       (*simpl. simpl in HZlength1. rewrite HZlength1.*)
       replace ((n * 32)%Z + (out_len - (n * 32)%Z)) with out_len by lia. assumption.
     }
@@ -1406,8 +1406,8 @@ Proof. intros.
     }
     Intros.
     replace_SEP 6 (
-        data_at sho (tarray tuchar use_len) (list_repeat (Z.to_nat use_len) Vundef) done_output *
-        data_at sho (tarray tuchar (out_len - done - use_len)) (list_repeat (Z.to_nat (out_len - done - use_len)) Vundef) (offset_val use_len done_output)
+        data_at sho (tarray tuchar use_len) (repeat Vundef (Z.to_nat use_len)) done_output *
+        data_at sho (tarray tuchar (out_len - done - use_len)) (repeat Vundef (Z.to_nat (out_len - done - use_len))) (offset_val use_len done_output)
     ).
     { 
       clear Hmultiple Heqdone_output.
@@ -1415,14 +1415,14 @@ Proof. intros.
       apply derives_refl'.
       rewrite Zmin_spec.
       if_tac.
-      { apply data_at_complete_split; repeat rewrite Zlength_list_repeat; auto; try lia.
+      { apply data_at_complete_split; repeat rewrite Zlength_repeat; auto; try lia.
         replace (32 + (out_len - done - 32)) with (out_len - done) by lia; assumption.
-        rewrite list_repeat_app.
+        rewrite <- repeat_app.
         rewrite <- Z2Nat.inj_add; try lia.
         replace (32 + (out_len - done - 32)) with (out_len - done) by lia; reflexivity.
       }
       {
-        apply data_at_complete_split; repeat rewrite Zlength_list_repeat; auto; try lia.
+        apply data_at_complete_split; repeat rewrite Zlength_repeat; auto; try lia.
         replace (out_len - done + (out_len - done - (out_len - done))) with (out_len - done) by lia; assumption.
         replace (out_len - done - (out_len - done)) with 0 by lia; simpl; rewrite app_nil_r; reflexivity.
       }
@@ -1524,7 +1524,7 @@ Proof. intros.
                        (data_at sho (tarray tuchar (out_len - _ - _)) _ _).
     replace_SEP 0 (data_at sho (tarray tuchar (out_len - done)) 
          ( (map Vubyte (sublist 0 use_len H256))
-           ++ (list_repeat (Z.to_nat (out_len - done - use_len)) Vundef))
+           ++ (repeat Vundef (Z.to_nat (out_len - done - use_len))))
          done_output).
     {
       (*clear Heqdone_output Hmultiple*)
@@ -1536,7 +1536,7 @@ Proof. intros.
       { 
         erewrite ( data_at_complete_split
                            (map Vint (sublist 0 32 (map Int.repr (map Byte.unsigned H256))))
-                           (list_repeat (Z.to_nat (out_len - n * 32 - 32)) Vundef)); try reflexivity.
+                           (repeat Vundef (Z.to_nat (out_len - n * 32 - 32)))); try reflexivity.
         2: autorewrite with sublist; replace (_ + _) with (out_len - n*32) by lia; solve [auto].
         2: autorewrite with sublist; lia.
         2: f_equal; autorewrite with sublist; rewrite !map_map; reflexivity.
@@ -1546,12 +1546,12 @@ Proof. intros.
         rewrite !sublist_map. rewrite !map_map. 
         erewrite (data_at_complete_split 
             (map (fun x : byte => Vint (Int.repr (Byte.unsigned x))) (sublist 0 (out_len - n * 32) H256))
-            (list_repeat (Z.to_nat (out_len - n * 32 - (out_len - n * 32))) Vundef)).
+            (repeat Vundef (Z.to_nat (out_len - n * 32 - (out_len - n * 32))))).
         3: reflexivity. 3: reflexivity. 4: reflexivity.
-        + rewrite Zlength_map, Zlength_sublist, Zlength_list_repeat, Z.sub_0_r, offset_offset_val; try lia.
+        + rewrite Zlength_map, Zlength_sublist, Zlength_repeat, Z.sub_0_r, offset_offset_val; try lia.
           trivial.
-        + rewrite Zlength_map, Zlength_sublist, Zlength_list_repeat, Zminus_diag, Z.sub_0_r, Z.add_0_r; try lia. trivial.
-        + rewrite Zlength_map, Zlength_sublist, Zlength_list_repeat; try lia.
+        + rewrite Zlength_map, Zlength_sublist, Zlength_repeat, Zminus_diag, Z.sub_0_r, Z.add_0_r; try lia. trivial.
+        + rewrite Zlength_map, Zlength_sublist, Zlength_repeat; try lia.
         + unfold Vubyte. f_equal.
       }
     }
@@ -1561,7 +1561,7 @@ Proof. intros.
                   data_at sho (tarray tuchar out_len) 
                     ((map Vubyte (sublist 0 done (snd (HLP done)))) ++
                      (map Vubyte (sublist 0 use_len H256) ++
-                      list_repeat (Z.to_nat (out_len - done - use_len)) Vundef)) output).
+                      repeat Vundef (Z.to_nat (out_len - done - use_len)))) output).
     {
       entailer!.
       apply derives_refl'.
@@ -1575,13 +1575,13 @@ Proof. intros.
       rewrite Zmin_spec. simpl in *.
       if_tac.
       apply data_at_complete_split;
-      repeat rewrite Zlength_app; repeat rewrite Zlength_map; try rewrite HZlength1; repeat rewrite Zlength_list_repeat; repeat rewrite Zlength_sublist; repeat rewrite Zlength_map; try rewrite hmac_common_lemmas.HMAC_Zlength; auto; try lia;
+      repeat rewrite Zlength_app; repeat rewrite Zlength_map; try rewrite HZlength1; repeat rewrite Zlength_repeat; repeat rewrite Zlength_sublist; repeat rewrite Zlength_map; try rewrite hmac_common_lemmas.HMAC_Zlength; auto; try lia;
       try rewrite HZlength_V.
       replace ((n * 32)%Z - 0 + (32 - 0 + (out_len - (n * 32)%Z - 32))) with out_len by lia;
       assumption. 
       replace ((n * 32)%Z - 0 + (out_len - (n * 32)%Z - 0 + (out_len - (n * 32)%Z - (out_len - (n * 32)%Z)))) with out_len by lia.
       apply data_at_complete_split;
-      repeat rewrite Zlength_app; repeat rewrite Zlength_map; try rewrite HZlength1; repeat rewrite Zlength_list_repeat; repeat rewrite Zlength_sublist; repeat rewrite Zlength_map; try rewrite hmac_common_lemmas.HMAC_Zlength; auto; try lia;
+      repeat rewrite Zlength_app; repeat rewrite Zlength_map; try rewrite HZlength1; repeat rewrite Zlength_repeat; repeat rewrite Zlength_sublist; repeat rewrite Zlength_map; try rewrite hmac_common_lemmas.HMAC_Zlength; auto; try lia;
       try rewrite HZlength_V.
       replace (n * 32 - 0 + (out_len - n * 32 - 0 + (out_len - n * 32 - (out_len - n * 32)))) with
          out_len by lia.
@@ -1768,7 +1768,7 @@ Lemma generate_loopbody: forall (StreamAdd: list mpred)
              (fst (HLP done))) a (Vptr b i) Info; FRZL StreamAdd;
    data_at sho (tarray tuchar out_len)
      (map Vubyte (sublist 0 done (snd (HLP done))) ++
-      list_repeat (Z.to_nat (out_len - done)) Vundef) output; K_vector gv))
+      repeat Vundef (Z.to_nat (out_len - done))) output; K_vector gv))
   (Ssequence
      (Ssequence
         (Sifthenelse
@@ -1871,7 +1871,7 @@ Lemma generate_loopbody: forall (StreamAdd: list mpred)
                 (fst (HLP a0))) a (Vptr b i) Info; FRZL StreamAdd;
       data_at sho (tarray tuchar out_len)
         (map Vubyte (sublist 0 a0 (snd (HLP a0))) ++
-         list_repeat (Z.to_nat (out_len - a0)) Vundef) output; K_vector gv))%assert).
+         repeat Vundef (Z.to_nat (out_len - a0))) output; K_vector gv))%assert).
 Proof. intros.
 eapply semax_post_flipped'.
 apply (loopbody_explicit StreamAdd); try assumption;

--- a/hmacdrbg/verif_hmac_drbg_other.v
+++ b/hmacdrbg/verif_hmac_drbg_other.v
@@ -379,8 +379,8 @@ Proof.
   (PROP (0<=k<=n )
    LOCAL (temp _p (offset_val k (Vptr b i)); temp _n (Vint (Int.repr (n-k)));
           temp _v (Vptr b i))
-   SEP (data_at sh (tarray tuchar n) (list_repeat (Z.to_nat k) (Vint Int.zero) ++
-                                       list_repeat (Z.to_nat (n-k)) Vundef) (Vptr b i)))).
+   SEP (data_at sh (tarray tuchar n) (repeat (Vint Int.zero) (Z.to_nat k) ++
+                                       repeat Vundef (Z.to_nat (n-k))) (Vptr b i)))).
   { Exists 0. rewrite Zminus_0_r. entailer!. simpl; cancel. }
   apply semax_loop with (
   (EX k : Z,
@@ -388,7 +388,7 @@ Proof.
    LOCAL (temp _p (offset_val k (Vptr b i)); temp _n (Vint (Int.repr (n - k)));
    temp _v (Vptr b i))
    SEP (data_at sh (tarray tuchar n)
-          (list_repeat (Z.to_nat k) (Vint Int.zero) ++ list_repeat (Z.to_nat (n-k)) Vundef)
+          (repeat (Vint Int.zero) (Z.to_nat k) ++ repeat Vundef (Z.to_nat (n-k)))
           (Vptr b i)))).
   2:{ apply extract_exists_pre. intros k. Intros. forward. entailer.
            Exists k. entailer!.
@@ -414,17 +414,17 @@ Proof.
       forward.
       Exists (k+1). rewrite ! Z.sub_add_distr. entailer!.
       unfold Ptrofs.of_ints, Ptrofs.of_int; normalize. 
-      rewrite upd_Znth_app2 by (rewrite ! Zlength_list_repeat; lia).
-      rewrite Zlength_list_repeat, Zminus_diag by lia.
-      assert (X: list_repeat (Z.to_nat k) (Vint Int.zero) ++
-               upd_Znth 0 (list_repeat (Z.to_nat (n - k)) Vundef)(Vint (Int.zero_ext 8 (Int.repr 0)))
-           = list_repeat (Z.to_nat (k + 1)) (Vint Int.zero) ++
-             list_repeat (Z.to_nat (n - k - 1)) Vundef).
+      rewrite upd_Znth_app2 by (rewrite ! Zlength_repeat; lia).
+      rewrite Zlength_repeat, Zminus_diag by lia.
+      assert (X: repeat (Vint Int.zero) (Z.to_nat k) ++
+               upd_Znth 0 (repeat Vundef (Z.to_nat (n - k)))(Vint (Int.zero_ext 8 (Int.repr 0)))
+           = repeat (Vint Int.zero) (Z.to_nat (k + 1)) ++
+             repeat Vundef (Z.to_nat (n - k - 1))).
       2: rewrite X; cancel.
-      rewrite Z2Nat.inj_add, <- list_repeat_app, <- app_assoc by lia. f_equal.
+      rewrite Z2Nat.inj_add, repeat_app, <- app_assoc by lia. f_equal.
       assert (X: (Z.to_nat (n - k) = 1+Z.to_nat (n-k-1))%nat).
       { specialize (Z2Nat.inj_add 1); simpl; intros. rewrite <- H1 by lia. f_equal; lia. }
-      rewrite X, <- list_repeat_app, upd_Znth_app1; clear X; trivial.
+      rewrite X, repeat_app, upd_Znth_app1; clear X; trivial.
       simpl; rewrite Zlength_cons, Zlength_nil; lia.
 Qed.
 

--- a/hmacdrbg/verif_hmac_drbg_reseed.v
+++ b/hmacdrbg/verif_hmac_drbg_reseed.v
@@ -96,14 +96,14 @@ Proof.
   (*freeze [1;2;3;4;5;6] FR3.*)
   assert_PROP (field_compatible (tarray tuchar 384) [] seed) as Hfield by entailer!.
   replace_SEP 0 ((data_at Tsh (tarray tuchar entropy_len)
-         (list_repeat (Z.to_nat entropy_len) (Vint Int.zero)) seed) * (data_at Tsh (tarray tuchar (384 - entropy_len))
-         (list_repeat (Z.to_nat (384 - entropy_len)) (Vint Int.zero)) (offset_val entropy_len seed))).
+         (repeat (Vint Int.zero) (Z.to_nat entropy_len)) seed) * (data_at Tsh (tarray tuchar (384 - entropy_len))
+         (repeat (Vint Int.zero) (Z.to_nat (384 - entropy_len))) (offset_val entropy_len seed))).
   {
     (*subst entropy_len.*)
-    erewrite <- data_at_complete_split with (length:=384)(AB:=list_repeat (Z.to_nat 384) (Vint Int.zero)); repeat rewrite Zlength_list_repeat; trivial; try lia.
+    erewrite <- data_at_complete_split with (length:=384)(AB:=repeat (Vint Int.zero) (Z.to_nat 384)); repeat rewrite Zlength_repeat; trivial; try lia.
     solve [go_lower; apply derives_refl]. 
     solve [rewrite Zplus_minus; assumption].
-    rewrite list_repeat_app, Z2Nat.inj_sub; try lia. rewrite le_plus_minus_r; trivial. apply Z2Nat.inj_le; try lia.
+    rewrite <- repeat_app, Z2Nat.inj_sub; try lia. rewrite le_plus_minus_r; trivial. apply Z2Nat.inj_le; try lia.
   }
   Intros.
 

--- a/hmacdrbg/verif_hmac_drbg_seed.v
+++ b/hmacdrbg/verif_hmac_drbg_seed.v
@@ -24,7 +24,7 @@ Require Import hmacdrbg.verif_hmac_drbg_seed_common.
 Opaque mbedtls_HMAC256_DRBG_reseed_function.
 Opaque initial_key. Opaque initial_value.
 Opaque mbedtls_HMAC256_DRBG_reseed_function.
-Opaque list_repeat. 
+Opaque repeat. 
 
 Lemma body_hmac_drbg_seed_256: semax_body HmacDrbgVarSpecs HmacDrbgFunSpecs
       f_mbedtls_hmac_drbg_seed hmac_drbg_seed_inst256_spec.
@@ -112,7 +112,7 @@ Proof.
     rewrite Int.unsigned_repr. reflexivity. rep_lia. }
   set (myABS := HMAC256DRBGabs initial_key initial_value rc 48 pr_flag 10000) in *.
   assert (myST: exists ST:hmac256drbgstate, ST =
-    ((info, (M2, p)), (map Vint (list_repeat 32 Int.one), (Vint (Int.repr rc),
+    ((info, (M2, p)), (map Vint (repeat Int.one 32), (Vint (Int.repr rc),
         (Vint (Int.repr 48), (Val.of_bool pr_flag, Vint (Int.repr 10000))))))). eexists; reflexivity.
   destruct myST as [ST HST].
 

--- a/hmacdrbg/verif_hmac_drbg_seed_buf.v
+++ b/hmacdrbg/verif_hmac_drbg_seed_buf.v
@@ -76,7 +76,7 @@ Proof.
 
   assert (exists xx:reptype t_struct_hmac256drbg_context_st, xx =
    (((*M1*)info, (M2, p)),
-    (list_repeat (Z.to_nat 32) (Vint Int.one),
+    (repeat (Vint Int.one) (Z.to_nat 32),
      (Vint (Int.repr reseed_counter),
       (Vint (Int.repr entropy_len),
        (Val.of_bool prediction_resistance,
@@ -95,9 +95,9 @@ Proof.
     unfold field_address. rewrite if_true. 2: assumption. simpl. cancel.
   }
   clear INI. thaw OTHER.
-  set (ABS:= HMAC256DRBGabs V (list_repeat 32 Byte.one) reseed_counter entropy_len prediction_resistance reseed_interval) in *.
+  set (ABS:= HMAC256DRBGabs V (repeat Byte.one 32) reseed_counter entropy_len prediction_resistance reseed_interval) in *.
   gather_SEP 1 2.
-  replace_SEP 0 (hmac256drbg_relate (*(HMAC256DRBGabs V0 (list_repeat 32 1) reseed_counter entropy_len prediction_resistance reseed_interval)*) ABS xx).
+  replace_SEP 0 (hmac256drbg_relate (*(HMAC256DRBGabs V0 (repeat 1 32) reseed_counter entropy_len prediction_resistance reseed_interval)*) ABS xx).
   { subst ABS. simpl hmac256drbg_relate.  unfold md_full.
      entailer!. simpl. entailer!.
      apply UNDER_SPEC.REP_FULL.
@@ -110,9 +110,9 @@ Proof.
   forward. Exists (Vint (Int.repr 0)). rewrite if_false; [ | intros N; inv N]. 
   thaw ALLSEP.
   unfold hmac256drbgabs_common_mpreds. simpl.
-  fold (list_repeat 32 Byte.one). fold (list_repeat 32 (Vint Int.one)).
+  fold (repeat Byte.one 32). fold (repeat (Vint Int.one) 32).
   remember(HMAC256_DRBG_update (contents_with_add data d_len Data) V
-              (list_repeat 32 Byte.one)) as HH.
+              (repeat Byte.one 32)) as HH.
   destruct HH as [KEY VALUE]. simpl.
   Exists KEY VALUE p. normalize.
   apply andp_right; [apply prop_right; repeat split; auto | cancel].
@@ -155,7 +155,7 @@ Definition hmac_drbg_seed_buf_spec2 :=
                          with (mds, (V', (RC', (EL', (PR', RI'))))),
                               HMAC256DRBGabs key V RC EL PR RI
                          => EX KEY:list Z, EX VAL:list Z, EX p:val,
-                          !!(HMAC256_DRBG_update (contents_with_add data d_len Data) V (list_repeat 32 1) = (KEY, VAL))
+                          !!(HMAC256_DRBG_update (contents_with_add data d_len Data) V (repeat 1 32) = (KEY, VAL))
                              && md_full key mds * malloc_token Tsh (sizeof (Tstruct _hmac_ctx_st noattr)) p *
                                 data_at Tsh t_struct_hmac256drbg_context_st ((info, (fst(snd mds), p)), (map Vint (map Int.repr VAL), (RC', (EL', (PR', RI'))))) ctx *
                                 hmac256drbg_relate (HMAC256DRBGabs KEY VAL RC EL PR RI) ((info, (fst(snd mds), p)), (map Vint (map Int.repr VAL), (RC', (EL', (PR', RI'))))) *
@@ -245,7 +245,7 @@ Proof.
 
   assert (exists xx:reptype t_struct_hmac256drbg_context_st, xx =
    (((*M1*)info, (M2, p)),
-    (list_repeat (Z.to_nat 32) (Vint Int.one),
+    (repeat (Vint Int.one) (Z.to_nat 32),
      (Vint (Int.repr reseed_counter),
       (Vint (Int.repr entropy_len),
        (Val.of_bool prediction_resistance,
@@ -265,9 +265,9 @@ Proof.
     unfold field_address. rewrite if_true. 2: assumption. simpl. cancel.
   }
   clear INI. thaw OTHER.
-  specialize (Forall_list_repeat isbyteZ 32 1); intros IB1.
-  set (ABS:= HMAC256DRBGabs V0 (list_repeat 32 1) reseed_counter entropy_len prediction_resistance reseed_interval) in *.
-  replace_SEP 1 (hmac256drbg_relate (*(HMAC256DRBGabs V0 (list_repeat 32 1) reseed_counter entropy_len prediction_resistance reseed_interval)*) ABS xx).
+  specialize (Forall_repeat isbyteZ 32 1); intros IB1.
+  set (ABS:= HMAC256DRBGabs V0 (repeat 1 32) reseed_counter entropy_len prediction_resistance reseed_interval) in *.
+  replace_SEP 1 (hmac256drbg_relate (*(HMAC256DRBGabs V0 (repeat 1 32) reseed_counter entropy_len prediction_resistance reseed_interval)*) ABS xx).
   { entailer!. subst ABS; unfold md_full. simpl.
     apply andp_right. apply prop_right. repeat split; trivial. apply IB1. split; lia.
     apply UNDER_SPEC.REP_FULL.

--- a/mailbox/verif_mailbox_write.v
+++ b/mailbox/verif_mailbox_write.v
@@ -64,10 +64,10 @@ Proof.
     apply map_ext_in; intros ? Hin.
     rewrite In_upto in Hin.
     destruct (eq_dec a b0); auto.
-    destruct (zlt a 0); [lia|].
+    destruct (Z_lt_dec a 0); [lia|].
     destruct Hin as (? & Hin); apply Z2Nat.inj_lt in Hin; auto; try lia.
     simpl in *; destruct (Z.to_nat a); auto.
-    repeat (destruct n0; [solve [auto]|]).
+    repeat (destruct n1; [solve [auto]|]).
     lia. }
   { assert (0 <= i < Zlength lasts) by lia.
     forward.

--- a/progs/conclib.v
+++ b/progs/conclib.v
@@ -162,7 +162,7 @@ Qed.
 Lemma Znth_last : forall {A}{d: Inhabitant A} l, Znth (Zlength l - 1) l = last l default.
 Proof.
   intros; unfold Znth.
-  destruct (zlt (Zlength l - 1) 0).
+  destruct (Z_lt_dec (Zlength l - 1) 0).
   - destruct l; auto.
     rewrite Zlength_correct in *; simpl length in *.
     rewrite Nat2Z.inj_succ in *; lia.
@@ -495,12 +495,6 @@ Proof.
   rewrite IHn; auto.
 Qed.
 
-Lemma sublist_repeat : forall {A} i j k (v : A), 0 <= i -> i <= j <= k ->
-  sublist i j (repeat v (Z.to_nat k)) = repeat v (Z.to_nat (j - i)).
-Proof.
-  intros; repeat rewrite repeat_list_repeat; apply sublist_list_repeat; auto.
-Qed.
-
 Lemma Znth_head : forall reqs head m, Zlength reqs <= m -> 0 <= head < m ->
   Zlength reqs > 0 ->
   Znth head (rotate (complete m reqs) head m) = Znth 0 reqs.
@@ -659,7 +653,7 @@ Proof.
   apply In_nth with (d := d) in H; destruct H as (n & ? & ?).
   exists (Z.of_nat n); split.
   - rewrite Zlength_correct; lia.
-  - destruct (zlt (Z.of_nat n) 0); [lia|].
+  - destruct (Z_lt_dec (Z.of_nat n) 0); [lia|].
     rewrite Nat2Z.id; auto.
 Qed.
 
@@ -667,7 +661,7 @@ Lemma In_upd_Znth_old : forall {A}{d: Inhabitant A} i (x y : A) l, In x l -> x <
   In x (upd_Znth i l y).
 Proof.
   intros.
-  destruct (zlt i (Zlength l)).
+  destruct (Z_lt_dec i (Zlength l)).
   - unfold_upd_Znth_old.
     apply In_Znth in H; destruct H as (j & ? & ?); subst.
     destruct (eq_dec j i); [subst; contradiction|].
@@ -683,7 +677,7 @@ Lemma Znth_combine : forall {A B} {a: Inhabitant A} {b: Inhabitant B} i (l1: lis
   Znth i (combine l1 l2) = (Znth i l1, Znth i l2).
 Proof.
   intros; unfold Znth.
-  destruct (zlt i 0); auto.
+  destruct (Z_lt_dec i 0); auto.
   apply combine_nth.
   rewrite !Zlength_correct in *; rep_lia.
 Qed.
@@ -697,7 +691,7 @@ Qed.
 Lemma nth_Znth : forall {A}{d: Inhabitant A} i l, nth i l default = Znth (Z.of_nat i) l.
 Proof.
   intros; unfold Znth.
-  destruct (zlt (Z.of_nat i) 0); [lia|].
+  destruct (Z_lt_dec (Z.of_nat i) 0); [lia|].
   rewrite Nat2Z.id; auto.
 Qed.
 

--- a/progs/dry_mem_lemmas.v
+++ b/progs/dry_mem_lemmas.v
@@ -283,7 +283,7 @@ Proof.
     rewrite data_at_rec_eq in Hr1; simpl in Hr1.
     unfold unfold_reptype in Hr1; simpl in Hr1.
     rewrite <- (Nat2Z.id n) in Hr1.
-    rewrite Znth_list_repeat_inrange in Hr1.
+    rewrite Znth_repeat_inrange in Hr1.
     unfold mapsto in Hr1; simpl in Hr1.
     rewrite if_true in Hr1 by auto.
     destruct Hr1 as [[] | (_ & ? & ? & [? Hr1] & Hg1)]; [contradiction|].

--- a/progs/tutorial1.v
+++ b/progs/tutorial1.v
@@ -72,8 +72,8 @@ Definition N : Z := 20.
 Lemma exercise4:
  let Delta := @abbreviate _ Delta1 in 
  forall sh p,
-    data_at sh (tarray tint N) (Vint (Int.repr 1) :: Vint (Int.repr 2) :: list_repeat (Z.to_nat (N-2)) Vundef) p
- |--  !! (0 <= Zlength (list_repeat (Z.to_nat (N-2)) Vundef) < Int.max_signed).
+    data_at sh (tarray tint N) (Vint (Int.repr 1) :: Vint (Int.repr 2) :: repeat Vundef (Z.to_nat (N-2))) p
+ |--  !! (0 <= Zlength (repeat Vundef (Z.to_nat (N-2))) < Int.max_signed).
 Proof.
 intros.
 simpl.
@@ -99,14 +99,14 @@ Definition N : Z := proj1_sig (opaque_constant 20).
 Lemma exercise4b:
  let Delta := @abbreviate _ Delta1 in 
  forall sh p,
-    data_at sh (tarray tint N) (Vint (Int.repr 1) :: Vint (Int.repr 2) :: list_repeat (Z.to_nat (N-2)) Vundef) p
- |--  !! (0 <= Zlength (list_repeat (Z.to_nat (N-2)) Vundef) < Int.max_signed).
+    data_at sh (tarray tint N) (Vint (Int.repr 1) :: Vint (Int.repr 2) :: repeat Vundef (Z.to_nat (N-2))) p
+ |--  !! (0 <= Zlength (repeat Vundef (Z.to_nat (N-2))) < Int.max_signed).
 Proof.
 intros.
 simpl.
 (* That's better; the data_at is more concise.  But now, unfortunately: *)
 entailer!.
-rewrite Zlength_list_repeat.
+rewrite Zlength_repeat.
 Fail rep_lia.
 (* now rep_lia does not know that N=20. *)
 Abort.
@@ -119,14 +119,14 @@ Hint Rewrite N_eq : rep_lia.
 Lemma exercise4c:
  let Delta := @abbreviate _ Delta1 in 
  forall sh p,
-    data_at sh (tarray tint N) (Vint (Int.repr 1) :: Vint (Int.repr 2) :: list_repeat (Z.to_nat (N-2)) Vundef) p
- |--  !! (0 <= Zlength (list_repeat (Z.to_nat (N-2)) Vundef) < Int.max_signed).
+    data_at sh (tarray tint N) (Vint (Int.repr 1) :: Vint (Int.repr 2) :: repeat Vundef (Z.to_nat (N-2))) p
+ |--  !! (0 <= Zlength (repeat Vundef (Z.to_nat (N-2))) < Int.max_signed).
 Proof.
 intros.
 simpl.
 (* That's still good; the data_at is more concise.  *)
 entailer!.
-rewrite Zlength_list_repeat.
+rewrite Zlength_repeat.
 rep_lia.
 rep_lia.
 Qed.

--- a/progs/verif_bin_search.v
+++ b/progs/verif_bin_search.v
@@ -53,7 +53,7 @@ Lemma Znth_In : forall A (d: Inhabitant A) i (l : list A) x (Hrange : 0 <= i < Z
                        (Hnth : Znth i l = x), In x l.
 Proof.
   unfold Znth; intros.
-  destruct (zlt i 0); [lia|].
+  destruct (Z_lt_dec i 0); [lia|].
   subst; apply nth_In.
   rewrite Zlength_correct in Hrange; auto.
   rep_lia.
@@ -67,7 +67,7 @@ Proof.
   apply In_nth with (d := d) in H; destruct H as (n & ? & ?).
   exists (Z.of_nat n); split.
   - rewrite Zlength_correct; lia.
-  - destruct (zlt (Z.of_nat n) 0); [lia|].
+  - destruct (Z_lt_dec (Z.of_nat n) 0); [lia|].
     rewrite Nat2Z.id; auto.
 Qed.
 

--- a/progs/verif_dotprod.v
+++ b/progs/verif_dotprod.v
@@ -161,7 +161,7 @@ forward_for_simple_bound 3
       PROP ()
       LOCAL (temp _x x; temp _y y; temp _z z)
       SEP (data_at Tsh (tarray tdouble 3) 
-          (map Vfloat (sublist 0 i fx) ++ list_repeat (Z.to_nat (3-i)) Vundef) x;
+          (map Vfloat (sublist 0 i fx) ++ repeat Vundef (Z.to_nat (3-i))) x;
    data_at Tsh (tarray tdouble 3) (map Vfloat fy) y;
    data_at Tsh (tarray tdouble 3) (map Vfloat fz) z)).
 * (* initializer *)

--- a/progs/verif_io_mem.v
+++ b/progs/verif_io_mem.v
@@ -298,7 +298,7 @@ Proof.
                  temp _k (Vint (Int.repr (Zlength (chars_of_Z i ++ [Byte.repr newline])))))
     SEP (mem_mgr gv; malloc_token Ews (tarray tuchar 5) buf;
             data_at Ews (tarray tuchar 5) (map Vubyte (chars_of_Z i) ++ Vubyte (Byte.repr newline) ::
-              list_repeat (Z.to_nat (4 - Zlength (chars_of_Z i))) Vundef) buf;
+              repeat Vundef (Z.to_nat (4 - Zlength (chars_of_Z i)))) buf;
             ITREE (write_list stdout (chars_of_Z i ++ [Byte.repr newline]);; tr))).
   - Intros.
     forward.
@@ -321,25 +321,25 @@ Proof.
     { rewrite Zlength_app, Zlength_cons, Zlength_nil, chars_of_Z_intr.
       destruct (Z.leb_spec i 0); auto; lia. }
     unfold replace_list; simpl.
-    rewrite (sublist_list_repeat _ _ 5 Vundef).
+    rewrite (sublist_repeat _ _ 5 Vundef).
     rewrite !Zlength_cons, Zlength_nil, Zlength_map; simpl.
     rewrite upd_Znth_app2.
-    rewrite Zlength_map, Zminus_diag, upd_Znth0_old, sublist_list_repeat; try lia.
+    rewrite Zlength_map, Zminus_diag, upd_Znth0_old, sublist_repeat; try lia.
     apply derives_refl'.
     f_equal.
     rewrite chars_of_Z_intr.
     destruct (Z.leb_spec i 0); try lia.
     rewrite zero_ext_inrange.
     f_equal; f_equal; f_equal; f_equal.
-    rewrite Zlength_list_repeat; try lia.
+    rewrite Zlength_repeat; try lia.
     { simpl; rewrite Int.unsigned_repr; rep_lia. }
-    { rewrite Zlength_list_repeat; lia. }
-    { rewrite Zlength_list_repeat; lia. }
-    { rewrite Zlength_map, Zlength_list_repeat; lia. }
+    { rewrite Zlength_repeat; lia. }
+    { rewrite Zlength_repeat; lia. }
+    { rewrite Zlength_map, Zlength_repeat; lia. }
     { rewrite Zlength_map; rep_lia. }
     { rewrite !Zlength_cons, Zlength_nil, Zlength_map; lia. }
   - forward_call (Ews, buf, chars_of_Z i ++ [Byte.repr newline],
-      5, list_repeat (Z.to_nat (4 - Zlength (chars_of_Z i))) Vundef, tr).
+      5, repeat Vundef (Z.to_nat (4 - Zlength (chars_of_Z i))), tr).
     { rewrite map_app, <- app_assoc; simpl; cancel. }
     forward_call (tarray tuchar 5, buf, gv).
     { rewrite if_false by auto; cancel. }

--- a/progs/verif_strlib.v
+++ b/progs/verif_strlib.v
@@ -167,7 +167,7 @@ forward_loop (EX i : Z,
     LOCAL (temp _i (Vptrofs (Ptrofs.repr i)); temp _dest dest; temp _src src)
     SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ [Byte.zero]) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + 1))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + 1)))) dest;
    data_at sh' (tarray tschar (Zlength ls + 1))
      (map Vbyte (ls ++ [Byte.zero])) src))
   break: (PROP ( )
@@ -175,7 +175,7 @@ forward_loop (EX i : Z,
    temp _src src)
    SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ [Byte.zero]) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + 1))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + 1)))) dest;
    data_at sh' (tarray tschar (Zlength ls + 1))
      (map Vbyte (ls ++ [Byte.zero])) src)).
 -
@@ -202,7 +202,7 @@ forward_loop (EX i : Z,
            temp _dest dest; temp _src src)
     SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ sublist 0 j ls) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + j))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + j)))) dest;
          data_at sh' (tarray tschar (Zlength ls + 1))
            (map Vbyte (ls ++ [Byte.zero])) src)).
   { Exists 0; entailer!.  autorewrite with sublist.
@@ -233,7 +233,7 @@ forward_loop (EX i : Z,
     unfold data_at; f_equal. 
     replace (n - (Zlength ld + Zlength ls))
      with (1 + (n - (Zlength ld + Zlength ls+1))) by rep_lia.
-    rewrite <- list_repeat_app' by rep_lia.
+    rewrite <- repeat_app' by rep_lia.
     rewrite upd_Znth_app1 by list_solve.
     rewrite app_assoc.
     simpl.
@@ -252,7 +252,7 @@ forward_loop (EX i : Z,
   rewrite (split_data_at_app_tschar _ n) by list_solve.
   replace (n - (Zlength ld + j))
     with (1 + (n - (Zlength ld + (j + 1)))) by rep_lia.
-  rewrite <- list_repeat_app' by rep_lia.
+  rewrite <- repeat_app' by rep_lia.
   cancel.
   rewrite upd_Znth_app1 by (autorewrite with sublist; rep_lia).
   rewrite app_Znth1 by list_solve.
@@ -393,7 +393,7 @@ forward_loop (EX i : Z,
   PROP (0 <= i < Zlength ls + 1)
   LOCAL (temp _i (Vptrofs (Ptrofs.repr i)); temp _dest dest; temp _src src)
   SEP (data_at sh (tarray tschar n)
-        (map Vbyte (sublist 0 i ls) ++ list_repeat (Z.to_nat (n - i)) Vundef) dest;
+        (map Vbyte (sublist 0 i ls) ++ repeat Vundef (Z.to_nat (n - i))) dest;
        data_at sh' (tarray tschar (Zlength ls + 1)) (map Vbyte (ls ++ [Byte.zero])) src)).
 *
  Exists 0. rewrite Z.sub_0_r; entailer!. simpl. entailer!.
@@ -416,7 +416,7 @@ forward_loop (EX i : Z,
    rewrite (split_data_at_app_tschar _ n) by list_solve.
    autorewrite with sublist.
    replace (n - Zlength ls) with (1 + (n - (Zlength ls + 1))) at 2 by list_solve.
-  rewrite <- list_repeat_app' by lia.
+  rewrite <- repeat_app' by lia.
   rewrite upd_Znth_app1 by list_solve.
   rewrite !split_data_at_app_tschar by list_solve.
   cancel.
@@ -432,7 +432,7 @@ forward_loop (EX i : Z,
   rewrite !(split_data_at_app_tschar _ n) by list_solve.
   autorewrite with sublist.
    replace (n - i) with (1 + (n-(i+ 1))) at 2 by list_solve.
-  rewrite <- list_repeat_app' by lia.
+  rewrite <- repeat_app' by lia.
   autorewrite with sublist.
   cancel.
   rewrite !split_data_at_app_tschar by list_solve.
@@ -515,7 +515,7 @@ forward_loop (EX i : Z,
     LOCAL (temp _i (Vptrofs (Ptrofs.repr i)); temp _dest dest; temp _src src)
     SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ [Byte.zero]) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + 1))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + 1)))) dest;
    data_at sh' (tarray tschar (Zlength ls + 1))
      (map Vbyte (ls ++ [Byte.zero])) src))
   break: (PROP ( )
@@ -523,7 +523,7 @@ forward_loop (EX i : Z,
    temp _src src)
    SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ [Byte.zero]) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + 1))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + 1)))) dest;
    data_at sh' (tarray tschar (Zlength ls + 1))
      (map Vbyte (ls ++ [Byte.zero])) src)).
 - (* before loop1 *)
@@ -538,7 +538,7 @@ forward_loop (EX i : Z,
            temp _dest dest; temp _src src)
     SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ sublist 0 j ls) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + j))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + j)))) dest;
          data_at sh' (tarray tschar (Zlength ls + 1))
            (map Vbyte (ls ++ [Byte.zero])) src)).
   (* before loop2 *)
@@ -613,7 +613,7 @@ forward_loop (EX i : Z,
   PROP (0 <= i < Zlength ls + 1)
   LOCAL (temp _i (Vptrofs (Ptrofs.repr i)); temp _dest dest; temp _src src)
   SEP (data_at sh (tarray tschar n)
-        (map Vbyte (sublist 0 i ls) ++ list_repeat (Z.to_nat (n - i)) Vundef) dest;
+        (map Vbyte (sublist 0 i ls) ++ repeat Vundef (Z.to_nat (n - i))) dest;
        data_at sh' (tarray tschar (Zlength ls + 1)) (map Vbyte (ls ++ [Byte.zero])) src)).
 -
   repeat step.

--- a/progs64/verif_bin_search.v
+++ b/progs64/verif_bin_search.v
@@ -54,7 +54,7 @@ Lemma Znth_In : forall A (d: Inhabitant A) i (l : list A) x (Hrange : 0 <= i < Z
                        (Hnth : Znth i l = x), In x l.
 Proof.
   unfold Znth; intros.
-  destruct (zlt i 0); [lia|].
+  destruct (Z_lt_dec i 0); [lia|].
   subst; apply nth_In.
   rewrite Zlength_correct in Hrange; auto.
   rep_lia.
@@ -68,7 +68,7 @@ Proof.
   apply In_nth with (d := d) in H; destruct H as (n & ? & ?).
   exists (Z.of_nat n); split.
   - rewrite Zlength_correct; lia.
-  - destruct (zlt (Z.of_nat n) 0); [lia|].
+  - destruct (Z_lt_dec (Z.of_nat n) 0); [lia|].
     rewrite Nat2Z.id; auto.
 Qed.
 

--- a/progs64/verif_strlib.v
+++ b/progs64/verif_strlib.v
@@ -168,7 +168,7 @@ forward_loop (EX i : Z,
     LOCAL (temp _i (Vptrofs (Ptrofs.repr i)); temp _dest dest; temp _src src)
     SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ [Byte.zero]) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + 1))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + 1)))) dest;
    data_at sh' (tarray tschar (Zlength ls + 1))
      (map Vbyte (ls ++ [Byte.zero])) src))
   break: (PROP ( )
@@ -176,7 +176,7 @@ forward_loop (EX i : Z,
    temp _src src)
    SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ [Byte.zero]) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + 1))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + 1)))) dest;
    data_at sh' (tarray tschar (Zlength ls + 1))
      (map Vbyte (ls ++ [Byte.zero])) src)).
 -
@@ -203,7 +203,7 @@ forward_loop (EX i : Z,
            temp _dest dest; temp _src src)
     SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ sublist 0 j ls) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + j))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + j)))) dest;
          data_at sh' (tarray tschar (Zlength ls + 1))
            (map Vbyte (ls ++ [Byte.zero])) src)).
   { Exists 0; entailer!.  autorewrite with sublist.
@@ -234,7 +234,7 @@ forward_loop (EX i : Z,
     unfold data_at; f_equal. 
     replace (n - (Zlength ld + Zlength ls))
      with (1 + (n - (Zlength ld + Zlength ls+1))) by rep_lia.
-    rewrite <- list_repeat_app' by rep_lia.
+    rewrite <- repeat_app' by rep_lia.
     rewrite upd_Znth_app1 by list_solve.
     rewrite app_assoc.
     simpl.
@@ -253,7 +253,7 @@ forward_loop (EX i : Z,
   rewrite (split_data_at_app_tschar _ n) by list_solve.
   replace (n - (Zlength ld + j))
     with (1 + (n - (Zlength ld + (j + 1)))) by rep_lia.
-  rewrite <- list_repeat_app' by rep_lia.
+  rewrite <- repeat_app' by rep_lia.
   cancel.
   rewrite upd_Znth_app1 by (autorewrite with sublist; rep_lia).
   rewrite app_Znth1 by list_solve.
@@ -394,7 +394,7 @@ forward_loop (EX i : Z,
   PROP (0 <= i < Zlength ls + 1)
   LOCAL (temp _i (Vptrofs (Ptrofs.repr i)); temp _dest dest; temp _src src)
   SEP (data_at sh (tarray tschar n)
-        (map Vbyte (sublist 0 i ls) ++ list_repeat (Z.to_nat (n - i)) Vundef) dest;
+        (map Vbyte (sublist 0 i ls) ++ repeat Vundef (Z.to_nat (n - i))) dest;
        data_at sh' (tarray tschar (Zlength ls + 1)) (map Vbyte (ls ++ [Byte.zero])) src)).
 *
  Exists 0. rewrite Z.sub_0_r; entailer!. simpl. entailer!.
@@ -417,7 +417,7 @@ forward_loop (EX i : Z,
    rewrite (split_data_at_app_tschar _ n) by list_solve.
    autorewrite with sublist.
    replace (n - Zlength ls) with (1 + (n - (Zlength ls + 1))) at 2 by list_solve.
-  rewrite <- list_repeat_app' by lia.
+  rewrite <- repeat_app' by lia.
   rewrite upd_Znth_app1 by list_solve.
   rewrite !split_data_at_app_tschar by list_solve.
   cancel.
@@ -433,7 +433,7 @@ forward_loop (EX i : Z,
   rewrite !(split_data_at_app_tschar _ n) by list_solve.
   autorewrite with sublist.
    replace (n - i) with (1 + (n-(i+ 1))) at 2 by list_solve.
-  rewrite <- list_repeat_app' by lia.
+  rewrite <- repeat_app' by lia.
   autorewrite with sublist.
   cancel.
   rewrite !split_data_at_app_tschar by list_solve.
@@ -516,7 +516,7 @@ forward_loop (EX i : Z,
     LOCAL (temp _i (Vptrofs (Ptrofs.repr i)); temp _dest dest; temp _src src)
     SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ [Byte.zero]) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + 1))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + 1)))) dest;
    data_at sh' (tarray tschar (Zlength ls + 1))
      (map Vbyte (ls ++ [Byte.zero])) src))
   break: (PROP ( )
@@ -524,7 +524,7 @@ forward_loop (EX i : Z,
    temp _src src)
    SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ [Byte.zero]) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + 1))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + 1)))) dest;
    data_at sh' (tarray tschar (Zlength ls + 1))
      (map Vbyte (ls ++ [Byte.zero])) src)).
 - (* before loop1 *)
@@ -539,7 +539,7 @@ forward_loop (EX i : Z,
            temp _dest dest; temp _src src)
     SEP (data_at sh (tarray tschar n)
           (map Vbyte (ld ++ sublist 0 j ls) ++
-           list_repeat (Z.to_nat (n - (Zlength ld + j))) Vundef) dest;
+           repeat Vundef (Z.to_nat (n - (Zlength ld + j)))) dest;
          data_at sh' (tarray tschar (Zlength ls + 1))
            (map Vbyte (ls ++ [Byte.zero])) src)).
   (* before loop2 *)
@@ -614,7 +614,7 @@ forward_loop (EX i : Z,
   PROP (0 <= i < Zlength ls + 1)
   LOCAL (temp _i (Vptrofs (Ptrofs.repr i)); temp _dest dest; temp _src src)
   SEP (data_at sh (tarray tschar n)
-        (map Vbyte (sublist 0 i ls) ++ list_repeat (Z.to_nat (n - i)) Vundef) dest;
+        (map Vbyte (sublist 0 i ls) ++ repeat Vundef (Z.to_nat (n - i))) dest;
        data_at sh' (tarray tschar (Zlength ls + 1)) (map Vbyte (ls ++ [Byte.zero])) src)).
 -
   repeat step.

--- a/sha/HMAC256_equivalence.v
+++ b/sha/HMAC256_equivalence.v
@@ -69,7 +69,7 @@ Definition ipad_v: Bvector b := of_list_length _ ipad_length.
 *)
 Lemma fpad_length (v:Bvector c): length (fpad (Vector.to_list v)) = p.
 Proof. unfold fpad, fpad_inner. rewrite bytesToBits_len.
-  repeat rewrite app_length. rewrite length_list_repeat, length_intlist_to_bytelist.
+  repeat rewrite app_length. rewrite repeat_length, length_intlist_to_bytelist.
   rewrite (mult_comm 4), plus_comm, Zlength_correct.
   rewrite bitsToBytes_len_gen with (n:=32%nat).
     reflexivity.
@@ -346,12 +346,12 @@ SearchAbout sha_splitandpad_inc.
 
   (* opad *)
   { apply bytes_bits_comp_ind.
-    apply Forall_list_repeat. unfold HP.Opad. lia.
+    apply Forall_repeat. unfold HP.Opad. lia.
     apply of_length_proof_irrel. }
 
   (* ipad *)
   { apply bytes_bits_comp_ind.
-    apply Forall_list_repeat. unfold HP.Ipad. lia.
+    apply Forall_repeat. unfold HP.Ipad. lia.
     apply of_length_proof_irrel. }
 
 Qed.

--- a/sha/HMAC256_spec_pad.v
+++ b/sha/HMAC256_spec_pad.v
@@ -197,10 +197,10 @@ Proof.
   { apply BLxor_length; erewrite bytes_bits_length; try eassumption.
          rewrite map_length, padded_key_len. reflexivity.
          unfold HP.HMAC_SHA256.sixtyfour.
-         rewrite -> length_list_repeat. reflexivity. }
+         rewrite -> repeat_length. reflexivity. }
   { apply BLxor_length; erewrite bytes_bits_length; try eassumption.
          rewrite map_length, padded_key_len. reflexivity.
          unfold HP.HMAC_SHA256.sixtyfour.
-         rewrite -> length_list_repeat. reflexivity. }
+         rewrite -> repeat_length. reflexivity. }
 Qed.
 *)

--- a/sha/HMAC_common_defs.v
+++ b/sha/HMAC_common_defs.v
@@ -113,9 +113,9 @@ Proof. intros.
 Defined.
 
 Lemma add_blocksize_length l n: 0<=n ->
-      BinInt.Z.add n (Zcomplements.Zlength l) = Zcomplements.Zlength ((Coqlib.list_repeat (Z.to_nat n) true) ++ l).
+      BinInt.Z.add n (Zcomplements.Zlength l) = Zcomplements.Zlength ((repeat true (Z.to_nat n)) ++ l).
 Proof. intros. do 2 rewrite Zlength_correct.
-  rewrite app_length, length_list_repeat, Nat2Z.inj_add, Z2Nat.id; trivial.
+  rewrite app_length, repeat_length, Nat2Z.inj_add, Z2Nat.id; trivial.
 Qed.
 
 Lemma hash_blocks_bits_len c b (B:(0<b)%nat) h

--- a/sha/HMAC_equivalence.v
+++ b/sha/HMAC_equivalence.v
@@ -185,7 +185,7 @@ Qed.
   rewrite N, H in H0; clear N H.
   apply bytesToBits_injective in H0; trivial.
   unfold PAD.HM.sixtyfour in H0.
-  apply list_repeat_injective in H0. inv H0.
+  apply repeat_injective in H0. inv H0.
   apply BS_pos.
 Qed.
 
@@ -237,10 +237,10 @@ Proof.
               apply InBlocks_len. destruct m. simpl. apply HP. assumption.
     apply OPADX. apply IPADX. (*
     apply bytes_bits_comp_ind.
-             unfold PAD.HM.sixtyfour. apply Forall_list_repeat. apply EQ.isbyteZ_Ipad.
+             unfold PAD.HM.sixtyfour. apply Forall_repeat. apply EQ.isbyteZ_Ipad.
              unfold opad_v. rewrite of_length_proof_irrel. reflexivity.
     apply bytes_bits_comp_ind.
-             unfold PAD.HM.sixtyfour. apply Forall_list_repeat. apply EQ.isbyteZ_Ipad.
+             unfold PAD.HM.sixtyfour. apply Forall_repeat. apply EQ.isbyteZ_Ipad.
              unfold ipad_v. rewrite of_length_proof_irrel. reflexivity.*)
 Qed.
    (*
@@ -314,12 +314,12 @@ Proof.
 
   (* opad *)
   { apply bytes_bits_comp_ind.
-    apply Forall_list_repeat. unfold HP.Opad. lia.
+    apply Forall_repeat. unfold HP.Opad. lia.
     apply of_length_proof_irrel. }
 
   (* ipad *)
   { apply bytes_bits_comp_ind.
-    apply Forall_list_repeat. unfold HP.Ipad. lia.
+    apply Forall_repeat. unfold HP.Ipad. lia.
     apply of_length_proof_irrel. }
 
 Qed.*)

--- a/sha/HMAC_functional_prog.v
+++ b/sha/HMAC_functional_prog.v
@@ -23,11 +23,11 @@ End HMAC_Module.
 
 Module HMAC_FUN (HF:HASH_FUNCTION)  <: HMAC_Module.
 
-Definition sixtyfour {A} (i:A): list A:= list_repeat HF.BlockSize i.
+Definition sixtyfour {A} (i:A): list A:= repeat i HF.BlockSize.
 
 (*Reading rfc4231 reveals that padding happens on the right*)
 Definition zeroPad (k: list byte) : list byte :=
-  k ++ list_repeat (HF.BlockSize-length k) Byte.zero.
+  k ++ repeat Byte.zero (HF.BlockSize-length k).
 
 Definition mkKey (l:list byte) : list byte :=
   if Z.gtb (Zlength l) (Z.of_nat HF.BlockSize)
@@ -74,14 +74,14 @@ Lemma SF_ByteRepr x:
                      sixtyfour x =
                      map Byte.unsigned (sixtyfour (Byte.repr x)).
 Proof. intros. unfold sixtyfour.
- rewrite map_list_repeat.
+ rewrite map_repeat.
  rewrite Byte.unsigned_repr; trivial. destruct H.
  assert (BMU: Byte.max_unsigned = 255). reflexivity. lia.
 Qed.
 *)
 
 Lemma length_SF {A} (a:A) :length (sixtyfour a) = HF.BlockSize.
-Proof. apply length_list_repeat. Qed.
+Proof. apply repeat_length. Qed.
 
 (*
 Lemma isbyte_hmaccore ipad opad m k:

--- a/sha/HMAC_spec_pad.v
+++ b/sha/HMAC_spec_pad.v
@@ -160,14 +160,14 @@ Module HM:= HP.HMAC_FUN HF.
                      HM.sixtyfour x =
                      map Byte.unsigned (HM.sixtyfour (Byte.repr x)).
 Proof. intros. unfold HM.sixtyfour.
- rewrite map_list_repeat.
+ rewrite map_repeat.
  rewrite Byte.unsigned_repr; trivial. destruct H.
  assert (BMU: Byte.max_unsigned = 255). reflexivity. lia.
 Qed.
 *)
 (*From hmac_common_lemmas TODO: Isolate*)
 (*Lemma length_SF {A} (a:A) :length (HM.sixtyfour a) = HF.BlockSize.
-Proof. apply length_list_repeat. Qed.
+Proof. apply repeat_length. Qed.
 *)
 (*From SHaInstantiation -- TODO: Isolate*)
 Lemma xor_equiv_byte: forall xpad XPAD k K, 

--- a/sha/SHA256.v
+++ b/sha/SHA256.v
@@ -46,7 +46,7 @@ Fixpoint str_to_bytes (str : string) : list byte :=
 Definition generate_and_pad msg :=
   let n := Zlength msg in
    bytelist_to_intlist (msg ++ [Byte.repr 128%Z]
-                ++ list_repeat (Z.to_nat (-(n + 9) mod 64)) Byte.zero)
+                ++ repeat Byte.zero (Z.to_nat (-(n + 9) mod 64)))
            ++ [Int.repr (n * 8 / Int.modulus); Int.repr (n * 8)].
 
 (*ROUND FUNCTION*)

--- a/sha/ShaInstantiation.v
+++ b/sha/ShaInstantiation.v
@@ -15,7 +15,7 @@ Require Import sha.hmac_common_lemmas.
 
 Require Import sha.pure_lemmas.
 Require Import sha.sha_padding_lemmas.
-Require Import VST.floyd.sublist. (*for Forall_list_repeat*)
+Require Import VST.floyd.sublist. (*for Forall_repeat*)
 Import List.
 
 Definition c := (32 * 8)%nat.
@@ -37,13 +37,13 @@ Definition sha_splitandpad (msg : Blist) : Blist :=
 Definition fpad_inner (msg : list byte) : list byte :=
   (let n := BlockSize + Zlength msg in
   [Byte.repr 128%Z]
-    ++ list_repeat (Z.to_nat (-(n + 9) mod 64)) Byte.zero
+    ++ repeat Byte.zero (Z.to_nat (-(n + 9) mod 64))
     ++ intlist_to_bytelist ([Int.repr (n * 8 / Int.modulus); Int.repr (n * 8)]))%list.
 
 Lemma fpad_inner_length l (L:length l = p): (length (fpad_inner (bitsToBytes l)) * 8)%nat = p.
 Proof.
   unfold fpad_inner. repeat rewrite app_length.
-  rewrite length_list_repeat, length_intlist_to_bytelist.
+  rewrite repeat_length, length_intlist_to_bytelist.
   rewrite (mult_comm 4), plus_comm, Zlength_correct.
   rewrite bitsToBytes_len_gen with (n:=32%nat).
     reflexivity.
@@ -81,7 +81,7 @@ Qed.
 Definition pad_inc (msg : list byte) : list byte :=
   let n := BlockSize + Zlength msg in
   msg ++ [Byte.repr 128%Z]
-      ++ list_repeat (Z.to_nat (-(n + 9) mod 64)) Byte.zero
+      ++ repeat Byte.zero (Z.to_nat (-(n + 9) mod 64))
       ++ intlist_to_bytelist ([Int.repr (n * 8 / Int.modulus); Int.repr (n * 8)]).
 
 Definition sha_splitandpad_inc (msg : Blist) : Blist :=
@@ -94,7 +94,7 @@ Lemma pad_inc_length: forall l, exists k, (0 < k /\ length (pad_inc l) = k*64)%n
 Proof. unfold pad_inc.
   induction l.
   simpl. exists (1%nat). lia.
-  destruct IHl as [k [K HK]]. repeat rewrite app_length in *. rewrite length_list_repeat in *.
+  destruct IHl as [k [K HK]]. repeat rewrite app_length in *. rewrite repeat_length in *.
   rewrite length_intlist_to_bytelist in *.
   remember (BinInt.Z.to_nat
         (BinInt.Z.modulo
@@ -251,9 +251,9 @@ Qed.
 
 Lemma pad_injective_Case5 l1 l2
   (H0 : (l1 ++ Byte.repr 128 :: nil) ++
-        list_repeat (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)) Byte.zero =
+        repeat Byte.zero (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)) =
         (l2 ++ Byte.repr 128 :: nil) ++
-        list_repeat (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)) Byte.zero)
+        repeat Byte.zero (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)))
   (H : (BlockSize + Zlength l1) * 8 =
        ((BlockSize + Zlength l2) * 8) mod Int.modulus)
   (Nonneg1 : 0 <= (BlockSize + Zlength l1) * 8)
@@ -271,12 +271,12 @@ Proof. symmetry in H.
          rewrite H. reflexivity.
        clear H.
        assert (length ((l1 ++ Byte.repr 128 :: nil) ++
-                list_repeat (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)) Byte.zero)
+                repeat Byte.zero (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)))
              = length ((l2 ++ Byte.repr 128 :: nil) ++
-                list_repeat (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)) Byte.zero)).
+                repeat Byte.zero (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)))).
        rewrite H0; trivial.
        clear H0. repeat rewrite app_length in H.
-       repeat rewrite length_list_repeat in H.
+       repeat rewrite repeat_length in H.
        clear - K n H.
        rewrite (pad_injective_aux l1 l2 k K n) in H. lia.
 Qed.
@@ -340,12 +340,12 @@ destruct d.
         rewrite <- (Nat2Z.id (length l2)).
         rewrite H0. reflexivity. }
       { assert (length ((l1 ++ Byte.repr 128 :: nil) ++
-                 list_repeat (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)) Byte.zero)
+                 repeat Byte.zero (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)))
               = length ((l2 ++ Byte.repr 128 :: nil) ++
-                 list_repeat (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)) Byte.zero)).
+                 repeat Byte.zero (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)))).
           rewrite H0; trivial.
         clear H0. repeat rewrite app_length in H1.
-        repeat rewrite length_list_repeat in H1.
+        repeat rewrite repeat_length in H1.
         rewrite (pad_injective_aux l2 l1 (k1-k2)) in H1.
           lia.
           rewrite Z.mul_sub_distr_r; lia.
@@ -404,7 +404,7 @@ Definition sha_splitandpad (msg : Blist) : Blist :=
 Definition fpad_inner (msg : list Z) : list Z :=
   (let n := BlockSize + Zlength msg in
   [128%Z]
-    ++ list_repeat (Z.to_nat (-(n + 9) mod 64)) 0
+    ++ repeat 0 (Z.to_nat (-(n + 9) mod 64))
     ++ intlist_to_Zlist ([Int.repr (n * 8 / Int.modulus); Int.repr (n * 8)]))%list.
 
 Definition fpad (msg : Blist) : Blist :=
@@ -425,7 +425,7 @@ Qed.
 Definition pad_inc (msg : list Z) : list Z :=
   let n := BlockSize + Zlength msg in
   msg ++ [128%Z]
-      ++ list_repeat (Z.to_nat (-(n + 9) mod 64)) 0
+      ++ repeat 0 (Z.to_nat (-(n + 9) mod 64))
       ++ intlist_to_Zlist ([Int.repr (n * 8 / Int.modulus); Int.repr (n * 8)]).
 
 Definition sha_splitandpad_inc (msg : Blist) : Blist :=
@@ -438,7 +438,7 @@ Lemma isbyteZ_pad_inc l (B:Forall isbyteZ l): Forall isbyteZ (pad_inc l).
 Proof. unfold pad_inc.
   apply Forall_app. split. trivial.
   apply Forall_app. split. constructor. split; lia. trivial.
-  apply Forall_app. split. apply Forall_list_repeat. split; lia.
+  apply Forall_app. split. apply Forall_repeat. split; lia.
   apply isbyte_intlist_to_Zlist.
 Qed.
 
@@ -446,7 +446,7 @@ Lemma pad_inc_length: forall l, exists k, (0 < k /\ length (pad_inc l) = k*64)%n
 Proof. unfold pad_inc.
   induction l.
   simpl. exists (1%nat). lia.
-  destruct IHl as [k [K HK]]. repeat rewrite app_length in *. rewrite length_list_repeat in *.
+  destruct IHl as [k [K HK]]. repeat rewrite app_length in *. rewrite repeat_length in *.
   rewrite pure_lemmas.length_intlist_to_Zlist in *.
   remember (BinInt.Z.to_nat
         (BinInt.Z.modulo
@@ -584,9 +584,9 @@ Qed.
 
 Lemma pad_injective_Case5 l1 l2
   (H0 : (l1 ++ 128 :: nil) ++
-        list_repeat (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)) 0 =
+        repeat 0 (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)) =
         (l2 ++ 128 :: nil) ++
-        list_repeat (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)) 0)
+        repeat 0 (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)))
   (H : (BlockSize + Zlength l1) * 8 =
        ((BlockSize + Zlength l2) * 8) mod Int.modulus)
   (Nonneg1 : 0 <= (BlockSize + Zlength l1) * 8)
@@ -604,12 +604,12 @@ Proof. symmetry in H.
          rewrite H. reflexivity.
        clear H.
        assert (length ((l1 ++ 128 :: nil) ++
-                list_repeat (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)) 0)
+                repeat 0 (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)))
              = length ((l2 ++ 128 :: nil) ++
-                list_repeat (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)) 0)).
+                repeat 0 (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)))).
        rewrite H0; trivial.
        clear H0. repeat rewrite app_length in H.
-       repeat rewrite length_list_repeat in H.
+       repeat rewrite repeat_length in H.
        clear - K n H.
        rewrite (pad_injective_aux l1 l2 k K n) in H. lia.
 Qed.
@@ -673,12 +673,12 @@ destruct d.
         rewrite <- (Nat2Z.id (length l2)).
         rewrite H0. reflexivity. }
       { assert (length ((l1 ++ 128 :: nil) ++
-                 list_repeat (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)) 0)
+                 repeat 0 (Z.to_nat (- (BlockSize + Zlength l1 + 9) mod 64)))
               = length ((l2 ++ 128 :: nil) ++
-                 list_repeat (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)) 0)).
+                 repeat 0 (Z.to_nat (- (BlockSize + Zlength l2 + 9) mod 64)))).
           rewrite H0; trivial.
         clear H0. repeat rewrite app_length in H1.
-        repeat rewrite length_list_repeat in H1.
+        repeat rewrite repeat_length in H1.
         rewrite (pad_injective_aux l2 l1 (k1-k2)) in H1.
           lia.
           rewrite Z.mul_sub_distr_r; lia.

--- a/sha/call_memcpy.v
+++ b/sha/call_memcpy.v
@@ -7,11 +7,11 @@ Local Open Scope nat.
 Local Open Scope logic.
 Import LiftNotation.
 
-Lemma Zlength_list_repeat:
-  forall {A} n (x:A), Zlength (list_repeat (Z.to_nat n) x) = Z.max 0 n.
+Lemma Zlength_repeat:
+  forall {A} n (x:A), Zlength (repeat x (Z.to_nat n)) = Z.max 0 n.
 Proof.
 intros.
-rewrite Zlength_correct, length_list_repeat.
+rewrite Zlength_correct, repeat_length.
 destruct (zlt n 0).
 rewrite Z.max_l by lia.
 rewrite Z2Nat_neg by auto. reflexivity.
@@ -66,7 +66,7 @@ rewrite <- app_nil_end.
 rewrite sublist_same by lia.
 f_equal.
 rewrite (sublist_nil hi), <- app_nil_end.
-rewrite sublist_app by (rewrite ?Zlength_list_repeat, ?Z.max_r; lia).
+rewrite sublist_app by (rewrite ?Zlength_repeat, ?Z.max_r; lia).
 rewrite ?Z.min_l by lia.
 rewrite ?Z.max_r by lia.
 rewrite sublist_nil, <- app_nil_end.
@@ -85,12 +85,12 @@ pose proof (Zlength_nonneg tgt).
 pose proof (Zlength_nonneg src).
 repeat rewrite Z.sub_diag.
 change (Z.to_nat 0) with 0.
-unfold list_repeat at 1.
+unfold repeat at 1.
 rewrite <- app_nil_end.
 rewrite sublist_same by lia.
 f_equal.
 rewrite sublist_nil, <- app_nil_end by lia.
-rewrite sublist_app by (rewrite ?Zlength_list_repeat, ?Z.max_r; lia).
+rewrite sublist_app by (rewrite ?Zlength_repeat, ?Z.max_r; lia).
 rewrite ?Z.min_l by lia.
 rewrite ?Z.max_r by lia.
 rewrite sublist_nil, <- app_nil_end by lia.
@@ -137,7 +137,7 @@ Lemma part1_splice_into_list:
 Proof.
  intros.
  unfold splice_into_list.
- rewrite (sublist_app); rewrite ?Zlength_list_repeat, ?Z.max_l by lia; try lia;
+ rewrite (sublist_app); rewrite ?Zlength_repeat, ?Z.max_l by lia; try lia;
  rewrite ?Zlength_sublist by lia;
  try (rewrite ?Zlength_correct; lia).
 rewrite ?Z.min_l by lia.
@@ -157,7 +157,7 @@ Proof.
  intros.
  unfold splice_into_list.
 rewrite <- app_ass.
- rewrite (sublist_app); rewrite ?Zlength_list_repeat, ?Z.max_r, ?Z.max_l by lia; try lia;
+ rewrite (sublist_app); rewrite ?Zlength_repeat, ?Z.max_r, ?Z.max_l by lia; try lia;
  rewrite ?Zlength_sublist by lia;
  try (rewrite ?Zlength_correct; lia).
 rewrite !Zlength_app.
@@ -182,7 +182,7 @@ Proof.
 intros.
 unfold splice_into_list.
 rewrite !Zlength_app.
-rewrite !Zlength_sublist; rewrite ?Zlength_app; rewrite ?Zlength_list_repeat; try lia.
+rewrite !Zlength_sublist; rewrite ?Zlength_app; rewrite ?Zlength_repeat; try lia.
 Qed.
 
 Local Arguments nested_field_type cs t gfs : simpl never.
@@ -473,7 +473,7 @@ Lemma call_memset_tuchar:
    (H0:  nested_field_type tp pathp = tarray tuchar np)
    (Hnp : (lop + len <= np)%Z)
    (H3:  JMeq vp vp')
-   (H4:  JMeq vp'' (splice_into_list lop (lop+len) (list_repeat (Z.to_nat len) (Vint c)) vp'))
+   (H4:  JMeq vp'' (splice_into_list lop (lop+len) (repeat (Vint c) (Z.to_nat len)) vp'))
    (H5: ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |--
          tc_exprlist Delta [tptr tvoid; tint; tuint] [e_p; e_c; e_n] &&
          local (`(eq (field_address0 tp (ArraySubsc lop :: pathp) p)) (eval_expr e_p)) &&
@@ -681,7 +681,7 @@ intros.
 apply JMeq_eq in H8. apply JMeq_eq in Hvpx.
 subst.
 apply part3_splice_into_list; try lia.
-rewrite Zlength_list_repeat. rewrite Z.max_r by lia. lia.
+rewrite Zlength_repeat. rewrite Z.max_r by lia. lia.
 } 
 cancel.
  rewrite array_at_data_at' by  (try solve [clear - FC; intuition]; lia).

--- a/sha/functional_prog.v
+++ b/sha/functional_prog.v
@@ -556,7 +556,7 @@ pose proof (roundup_ge (Zlength msg + 9) 64).
 assert (Zlength msg >= 0) by (rewrite Zlength_correct; lia).
 exists (Z.to_nat (roundup (Zlength msg+9) 64 / 4 - 2)).
 repeat rewrite app_length.
-rewrite length_list_repeat.
+rewrite repeat_length.
 simpl length.
 symmetry.
 transitivity (Z.to_nat (roundup (Zlength msg + 9) 64 / 4 - 2) * Z.to_nat 4)%nat; [reflexivity |].
@@ -700,7 +700,7 @@ rewrite H4.
 assert (0 <= Zlength ccc < 4)
  by (clear - H3; rewrite Zlength_correct; lia).
 rewrite Z2Nat.inj_add by lia.
-rewrite <- list_repeat_app.
+rewrite repeat_app.
 replace (Zlength msg / 4 * 4) with (Zlength msg - Zlength ccc).
 2:{
 rewrite Heqccc.
@@ -712,8 +712,8 @@ rewrite Nat2Z.inj_mul. change (Z.of_nat 4) with 4.
 rewrite Z2Nat.id  by lia.
  lia.
 } 
-match goal with |- context [_ ++ list_repeat (Z.to_nat (4 * ?qq)) Byte.zero] =>
- assert (bytelist_to_intlist (list_repeat (Z.to_nat (4 * qq)) Byte.zero) =
+match goal with |- context [_ ++ repeat Byte.zero (Z.to_nat (4 * ?qq))] =>
+ assert (bytelist_to_intlist (repeat Byte.zero (Z.to_nat (4 * qq))) =
   zeros ((Zlength msg + 8) / 64 * 16 + 15 - (Zlength msg + 8) / 4));
   set (Q := qq) in *
 end. {

--- a/sha/general_lemmas.v
+++ b/sha/general_lemmas.v
@@ -23,8 +23,8 @@ induction al; destruct bl,n; simpl; intros; auto.
 inv H.
 Qed.
 
-Lemma list_repeat_injective {A} (a a':A) n: (0<n)%nat ->
-      list_repeat n a = list_repeat n a' -> a=a'.
+Lemma repeat_injective {A} (a a':A) n: (0<n)%nat ->
+      repeat a n = repeat a' n -> a=a'.
   Proof. intros.
     destruct n. lia. simpl in H0. inversion H0. trivial.
   Qed.
@@ -357,14 +357,14 @@ Proof.
  rewrite Z.mul_add_distr_r; lia.
 Qed.
 
-Lemma nth_list_repeat: forall A i n (x :A),
-    nth i (list_repeat n x) x = x.
+Lemma nth_repeat: forall A i n (x :A),
+    nth i (repeat x n) x = x.
 Proof.
  induction i; destruct n; simpl; auto.
 Qed.
 
-Lemma map_list_repeat:
+Lemma map_repeat:
   forall A B (f: A -> B) n x,
-     map f (list_repeat n x) = list_repeat n (f x).
+     map f (repeat x n) = repeat (f x) n.
 Proof. induction n; simpl; intros; f_equal; auto.
 Qed.

--- a/sha/hmac_common_lemmas.v
+++ b/sha/hmac_common_lemmas.v
@@ -24,14 +24,14 @@ Proof. apply firstn_precise. simpl. reflexivity. Qed.
 Lemma length_SF {A} (x:A): length (HMAC_SHA256.sixtyfour x) = 64%nat.
 Proof.
   unfold HMAC_SHA256.sixtyfour.
-  rewrite length_list_repeat; trivial.
+  rewrite repeat_length; trivial.
 Qed.
 
 Lemma Zlength_mkArgZ k pad: Zlength (HMAC_SHA256.mkArg k pad) = Z.of_nat (min (length k) 64).
 Proof. intros. repeat rewrite Zlength_correct.
    unfold HMAC_SHA256.mkArg, HMAC_SHA256.sixtyfour.
    repeat rewrite map_length.
-   rewrite combine_length, length_list_repeat . trivial.
+   rewrite combine_length, repeat_length. trivial.
 Qed.
 
 Lemma nth_zeropad_left {d d'}: forall l i (I: 0<= i < Zlength l),
@@ -56,7 +56,7 @@ Lemma nth_zeropad_right {d} l i (I: Zlength l <= i < 64):
       nth (Z.to_nat i) (HMAC_SHA256.zeroPad l) d = Byte.zero.
 Proof. unfold HMAC_SHA256.zeroPad.
   specialize (Zlength_nonneg l). intros.
-  rewrite app_nth2. rewrite nth_list_repeat'. trivial.
+  rewrite app_nth2. rewrite nth_repeat'. trivial.
   apply minus_lt_compat_r. destruct I. apply Z2Nat.inj_lt in H1. apply H1.
   lia.
   lia.
@@ -78,7 +78,7 @@ Qed.
 
 Lemma zeroPad_BlockSize: forall k, (length k <= SHA256.BlockSize)%nat ->
   length (HMAC_SHA256.zeroPad k) = SHA256.BlockSize%nat.
-Proof. unfold HMAC_SHA256.zeroPad. intros. rewrite app_length, (*length_Nlist*) length_list_repeat. lia.
+Proof. unfold HMAC_SHA256.zeroPad. intros. rewrite app_length, (*length_Nlist*) repeat_length. lia.
 Qed.
 
 Lemma length_SHA256': forall l,

--- a/sha/hmac_pure_lemmas.v
+++ b/sha/hmac_pure_lemmas.v
@@ -112,9 +112,9 @@ Proof. intros i.
       destruct (IHi l d) as [? [? ?]]. lia. rewrite H. exists x; split; trivial. right; trivial.
 Qed.
 
-Lemma skipn_list_repeat:
+Lemma skipn_repeat:
    forall A k n (a: A),
-     (k <= n)%nat -> skipn k (list_repeat n a) = list_repeat (n-k) a.
+     (k <= n)%nat -> skipn k (repeat a n) = repeat a (n-k).
 Proof.
  induction k; destruct n; simpl; intros; auto.
  apply IHk; auto. lia.
@@ -269,8 +269,8 @@ Proof. intros f n.
     exists x; eauto.
 Qed.
 
-Lemma nth_list_repeat' {A}: forall (a d:A) k i (Hik: (i <k)%nat),
-      nth i (list_repeat k a) d = a.
+Lemma nth_repeat' {A}: forall (a d:A) k i (Hik: (i <k)%nat),
+      nth i (repeat a k) d = a.
 Proof. intros a d k. induction k; simpl; trivial. intros. lia.
  intros. destruct i; simpl; trivial. rewrite IHk. trivial. lia. Qed.
 

--- a/sha/pure_lemmas.v
+++ b/sha/pure_lemmas.v
@@ -340,10 +340,10 @@ Lemma generate_and_pad_lemma1:
    (H3: Zlength dd < CBLOCKz)
    (H2 : (LBLOCKz | Zlength hashed'))
    (H5 : intlist_to_bytelist hashed' ++ dd' =
-     intlist_to_bytelist hashed ++ dd ++ [Byte.repr 128] ++ list_repeat (Z.to_nat pad) Byte.zero),
+     intlist_to_bytelist hashed ++ dd ++ [Byte.repr 128] ++ repeat Byte.zero (Z.to_nat pad)),
    let lastblock :=
                (dd' ++
-                list_repeat (Z.to_nat (CBLOCKz - 8 - Zlength dd')) Byte.zero ++
+                repeat Byte.zero (Z.to_nat (CBLOCKz - 8 - Zlength dd')) ++
                 intlist_to_bytelist [hi_part bitlen; lo_part bitlen])
    in let lastblock' :=
              bytelist_to_intlist lastblock
@@ -366,7 +366,7 @@ repeat rewrite app_ass.
 f_equal. f_equal. f_equal.
 rewrite <- app_ass.
 f_equal.
-rewrite list_repeat_app.
+rewrite <- repeat_app.
 f_equal.
 clear - H5 H2 H1 H0 PAD.
 assert (Zlength dd' <= 56) by (change CBLOCKz with 64 in H0; lia).
@@ -383,7 +383,7 @@ rewrite Zlength_app.
 forget (Zlength (intlist_to_bytelist hashed ++ dd)) as B.
 rewrite Zlength_app.
 rewrite Zlength_cons, Zlength_nil, Zlength_correct.
-rewrite length_list_repeat. rewrite Z2Nat.id by lia. lia.
+rewrite repeat_length. rewrite Z2Nat.id by lia. lia.
 } 
 change (Z.of_nat CBLOCK - 8) with 56.
 clear H5.
@@ -418,7 +418,7 @@ f_equal. {
  reflexivity.
 *
  autorewrite with sublist.
- rewrite Zlength_list_repeat by (apply Z_mod_lt; compute; auto).
+ rewrite Zlength_repeat by (apply Z_mod_lt; compute; auto).
  forget ( Zlength hashed * 4 + Zlength dd) as d.
  change (Z.succ 0) with 1.
  change WORD with 4.

--- a/sha/sha_lemmas.v
+++ b/sha/sha_lemmas.v
@@ -216,7 +216,7 @@ Ltac Omega1 := Omega (helper1 || helper2).
 Ltac Omega1 := rep_lia.
 
 Ltac MyOmega :=
-  rewrite ?length_list_repeat, ?skipn_length, ?map_length,
+  rewrite ?repeat_length, ?skipn_length, ?map_length,
    ?Zlength_map, ?Zlength_nil;
   pose proof CBLOCK_eq;
 (*  pose proof CBLOCKz_eq;*)

--- a/sha/sha_padding_lemmas.v
+++ b/sha/sha_padding_lemmas.v
@@ -20,7 +20,7 @@ Inductive InWords : list byte -> Prop :=
 Definition pad (msg : list byte) : list byte :=
   let n := Zlength msg in
   msg ++ [Byte.repr 128%Z]
-      ++ list_repeat (Z.to_nat (-(n + 9) mod 64)) Byte.zero
+      ++ repeat Byte.zero (Z.to_nat (-(n + 9) mod 64))
       ++ intlist_to_bytelist (([Int.repr (n * 8 / Int.modulus); Int.repr (n * 8)])%list).
 
 Definition generate_and_pad' (msg : list byte) : list int :=
@@ -32,14 +32,14 @@ Definition generate_and_pad' (msg : list byte) : list int :=
 Lemma fstpad_len :
   forall (msg : list byte),
     Datatypes.length (msg ++ [Byte.repr 128]
-                 ++ list_repeat (Z.to_nat (- (Zlength msg + 9) mod 64)) Byte.zero)
+                 ++ repeat Byte.zero (Z.to_nat (- (Zlength msg + 9) mod 64)))
 = (Datatypes.length msg + (S (Z.to_nat (- (Zlength msg + 9) mod 64))))%nat.
 Proof.
   intros msg.
   simpl.
   rewrite -> app_length.
   simpl.
-  rewrite -> length_list_repeat.
+  rewrite -> repeat_length.
   reflexivity.
 Qed.
 
@@ -79,13 +79,13 @@ Proof.
     intros. induction n. reflexivity. lia.
   rewrite -> succ.
   assert ((length msg +
-      (length (list_repeat (Z.to_nat (- (Zlength msg + 9) mod 64)) Byte.zero) + 8 +
+      (length (repeat Byte.zero (Z.to_nat (- (Zlength msg + 9) mod 64))) + 8 +
        1))%nat = (length msg +
-      (length (list_repeat (Z.to_nat (- (Zlength msg + 9) mod 64)) Byte.zero) + 9))%nat) by lia.
+      (length (repeat Byte.zero (Z.to_nat (- (Zlength msg + 9) mod 64))) + 9))%nat) by lia.
   rewrite -> H. clear H.
 
   rewrite -> Zlength_correct.
-  rewrite -> length_list_repeat.
+  rewrite -> repeat_length.
 
   repeat rewrite -> Nat2Z.inj_add.
   rewrite -> Z2Nat.id.
@@ -155,7 +155,7 @@ Qed.
 
 Lemma total_pad_len_Zlist : forall (msg : list byte), exists (n : nat),
      length
-       (msg ++ [Byte.repr 128] ++ list_repeat (Z.to_nat (- (Zlength msg + 9) mod 64)) Byte.zero)
+       (msg ++ [Byte.repr 128] ++ repeat Byte.zero (Z.to_nat (- (Zlength msg + 9) mod 64)))
      =  (n * Z.to_nat WORD (* 4 *))%nat.
 Proof.
   intros msg.
@@ -171,7 +171,7 @@ Proof.
   assert (Pos.to_nat 4 = 4%nat) by reflexivity.
   (*rewrite -> H0. clear H0.*)
 
-  rewrite -> length_list_repeat in *.
+  rewrite -> repeat_length in *.
 
   assert (add_both: (length msg + S (Z.to_nat (- (Zlength msg + 9) mod 64) ))%nat =
       (x * 64 - 8)%nat) by lia. clear H.
@@ -187,7 +187,7 @@ Qed.
 Lemma pad_inwords :
   forall (msg : list byte),
     InWords (msg ++ [Byte.repr 128]
-                 ++ list_repeat (Z.to_nat (- (Zlength msg + 9) mod 64)) Byte.zero).
+                 ++ repeat Byte.zero (Z.to_nat (- (Zlength msg + 9) mod 64))).
 Proof.
   intros msg.
   apply InWords_len4.

--- a/sha/spec_hmac.v
+++ b/sha/spec_hmac.v
@@ -284,7 +284,7 @@ Definition HMAC_Cleanup_spec :=
   POST [ tvoid ]
           PROP ()
           LOCAL ()
-          SEP(data_block wsh (list_repeat (Z.to_nat(sizeof t_struct_hmac_ctx_st)) Byte.zero) c).
+          SEP(data_block wsh (repeat Byte.zero (Z.to_nat(sizeof t_struct_hmac_ctx_st))) c).
 
 Definition HMAC_Cleanup_spec1 :=
   DECLARE _HMAC_cleanup
@@ -296,7 +296,7 @@ Definition HMAC_Cleanup_spec1 :=
   POST [ tvoid ]
           PROP ()
           LOCAL ()
-          SEP(data_block wsh (list_repeat (Z.to_nat(sizeof t_struct_hmac_ctx_st)) Byte.zero) c).
+          SEP(data_block wsh (repeat Byte.zero (Z.to_nat(sizeof t_struct_hmac_ctx_st))) c).
 
 
 (************************ Specification of oneshot HMAC *******************************************************)

--- a/sha/spec_sha.v
+++ b/sha/spec_sha.v
@@ -104,7 +104,7 @@ Definition memset_spec :=
        SEP (memory_block sh n p)
     POST [ tptr tvoid ]
        PROP() LOCAL(temp ret_temp p)
-       SEP(data_at sh (tarray tuchar n) (list_repeat (Z.to_nat n) (Vint c)) p).
+       SEP(data_at sh (tarray tuchar n) (repeat (Vint c) (Z.to_nat n)) p).
 
 Definition K_vector (gv: globals) : mpred :=
   data_at Ews (tarray tuint (Zlength K256)) (map Vint K256) (gv _K256).

--- a/sha/verif_hkdf.v
+++ b/sha/verif_hkdf.v
@@ -24,10 +24,10 @@ assert_PROP (isptr v_prk_len /\ field_compatible (tuint) [] v_prk_len) by entail
 unfold data_at_, field_at_.
 rewrite field_at_data_at. simpl.
 rewrite field_at_data_at. unfold tarray. simpl.
-assert (JM: default_val (Tarray tuchar 64 noattr) = sublist 0 64 (list_repeat 64 Vundef)).
-{ rewrite sublist_list_repeat with (k:=64); try lia. reflexivity. }
+assert (JM: default_val (Tarray tuchar 64 noattr) = sublist 0 64 (repeat Vundef 64)).
+{ rewrite sublist_repeat with (k:=64); try lia. reflexivity. }
 erewrite  split2_data_at_Tarray with (n1:=32); [ | lia | | apply JM | reflexivity | reflexivity]. 
-2: rewrite Zlength_list_repeat'; simpl; lia.
+2: rewrite Zlength_repeat'; simpl; lia.
 normalize. 
 freeze FR1 := - (data_at _ _ _ (field_address _ nil v_prk))
              (data_at _ _ _ (field_address _ nil v_prk_len))

--- a/sha/verif_hkdf_expand.v
+++ b/sha/verif_hkdf_expand.v
@@ -17,12 +17,12 @@ Definition OUTpred PrkCont InfoCont sh z r cont p: mpred:=
   memory_block sh r (offset_val z p).
 
 Definition PREVcont PRK INFO (i: Z): reptype (Tarray tuchar 32 noattr) :=
-     if zeq i 0 then list_repeat 32 Vundef 
+     if zeq i 0 then repeat Vundef 32
      else (map Vubyte (Ti (CONT PRK) (CONT INFO) (Z.to_nat i))).
 
 Lemma PREV_len PRK INFO i: 0 <= i -> Zlength (PREVcont PRK INFO i) = 32.
 Proof. intros. unfold PREVcont.
-destruct (zeq i 0). rewrite Zlength_list_repeat'; reflexivity.
+destruct (zeq i 0). rewrite Zlength_repeat'; reflexivity.
 assert (exists n, Z.to_nat i = S n).
 { specialize (Z2Nat_inj_0 i). intros.
   destruct (Z.to_nat i). lia. eexists; reflexivity. }
@@ -193,10 +193,10 @@ destruct prevPtr as [prevPtr prevFC].
 
 unfold data_at_ at 2. unfold field_at_.
 rewrite field_at_data_at. simpl. unfold tarray.
-assert (JM: default_val (Tarray tuchar 64 noattr) = sublist 0 64 (list_repeat 64 Vundef)).
-{ (*subst vv.*) rewrite sublist_list_repeat with (k:=64); try lia; reflexivity. }
+assert (JM: default_val (Tarray tuchar 64 noattr) = sublist 0 64 (repeat Vundef 64)).
+{ (*subst vv.*) rewrite sublist_repeat with (k:=64); try lia; reflexivity. }
 erewrite  split2_data_at_Tarray with (n1:=32); [ | lia | | apply JM | reflexivity | reflexivity].
- 2: rewrite Zlength_list_repeat'; simpl; lia.
+ 2: rewrite Zlength_repeat'; simpl; lia.
 normalize.
 rewrite field_address_offset by auto with field_compatible. simpl.
 rewrite isptr_offset_val_zero; trivial. 

--- a/sha/verif_hmac_cleanup.v
+++ b/sha/verif_hmac_cleanup.v
@@ -27,8 +27,8 @@ forward_call (wsh, c, sizeof t_struct_hmac_ctx_st, Int.zero).
 pose proof (sizeof_pos t_struct_hmac_ctx_st).
 forget (sizeof t_struct_hmac_ctx_st) as NN.
 forward.
-unfold data_block. simpl. rewrite Zlength_list_repeat by lia.
-rewrite !map_list_repeat.
+unfold data_block. simpl. rewrite Zlength_repeat by lia.
+rewrite !map_repeat.
  entailer!; auto.
 Qed.
 
@@ -44,9 +44,9 @@ Lemma cleanupbodyproof1 Espec wsh c h
      (PROP ( )
       LOCAL ()
       SEP (data_block wsh
-             (list_repeat
-                (Z.to_nat (sizeof t_struct_hmac_ctx_st))
-                Byte.zero) c) * stackframe_of f_HMAC_cleanup)).
+             (repeat Byte.zero
+                (Z.to_nat (sizeof t_struct_hmac_ctx_st))) c) 
+		* stackframe_of f_HMAC_cleanup)).
 Proof. abbreviate_semax.
 set (x := fn_body f_HMAC_cleanup); hnf in x; subst x.
 Intros key.
@@ -60,8 +60,8 @@ forward_call (wsh, c, sizeof t_struct_hmac_ctx_st, Int.zero).
 pose proof (sizeof_pos t_struct_hmac_ctx_st).
 forget (sizeof t_struct_hmac_ctx_st) as NN.
 forward.
-unfold data_block. simpl. rewrite Zlength_list_repeat by lia.
-rewrite !map_list_repeat.
+unfold data_block. simpl. rewrite Zlength_repeat by lia.
+rewrite !map_repeat.
  entailer!; auto.
 Qed.
 

--- a/sha/verif_hmac_double.v
+++ b/sha/verif_hmac_double.v
@@ -121,7 +121,7 @@ simpl.
 
 forward_call (Tsh, h5,c).
 match goal with |- context [data_block  Tsh ?A c] =>
-  change A with (list_repeat (Z.to_nat n324) Byte.zero)
+  change A with (repeat Byte.zero (Z.to_nat n324))
 end.
 forward.
 clear H2.
@@ -133,7 +133,7 @@ Exists dig2.
 unfold data_block at 1. simpl. entailer!.
 rewrite <- memory_block_data_at_ by auto.
 change (sizeof (Tstruct _hmac_ctx_st noattr))
-   with (sizeof (tarray tuchar (Zlength (list_repeat (Z.to_nat n324) 0)))).
+   with (sizeof (tarray tuchar (Zlength (repeat 0 (Z.to_nat n324))))).
 rewrite memory_block_data_at_ by auto.
 cancel.
 

--- a/sha/verif_hmac_init_part1.v
+++ b/sha/verif_hmac_init_part1.v
@@ -375,11 +375,11 @@ Proof. intros.
      assert (XX: (SHA256.BlockSize - length key = Z.to_nat SF)%nat).
           subst SF. rewrite Zlength_correct, Z2Nat.inj_sub, Nat2Z.id. reflexivity. lia.
      rewrite XX(*, HeqKCONT*).
-     repeat rewrite map_list_repeat.
+     repeat rewrite map_repeat.
      rewrite sublist_same; trivial. (*subst l64 l.*)
      change (Tarray tuchar 64 noattr) with (tarray tuchar 64).
      rewrite field_address0_offset by auto with field_compatible. simpl. rewrite Z.mul_1_l.
      change (0 + Zlength key) with (Zlength key).
      Time cancel. apply derives_refl.
-     rewrite Zlength_list_repeat', Z2Nat.id; lia.
+     rewrite Zlength_repeat', Z2Nat.id; lia.
 Time Qed. (*0.6s versus 10s versus 18s*)

--- a/sha/verif_hmac_init_part2.v
+++ b/sha/verif_hmac_init_part2.v
@@ -109,7 +109,7 @@ Proof. intros.
   2: rewrite Zlength_map; rewrite ZLI; lia.
   f_equal. rewrite Znth_map. f_equal.
            unfold HMAC_SHA256.mkArg.
-           unfold Znth. unfold Znth in X. destruct (zlt i 0). discriminate.
+           unfold Znth. unfold Znth in X. destruct (Z_lt_dec i 0). discriminate.
            specialize (map_nth (fun p : byte * byte => Byte.xor (fst p) (snd p))
                                        (combine (HMAC_SHA256.mkKey key) (HMAC_SHA256.sixtyfour Ipad))
                                        (Byte.zero, Byte.zero)
@@ -122,7 +122,7 @@ Proof. intros.
                    unfold fst, snd. 
                    remember (HMAC_SHA256.sixtyfour Ipad).
                    assert (NTH: nth (Z.to_nat i) l Byte.zero = Byte.repr 54).
-                     subst l. apply nth_list_repeat'. apply (Z2Nat.inj_lt _ 64). apply I. lia. lia.
+                     subst l. apply nth_repeat'. apply (Z2Nat.inj_lt _ 64). apply I. lia. lia.
                    rewrite NTH. auto. 
                    rewrite ZLI; assumption.
   rewrite sublist_sublist; try lia.
@@ -165,7 +165,7 @@ Proof. intros.
   2: rewrite Zlength_map, ZLO; lia.
   f_equal. rewrite Znth_map. f_equal.
            unfold HMAC_SHA256.mkArg.
-           unfold Znth. unfold Znth in X. destruct (zlt i 0). discriminate.
+           unfold Znth. unfold Znth in X. destruct (Z_lt_dec i 0). discriminate.
            specialize (map_nth (fun p : byte * byte => Byte.xor (fst p) (snd p))
                                        (combine (HMAC_SHA256.mkKey key) (HMAC_SHA256.sixtyfour Opad))
                                        (Byte.zero, Byte.zero)
@@ -179,7 +179,7 @@ Proof. intros.
                     unfold fst, snd.
                    remember (HMAC_SHA256.sixtyfour Opad).
                    assert (NTH: nth (Z.to_nat i) l Byte.zero = Byte.repr 92).
-                     subst l. apply nth_list_repeat'. apply (Z2Nat.inj_lt _ 64). apply I. lia. lia.
+                     subst l. apply nth_repeat'. apply (Z2Nat.inj_lt _ 64). apply I. lia. lia.
                    rewrite NTH; trivial.
                    rewrite ZLO; assumption.
   rewrite sublist_sublist; try lia.
@@ -282,7 +282,7 @@ Proof. intros. abbreviate_semax.
         destruct Xb as [qb Qb].
         assert (X: Znth i (map Vubyte (HMAC_SHA256.mkKey key))
                    = Vubyte qb). (* (Int.zero_ext 8 q)).*)
-          { unfold Znth. destruct (zlt i 0). lia.
+          { unfold Znth. destruct (Z_lt_dec i 0). lia.
             rewrite nth_indep with (d':=Vubyte Byte.zero).
             2:{ repeat rewrite map_length. rewrite mkKey_length. unfold SHA256.BlockSize; simpl. apply (Z2Nat.inj_lt _ 64); lia. }
             repeat rewrite map_nth. rewrite Qb. trivial.
@@ -415,7 +415,7 @@ freeze FR1 := - (data_at _ _ _ (Vptr ckb _)) (data_block _ _ _).
         destruct Xb as [qb Qb].
         assert (X: Znth i (map Vubyte (HMAC_SHA256.mkKey key))
                    = Vubyte qb). (* (Int.zero_ext 8 q)).*)
-          { unfold Znth. destruct (zlt i 0). lia.
+          { unfold Znth. destruct (Z_lt_dec i 0). lia.
             rewrite nth_indep with (d':=Vubyte Byte.zero).
               2:{ repeat rewrite map_length. rewrite mkKey_length. unfold SHA256.BlockSize; simpl. apply (Z2Nat.inj_lt _ 64); lia. }
             repeat rewrite map_nth. rewrite Qb. trivial.

--- a/sha/verif_sha_bdo4.v
+++ b/sha/verif_sha_bdo4.v
@@ -24,9 +24,9 @@ Lemma loop1_aux_lemma1:
   (0 <= i < Zlength b) ->
   Zlength b <= 16 ->
   upd_Znth i
-          (map Vint (sublist 0 i b) ++ list_repeat (Z.to_nat (16 - i)) Vundef)
+          (map Vint (sublist 0 i b) ++ repeat Vundef (Z.to_nat (16 - i)))
           (Vint (Znth i b))
-  =  map Vint (sublist 0 (i+1) b) ++ list_repeat (Z.to_nat (16 - (i+1))) Vundef.
+  =  map Vint (sublist 0 (i+1) b) ++ repeat Vundef (Z.to_nat (16 - (i+1))).
 Proof.
 intros. list_solve.
 Qed.
@@ -91,7 +91,7 @@ forward_for_simple_bound 16
                  gvars gv)
      SEP (K_vector gv;
        data_at Tsh (tarray tuint LBLOCKz)
-           (map Vint (sublist 0 i b) ++ list_repeat (Z.to_nat (16-i)) Vundef)
+           (map Vint (sublist 0 i b) ++ repeat Vundef (Z.to_nat (16-i)))
             Xv;
        data_block sh (intlist_to_bytelist b) data)).
 * (* precondition of loop entails the loop invariant *)

--- a/sha/verif_sha_final.v
+++ b/sha/verif_sha_final.v
@@ -129,7 +129,7 @@ entailer!.
 erewrite field_at_Tarray; try reflexivity; try apply JMeq_refl; try lia;
   [ | compute; clear; intuition].
 rewrite (split3seg_array_at _ _ _ 0 (Zlength dd') 56 64); try Omega1.
-2: rewrite !Zlength_app, !Zlength_map, !Zlength_list_repeat by lia;
+2: rewrite !Zlength_app, !Zlength_map, !Zlength_repeat by lia;
   lia.
 autorewrite with sublist in *|-.
 simpl.

--- a/sha/verif_sha_final2.v
+++ b/sha/verif_sha_final2.v
@@ -14,7 +14,7 @@ Lemma cancel_field_at_array_partial_undef:
   Zlength (al++bl) = n ->
   Zlength bl = blen ->
   JMeq v1 (al++bl) ->
-  JMeq v2 (al++list_repeat (Z.to_nat blen) (default_val t)) ->
+  JMeq v2 (al++repeat (default_val t) (Z.to_nat blen)) ->
   field_at sh t1 gfs v1 p
    |-- field_at sh t1 gfs v2 p.
 Proof.
@@ -153,7 +153,7 @@ semax (func_tycontext f_SHA256_Final Vprog Gtot nil)
               (LBLOCKz | Zlength hashed');
               intlist_to_bytelist hashed' ++ dd' =
               intlist_to_bytelist (s256a_hashed a) ++  (s256a_data a)
-                  ++ [Byte.repr 128%Z] ++ list_repeat (Z.to_nat pad) Byte.zero)
+                  ++ [Byte.repr 128%Z] ++ repeat Byte.zero (Z.to_nat pad))
    LOCAL
    (temp _n (Vint (Int.repr (Zlength dd')));
     temp _p (field_address t_struct_SHA256state_st [StructField _data] c);
@@ -164,7 +164,7 @@ semax (func_tycontext f_SHA256_Final Vprog Gtot nil)
             (Vint (lo_part (s256a_len a)),
              (Vint (hi_part (s256a_len a)),
               (map Vubyte dd'
-                 ++ list_repeat (Z.to_nat (CBLOCKz - Zlength dd')) Vundef,
+                 ++ repeat Vundef (Z.to_nat (CBLOCKz - Zlength dd')),
                Vundef))))
            c;
            K_vector gv;
@@ -194,8 +194,8 @@ replace_SEP 0  (data_at wsh t_struct_SHA256state_st
            (Vint (hi_part (s256a_len a)),
            (map Vubyte (s256a_data a) ++
             [Vint (Int.repr 128)] ++
-            list_repeat (Z.to_nat (64 - (Zlength (s256a_data a) + 1)))
-              Vundef, Vint (Int.repr (Zlength (s256a_data a))))))) c).
+            repeat Vundef (Z.to_nat (64 - (Zlength (s256a_data a) + 1))),
+	        Vint (Int.repr (Zlength (s256a_data a))))))) c).
  unfold_data_at (data_at _ _ _ _).
  rewrite field_at_data_at with (gfs := [StructField _data]) by reflexivity.
  unfold data_at.
@@ -242,17 +242,17 @@ evar (V: list val).
  abbreviate_semax.
 replace (ddlen + 1 + (CBLOCKz - (ddlen + 1))) with CBLOCKz by (clear; lia).
 change 64 with CBLOCKz.
-pose (ddz := ((dd ++ [Byte.repr 128]) ++ list_repeat (Z.to_nat (CBLOCKz-(ddlen+1))) Byte.zero)).
+pose (ddz := ((dd ++ [Byte.repr 128]) ++ repeat Byte.zero (Z.to_nat (CBLOCKz-(ddlen+1))))).
 
 replace (splice_into_list (ddlen + 1) CBLOCKz
-           (list_repeat (Z.to_nat (CBLOCKz - (ddlen + 1))) (Vint Int.zero))
+           (repeat (Vint Int.zero) (Z.to_nat (CBLOCKz - (ddlen + 1))))
            (map Vubyte dd ++
-            Vint (Int.repr 128) :: list_repeat (Z.to_nat fill_len) Vundef))
+            Vint (Int.repr 128) :: repeat Vundef (Z.to_nat fill_len)))
   with  (map Vubyte ddz).
 2:{
  clear - Hddlen. subst ddz fill_len ddlen. rewrite !map_app.
  change (cons (Vint (Int.repr 128))) with (app [Vint (Int.repr 128)]).
- rewrite map_list_repeat.
+ rewrite map_repeat.
  rewrite <- ?app_ass.
  unfold splice_into_list.
  change CBLOCKz with 64 in *.

--- a/sha/verif_sha_final3.v
+++ b/sha/verif_sha_final3.v
@@ -186,7 +186,7 @@ Proof.
        (map Vint (hash_blocks init_registers (generate_and_pad msg)),
         (Vundef,
          (Vundef,
-          (list_repeat (Z.to_nat CBLOCKz) (Vint Int.zero), Vint Int.zero)))) c). {
+          (repeat (Vint Int.zero) (Z.to_nat CBLOCKz), Vint Int.zero)))) c). {
    unfold_data_at (data_at _ _ _ c).
    change (Z.to_nat 64) with (Z.to_nat CBLOCKz).
    rewrite field_at_data_at with (gfs := [StructField _data]) by reflexivity.
@@ -212,12 +212,12 @@ Proof.
                 temp _c c)
    SEP
    (data_at wsh t_struct_SHA256state_st
-       (map Vint hashedmsg, (Vundef, (Vundef, (list_repeat (Z.to_nat 64) (Vint Int.zero), Vint Int.zero))))
+       (map Vint hashedmsg, (Vundef, (Vundef, (repeat (Vint Int.zero) (Z.to_nat 64), Vint Int.zero))))
       c;
     K_vector gv;
     data_at shmd (tarray tuchar 32)
          (map Vubyte (intlist_to_bytelist (sublist 0 i hashedmsg))
-           ++ list_repeat (Z.to_nat (32 - WORD*i)) Vundef) md)
+           ++ repeat Vundef (Z.to_nat (32 - WORD*i))) md)
      )).
 *
  entailer!.
@@ -327,7 +327,7 @@ forall (hashed': list int) (dd' : list byte) (pad : Z),
 (0 <= pad < 8)%Z ->
 (LBLOCKz | Zlength hashed') ->
 intlist_to_bytelist hashed' ++ dd' =
-intlist_to_bytelist hashed ++ dd ++ [Byte.repr 128%Z] ++ list_repeat (Z.to_nat pad) Byte.zero ->
+intlist_to_bytelist hashed ++ dd ++ [Byte.repr 128%Z] ++ repeat Byte.zero (Z.to_nat pad) ->
 semax
      (func_tycontext f_SHA256_Final Vprog Gtot nil)
   (PROP  ()
@@ -339,8 +339,8 @@ semax
       SEP
       (field_at wsh t_struct_SHA256state_st [StructField _data]
            (map Vubyte dd' ++
-            list_repeat (Z.to_nat (CBLOCKz - 8 - Zlength dd')) (Vubyte Byte.zero)
-              ++ list_repeat (Z.to_nat 8) Vundef) c;
+            repeat (Vubyte Byte.zero) (Z.to_nat (CBLOCKz - 8 - Zlength dd'))
+              ++ repeat Vundef (Z.to_nat 8)) c;
       field_at wsh t_struct_SHA256state_st [StructField _num] Vundef c;
       field_at wsh t_struct_SHA256state_st [StructField _Nh] (Vint (hi_part bitlen)) c;
       field_at wsh t_struct_SHA256state_st [StructField _Nl] (Vint (lo_part bitlen)) c;
@@ -377,7 +377,7 @@ Proof.
    | reflexivity | lia | apply JMeq_refl].
   rewrite <- app_ass.
    change (Z.to_nat 8) with (Z.to_nat 4 + Z.to_nat 4)%nat.
-   rewrite <- list_repeat_app.
+   rewrite repeat_app.
    rewrite (split3seg_array_at _ _ _ 0 56 60) by (autorewrite with sublist; rep_lia).
    rewrite <- !app_ass.
    assert (CBZ := CBLOCKz_eq).
@@ -423,8 +423,8 @@ Proof.
   replace_SEP 0
     (field_at wsh t_struct_SHA256state_st [StructField _data]
          (map Vubyte dd' ++
-             list_repeat (Z.to_nat (CBLOCKz - 8 - Zlength dd'))
-               (Vubyte Byte.zero) ++ ((map Vubyte hibytes) ++ (map Vubyte lobytes))) c).
+             repeat (Vubyte Byte.zero) (Z.to_nat (CBLOCKz - 8 - Zlength dd'))
+                ++ ((map Vubyte hibytes) ++ (map Vubyte lobytes))) c).
   {
     assert (LENhi: Zlength hibytes = 4) by reflexivity.
     clearbody hibytes. clearbody lobytes.
@@ -455,7 +455,7 @@ Proof.
            make_Vptr c;  simpl;  rewrite Ptrofs.sub_add_opp;
            rewrite !Ptrofs.add_assoc; normalize).
   subst hibytes; subst lobytes.
-  rewrite <- !map_list_repeat.
+  rewrite <- !map_repeat.
   rewrite <- !map_app.
   rewrite <- intlist_to_bytelist_app.
   simpl ([_] ++ [_]).

--- a/sha/verif_sha_init.v
+++ b/sha/verif_sha_init.v
@@ -22,7 +22,7 @@ Time do 8 (forward; unfold upd_Znth; if_tac;
 Time repeat forward. (* 14 sec *)
 unfold sha256state_.
 Exists (map Vint init_registers,
-      (Vint Int.zero, (Vint Int.zero, (list_repeat (Z.to_nat 64) Vundef, Vint Int.zero)))).
+      (Vint Int.zero, (Vint Int.zero, (repeat Vundef (Z.to_nat 64), Vint Int.zero)))).
 unfold_data_at (data_at _ _ _ _).
 Time entailer!. (* 5.2 sec *)
 repeat split; auto.

--- a/sha/verif_sha_update.v
+++ b/sha/verif_sha_update.v
@@ -78,7 +78,7 @@ replace_SEP 0 (data_at wsh t_struct_SHA256state_st
         (Vint (lo_part (s256a_len a + len * 8)),
         (Vint (hi_part (s256a_len a + len * 8)),
         (map Vubyte (s256a_data a)++
-         list_repeat (Z.to_nat (CBLOCKz - Zlength (s256a_data a))) Vundef,
+         repeat Vundef (Z.to_nat (CBLOCKz - Zlength (s256a_data a))),
          Vint (Int.repr (Zlength (s256a_data a))))))) c). {
   unfold_data_at (data_at _ _ _ _); entailer!.
   assert (legal_nested_field t_struct_SHA256state_st [StructField _data]).
@@ -201,7 +201,7 @@ forward_if (   PROP  ()
   unfold_data_at (data_at _ _ _ c).
   eapply(call_memcpy_tuchar
    (*dst*) wsh t_struct_SHA256state_st [StructField _data] 0
-                   (list_repeat (Z.to_nat CBLOCKz) Vundef) c
+                   (repeat Vundef (Z.to_nat CBLOCKz)) c
    (*src*) sh (tarray tuchar (Zlength data)) [] b4d
                    (map Int.repr (map Byte.unsigned data))
                    d
@@ -223,7 +223,7 @@ forward_if (   PROP  ()
  Exists    (map Vint (hash_blocks init_registers (hashed ++ blocks)),
                 (Vint (lo_part (bitlength hashed dd + len * 8)),
                  (Vint (hi_part (bitlength hashed dd + len * 8)),
-                  (map Vubyte dd' ++ list_repeat (Z.to_nat (64-(len-b4d))) Vundef,
+                  (map Vubyte dd' ++ repeat Vundef (Z.to_nat (64-(len-b4d))),
                    Vint (Int.repr (Zlength dd')))))).
  rewrite <- UAE.
 assert (Hbb: bitlength hashed dd + len * 8 =

--- a/sha/verif_sha_update3.v
+++ b/sha/verif_sha_update3.v
@@ -84,7 +84,7 @@ Definition inv_at_inner_if wsh sh hashed len c d dd data gv :=
                  (map Vint (hash_blocks init_registers hashed),
                   (Vint (lo_part (bitlength hashed dd + len*8)),
                    (Vint (hi_part (bitlength hashed dd + len*8)),
-                    (map Vubyte dd ++ list_repeat (Z.to_nat (CBLOCKz-Zlength dd)) Vundef,
+                    (map Vubyte dd ++ repeat Vundef (Z.to_nat (CBLOCKz-Zlength dd)),
                      Vint (Int.repr (Zlength dd))))))
                c;
      K_vector gv;
@@ -110,7 +110,7 @@ Definition sha_update_inv wsh sh hashed len c d (dd: list byte) (data: list byte
                  ((map Vint (hash_blocks init_registers (hashed++blocks)),
                   (Vint (lo_part (bitlength hashed dd + len*8)),
                    (Vint (hi_part (bitlength hashed dd + len*8)),
-                    (list_repeat (Z.to_nat CBLOCKz) Vundef, Vundef)))) : reptype t_struct_SHA256state_st)
+                    (repeat Vundef (Z.to_nat CBLOCKz), Vundef)))) : reptype t_struct_SHA256state_st)
                c;
             data_block sh data d)).
 
@@ -158,7 +158,7 @@ Lemma update_inner_if_sha256_state_:
 field_at wsh t_struct_SHA256state_st [StructField _data]
   (map Vubyte dd ++
    sublist 0 len (map Vubyte data) ++
-   list_repeat (Z.to_nat (CBLOCKz - Zlength dd - len)) Vundef) c *
+   repeat Vundef (Z.to_nat (CBLOCKz - Zlength dd - len))) c *
 field_at sh (tarray tuchar (Zlength data)) [] (map Vubyte data) d *
 field_at wsh t_struct_SHA256state_st [StructField _h]
   (map Vint (hash_blocks init_registers hashed)) c *
@@ -177,7 +177,7 @@ intros.
                   (Vint (lo_part (bitlength hashed dd + len*8)),
                    (Vint (hi_part (bitlength hashed dd + len*8)),
                     (map Vubyte (dd ++ sublist 0 len data)
-                       ++list_repeat (Z.to_nat (64 - Zlength dd - len)) Vundef,
+                       ++ repeat Vundef (Z.to_nat (64 - Zlength dd - len)),
                      Vint (Int.repr (Zlength dd + len)))))).
   unfold_data_at (data_at _ _ _ c).
   rewrite prop_true_andp.
@@ -264,7 +264,7 @@ forward_if.
   eapply(call_memcpy_tuchar
    (*dst*) wsh t_struct_SHA256state_st [StructField _data] (Zlength dd)
               (map Vubyte dd
-                       ++list_repeat (Z.to_nat k) Vundef)
+                       ++repeat Vundef (Z.to_nat k))
                c
    (*src*) sh (tarray tuchar (Zlength data)) [ ] 0 (map Int.repr (map Byte.unsigned data))  d
    (*len*) k
@@ -330,7 +330,7 @@ forward_if.
      by (instantiate (1:=LBLOCKz); assumption).
   rewrite splice_into_list_simplify0;
    [
-   | rewrite Zlength_correct, length_list_repeat; reflexivity
+   | rewrite Zlength_correct, repeat_length; reflexivity
    | rewrite !Zlength_map; auto
    ].
   rewrite bytelist_to_intlist_to_bytelist;
@@ -362,7 +362,7 @@ forward_if.
   eapply(call_memcpy_tuchar
    (*dst*) wsh t_struct_SHA256state_st [StructField _data] (Zlength dd)
                      (map Vubyte dd ++
-         list_repeat (Z.to_nat (CBLOCKz - Zlength dd)) Vundef) c
+         repeat Vundef (Z.to_nat (CBLOCKz - Zlength dd))) c
    (*src*) sh (tarray tuchar (Zlength data)) [ ] 0 (map Int.repr (map Byte.unsigned data))  d
    (*len*) (len)
         Frame);
@@ -382,9 +382,9 @@ forward_if.
   change 64%Z with CBLOCKz.
   replace (CBLOCKz - (Zlength dd + (CBLOCKz - Zlength dd)))%Z
     with 0%Z by (clear; lia).
-  change (list_repeat (Z.to_nat 0) Vundef) with (@nil val).
+  change (repeat Vundef (Z.to_nat 0)) with (@nil val).
   autorewrite with sublist.
-  rewrite sublist_list_repeat by Omega1.
+  rewrite sublist_repeat by Omega1.
   clear H5 H6.
   forward. (* c->num = n+(unsigned int)len; *)
   weak_normalize_postcondition.

--- a/sha/verif_sha_update4.v
+++ b/sha/verif_sha_update4.v
@@ -77,7 +77,7 @@ semax
                  (map Vint (hash_blocks init_registers hashed),
                   (Vint (lo_part (bitlength hashed dd + len*8)),
                    (Vint (hi_part (bitlength hashed dd + len*8)),
-                    (map Vubyte dd ++ list_repeat (Z.to_nat (CBLOCKz-Zlength dd)) Vundef,
+                    (map Vubyte dd ++ repeat Vundef (Z.to_nat (CBLOCKz-Zlength dd)),
                      Vint (Int.repr (Zlength dd))))))
                c;
      K_vector gv;

--- a/tweetnacl20140427/spec_salsa.v
+++ b/tweetnacl20140427/spec_salsa.v
@@ -416,7 +416,7 @@ Lemma ZContS bytes n: ZCont (S n) bytes = snd (ZZ (ZCont n bytes) 8). reflexivit
 
 Definition bytes_at x q i mbytes :=
 match x with
-  Vint _ => list_repeat (Z.to_nat i) (Byte.zero)
+  Vint _ => repeat (Byte.zero) (Z.to_nat i)
 | _ => sublist q (q+i) mbytes
 end.
 
@@ -424,7 +424,7 @@ end.
 Lemma Zlength_bytes_at x q i mbytes : 0<=q -> 0 <= i ->
   q + i <= Zlength mbytes -> Zlength (bytes_at x q i mbytes) = i.
 Proof. intros. destruct x; simpl; try rewrite Zlength_sublist; try lia.
-  rewrite Zlength_list_repeat; lia.
+  rewrite Zlength_repeat; lia.
 Qed.
 
 Definition bxorlist := combinelist _ Byte.xor.
@@ -605,11 +605,11 @@ Definition f_crypto_stream_xsalsa20_tweet_spec :=
        LOCAL (temp ret_temp (Vint (Int.repr 0)))
        SEP (Sigma_vector (gv _sigma);
             EX HSalsaRes:_, crypto_stream_xor_postsep d Nonce2 HSalsaRes
-              (list_repeat (Z.to_nat (Int64.unsigned d)) Byte.zero) (Int64.unsigned d)
+              (repeat Byte.zero (Z.to_nat (Int64.unsigned d))) (Int64.unsigned d)
               (offset_val 16 nonce) c nullval;
             data_at Tsh (Tarray tuchar 16 noattr) (SixteenByte2ValList Nonce) nonce;
             ThirtyTwoByte K k).
-(*            crypto_stream_xor_postsep d Nonce K (list_repeat (Z.to_nat (Int64.unsigned d)) Byte.zero) (Int64.unsigned d) nonce c k nullval). *)
+(*            crypto_stream_xor_postsep d Nonce K (repeat Byte.zero (Z.to_nat (Int64.unsigned d))) (Int64.unsigned d) nonce c k nullval). *)
 
 (*TODO: support the following part of the tetxual spec:
       m and c can point to the same address (in-place encryption/decryption). 
@@ -632,7 +632,7 @@ Definition f_crypto_stream_salsa20_tweet_spec :=
        LOCAL (temp ret_temp (Vint (Int.repr 0)))
        SEP (Sigma_vector (gv _sigma);
             ThirtyTwoByte K k;
-            crypto_stream_xor_postsep d Nonce K (list_repeat (Z.to_nat (Int64.unsigned d)) Byte.zero) (Int64.unsigned d) nonce c nullval). 
+            crypto_stream_xor_postsep d Nonce K (repeat Byte.zero (Z.to_nat (Int64.unsigned d))) (Int64.unsigned d) nonce c nullval). 
 
 Definition vn_spec :=
   DECLARE _vn

--- a/tweetnacl20140427/tweetNaclBase.v
+++ b/tweetnacl20140427/tweetNaclBase.v
@@ -8,8 +8,8 @@ Require Import sha.general_lemmas.
 Require Import ZArith.
 Local Open Scope Z.
 
-Lemma Zlength_list_repeat' {A} n (v:A): Zlength (list_repeat n v) = Z.of_nat n.
-Proof. rewrite Zlength_correct, length_list_repeat; trivial. Qed.
+Lemma Zlength_repeat' {A} n (v:A): Zlength (repeat v n) = Z.of_nat n.
+Proof. rewrite Zlength_correct, repeat_length; trivial. Qed.
 
 Lemma Zlength_cons' {A} (a:A) l: Zlength (a::l) = 1 + Zlength l.
   do 2 rewrite Zlength_correct. simpl. rewrite Zpos_P_of_succ_nat,<- Z.add_1_l; trivial. Qed.
@@ -86,7 +86,7 @@ Qed.
 
 Lemma app_Znth1: forall (A : Type){d: Inhabitant A} (l l' : list A) (n :Z),
            (n < Zlength l) -> Znth n (l ++ l') = Znth n l.
-Proof. intros. unfold Znth. destruct (zlt n 0). trivial.
+Proof. intros. unfold Znth. destruct (Z_lt_dec n 0). trivial.
        apply app_nth1. apply Z2Nat.inj_lt in H.
          rewrite ZtoNat_Zlength in H. trivial.
          lia.
@@ -96,13 +96,13 @@ Qed.
 Lemma app_Znth2: forall (A : Type) {d: Inhabitant A}(l l' : list A) (n : Z),
                (Zlength l <= n) -> Znth n (l ++ l') = Znth (n - Zlength l) l'.
 Proof. intros. specialize (Zlength_nonneg l); intros. unfold Znth.
-       destruct (zlt n 0). lia.
-       destruct (zlt (n - Zlength l) 0).
+       destruct (Z_lt_dec n 0). lia.
+       destruct (Z_lt_dec (n - Zlength l) 0).
          destruct (Z.sub_le_mono_r (Zlength l) n (Zlength l)) as [? _].
          specialize (H1 H). rewrite Z.sub_diag in H1. remember (n - Zlength l). clear - l0 H1. lia.
        rewrite app_nth2.
         rewrite Z2Nat.inj_sub, ZtoNat_Zlength; trivial.
-        apply Z2Nat.inj_le in H; trivial. rewrite ZtoNat_Zlength in H; trivial. clear - g; lia.
+        apply Z2Nat.inj_le in H; trivial. rewrite ZtoNat_Zlength in H; trivial. lia.
 Qed.
 
 Lemma nth_extensional {A}: forall l1 l2 (L:length l1 = length l2) (d:A)
@@ -129,7 +129,7 @@ Proof. intros.
   assert (I: 0 <= (Z.of_nat i) < Zlength l1).
     split. apply (Nat2Z.inj_le 0). apply H1. rewrite Zlength_correct. apply Nat2Z.inj_lt. apply H1.
   specialize (H0 _ I). unfold Znth in H0.
-  destruct (zlt (Z.of_nat i) 0). lia.
+  destruct (Z_lt_dec (Z.of_nat i) 0). lia.
   rewrite Nat2Z.id in H0. trivial.
 Qed.
 
@@ -141,11 +141,11 @@ Qed.
 
 (*Lemma map_Znth {A B : Type}{d: Inhabitant A} (f : A -> B) l n:
       Znth n (map f l) = f (Znth n l).
-Proof. unfold Znth. destruct (zlt n 0); simpl. trivial. apply map_nth. Qed.
+Proof. unfold Znth. destruct (Z_lt_dec n 0); simpl. trivial. apply map_nth. Qed.
 
 Lemma Znth_map' {A B : Type} (f : A -> B) d d' i al:
         (0<= i < Zlength al)%Z -> Znth i (map f al) d = f (Znth i al d').
-Proof. unfold Znth; intros. destruct (zlt i 0); simpl. lia. apply nth_map'.
+Proof. unfold Znth; intros. destruct (Z_lt_dec i 0); simpl. lia. apply nth_map'.
   destruct H. rewrite Zlength_correct in H0. apply Z2Nat.inj_lt in H0.
    rewrite Nat2Z.id in H0. assumption. assumption. lia.
 Qed.
@@ -265,7 +265,7 @@ Lemma combinelist_char_Znth {d: Inhabitant A} xs ys l (C: combinelist xs ys = So
       i (L:0 <= i < Zlength l): Znth i l = f (Znth i xs) (Znth i ys).
 Proof.
   unfold Znth.
-  destruct (zlt i 0). lia.
+  destruct (Z_lt_dec i 0). lia.
   rewrite (combinelist_char_nth _ _ _ C); trivial.
   split. lia. destruct (Z2Nat.inj_lt i (Zlength l)). lia. lia.
   rewrite ZtoNat_Zlength in H; apply H. lia.
@@ -312,12 +312,12 @@ Lemma Znth_mapVint: forall {d: Inhabitant _} l i, 0<=i< Zlength l -> exists x, Z
 Proof. unfold Znth.
   induction l; simpl; intros.
   rewrite Zlength_correct in H; simpl in *. lia.
-  destruct (zlt i 0); subst; simpl in *. lia. clear g.
+  destruct (Z_lt_dec i 0); subst; simpl in *. lia. clear n.
   remember (Z.to_nat i). destruct n. exists a; trivial.
   rewrite Zlength_cons in H.
   destruct (zeq i 0); subst.  simpl in Heqn. lia.
   destruct (IHl (i-1)). lia.
-  destruct (zlt (i - 1) 0). subst;  lia.
+  destruct (Z_lt_dec (i - 1) 0). subst;  lia.
   rewrite Z2Nat.inj_sub in H0. rewrite <- Heqn in H0. simpl in H0. rewrite <- minus_n_O in H0.
      rewrite H0. exists x; trivial. lia.
 Qed.

--- a/tweetnacl20140427/verif_crypto_stream.v
+++ b/tweetnacl20140427/verif_crypto_stream.v
@@ -19,9 +19,9 @@ Lemma crypto_stream_salsa20_tweet_ok: semax_body SalsaVarSpecs (*(crypto_stream_
 Proof.
 start_function.
 abbreviate_semax.
-forward_call (c, k, nullval, nonce, d, Nonce, K, list_repeat (Z.to_nat (Int64.unsigned d)) Byte.zero, gv).
+forward_call (c, k, nullval, nonce, d, Nonce, K, repeat Byte.zero (Z.to_nat (Int64.unsigned d)), gv).
 { simpl; entailer!. }
-apply Zlength_list_repeat. apply Int64.unsigned_range.
+apply Zlength_repeat. apply Int64.unsigned_range.
 
 forward.
 Qed.

--- a/tweetnacl20140427/verif_crypto_stream_salsa20_xor.v
+++ b/tweetnacl20140427/verif_crypto_stream_salsa20_xor.v
@@ -382,7 +382,7 @@ Proof.
   rewrite (Z.add_assoc q), (sublist_hi_plus xbytes), (sublist_hi_plus mbytes). 
   destruct x; try contradiction.
       - destruct M as [M1 M2]. subst i y. simpl. simpl in X.
-        rewrite Z2Nat.inj_add, <- list_repeat_app.
+        rewrite Z2Nat.inj_add, repeat_app.
         apply bxorlist_app. assumption.
         rewrite sublist_len_1. simpl. subst b. reflexivity.
         lia. lia. lia.
@@ -450,7 +450,7 @@ loop1_statement
          EX  l : list byte,
           !!(bxorlist (bytes_at mInit q 64 mbytes) (sublist 0 64 xbytes) = Some l) &&
           data_at Tsh (Tarray tuchar cLen noattr)
-            (Bl2VL l ++ list_repeat (Z.to_nat (cLen - 64)) Vundef) c))).
+            (Bl2VL l ++ repeat Vundef (Z.to_nat (cLen - 64))) c))).
 Proof. intros.
 Intros.
 unfold loop1_statement.       
@@ -468,7 +468,7 @@ forward_for_simple_bound 64 (EX i:Z,
                         (sublist 0 i xbytes)
                = Some l)
          && data_at Tsh (Tarray tuchar cLen noattr)
-                        (Bl2VL l ++ list_repeat (Z.to_nat (cLen - i)) Vundef) c))).
+                        (Bl2VL l ++ repeat Vundef (Z.to_nat (cLen - i))) c))).
 { entailer!. autorewrite with sublist.
   Exists (@nil byte). 
   unfold Bl2VL; simpl.
@@ -545,7 +545,7 @@ rename H into I.
     autorewrite with sublist in LL.
     rewrite upd_Znth_app2.  
     2:{ rewrite Zlength_Bl2VL. autorewrite with sublist. lia. }
-    rewrite Zlength_Bl2VL, LL, Zminus_diag, upd_Znth0_old, sublist_list_repeat; try lia.
+    rewrite Zlength_Bl2VL, LL, Zminus_diag, upd_Znth0_old, sublist_repeat; try lia.
     2: autorewrite with sublist; lia.
     2: autorewrite with sublist; lia.
     simpl. thaw FR3.
@@ -585,7 +585,7 @@ EX i:Z,
                         (sublist 0 i xbytes)
                = Some l)
          && data_at Tsh (Tarray tuchar cLen noattr)
-                        (Bl2VL l ++ list_repeat (Z.to_nat (cLen - i)) Vundef) c)).
+                        (Bl2VL l ++ repeat Vundef (Z.to_nat (cLen - i))) c)).
 
 Definition loop2_statement:=
 Sfor (Sset _i (Econst_int (Int.repr 0) tint))
@@ -727,7 +727,7 @@ forward_for_simple_bound (Int64.unsigned b)
     autorewrite with sublist in LL.
     rewrite upd_Znth_app2.  
     2:{ rewrite Zlength_Bl2VL. autorewrite with sublist. lia. }
-    rewrite Zlength_Bl2VL, LL, Zminus_diag, upd_Znth0_old, sublist_list_repeat; try lia.
+    rewrite Zlength_Bl2VL, LL, Zminus_diag, upd_Znth0_old, sublist_repeat; try lia.
     2: autorewrite with sublist; lia.
     2: autorewrite with sublist; lia.
     simpl. thaw FR3.
@@ -750,7 +750,7 @@ forward_for_simple_bound (Int64.unsigned b)
       rewrite X; trivial.
 + entailer!.
 Intros l; Exists l.
-rewrite Zminus_diag, list_repeat_0, app_nil_r.
+rewrite Zminus_diag, repeat_0, app_nil_r.
 entailer!.
 Qed.
 
@@ -828,16 +828,16 @@ forward_for_simple_bound 16 (EX i:Z,
    LOCAL  (lvar _x (tarray tuchar 64) v_x; lvar _z (tarray tuchar 16) v_z;
    temp _c c; temp _m m; temp _b (Vlong b); temp _n nonce; temp _k k; gvars gv)
    SEP  (FRZL FR1; EX l:_, !!(Zlength l + i = 16) && data_at Tsh (tarray tuchar 16) 
-          ((list_repeat (Z.to_nat i) (Vint Int.zero)) ++ l) v_z))).
-{ Exists (list_repeat 16 Vundef). entailer!. simpl; cancel. }
+          ((repeat (Vint Int.zero) (Z.to_nat i)) ++ l) v_z))).
+{ Exists (repeat Vundef 16). entailer!. simpl; cancel. }
 { rename H into I. Intros l. rename H into LI16.
   forward. Exists (sublist 1 (Zlength l) l). entailer!.
     rewrite Zlength_sublist; lia.
   apply derives_refl'. f_equal. 
-  rewrite Z2Nat.inj_add, <- list_repeat_app, <- app_assoc; try lia. 
+  rewrite Z2Nat.inj_add, repeat_app, <- app_assoc; try lia. 
   rewrite upd_Znth_app2.
-  rewrite Zlength_list_repeat, Zminus_diag, upd_Znth0_old. reflexivity. lia. lia.
-  repeat rewrite Zlength_list_repeat; lia. 
+  rewrite Zlength_repeat, Zminus_diag, upd_Znth0_old. reflexivity. lia. lia.
+  repeat rewrite Zlength_repeat; lia. 
 }
 Intros l. destruct l.
 2: specialize (Zlength_nonneg l); intros;
@@ -854,7 +854,7 @@ forward_for_simple_bound 8 (EX i:Z,
    SEP 
    (FRZL FR2; data_at Tsh (Tarray tuchar 16 noattr)
         (sublist 0 i (SixteenByte2ValList Nonce) ++
-         (list_repeat (Z.to_nat (16-i)) (Vint Int.zero))) v_z;
+         (repeat (Vint Int.zero) (Z.to_nat (16-i)))) v_z;
    data_at Tsh (Tarray tuchar 16 noattr) (SixteenByte2ValList Nonce) nonce))).
 { entailer!. }
 { rename H into I.
@@ -881,7 +881,7 @@ forward_for_simple_bound 8 (EX i:Z,
   entailer!.
   apply derives_refl'. f_equal.
   rewrite upd_Znth_app2; try autorewrite with sublist. 2: lia.
-  rewrite upd_Znth0_old, <- (@sublist_rejoin val 0 i (i+1)), <- app_assoc. 4 : rewrite Zlength_list_repeat; lia. f_equal.
+  rewrite upd_Znth0_old, <- (@sublist_rejoin val 0 i (i+1)), <- app_assoc. 4 : rewrite Zlength_repeat; lia. f_equal.
   rewrite <- Znth_cons_sublist.
   f_equal. rewrite Znth_map.
      rewrite Znth_map.
@@ -901,7 +901,7 @@ rename c into cInit. rename m into mInit. rename b into bInit. thaw FR2.
   remember ((Byte.zero, Byte.zero, Byte.zero, Byte.zero):QuadByte) as ZeroQuadByte.
   destruct Nonce as [[[N0 N1] N2] N3].
   assert (sublist 0 8 (SixteenByte2ValList (N0, N1, N2, N3)) ++
-       list_repeat (Z.to_nat (16 - 8)) (Vint Int.zero)
+       repeat (Vint Int.zero) (Z.to_nat (16 - 8))
      = (SixteenByte2ValList (((N0, N1), ZeroQuadByte), ZeroQuadByte))).
   { do 2 rewrite SixteenByte2ValList_char. 
     rewrite app_assoc, sublist_app1; try lia. 

--- a/tweetnacl20140427/verif_fcore_jbody.v
+++ b/tweetnacl20140427/verif_fcore_jbody.v
@@ -138,7 +138,7 @@ Proof. intros. unfold array_copy1_statement. abbreviate_semax.
             && data_at Tsh (tarray tuint 4) l t;
        data_at Tsh (tarray tuint 16) (map Vint xs) x))).
   (*1.3*)
-  { Exists (list_repeat 4 Vundef). (*Time*) entailer!. (*2.2*) }
+  { Exists (repeat Vundef 4). (*Time*) entailer!. (*2.2*) }
   { rename i into m. rename H into M. Intros T.
     rename H into HT.
     (*Time*) assert_PROP (Zlength T = 4) as TL by entailer!. (*2.2 versus 5.7*)

--- a/tweetnacl20140427/verif_fcore_loop1.v
+++ b/tweetnacl20140427/verif_fcore_loop1.v
@@ -15,7 +15,7 @@ Require Import tweetnacl20140427.spec_salsa. Opaque Snuffle.Snuffle. Opaque fcor
 
 Definition X_content (x: SixteenByte * SixteenByte * (SixteenByte * SixteenByte))
                      (i:Z) (l:list val) : Prop :=
-    l = upd_upto x (Z.to_nat i) (list_repeat 16 Vundef).
+    l = upd_upto x (Z.to_nat i) (repeat Vundef 16).
 
 Lemma XcontUpdate Nonce C Key1 Key2 i l
       (I: 0 <= i < 4)
@@ -142,7 +142,7 @@ Time forward_for_simple_bound 4 (EX i:Z,
    SEP  (FR;
          EX l:_, !!(X_content data i l) && data_at Tsh (tarray tuint 16) l x;
          CoreInSEP data (nonce, c, k))). (*0.8 versus 2.1*)
-{ Exists (list_repeat 16 Vundef). Time entailer!. (*1.3 versus 4.2*) }
+{ Exists (repeat Vundef 16). Time entailer!. (*1.3 versus 4.2*) }
 { rename H into I.
 
   destruct data as ((Nonce, C), Key). unfold CoreInSEP.

--- a/tweetnacl20140427/verif_fcore_loop2.v
+++ b/tweetnacl20140427/verif_fcore_loop2.v
@@ -16,11 +16,18 @@ Definition Y_content (y: list val)
           l1++yy=y /\ xx++l2=X /\
           Zlength l1=i /\ Zlength xx =i.
 
+Lemma in_repeat: forall {A : Type} (n : nat) (x y : A),
+       In y (repeat x n) -> y = x.
+Proof.
+intros.
+induction n; simpl in *. contradiction. destruct H; auto.
+Qed.
+
 Lemma f_core_loop2: forall (Espec : OracleKind) FR c k h nonce out w x y t
   (data : SixteenByte * SixteenByte * (SixteenByte * SixteenByte))
   (Delta := func_tycontext f_core SalsaVarSpecs SalsaFunSpecs nil)
   (xInit : list val)
-  (XInit : xInit = upd_upto data 4 (list_repeat 16 Vundef)),
+  (XInit : xInit = upd_upto data 4 (repeat Vundef 16)),
 @semax CompSpecs Espec
 Delta
   (PROP  ()
@@ -62,12 +69,12 @@ Proof. intros. abbreviate_semax.
       lvar _x (tarray tuint 16) x; lvar _w (tarray tuint 16) w; temp _out out; temp _in nonce;
       temp _k k; temp _c c; temp _h (Vint (Int.repr h)))
     SEP  (FR; data_at Tsh (tarray tuint 16) xInit x;
-          EX l:_, !!(Y_content xInit i l (list_repeat 16 Vundef)) &&
+          EX l:_, !!(Y_content xInit i l (repeat Vundef 16)) &&
               data_at Tsh (tarray tuint 16) l y)).
   (*1.2*)
   { clear. Time entailer!. (*1.9*)
-    Exists (list_repeat 16 Vundef). Time entailer!. (*0.4*)
-    exists nil,  (list_repeat 16 Vundef).
+    Exists (repeat Vundef 16). Time entailer!. (*0.4*)
+    exists nil,  (repeat Vundef 16).
       exists xInit, nil; simpl. repeat split; auto. }
   { rename H into I. Intros Y. rename H into YCONT.
     destruct (upd_upto_Vint data i I) as [vi Vi].
@@ -75,7 +82,7 @@ Proof. intros. abbreviate_semax.
       assert (V: exists v yT, yy = (Vint v)::yT).
         destruct yy. rewrite app_nil_r in APP2. subst l1 xInit.
          rewrite upd_upto_Zlength in L1. lia.
-         rewrite Zlength_list_repeat'. trivial. simpl; lia. subst xInit.
+         rewrite Zlength_repeat'. trivial. simpl; lia. subst xInit.
         rewrite <- APP2, app_Znth2, L1, Zminus_diag, Znth_0_cons in Vi. rewrite Vi.
         eexists; eexists; reflexivity. lia.
       destruct V as [v [yT ?]]. subst yy; simpl.
@@ -93,9 +100,9 @@ Proof. intros. abbreviate_semax.
         + clear - APP2 APP3 I L2.
           assert (TT: exists lT, l2 = Vundef::lT).
           { destruct l2.
-            - rewrite app_nil_r in *. subst xx; rewrite <- L2, Zlength_list_repeat' in I.
+            - rewrite app_nil_r in *. subst xx; rewrite <- L2, Zlength_repeat' in I.
               simpl in I; lia.
-            - rewrite (in_list_repeat 16 Vundef v0). eexists; reflexivity.
+            - rewrite (in_repeat 16 Vundef v0). eexists; reflexivity.
               rewrite <- APP3. apply in_app. right; left; trivial. }
           destruct TT as [lT LT2]; subst l2.
           exists (l1 ++ [Vint v]), lT, yT, (xx ++ [Vundef]).

--- a/tweetnacl20140427/verif_fcore_loop3.v
+++ b/tweetnacl20140427/verif_fcore_loop3.v
@@ -456,7 +456,7 @@ Time forward_for_simple_bound 20 (EX i:Z,
    SEP  (FR; data_at_ Tsh (tarray tuint 4) t;
       EX l:_, !!(WcontI r (Z.to_nat j) l) && data_at Tsh (tarray tuint 16) l w;
       data_at Tsh (tarray tuint 16) (map Vint r) x))). (*1.5*)
-  { Time entailer!. (*2.5*) Exists (list_repeat 16 Vundef). Time entailer!. (*0.1*) }
+  { Time entailer!. (*2.5*) Exists (repeat Vundef 16). Time entailer!. (*0.1*) }
   { rename H into J. rename i0 into j.
     Intros wlist. rename H into WCONT.
     destruct (Znth_mapVint r ((5 * j + 4 * 0) mod 16)) as [t0 T0].

--- a/tweetnacl20140427/verif_ld_st.v
+++ b/tweetnacl20140427/verif_ld_st.v
@@ -297,7 +297,7 @@ Time forward_for_simple_bound 4 (EX i:Z,
    LOCAL (temp _x x; temp _u (Vint (iterShr8 u (Z.to_nat i))))
    SEP (data_at Tsh (tarray tuchar 4) 
               (sublist 0 i (map Vint (map Int.repr (map Byte.unsigned ([u0;u1;u2;u3])))) ++ 
-               list_repeat (Z.to_nat(4-i)) Vundef)
+               repeat Vundef (Z.to_nat(4-i)))
                 x))).
 { entailer!. simpl; cancel. }
 { rename H into I.
@@ -472,7 +472,7 @@ Time forward_for_simple_bound 8 (EX i:Z,
   (PROP  ()
    LOCAL (temp _x x; temp _u (Vlong (iter64Shr8 u (Z.to_nat i))))
    SEP (data_at Tsh (tarray tuchar 8) 
-              (list_repeat (Z.to_nat(8-i)) Vundef ++
+              (repeat Vundef (Z.to_nat(8-i)) ++
                sublist (8-i) 8 (map Vint (map Int.repr (map Byte.unsigned ([b3;b2;b1;b0;c3;c2;c1;c0])))))
                 x))).
 { entailer!. } 2: solve [forward].
@@ -1091,7 +1091,7 @@ forward_for (EX z:_,
    LOCAL (temp _i (Vint (Int.repr z)); temp _x x; 
           temp _u (Vlong u))
    SEP (data_at Tsh (tarray tuchar 8) (Data z) x))). 
-{ Exists 7. entailer!. myadmit. (*Data 7 = list_repeat 8 Vundef*) }
+{ Exists 7. entailer!. myadmit. (*Data 7 = repeat Vundef 8*) }
 
 eapply semax_for with (A:=Z)(v:= fun a => Val.of_bool (negb (Int.lt (Int.repr a) (Int.repr 0)))).
  solve [ reflexivity].
@@ -1145,7 +1145,7 @@ Time forward_for_simple_bound 8 (EX i:Z,
    LOCAL (temp _x x; temp _u (Vlong (iter64Shr8 u (Z.to_nat i))))
    SEP (data_at Tsh (tarray tuchar 8) 
               (sublist 0 i (map Vint (map Int.repr (map Byte.unsigned ([w0;w1;w2;w3;u0;u1;u2;u3])))) ++ 
-               list_repeat (Z.to_nat(8-i)) Vundef)
+               repeat Vundef (Z.to_nat(8-i)))
                 x))).
 { entailer!. }
 { rename H into I.

--- a/tweetnacl20140427/verif_salsa_base.v
+++ b/tweetnacl20140427/verif_salsa_base.v
@@ -370,7 +370,7 @@ Lemma upd_upto_Zlength data l (H: Zlength l = 16): forall i (I:(0<=i<=4)%nat),
 Qed.
 
 Lemma upd_upto_Vint data: forall n, 0<=n<16 ->
-      exists i, Znth n (upd_upto data 4 (list_repeat 16 Vundef)) = Vint i.
+      exists i, Znth n (upd_upto data 4 (repeat Vundef 16)) = Vint i.
   Proof. unfold upd_upto; intros. destruct data as [[N C] [K1 K2]].
    repeat rewrite (upd_Znth_lookup' 16); trivial; simpl; try lia.
    if_tac. eexists; reflexivity.   if_tac. eexists; reflexivity.

--- a/util/list-solver
+++ b/util/list-solver
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+mkdir -p sublist
+cp floyd/sublist.v sublist/sublist.v
+sed 's/port VST.floyd./port /' floyd/Zlength_solver.v >sublist/Zlength_solver.v
+sed 's/port VST.floyd./port /' floyd/list_solver.v >sublist/list_solver.v
+cd sublist
+echo "coqc -I . sublist.v"
+coqc -I . sublist.v
+echo "coqc -I . Zlength_solver.v"
+coqc -I . Zlength_solver.v
+echo "coqc -I . list_solver.v"
+coqc -I . list_solver.v


### PR DESCRIPTION
1. Where CompCert uses list_repeat,zlt,zeq that have since been
  added to the Coq Standard Library as repeat, Z_lt_ge_dec, Z.eq_dec,
  use the Standard Library versions instead of the CompCert versions.

2. Make the list_solver (floyd/sublist, floyd/Znth_solve, floyd/list_solver)
  mostly independent of CompCert and VST, so that it can be used
  in other developments besides VST.