### PR TITLE
Support platforms where endianness is a parameter (ARM)

### DIFF
--- a/veric/initialize.v
+++ b/veric/initialize.v
@@ -349,7 +349,11 @@ Proof.
 intros; hnf; intros.
 transitivity
   (Some (decode_val chunk (list_repeat (size_chunk_nat chunk) (Byte Byte.zero)))).
-2: destruct chunk; reflexivity.
+2: destruct chunk; (
+     simpl list_repeat;
+     cbv delta [decode_val decode_int proj_bytes rev_if_be rev] iota beta zeta;
+     try rewrite Tauto.if_same;
+     reflexivity).
 apply loadbytes_load; auto.
 clear H2.
 rewrite size_chunk_conv in *.


### PR DESCRIPTION
On ARM platforms, the endianness is a parameter, rather than a defined value as for x86:

(https://github.com/AbsInt/CompCert/blob/1f35599abe1b82f565a9a1b1ee03f60df362f22d/arm/Archi.v#L24)
(https://github.com/AbsInt/CompCert/blob/1f35599abe1b82f565a9a1b1ee03f60df362f22d/x86_32/Archi.v#L24)

This leads in a few places to issues in reflexivity proofs, because terms don't evaluate cause of the parameter. This PR changes the proofs such that they also work when the endianness is unknown.

With this change the full VST build (including examples in progs) runs through with a CompCert configured for arm32 (tested with armv7a-eabihf).

Note: in some cases I pulled out an equality proof into an extra lemma - even though this lemma doesn't have any parameters - because the rewrite with `Tauto.if_same` was tricky inside of the larger lemma and also the rewrite requires careful evaluation, so that the `if` with the parameter is visible but not under a binder.