### PR TITLE
Ci fixes

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -2,8 +2,14 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - release-v2.7
+      - release-v2.8
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build:

--- a/coq-vst-32.opam
+++ b/coq-vst-32.opam
@@ -16,7 +16,10 @@ homepage: "http://vst.cs.princeton.edu/"
 dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
 bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
-build: [make "BITSIZE=32" "-j%{jobs}%" "msl" "sepcomp" "veric" "floyd"]
+build: [
+  [make "BITSIZE=32" "depend"]
+  [make "BITSIZE=32" "-j%{jobs}%" "msl" "sepcomp" "veric" "floyd"]
+]
 run-test: [make "BITSIZE=32" "-j%{jobs}%" "progs" "sha-hmac" "mailbox"]
 install: [
 	make "BITSIZE=32" "install"

--- a/coq-vst.opam
+++ b/coq-vst.opam
@@ -16,7 +16,10 @@ homepage: "http://vst.cs.princeton.edu/"
 dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
 bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
-build: [make "BITSIZE=64" "-j%{jobs}%" "msl" "sepcomp" "veric" "floyd"]
+build: [
+  [make "BITSIZE=64" "depend"]
+  [make "BITSIZE=64" "-j%{jobs}%" "msl" "sepcomp" "veric" "floyd"]
+]
 run-test: [make "BITSIZE=64" "-j%{jobs}%" "progs"]
 install: [
 	make "BITSIZE=64" "install"


### PR DESCRIPTION
This PR fixes two issues with CI discussed along PR #346:

- CI does not run `make depend` so that CI fails randomly
- CI is run twice needlessly on PR branches