### PR TITLE
Fix issue #485: make install with IGNORECOQVERSION

### DIFF
--- a/util/calc_install_files
+++ b/util/calc_install_files
@@ -1,5 +1,5 @@
 #!/bin/bash
 #  The $1 argument of this script should be $(PROGSDIR)
 make depend >& /dev/null
-make CLIGHTGEN="CLIGHTGEN" -Bn veric floyd $1 2>/dev/null | \
+make CLIGHTGEN="CLIGHTGEN" IGNORECOQVERSION=true -Bn veric floyd $1 2>/dev/null | \
  awk '/^echo COQC /{print $NF}/^CLIGHTGEN/{print $NF}'


### PR DESCRIPTION
This PR fixes issue #485.

The root cause was that IGNORECOQVERSION was not passed on to sub make calls in `calc_install_files`, so that the sub make aborts immediately in case the IGNORECOQVERSION=true is actually required as in a .dev build.

I will merge this immediately since it is trivial to undo in case this should be required and this keeps me from making progress with the new Coq Platform release (including VST 2.8).