### PR TITLE
CI: increase timeout for CompCert buil in Travis to 20 min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,8 @@ install:
 - opam show coq-compcert-32
 - travis_wait 15 opam install -j ${NJOBS} -y coq=${COQ_VERSION} ${EXTRA_OPAM}
 - opam install -j ${NJOBS} -y coq=${COQ_VERSION} coq-ext-lib coq-flocq
-- travis_wait 15 opam install -j ${NJOBS} -y coq-compcert=${COMPCERT_VERSION}
-- travis_wait 15 opam install -j ${NJOBS} -y coq-compcert-32=${COMPCERT_VERSION}
+- travis_wait 20 opam install -j ${NJOBS} -y coq-compcert=${COMPCERT_VERSION}
+- travis_wait 20 opam install -j ${NJOBS} -y coq-compcert-32=${COMPCERT_VERSION}
 - opam list
 - file `which coqc`
 # - WC=`which coqc`


### PR DESCRIPTION
In Travis CI the CompCert build sometimes times out, e.g. in

https://github.com/PrincetonUniversity/VST/runs/2829429696

This PR increases the timeout from 15 to 20 minutes. In the 32 bit build of the above run, it succeeded in 14min 3sec.