### PR TITLE
change size of the lock type to be 6 Tpointers wide

### DIFF
--- a/concurrency/lksize.v
+++ b/concurrency/lksize.v
@@ -3,7 +3,7 @@ Require Import compcert.common.Memdata.
 Require Import Coq.ZArith.ZArith.
 
 (* LKSIZE should match sizeof(semax_conc.tlock).  *)
-Definition LKSIZE:= (2 * size_chunk Mptr)%Z.
+Definition LKSIZE:= (6 * size_chunk Mptr)%Z.
 Definition LKSIZE_nat:= Z.to_nat LKSIZE.
 
 Lemma LKSIZE_pos : (0 < LKSIZE)%Z.
@@ -15,7 +15,7 @@ Qed.
 Lemma LKSIZE_int : (size_chunk Mint32 < LKSIZE)%Z.
 Proof.
   unfold LKSIZE; simpl.
-  rewrite size_chunk_Mptr; destruct Archi.ptr64; omega.
+  rewrite size_chunk_Mptr. destruct Archi.ptr64; simpl; omega.
 Qed.
 
 Ltac lkomega := pose proof LKSIZE_pos; pose proof LKSIZE_int; simpl in *; try omega.

--- a/concurrency/semax_conc.v
+++ b/concurrency/semax_conc.v
@@ -38,7 +38,7 @@ clightgen when threads.h is included first *)*)
 
 Definition voidstar_funtype := Tfunction (Tcons (tptr tvoid) Tnil) (tptr tvoid) cc_default.
 (* Definition tlock := Tstruct _lock_t noattr. *)
-Definition tlock := (Tarray (Tpointer Tvoid noattr) 2 noattr).
+Definition tlock := (Tarray (Tpointer Tvoid noattr) 6 noattr).
 (* Notation tlock := tuint (only parsing). *)
 
 Goal forall (cenv: composite_env), @sizeof cenv tlock = LKSIZE.


### PR DESCRIPTION
The size of the lock type should be 6 pointers wide on 32-bit machines. IIRC the size is 8 Tpointers wide on 64-bit machines, but since this branch mainly serves deepweb which depends on the 32-bit clightgen, I ignore the 64-bit version on this branch.