### PR TITLE
Add msl and sepcomp to calc_install_files

### DIFF
--- a/util/calc_install_files
+++ b/util/calc_install_files
@@ -1,5 +1,5 @@
 #!/bin/bash
 #  The $1 argument of this script should be $(PROGSDIR)
 make depend >& /dev/null
-make CLIGHTGEN="CLIGHTGEN" IGNORECOQVERSION=true -Bn veric floyd $1 2>/dev/null | \
+make CLIGHTGEN="CLIGHTGEN" IGNORECOQVERSION=true -Bn msl sepcomp veric floyd $1 2>/dev/null | \
  awk '/^echo COQC /{print $NF}/^CLIGHTGEN/{print $NF}'


### PR DESCRIPTION
# tl;dr

This PR provides a quick-fix for a simple omission in `util/calc_install_files`. This omission impacts the VST installation process: in particular, it prevents `opam install` and `make install` from providing a complete installation of MSL and sepcomp theories.

# Full explanation

`Makefile` uses a shell script (`util/calc_install_files`) to determine which files to install:

```Makefile
# https://github.com/PrincetonUniversity/VST/blob/master/Makefile#L638
INSTALL_FILES_SRC=$(shell COMPCERT=$(COMPCERT) COMPCERT_INST_DIR=$(COMPCERT_INST_DIR) BITSIZE=$(BITSIZE) ARCH=$(ARCH) util/calc_install_files $(PROGSDIR))

# ...

# https://github.com/PrincetonUniversity/VST/blob/master/Makefile#L737
install: VST.config
	install -d "$(INSTALLDIR)"
	for d in $(sort $(dir $(INSTALL_FILES) $(EXTRA_INSTALL_FILES))); do install -d "$(INSTALLDIR)/$$d"; done
	for f in $(INSTALL_FILES); do install -m 0644 $$f "$(INSTALLDIR)/$$(dirname $$f)"; done
	for f in $(EXTRA_INSTALL_FILES); do install -m 0644 $$f "$(INSTALLDIR)/$$(dirname $$f)"; done
```

This shell script (re)-invokes `make` and processes the output:
```bash
# https://github.com/PrincetonUniversity/VST/blob/master/util/calc_install_files#L4
make CLIGHTGEN="CLIGHTGEN" IGNORECOQVERSION=true -Bn veric floyd $1 2>/dev/null | \
 awk '/^echo COQC /{print $NF}/^CLIGHTGEN/{print $NF}'
```

As can be seen above, the shell script provides `make` with a _hard coded_ list of targets (`veric` and `floyd`).

This list does not include `msl` or `sepcomp`. As a result, copies of VST installed via `opam install` or `make install` are incomplete, containing only those portions of `msl` and `sepcomp` that are used by `veric` or `floyd`.

This PR provides a quick-fix by adding these targets to the shell script.