### PR TITLE
Make pointer_val_val a still right definition under 64-bit.

### DIFF
--- a/floyd/reptype_lemmas.v
+++ b/floyd/reptype_lemmas.v
@@ -620,7 +620,7 @@ Definition Int_zero := Int.mkint 0 zero_in_range.
 Definition pointer_val_val (pv: pointer_val): val :=
   match pv with
   | ValidPointer b i => Vptr b i
-  | NullPointer => Vint Int.zero (* Vint Int_zero *)
+  | NullPointer => if Archi.ptr64 then Vlong Int64.zero else Vint Int.zero
   end.
 
 Definition reptype': type -> Type :=

--- a/floyd/reptype_lemmas.v
+++ b/floyd/reptype_lemmas.v
@@ -620,7 +620,7 @@ Definition Int_zero := Int.mkint 0 zero_in_range.
 Definition pointer_val_val (pv: pointer_val): val :=
   match pv with
   | ValidPointer b i => Vptr b i
-  | NullPointer => if Archi.ptr64 then Vlong Int64.zero else Vint Int.zero
+  | NullPointer => nullval
   end.
 
 Definition reptype': type -> Type :=


### PR DESCRIPTION
The CertiGraph project uses`pointer_val` and related functions such as `pointer_val_val` extensively (although the GC proof does not use it). The null pointer is different under 32-bit and 64-bit. So I made the pull request.