### PR TITLE
Adapt to coq/coq#13837 ("apply with" does not rename arguments)

### DIFF
--- a/compcert/common/Smallstep.v
+++ b/compcert/common/Smallstep.v
@@ -960,7 +960,7 @@ Qed.
 
 Lemma forward_simulation_determ: forward_simulation L1 L2.
 Proof.
-  apply Forward_simulation with (order0 := lex_ord order lt) (match_states0 := match_states_later);
+  apply @Forward_simulation with (order := lex_ord order lt) (match_states := match_states_later);
   constructor.
 - apply wf_lex_ord. apply wf_order. apply lt_wf.
 - intros. exploit match_initial_states; eauto. intros (i & s2 & A & B).

--- a/concurrency/conclib.v
+++ b/concurrency/conclib.v
@@ -12,6 +12,9 @@ Import FashNotation.
 Import LiftNotation.
 Import compcert.lib.Maps.
 
+(* rewrite is really annoying to fix in a backwards compatible way so just set the option. *)
+Local Set Apply With Renaming.
+
 (* general list lemmas *)
 Notation vint z := (Vint (Int.repr z)).
 Notation vptrofs z := (Vptrofs (Ptrofs.repr z)).

--- a/floyd/PTops.v
+++ b/floyd/PTops.v
@@ -484,7 +484,7 @@ Lemma merge_consistent_PTrees_e': forall {X} (eqX: X -> X -> bool)
   m ! i = Some x <-> m1 ! i = Some x \/ m2 ! i = Some x.
 Proof.
  intros. 
- apply merge_consistent_PTrees_e with (i0:=i) in H; auto.
+ apply @merge_consistent_PTrees_e with (i:=i) in H; auto.
  destruct (m1 ! i) eqn:?H.
  destruct (m2 ! i) eqn:?H.
  destruct H. apply eqX_prop in H; subst x1.

--- a/floyd/SeparationLogicAsLogic.v
+++ b/floyd/SeparationLogicAsLogic.v
@@ -2548,11 +2548,11 @@ destruct Sub as [[Tsigs CC] Sub]. subst cc' sig'. simpl in Sub.
 destruct SB as [SB1 [SB2 SB3]].
 split3; trivial. intros.
 specialize (Sub ts x).
-eapply semax_adapt
+eapply @semax_adapt
  with
-  (Q'0:= frame_ret_assert (function_body_ret_assert (fn_return f) (Q' ts x))
+  (Q':= frame_ret_assert (function_body_ret_assert (fn_return f) (Q' ts x))
            (stackframe_of f))
-  (P'0 := EX vals:list val,
+  (P' := EX vals:list val,
     EX ts1:list Type, EX x1 : _,
     EX FR: mpred, 
     !!((tc_vals (map snd (fn_params f)) vals) /\

--- a/floyd/call_lemmas.v
+++ b/floyd/call_lemmas.v
@@ -1065,7 +1065,7 @@ eapply derives_trans;[ apply andp_derives; [apply derives_refl | apply andp_left
   apply later_left2. normalize.
   rewrite <- andp_assoc. rewrite andp_comm.
   apply derives_extract_prop. intro VL.
-  apply msubst_eval_exprlist_eq with (P0:=P)(R0:=R)(GV0:=GV) in MSUBST.
+  apply @msubst_eval_exprlist_eq with (P:=P)(R:=R)(GV:=GV) in MSUBST.
 
 clear - PTREE PTREE' FRAME PPRE LEN CHECKG MSUBST VL.
 rewrite andp_assoc. apply andp_left2.

--- a/floyd/data_at_rec_lemmas.v
+++ b/floyd/data_at_rec_lemmas.v
@@ -907,7 +907,7 @@ Proof.
     rewrite default_val_eq. simpl.
     intros.
     rewrite !at_offset_eq3.
-    rewrite default_val_eq with (t0 := (Tarray t z a)), unfold_fold_reptype.
+    rewrite @default_val_eq with (t := (Tarray t z a)), unfold_fold_reptype.
     eapply derives_trans.
     apply IH; auto.
     - pose_size_mult cs t (0 :: i :: i + 1 :: Z.max 0 z :: nil).

--- a/floyd/efield_lemmas.v
+++ b/floyd/efield_lemmas.v
@@ -396,7 +396,7 @@ Proof.
   +
     eapply isBinOpResultType_add_ptr_long; [auto | apply typeconv_typeconv'_eq; eassumption | |].
     - destruct H3 as [_ [? [_ [_ ?]]]].
-      eapply nested_field_type_complete_legal_cosu_type with (gfs0 := gfs) in H3; auto.
+      eapply @nested_field_type_complete_legal_cosu_type with (gfs := gfs) in H3; auto.
       rewrite H2 in H3.
       exact H3.
     - destruct (typeof (nested_efield e efs tts)); try solve [inv H5];
@@ -430,7 +430,7 @@ Proof.
    destruct i; simpl; eexists; reflexivity. (* Archi.ptr64 = false *)
   + eapply isBinOpResultType_add_ptr_ptrofs; [auto | apply typeconv_typeconv'_eq; eassumption | |].
     - destruct H3 as [_ [? [_ [_ ?]]]].
-      eapply nested_field_type_complete_legal_cosu_type with (gfs0 := gfs) in H3; auto.
+      eapply @nested_field_type_complete_legal_cosu_type with (gfs := gfs) in H3; auto.
       rewrite H2 in H3.
       exact H3.
     - destruct (typeof (nested_efield e efs tts)); try solve [inv H5];
@@ -463,7 +463,7 @@ Proof.
    destruct i; simpl; eexists; reflexivity.
   + eapply isBinOpResultType_add_ptr; [auto | apply typeconv_typeconv'_eq; eassumption | |].
     - destruct H3 as [_ [? [_ [_ ?]]]].
-      eapply nested_field_type_complete_legal_cosu_type with (gfs0 := gfs) in H3; auto.
+      eapply @nested_field_type_complete_legal_cosu_type with (gfs := gfs) in H3; auto.
       rewrite H2 in H3.
       exact H3.
     - destruct (typeof (nested_efield e efs tts)); try solve [inv H5];

--- a/floyd/field_at.v
+++ b/floyd/field_at.v
@@ -344,7 +344,7 @@ Proof.
   clear ZL.
   revert v0 v1 H.
   unfold field_at.
-  rewrite nested_field_type_ArraySubsc with (i0 := i).
+  rewrite @nested_field_type_ArraySubsc with (i := i).
   intros.
   specialize (H (Znth (i - lo) v0) (Znth (i - lo) v1)).
   do 3 (spec H; [auto |]).
@@ -523,7 +523,7 @@ Proof.
       by (apply ND_prop_ext; unfold field_compatible; tauto; apply ND_prop_ext; tauto).
     normalize.
   }
-  rewrite nested_field_offset_ind with (gfs0 := StructField i :: gfs) by auto.
+  rewrite @nested_field_offset_ind with (gfs := StructField i :: gfs) by auto.
   unfold gfield_offset; rewrite H.
   f_equal; [| f_equal].
   + apply ND_prop_ext.
@@ -609,7 +609,7 @@ Proof.
       by (apply ND_prop_ext; unfold field_compatible; tauto).
     normalize.
   }
-  rewrite nested_field_offset_ind with (gfs0 := UnionField i :: gfs) by auto.
+  rewrite @nested_field_offset_ind with (gfs := UnionField i :: gfs) by auto.
   unfold gfield_offset; rewrite H.
   change (sizeof ?A) with (expr.sizeof A) in *.
   f_equal; [| f_equal].
@@ -649,7 +649,7 @@ Proof.
   unfold array_at, field_at.
   rewrite array_pred_len_1 by lia.
   revert v' H.
-  rewrite nested_field_type_ArraySubsc with (i0 := i).
+  rewrite @nested_field_type_ArraySubsc with (i := i).
   intros.
   apply JMeq_eq in H; rewrite H.
   f_equal.
@@ -674,7 +674,7 @@ Proof.
     assert (field_compatible0 t (gfs SUB mid) p) by (apply (field_compatible0_range _ lo hi); auto).
     tauto.
   + intros [? ?].
-    rewrite split_array_pred with (mid0 := mid) by auto.
+    rewrite @split_array_pred with (mid := mid) by auto.
     rewrite H0; auto.
 Qed.
 
@@ -829,12 +829,12 @@ Proof.
     f_equal.
     f_equal.
     f_equal.
-    rewrite nested_field_offset_ind with (gfs0 := nil) by (apply (field_compatible0_nested_field_array t gfs lo hi p); auto).
+    rewrite @nested_field_offset_ind with (gfs := nil) by (apply (field_compatible0_nested_field_array t gfs lo hi p); auto).
     assert (field_compatible0 t (gfs SUB i') p)
       by (apply (field_compatible0_range _ lo hi); auto; lia).
-    rewrite nested_field_offset_ind with (gfs0 := ArraySubsc i' :: _) by auto.
-    rewrite nested_field_offset_ind with (gfs0 := ArraySubsc lo :: _) by auto.
-    rewrite nested_field_type_ind with (gfs0 := ArraySubsc 0 :: _).
+    rewrite @nested_field_offset_ind with (gfs := ArraySubsc i' :: _) by auto.
+    rewrite @nested_field_offset_ind with (gfs := ArraySubsc lo :: _) by auto.
+    rewrite @nested_field_type_ind with (gfs := ArraySubsc 0 :: _).
     rewrite field_compatible0_cons in H4.
     destruct (nested_field_type t gfs); try tauto.
     unfold gfield_offset, gfield_type.
@@ -1097,7 +1097,7 @@ Proof.
   1: rewrite Zlength_Zrepeat by (rewrite Zlength_correct in H1; lia); lia.
   intros.
   destruct (field_compatible0_dec t (ArraySubsc i :: gfs) p).
-  + revert u1 H5; erewrite <- nested_field_type_ArraySubsc with (i0 := i); intros.
+  + revert u1 H5; erewrite <- @nested_field_type_ArraySubsc with (i := i); intros.
     apply JMeq_eq in H5; rewrite H5. unfold Znth. rewrite if_false by lia.
     unfold Zrepeat; rewrite nth_repeat.
     apply field_at_field_at_; auto.
@@ -1151,7 +1151,7 @@ Proof.
     split.
     - rewrite sizeof_Tunion.
       erewrite co_consistent_sizeof by apply get_co_consistent.
-      rewrite complete_legal_cosu_type_Tunion with (a0 := a)
+      rewrite @complete_legal_cosu_type_Tunion with (a := a)
         by (rewrite <- H; apply nested_field_type_complete_legal_cosu_type;
             unfold field_compatible in *; tauto).
       pose proof align_le (sizeof_composite cenv_cs Union (co_members (get_co id)))
@@ -1212,8 +1212,8 @@ Proof.
       rewrite upd_Znth_same by lia.
       exact H1.
     }
-    rewrite sublist_upd_Znth_l with (lo0 := 0) by lia.
-    rewrite sublist_upd_Znth_r with (lo0 := (i + 1 - lo)) by lia.
+    rewrite @sublist_upd_Znth_l with (lo := 0) by lia.
+    rewrite @sublist_upd_Znth_r with (lo := (i + 1 - lo)) by lia.
     unfold fst; cancel.
 Qed.
 
@@ -2411,10 +2411,10 @@ Lemma nonreadable_readable_memory_block_data_at_join
 Proof.
 intros.
 apply pred_ext; saturate_local.
-rewrite nonreadable_memory_block_data_at with (v0:=v); auto.
+rewrite @nonreadable_memory_block_data_at with (v:=v); auto.
 unfold data_at.
 erewrite field_at_share_join; eauto. apply derives_refl.
-rewrite nonreadable_memory_block_data_at with (v0:=v); auto.
+rewrite @nonreadable_memory_block_data_at with (v:=v); auto.
 unfold data_at.
 erewrite field_at_share_join; eauto.
 apply derives_refl.

--- a/floyd/forward_lemmas.v
+++ b/floyd/forward_lemmas.v
@@ -680,7 +680,7 @@ intros.
 apply semax_loop with (Q':= (EX a:A, PQR a)).
 *
  apply extract_exists_pre; intro a.
- apply semax_seq with (Q0 := PROPx (typed_true (typeof test) (v a) :: P a) (LOCALx (Q a) (SEPx (R a)))).
+ apply @semax_seq with (Q := PROPx (typed_true (typeof test) (v a) :: P a) (LOCALx (Q a) (SEPx (R a)))).
  apply semax_pre with (tc_expr Delta (Eunop Onotbool test (Tint I32 Signed noattr)) 
                                         && (local (`(eq (v a)) (eval_expr test)) && (PROPx (P a) (LOCALx (Q a) (SEPx (R a))))));
    [ | apply semax_ifthenelse; auto].

--- a/floyd/globals_lemmas.v
+++ b/floyd/globals_lemmas.v
@@ -1115,7 +1115,7 @@ red. constructor; auto. intros. lia.
 unfold sizeof; simpl.
 rewrite Z.max_r by lia.
 unfold data_at.
-erewrite field_at_Tarray with (n0:=n);
+erewrite @field_at_Tarray with (n:=n);
   [ | apply I | reflexivity | lia | apply JMeq_refl].
 unfold mapsto_zeros.
 destruct (gz i) eqn:?H;

--- a/floyd/loadstore_mapsto.v
+++ b/floyd/loadstore_mapsto.v
@@ -102,7 +102,7 @@ forall (Delta: tycontext) sh id P Q R e1 t1 (v2: val),
              (SEPx R)))).
 Proof.
   intros until 1. intros HCAST H_READABLE H1. pose proof I.
-  eapply semax_pre_post'; [ | | apply semax_cast_load with (sh0:=sh)(v3:= v2); auto].
+  eapply semax_pre_post'; [ | | apply @semax_cast_load with (sh:=sh)(v2:= v2); auto].
   + instantiate (1:= PROPx (tc_val t1 (force_val (sem_cast (typeof e1) t1 v2)) :: P) (LOCALx Q (SEPx R))).
     apply later_left2.
     match goal with |- ?A |-- _ => rewrite <- (andp_dup A) end.

--- a/floyd/local2ptree_eval.v
+++ b/floyd/local2ptree_eval.v
@@ -267,7 +267,7 @@ revert tys vl H; induction el; destruct tys, vl; intros;
   specialize (IHel _ _ Heqo0).
   simpl eval_exprlist.
   destruct (msubst_eval_expr Delta T1 T2 GV a) eqn:?; inv Heqo.
-  apply msubst_eval_expr_eq with (P0:=P)(GV0:=GV)(R0:=R) in Heqo1.
+  apply @msubst_eval_expr_eq with (P:=P) (GV:=GV) (R:=R) in Heqo1.
   apply derives_trans with (local (`(eq v0) (eval_expr a)) && local (`(eq vl) (eval_exprlist tys el))).
   apply andp_right; auto.
   go_lowerx. unfold_lift. intros. apply prop_right.

--- a/floyd/nested_loadstore.v
+++ b/floyd/nested_loadstore.v
@@ -30,7 +30,7 @@ Lemma reptype_Tarray_JMeq_constr0: forall t gfs t0 n a (v: reptype (nested_field
 Proof.
   intros.
   apply JMeq_sigT.
-  rewrite nested_field_type_ind with (gfs0 := cons _ _).
+  rewrite @nested_field_type_ind with (gfs := cons _ _).
   rewrite !H0.
   rewrite reptype_eq.
   auto.
@@ -44,7 +44,7 @@ Lemma reptype_Tarray_JMeq_constr1: forall t gfs t0 n a i (v: reptype (nested_fie
 Proof.
   intros.
   apply JMeq_sigT.
-  rewrite nested_field_type_ind with (gfs0 := cons _ _).
+  rewrite @nested_field_type_ind with (gfs := cons _ _).
   reflexivity.
 Qed.
 
@@ -56,7 +56,7 @@ Lemma reptype_Tarray_JMeq_constr2: forall t gfs t0 n a i (v': reptype (nested_fi
 Proof.
   intros.
   apply JMeq_sigT.
-  rewrite nested_field_type_ArraySubsc with (i0 := i).
+  rewrite @nested_field_type_ArraySubsc with (i := i).
   auto.
 Qed.
 
@@ -136,7 +136,7 @@ Proof.
         unfold upd_gfield_reptype.
         eapply JMeq_trans; [apply fold_reptype_JMeq |].
         apply (JMeq_trans (unfold_reptype_JMeq _ v)) in H4.
-        revert v' v0' H4 H5; rewrite nested_field_type_ind with (gfs0 := cons _ _), H2; simpl; intros.
+        revert v' v0' H4 H5; rewrite @nested_field_type_ind with (gfs := cons _ _), H2; simpl; intros.
         apply JMeq_eq in H4; apply JMeq_eq in H5.
         subst; apply JMeq_refl.
       + apply allp_right; intro v0.
@@ -154,14 +154,14 @@ Proof.
         unfold upd_gfield_reptype.
         eapply JMeq_trans; [apply fold_reptype_JMeq |].
         apply (JMeq_trans (unfold_reptype_JMeq _ v)) in H4.
-        revert v' v0' H4 H5; rewrite nested_field_type_ind with (gfs0 := cons _ _), H2; simpl; intros.
+        revert v' v0' H4 H5; rewrite @nested_field_type_ind with (gfs := cons _ _), H2; simpl; intros.
         apply JMeq_eq in H4; apply JMeq_eq in H5.
         subst; apply JMeq_refl.
     }
     apply (array_at_ramif sh t gfs t0 z a 0 z i v' v0 p); auto.
     eapply JMeq_trans; [apply @JMeq_sym, H |]; clear v0 H.
     revert v v' H4.
-    rewrite nested_field_type_ind with (gfs0 := cons _ _), H2.
+    rewrite @nested_field_type_ind with (gfs := cons _ _), H2.
     unfold proj_gfield_reptype, gfield_type.
     intros.
     apply (JMeq_trans (unfold_reptype_JMeq _ v)) in H4.

--- a/floyd/nested_pred_lemmas.v
+++ b/floyd/nested_pred_lemmas.v
@@ -52,7 +52,7 @@ Proof.
   unfold nested_fields_pred.
   intros.
   unfold nested_pred.
-  rewrite type_func_eq with (t0 := t) (A := (fun _ => bool)) at 1 by auto.
+  rewrite type_func_eq with (A := (fun _ => bool)) at 1 by auto.
   destruct t; auto.
   + f_equal. unfold FTI_aux.
     rewrite decay_spec.
@@ -295,14 +295,14 @@ Ltac pose_sizeof_co t :=
     pose proof sizeof_Tstruct id a;
     assert (sizeof_struct cenv_cs 0 (co_members (get_co id)) <= co_sizeof (get_co id)); [
       rewrite co_consistent_sizeof with (env := cenv_cs) by (apply get_co_consistent);
-      rewrite complete_legal_cosu_type_Tstruct with (a0 := a) by auto;
+      rewrite @complete_legal_cosu_type_Tstruct with (a := a) by auto;
       apply align_le, co_alignof_pos
        |]
   | Tunion ?id ?a =>
     pose proof sizeof_Tunion id a;
     assert (sizeof_union cenv_cs (co_members (get_co id)) <= co_sizeof (get_co id)); [
       rewrite co_consistent_sizeof with (env := cenv_cs) by (apply get_co_consistent);
-      rewrite complete_legal_cosu_type_Tunion with (a0 := a) by auto;
+      rewrite @complete_legal_cosu_type_Tunion with (a := a) by auto;
       apply align_le, co_alignof_pos
        |]
   end.

--- a/floyd/sublist.v
+++ b/floyd/sublist.v
@@ -1212,7 +1212,7 @@ Lemma sublist_last_1 : forall {A}{d: Inhabitant A} lo hi (al : list A), 0 <= lo 
   sublist lo (hi + 1) al = sublist lo hi al ++ [Znth hi al].
 Proof.
   intros.
-  erewrite sublist_split with (mid := hi)(hi0 := hi + 1), sublist_len_1; auto; lia.
+  erewrite @sublist_split with (mid := hi) (hi := hi + 1), sublist_len_1; auto; lia.
 Qed.
 
 Lemma Zlen_le_1_rev:
@@ -2257,7 +2257,7 @@ Lemma Forall2_upd_Znth_l : forall {A B}{d: Inhabitant B} (P : A -> B -> Prop) l1
   P x (Znth i l2) -> 0 <= i < Zlength l1 -> Forall2 P (upd_Znth i l1 x) l2.
 Proof.
   intros.
-  erewrite <- upd_Znth_triv with (l := l2)(i0 := i); eauto.
+  erewrite <- @upd_Znth_triv with (l := l2)(i := i); eauto.
   apply Forall2_upd_Znth; eauto; lia.
   apply Forall2_Zlength in H; lia.
 Qed.
@@ -2266,7 +2266,7 @@ Lemma Forall2_upd_Znth_r : forall {A B}{d: Inhabitant A} (P : A -> B -> Prop) l1
   P (Znth i l1) x -> 0 <= i < Zlength l1 -> Forall2 P l1 (upd_Znth i l2 x).
 Proof.
   intros.
-  erewrite <- upd_Znth_triv with (l := l1)(i0 := i) by (eauto; lia).
+  erewrite <- @upd_Znth_triv with (l := l1)(i := i) by (eauto; lia).
   apply Forall2_upd_Znth; eauto.
   apply Forall2_Zlength in H; lia.
 Qed.

--- a/floyd/subsume_funspec.v
+++ b/floyd/subsume_funspec.v
@@ -211,7 +211,7 @@ Lemma semax_call_subsume:
          (normal_ret_assert
           (EX old:val, substopt ret (`old) F * maybe_retval (Q ts x) retsig ret)).
 Proof. intros.
-eapply semax_pre. 2: apply semax_call with (P0:=P)(NEP0:=NEP)(NEQ0:=NEQ); trivial; eassumption.
+eapply semax_pre. 2: apply @semax_call with (P:=P) (NEP:=NEP) (NEQ:=NEQ); trivial; eassumption.
 apply andp_left2. apply andp_derives; trivial. apply andp_derives; trivial.
 unfold liftx, lift. simpl. intros rho. clear - H.
 remember (mk_funspec (argsig, retsig) cc A P Q NEP NEQ) as gs.
@@ -237,7 +237,7 @@ Lemma semax_call_subsume_si:
          (normal_ret_assert
           (EX old:val, substopt ret (`old) F * maybe_retval (Q ts x) retsig ret)).
 Proof. intros.
-eapply semax_pre. 2: apply semax_call with (P0:=P)(NEP0:=NEP)(NEQ0:=NEQ); trivial; eassumption.
+eapply semax_pre. 2: apply @semax_call with (P:=P) (NEP:=NEP) (NEQ:=NEQ); trivial; eassumption.
 apply andp_left2. apply andp_derives; trivial. apply andp_derives; trivial.
 unfold liftx, lift. simpl. clear. intros rho.
 rewrite andp_comm. constructor. apply func_ptr_si_mono.

--- a/progs/verif_bin_search.v
+++ b/progs/verif_bin_search.v
@@ -177,7 +177,7 @@ Lemma sublist_In_sublist : forall A (l : list A) x lo hi lo' hi' (Hlo : 0 <= lo 
   (Hhi : hi' <= hi), In x (sublist lo' hi' l) -> In x (sublist lo hi l).
 Proof.
   intros.
-  apply sublist_In with (lo0 := lo' - lo)(hi0 := hi' - lo); rewrite sublist_sublist;
+  apply @sublist_In with (lo := lo' - lo) (hi := hi' - lo); rewrite sublist_sublist;
     try split; try lia.
   - repeat rewrite Z.sub_simpl_r; auto.
   - destruct (Z_le_dec hi' lo'); try lia.

--- a/sepcomp/step_lemmas.v
+++ b/sepcomp/step_lemmas.v
@@ -68,8 +68,8 @@ Section safety.
     inv H1; auto.
     erewrite corestep_not_at_external in H3; eauto; congruence.
     eapply safeN_halted; eauto.
-    apply corestep_not_halted with (i0:=i) in H0. contradiction.
-    apply corestep_not_halted with (i0:=i) in H0. contradiction.
+    apply @corestep_not_halted with (i:=i) in H0. contradiction.
+    apply @corestep_not_halted with (i:=i) in H0. contradiction.
   Unshelve. apply Integers.Int.zero.
 Qed.
 

--- a/veric/invariants.v
+++ b/veric/invariants.v
@@ -505,16 +505,16 @@ Proof.
                erewrite app_nth2, minus_diag; auto.
          -- exists c'; split; auto.
             erewrite (app_removelast_last None), Ha by auto.
-            apply list_join_filler with (n0 := 1%nat); auto; simpl in *; lia.
+            apply @list_join_filler with (n := 1%nat); auto; simpl in *; lia.
   - split.
     + split; [eapply list_join_length; eauto|].
       intros ?? Hnth.
-      apply list_join_nth with (n0 := n) in H.
+      apply @list_join_nth with (n := n) in H.
       rewrite Hnth in H; inv H; auto.
       inv H3; auto.
     + split; [apply join_comm in H; eapply list_join_length; eauto|].
       intros ?? Hnth.
-      apply list_join_nth with (n0 := n) in H.
+      apply @list_join_nth with (n := n) in H.
       rewrite Hnth in H; inv H; auto.
       inv H3; auto.
   - induction a; unfold list_incl; intros.

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -1482,7 +1482,7 @@ eapply Hempty. eassumption.
 }
 assert (Hty: typelist_of_type_list params = tys) by (rewrite H7, TTL3; trivial).
 rewrite (age_level _ _ Hage).
-eapply jsafeN_external with (x0 := x'); eauto.
+eapply @jsafeN_external with (x := x'); eauto.
 
 + (*1/3*)
   simpl.
@@ -2925,7 +2925,7 @@ Proof.
       eapply semax_call_aux2 with (bl:=nil)(a:=Econst_int Int.zero tint)
                                   (Q:=Q)(fsig:=(clientparams,retty)); eauto.
       + red. red. red. eauto.
-        apply ext_join_sub_approx with (n0 := level jm') in Hext.
+        apply @ext_join_sub_approx with (n := level jm') in Hext.
         eapply joins_comm, join_sub_joins_trans; eauto.
         apply joins_comm; auto.
       + rewrite closed_wrt_modvars_Scall; auto.
@@ -3768,10 +3768,10 @@ apply (boxy_e _ _ (extend_tc_expr _ _ _) _ _ H8'') in TCa.
 apply (boxy_e _ _ (extend_tc_exprlist _ _ _ _) _ _ H8'') in TCbl.
 apply (boxy_e _ _ (extend_tc_expr _ _ _) _ _ H8'') in TCa'.
 apply (boxy_e _ _ (extend_tc_exprlist _ _ _ _) _ _ H8'') in TCbl'.
-eapply denote_tc_resource with (a'1 := m_phi jm) in TCa; auto.
-eapply denote_tc_resource with (a'1 := m_phi jm) in TCa'; auto.
-eapply denote_tc_resource with (a'1 := m_phi jm) in TCbl; auto.
-eapply denote_tc_resource with (a'1 := m_phi jm) in TCbl'; auto.
+eapply @denote_tc_resource with (a' := m_phi jm) in TCa; auto.
+eapply @denote_tc_resource with (a' := m_phi jm) in TCa'; auto.
+eapply @denote_tc_resource with (a' := m_phi jm) in TCbl; auto.
+eapply @denote_tc_resource with (a' := m_phi jm) in TCbl'; auto.
 assert (forall vf, Clight.eval_expr psi vx tx (m_dry jm) a vf
                -> Clight.eval_expr psi vx tx (m_dry jm) a' vf). {
 clear - TCa TCa' H7 H7' H0 Heqrho HGG TS HGpsi.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -221,9 +221,7 @@ intros.
   remember (level m) as N.
   destruct N; [constructor|].
   case_eq (age1 m); [intros m' H |  intro; apply age1_level0 in H; lia].
-  eapply jsafeN_step with
-   (* (c' := State f Sskip (Kseq Scontinue (Kloop1 Sskip Sskip k)) ve te)*)
-    (m'0 := m').
+  eapply jsafeN_step.
   split3.
   replace (m_dry m') with (m_dry m) by (destruct (age1_juicy_mem_unpack _ _ H); auto).
   apply Hstep.
@@ -258,8 +256,7 @@ intros.
   remember (level m) as N.
   destruct N; [constructor|].
   case_eq (age1 m); [intros m' H |  intro; apply age1_level0 in H; lia].
-  eapply jsafeN_step with
-    (m'0 := m').
+  eapply jsafeN_step.
   split3.
   replace (m_dry m') with (m_dry m) by (destruct (age1_juicy_mem_unpack _ _ H); auto).
   apply Hstep.

--- a/veric/semax_loop.v
+++ b/veric/semax_loop.v
@@ -393,7 +393,7 @@ Proof.
       +  simpl proj_ret_assert.
           destruct vl2. intros ? ? ? ? [[_ [? _]] _]; discriminate.
           rewrite (prop_true_andp (None=None)) by auto.
-        apply (assert_safe_adj') with (k0:=Kseq (Sloop body incr) k); auto.
+        apply @assert_safe_adj' with (k:=Kseq (Sloop body incr) k); auto.
         - simpl; repeat intro. auto.
         - eapply subp_trans'; [ |  eapply H1].
           apply derives_subp.
@@ -403,7 +403,7 @@ Proof.
           unfold frame_ret_assert. normalize.
           rewrite sepcon_comm. auto.
       + unfold exit_cont.
-        apply (assert_safe_adj') with (k0:= k); auto.
+        apply @assert_safe_adj' with (k:= k); auto.
         - simpl. destruct k; simpl; auto; hnf; auto.
         - simpl proj_ret_assert.
           eapply subp_trans'; [ |  eapply (H3 EK_normal None tx2 vx2)].
@@ -429,7 +429,7 @@ Proof.
     destruct vl.
     simpl proj_ret_assert.
     intros ? ? ? ? [[_ [? _]] _]; discriminate.
-    apply (assert_safe_adj') with (k0:= Kseq incr (Kloop2 body incr k)); auto.
+    apply @assert_safe_adj' with (k:= Kseq incr (Kloop2 body incr k)); auto.
     simpl. repeat intro. eapply jsafeN_local_step. econstructor; auto.
     intros; eapply age_safe; eauto.
     eapply subp_trans'; [ | apply H0].
@@ -467,7 +467,7 @@ Proof.
     unfold exit_cont.
     destruct vl2.
     intros ? ? ? ? [[_ [? _]] _]; discriminate.
-    apply (assert_safe_adj') with (k0:=Kseq (Sloop body incr) k); auto.
+    apply @assert_safe_adj' with (k:=Kseq (Sloop body incr) k); auto.
     - repeat intro. auto.
     - eapply subp_trans'; [ | eapply H1; eauto].
       apply derives_subp.
@@ -483,7 +483,7 @@ Proof.
     }
     {
     unfold exit_cont.
-    apply (assert_safe_adj') with (k0 := k); auto.
+    apply @assert_safe_adj' with (k := k); auto.
     - simpl. destruct k; simpl; repeat intro; auto.
     - 
     destruct vl2.

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -2617,11 +2617,11 @@ Proof.
  subst sig'.
  split3; trivial. intros.
  specialize (Sub ts x).
- eapply semax_adapt
+ eapply @semax_adapt
  with
-  (Q'0:= frame_ret_assert (function_body_ret_assert (fn_return f) (Q' ts x))
+  (Q':= frame_ret_assert (function_body_ret_assert (fn_return f) (Q' ts x))
            (stackframe_of f))
-  (P'0 := fun tau =>
+  (P' := fun tau =>
     EX vals:list val,
     EX ts1:list Type, EX x1 : dependent_type_functor_rec ts1 A mpred,
     EX FR: mpred,

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -587,7 +587,7 @@ Proof.
     unfold tc_bool in *. remember (is_neutral_cast (implicit_deref (typeof e)) t).
     destruct b; inv H0.
     apply tc_val_tc_val'.
-    apply neutral_cast_tc_val with (Delta0 := Delta')(phi:=m_phi jm'); auto.
+    apply @neutral_cast_tc_val with (Delta := Delta') (phi:=m_phi jm'); auto.
     unfold guard_environ in *. destruct TC'; auto.
   + destruct H0.
     split; auto.
@@ -711,7 +711,7 @@ split3; auto.
   assert (is_neutral_cast (implicit_deref (typeof e)) t = true).
   destruct (typeof e), t; inversion H98; reflexivity.
   apply tc_val_tc_val'.
-  apply neutral_cast_tc_val with (Delta0 := Delta')(phi:=m_phi jm'); auto.
+  apply @neutral_cast_tc_val with (Delta := Delta') (phi:=m_phi jm'); auto.
   apply neutral_isCastResultType; auto.
   unfold guard_environ in *. destruct TC'; auto.
 +
@@ -836,7 +836,7 @@ split3; auto.
   rewrite denote_tc_assert_andp in TC3. destruct TC3.
   rewrite denote_tc_assert_andp in TC3'. destruct TC3'.
   apply tc_val_tc_val'.
-  apply tc_val_sem_cast with (Delta0 := Delta')(phi:=m_phi jm'); auto.
+  apply @tc_val_sem_cast with (Delta := Delta') (phi:=m_phi jm'); auto.
   eapply guard_environ_e1; eauto.
 +
   destruct H0.

--- a/veric/semax_switch.v
+++ b/veric/semax_switch.v
@@ -375,7 +375,7 @@ apply prop_andp_subp'; intros [H4 H4'].
 set (rho := construct_rho (filter_genv psi) vx tx) in *.
 specialize (H0 rho).
 inv H0. rename derivesI into H0.
-apply frame_tc_expr with (F0 := F rho) in  H0.
+apply @frame_tc_expr with (F := F rho) in  H0.
 rewrite sepcon_comm in H0.
 apply subp_i1.
 eapply derives_trans.

--- a/veric/seplog.v
+++ b/veric/seplog.v
@@ -503,7 +503,7 @@ rewrite exp_sepcon2, exp_andp2; apply subp_exp_left; intro x2.
 rewrite exp_sepcon2, exp_andp2; apply subp_exp_left; intro G.
 eapply subp_trans, subp_exp_spec.
 eapply subp_trans, subp_exp_spec.
-eapply subp_trans, subp_exp_spec with (x0 := F*G).
+eapply subp_trans, @subp_exp_spec with (x := F*G).
 eapply derives_trans, subp_derives, derives_refl; [|apply andp_derives, distrib_sepcon_andp; apply derives_refl].
 rewrite andp_comm, andp_assoc; apply subp_andp.
 + rewrite sepcon_assoc; apply subp_refl.


### PR DESCRIPTION
Should be backwards compatible.