### PR TITLE
Update sha development to work with both 32-bit and 64-bit CompCert.

### DIFF
--- a/sha/call_memcpy.v
+++ b/sha/call_memcpy.v
@@ -364,6 +364,7 @@ eapply semax_pre_post';
  (*rewrite <- H6, <- H7, <- H8.*)
  normalize. unfold PROPx, LOCALx, SEPx, local, liftx, lift1, lift. simpl. unfold liftx, lift. simpl. normalize.
  
+ try rewrite sem_cast_i2i_correct_range by (rewrite <- H8; auto).
 (* split3; try (repeat split; auto; congruence).*)
  apply andp_right.
  { apply prop_right; split3; auto. repeat split; trivial.  congruence.  }
@@ -596,6 +597,8 @@ eapply semax_pre_post';
  unfold PROPx, LOCALx, SEPx, local, liftx, lift1, lift. simpl. unfold liftx, lift. simpl. normalize.
  
 (* split3; try (repeat split; auto; congruence).*)
+ try rewrite sem_cast_i2i_correct_range by (rewrite <- H2; auto).
+ try rewrite sem_cast_i2i_correct_range by (rewrite <- H6; auto).
  apply andp_right.
  { apply prop_right; split3; auto. repeat split; trivial; congruence. }
  subst Frame.

--- a/sha/verif_sha_bdo7.v
+++ b/sha/verif_sha_bdo7.v
@@ -245,6 +245,8 @@ assert (LBE := LBLOCK_zeq).
 change LBLOCKz with 16%Z in H0.
 change (tarray tuint LBLOCKz) with (tarray tuint 16).
 change LBLOCKz with 16%Z in H.
+assert (Hand15 : forall j, Int.min_signed <= Z.land j 15 <= Int.max_signed)
+ by (intros j; assert  (X:=Z.mod_pos_bound j 16); rewrite Zland_15; cbn; lia).
 forward.	(*s0 = X[(i+1)&0x0f]; *)
 autorewrite with sublist. rewrite Zland_15.
 forward. (* s0 = sigma0(s0); *)


### PR DESCRIPTION
This patch allows `make sha` to run successfully when building with both 32-bit and 64-bit versions.