### PR TITLE
Adapt to coq/coq#13448

### DIFF
--- a/floyd/library.v
+++ b/floyd/library.v
@@ -208,7 +208,7 @@ Proof.
  apply derives_extract_prop; intro.
  destruct H; unfold_lift in H.
  unfold_lift in H0. destruct ret; try contradiction.
- unfold eval_id in H. simpl in H. subst p.
+ unfold eval_id in H. Transparent peq. simpl in H. Opaque peq. subst p.
  if_tac. rewrite H; entailer!.
  renormalize. entailer!.
 Qed.


### PR DESCRIPTION
To the best of my understanding the fact that `peq` was simplified away was a bug.
This PR should be backward compatible.
