### PR TITLE
Adapt to coq/coq#15071 (namegen doesn't avoid names from imported modules)

### DIFF
--- a/msl/functors.v
+++ b/msl/functors.v
@@ -119,11 +119,11 @@ Module CovariantFunctorLemmas.
 Import CovariantFunctor.
 
 Lemma fmap_id {F: functor} : forall A, fmap F (id A) = id (F A).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_id0. Qed.
+Proof. intros. destruct F as [F FM [ff_id ?]]; simpl. apply ff_id. Qed.
 
 Lemma fmap_comp {F: functor} : forall A B C (f : B -> C) (g : A -> B),
   fmap F f oo fmap F g = fmap F (f oo g).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_comp0. Qed.
+Proof. intros. destruct F as [F FM [? ff_comp]]; simpl. apply ff_comp. Qed.
 
 Lemma fmap_app {F: functor} : forall A B C (f : B -> C) (g : A -> B) x,
   fmap F f (fmap F g x) = fmap F (f oo g) x.
@@ -136,11 +136,11 @@ Module ContraVariantFunctorLemmas.
 Import ContraVariantFunctor.
 
 Lemma fmap_id {F: functor} : forall A, fmap F (id A) = id (F A).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_id0. Qed.
+Proof. intros. destruct F as [F FM [ff_id ?]]; simpl. apply ff_id. Qed.
 
 Lemma fmap_comp {F: functor} : forall A B C (f : C -> B) (g : B -> A),
   fmap F f oo fmap F g = fmap F (g oo f).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_comp0. Qed.
+Proof. intros. destruct F as [F FM [? ff_comp]]; simpl. apply ff_comp. Qed.
 
 Lemma fmap_app {F: functor} : forall A B C (f : C -> B) (g : B -> A) x,
   fmap F f (fmap F g x) = fmap F (g oo f) x.
@@ -153,12 +153,12 @@ Module MixVariantFunctorLemmas.
 Import MixVariantFunctor.
 
 Lemma fmap_id {F: functor} : forall A, fmap F (id A) (id A) = id (F A).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_id0. Qed.
+Proof. intros. destruct F as [F FM [ff_id ?]]; simpl. apply ff_id. Qed.
 
 Lemma fmap_comp {F: functor} : forall A B C (f1 : B -> C) (f2: C -> B)
 (g1 : A -> B) (g2: B -> A),
   fmap F f1 f2 oo fmap F g1 g2 = fmap F (f1 oo g1) (g2 oo f2).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_comp0. Qed.
+Proof. intros. destruct F as [F FM [? ff_comp]]; simpl. apply ff_comp. Qed.
 
 Lemma fmap_app {F: functor} : forall A B C (f1 : B -> C) (f2: C -> B)
 (g1 : A -> B) (g2: B -> A) x,
@@ -172,12 +172,12 @@ Module CovariantBiFunctorLemmas.
 Import CovariantBiFunctor.
 
 Lemma fmap_id {F: functor} : forall A1 A2, fmap F (id A1) (id A2) = id (F A1 A2).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_id0. Qed.
+Proof. intros. destruct F as [F FM [ff_id ?]]; simpl. apply ff_id. Qed.
 
 Lemma fmap_comp {F: functor} : forall A1 A2 B1 B2 C1 C2 (f1 : B1 -> C1)
 (f2: B2 -> C2) (g1 : A1 -> B1) (g2: A2 -> B2),
   fmap F f1 f2 oo fmap F g1 g2 = fmap F (f1 oo g1) (f2 oo g2).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_comp0. Qed.
+Proof. intros. destruct F as [F FM [? ff_comp]]; simpl. apply ff_comp. Qed.
 
 Lemma fmap_app {F: functor} : forall A1 A2 B1 B2 C1 C2 (f1 : B1 -> C1)
 (f2: B2 -> C2) (g1 : A1 -> B1) (g2: A2 -> B2) x,
@@ -191,12 +191,12 @@ Module CoContraVariantBiFunctorLemmas.
 Import CoContraVariantBiFunctor.
 
 Lemma fmap_id {F: functor} : forall A1 A2, fmap F (id A1) (id A2) = id (F A1 A2).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_id0. Qed.
+Proof. intros. destruct F as [F FM [ff_id ?]]; simpl. apply ff_id. Qed.
 
 Lemma fmap_comp {F: functor} : forall A1 A2 B1 B2 C1 C2 (f1 : B1 -> C1)
 (f2: C2 -> B2) (g1 : A1 -> B1) (g2: B2 -> A2),
   fmap F f1 f2 oo fmap F g1 g2 = fmap F (f1 oo g1) (g2 oo f2).
-Proof. intros. destruct F as [F FM [? ?]]; simpl. apply ff_comp0. Qed.
+Proof. intros. destruct F as [F FM [? ff_comp]]; simpl. apply ff_comp. Qed.
 
 Lemma fmap_app {F: functor} : forall A1 A2 B1 B2 C1 C2 (f1 : B1 -> C1)
 (f2: C2 -> B2) (g1 : A1 -> B1) (g2: B2 -> A2) x,

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -1385,7 +1385,7 @@ destruct k; try contradiction.
   split. eapply step_skip_call; eauto. hnf; auto. auto. auto.
 Qed.
 
-Lemma semax_call_external: forall
+Lemma semax_call_external
  (CS : compspecs) (Espec : OracleKind) (Delta : tycontext)
  (A : TypeTree)
  (P : forall ts : list Type,  (dependent_type_functor_rec ts (ArgsTT A)) mpred)
@@ -1417,16 +1417,15 @@ Lemma semax_call_external: forall
 (* (H16' : type_of_fundef ff =
        Tfunction (type_of_params (fst fsig)) (snd fsig) cc)*)
  (TC8 : tc_vals (fst fsig) args)
- (Hargs : Datatypes.length (fst fsig) = Datatypes.length args),
- let ctl := Kcall ret curf vx tx k : cont in
- forall (HR : (ALL rho' : environ,
+ (Hargs : Datatypes.length (fst fsig) = Datatypes.length args)
+ (ctl := Kcall ret curf vx tx k : cont)
+ (HR : (ALL rho' : environ,
       |> ! ((EX old : val,
              substopt ret (`old) F rho' *
              maybe_retval (Q ts x) (snd fsig) ret rho') >=>
-            own.bupd (RA_normal R rho'))) (m_phi jm)),
- jsafeN OK_spec psi (level jm) ora (Callstate ff args ctl) jm.
+            own.bupd (RA_normal R rho'))) (m_phi jm))
+ : jsafeN OK_spec psi (level jm) ora (Callstate ff args ctl) jm.
 Proof.
-intros.
 destruct TC3 as [TC3 TC3'].
 rename H5 into H15.
 unfold believe_external in H15.
@@ -1435,7 +1434,7 @@ destruct ff; try contradiction H15.
 
 destruct H15 as [[H5 H15] Hretty]. hnf in H5.
 destruct H5 as [H5 [H5' [Eef Hinline]]]. subst c.
-inversion H5. destruct fsig0 as [params retty].
+inversion H5. destruct fsig as [params retty].
 injection H2; clear H2; intros H8 H7. subst t0.
 rename t into tys. subst rho.
 destruct (age1 jm) as  [jm' |] eqn:Hage.
@@ -2283,8 +2282,8 @@ unfold k at 1 in H; clearbody k;
 induction ctl; try discriminate; eauto.
 Qed.
 
-Lemma semax_call_aux2:
- forall (CS : compspecs) (Espec : OracleKind) (Delta : tycontext)
+Lemma semax_call_aux2
+  (CS : compspecs) (Espec : OracleKind) (Delta : tycontext)
   (A : TypeTree)
   (P : forall ts : list Type,
      _functor (dependent_type_functor_rec ts (ArgsTT A)) mpred)
@@ -2322,26 +2321,24 @@ Lemma semax_call_aux2:
   (H17 : list_norepet (map fst (fn_params f) ++ map fst (fn_temps f)))
   (H17' : list_norepet (map fst (fn_vars f)))
   (H18 : fst fsig = map snd (fst (fn_funsig f)) /\
-      snd fsig = snd (fn_funsig f) (*/\ list_norepet (map fst (fst fsig))*)),
-forall vx tx k rho
+      snd fsig = snd (fn_funsig f) (*/\ list_norepet (map fst (fst fsig))*))
+  vx tx k rho
   (H0 : rho = construct_rho (filter_genv psi) vx tx)
   (H1 : app_pred (|> rguard Espec psi Delta curf (frame_ret_assert R F0) k)
        (level (m_phi jm)))
-  (TC3 : guard_environ Delta curf rho),
-app_pred
-  (!! closed_wrt_modvars (fn_body f) (fun _ : environ => F0 rho * F rho) &&
-   rguard Espec psi (func_tycontext' f Delta) f
-     (frame_ret_assert
-        (frame_ret_assert (function_body_ret_assert (fn_return f) (Q ts x))
-           (stackframe_of' cenv_cs f)) (fun _ : environ => F0 rho * F rho))
-     (Kcall ret curf vx tx k)) (level jmx).
+  (TC3 : guard_environ Delta curf rho)
+  : app_pred
+      (!! closed_wrt_modvars (fn_body f) (fun _ : environ => F0 rho * F rho) &&
+       rguard Espec psi (func_tycontext' f Delta) f
+         (frame_ret_assert
+            (frame_ret_assert (function_body_ret_assert (fn_return f) (Q ts x))
+                              (stackframe_of' cenv_cs f)) (fun _ : environ => F0 rho * F rho))
+         (Kcall ret curf vx tx k)) (level jmx).
 Proof.
-intros.
 pose proof I.
 assert (LATER : laterR (level (m_phi jm)) (level (m_phi jmx))). {
   apply laterR_level'. apply age_laterR. apply age_jm_phi. auto.
 }
-rename fsig0 into fsig.
 set (ctl := Kcall ret curf vx tx k) in *.
 do 2 pose proof I.
  split.

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -511,8 +511,8 @@ Proof.
   rewrite <- TTL1; trivial.
 Qed.
 
-Lemma semax_func_cons: forall 
-     fs id f fsig cc (A: TypeTree) P Q NEP NEQ (V: varspecs) (G G': funspecs) {C: compspecs} ge b,
+Lemma semax_func_cons
+     fs id f fsig cc (A: TypeTree) P Q NEP NEQ (V: varspecs) (G G': funspecs) {C: compspecs} ge b :
   andb (id_in_list id (map (@fst _ _) G))
   (andb (negb (id_in_list id (map (@fst ident Clight.fundef) fs)))
     (semax_body_params_ok f)) = true ->
@@ -529,8 +529,7 @@ Lemma semax_func_cons: forall
   semax_func V G ge ((id, Internal f)::fs)
        ((id, mk_funspec fsig cc A P Q NEP NEQ)  :: G').
 Proof.
-intros until C.
-intros ge b H' COMPLETE Hvars Hcc Hb1 Hb2 SB [HfsG' [Hfs HG]].
+intros H' COMPLETE Hvars Hcc Hb1 Hb2 SB [HfsG' [Hfs HG]].
 apply andb_true_iff in H'.
 destruct H' as [Hin H'].
 apply andb_true_iff in H'.
@@ -544,7 +543,7 @@ split3.
 intros ge' H0 HGG n.
 specialize (HG _ H0 HGG).
 hnf in HG |- *. 
-intros v fsig cc' A' P' Q'.
+intros v fsig0 cc' A' P' Q'.
 apply derives_imp.
 clear n.
 intros n ?.
@@ -587,7 +586,7 @@ intros ts x.
 simpl in H1. specialize (H0 id); unfold fundef in H0; simpl in H0. rewrite Hb1 in H0; simpl in H0.
 pose proof (semax_func_cons_aux (Build_genv ge' cenv_cs) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ H0 Hni HfsG' H1).
 destruct H2 as [H4' [H4 [H4a [H4b H4c]]]].
-subst A' fsig cc'.
+subst A' fsig0 cc'.
 apply JMeq_eq in H4b.
 apply JMeq_eq in H4c.
 subst P' Q'.
@@ -619,7 +618,7 @@ apply andp_left1.
 apply sepcon_derives; auto.
 apply andp_left2; trivial.
 * (***   Vptr b Ptrofs.zero <> v'  ********)
-apply (HG n v fsig cc' A' P' Q'); auto.
+apply (HG n v fsig0 cc' A' P' Q'); auto.
 destruct H1 as [id' [NEP' [NEQ' [? B]]]].
 simpl in H1. rewrite PTree.gsspec in H1.
 destruct (peq id' id); subst.


### PR DESCRIPTION
Should be backwards compatible.