### PR TITLE
Removed submodule checkout step

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -26,8 +26,6 @@ jobs:
           - coq-vst-32
     steps:
       - uses: actions/checkout@v2
-      - name: Checkout submodules
-        uses: textbook/git-checkout-submodule-action@2.1.1
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: ${{ matrix.opam_name }}.opam


### PR DESCRIPTION
This PR attempts to fix the CI.

We will know if the fix works based on how the CI responds to this PR.

# What changed?

I'm not certain. However, I do know that the [docker-coq-action](https://github.com/coq-community/docker-coq-action/) is designed to install from the local opam file, which maybe (maybe?) does not require an explicit submodule checkout step.

We'll see.