### PR TITLE
Updating verif_hashtable_atomic to new VST version

### DIFF
--- a/atomics/hashtable_atomic.v
+++ b/atomics/hashtable_atomic.v
@@ -6,19 +6,20 @@ Local Open Scope string_scope.
 Local Open Scope clight_scope.
 
 Module Info.
-  Definition version := "3.9".
+  Definition version := "3.10".
   Definition build_number := "".
   Definition build_tag := "".
   Definition build_branch := "".
   Definition arch := "x86".
-  Definition model := "32sse2".
-  Definition abi := "macos".
-  Definition bitsize := 32.
+  Definition model := "64".
+  Definition abi := "standard".
+  Definition bitsize := 64.
   Definition big_endian := false.
-  Definition source_file := "atomics/hashtable_atomic.c".
-  Definition normalized := true.
+  Definition source_file := "hashtable_atomic.c".
+  Definition normalized := false.
 End Info.
 
+Definition ___builtin_ais_annot : ident := $"__builtin_ais_annot".
 Definition ___builtin_annot : ident := $"__builtin_annot".
 Definition ___builtin_annot_intval : ident := $"__builtin_annot_intval".
 Definition ___builtin_bswap : ident := $"__builtin_bswap".
@@ -128,21 +129,21 @@ Definition _t'5 : ident := 132%positive.
 
 Definition v_m_entries := {|
   gvar_info := (tarray (Tstruct _entry noattr) 16384);
-  gvar_init := (Init_space 131072 :: nil);
+  gvar_init := (Init_space 262144 :: nil);
   gvar_readonly := false;
   gvar_volatile := false
 |}.
 
 Definition v_thread_locks := {|
   gvar_info := (tarray (tptr (Tstruct _lock_t noattr)) 3);
-  gvar_init := (Init_space 12 :: nil);
+  gvar_init := (Init_space 24 :: nil);
   gvar_readonly := false;
   gvar_volatile := false
 |}.
 
 Definition v_results := {|
   gvar_info := (tarray (tptr tint) 3);
-  gvar_init := (Init_space 12 :: nil);
+  gvar_init := (Init_space 24 :: nil);
   gvar_readonly := false;
   gvar_volatile := false
 |}.
@@ -150,15 +151,15 @@ Definition v_results := {|
 Definition f_surely_malloc := {|
   fn_return := (tptr tvoid);
   fn_callconv := cc_default;
-  fn_params := ((_n, tuint) :: nil);
+  fn_params := ((_n, tulong) :: nil);
   fn_vars := nil;
   fn_temps := ((_p, (tptr tvoid)) :: (_t'1, (tptr tvoid)) :: nil);
   fn_body :=
 (Ssequence
   (Ssequence
     (Scall (Some _t'1)
-      (Evar _malloc (Tfunction (Tcons tuint Tnil) (tptr tvoid) cc_default))
-      ((Etempvar _n tuint) :: nil))
+      (Evar _malloc (Tfunction (Tcons tulong Tnil) (tptr tvoid) cc_default))
+      ((Etempvar _n tulong) :: nil))
     (Sset _p (Etempvar _t'1 (tptr tvoid))))
   (Ssequence
     (Sifthenelse (Eunop Onotbool (Etempvar _p (tptr tvoid)) tint)
@@ -615,9 +616,9 @@ Definition f_main := {|
               (Ssequence
                 (Ssequence
                   (Scall (Some _t'1)
-                    (Evar _surely_malloc (Tfunction (Tcons tuint Tnil)
+                    (Evar _surely_malloc (Tfunction (Tcons tulong Tnil)
                                            (tptr tvoid) cc_default))
-                    ((Esizeof (Tstruct _lock_t noattr) tuint) :: nil))
+                    ((Esizeof (Tstruct _lock_t noattr) tulong) :: nil))
                   (Sset _l
                     (Ecast (Etempvar _t'1 (tptr tvoid))
                       (tptr (Tstruct _lock_t noattr)))))
@@ -633,9 +634,9 @@ Definition f_main := {|
                   (Ssequence
                     (Ssequence
                       (Scall (Some _t'2)
-                        (Evar _surely_malloc (Tfunction (Tcons tuint Tnil)
+                        (Evar _surely_malloc (Tfunction (Tcons tulong Tnil)
                                                (tptr tvoid) cc_default))
-                        ((Esizeof tint tuint) :: nil))
+                        ((Esizeof tint tulong) :: nil))
                       (Sassign
                         (Ederef
                           (Ebinop Oadd (Evar _results (tarray (tptr tint) 3))
@@ -662,9 +663,9 @@ Definition f_main := {|
                 (Ssequence
                   (Ssequence
                     (Scall (Some _t'3)
-                      (Evar _surely_malloc (Tfunction (Tcons tuint Tnil)
+                      (Evar _surely_malloc (Tfunction (Tcons tulong Tnil)
                                              (tptr tvoid) cc_default))
-                      ((Esizeof tint tuint) :: nil))
+                      ((Esizeof tint tulong) :: nil))
                     (Sset _t
                       (Ecast (Etempvar _t'3 (tptr tvoid)) (tptr tint))))
                   (Ssequence
@@ -759,20 +760,20 @@ Definition composites : list composite_definition :=
 Definition global_definitions : list (ident * globdef fundef type) :=
 ((___compcert_va_int32,
    Gfun(External (EF_runtime "__compcert_va_int32"
-                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
      (Tcons (tptr tvoid) Tnil) tuint cc_default)) ::
  (___compcert_va_int64,
    Gfun(External (EF_runtime "__compcert_va_int64"
-                   (mksignature (AST.Tint :: nil) AST.Tlong cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tlong cc_default))
      (Tcons (tptr tvoid) Tnil) tulong cc_default)) ::
  (___compcert_va_float64,
    Gfun(External (EF_runtime "__compcert_va_float64"
-                   (mksignature (AST.Tint :: nil) AST.Tfloat cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
      (Tcons (tptr tvoid) Tnil) tdouble cc_default)) ::
  (___compcert_va_composite,
    Gfun(External (EF_runtime "__compcert_va_composite"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
-                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tulong Tnil))
      (tptr tvoid) cc_default)) ::
  (___compcert_i64_dtos,
    Gfun(External (EF_runtime "__compcert_i64_dtos"
@@ -843,6 +844,12 @@ Definition global_definitions : list (ident * globdef fundef type) :=
                    (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
                      cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
      cc_default)) ::
+ (___builtin_ais_annot,
+   Gfun(External (EF_builtin "__builtin_ais_annot"
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
  (___builtin_bswap64,
    Gfun(External (EF_builtin "__builtin_bswap64"
                    (mksignature (AST.Tlong :: nil) AST.Tlong cc_default))
@@ -865,8 +872,8 @@ Definition global_definitions : list (ident * globdef fundef type) :=
      (Tcons tuint Tnil) tint cc_default)) ::
  (___builtin_clzl,
    Gfun(External (EF_builtin "__builtin_clzl"
-                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
-     (Tcons tuint Tnil) tint cc_default)) ::
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
  (___builtin_clzll,
    Gfun(External (EF_builtin "__builtin_clzll"
                    (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
@@ -877,8 +884,8 @@ Definition global_definitions : list (ident * globdef fundef type) :=
      (Tcons tuint Tnil) tint cc_default)) ::
  (___builtin_ctzl,
    Gfun(External (EF_builtin "__builtin_ctzl"
-                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
-     (Tcons tuint Tnil) tint cc_default)) ::
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
  (___builtin_ctzll,
    Gfun(External (EF_builtin "__builtin_ctzll"
                    (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
@@ -902,10 +909,10 @@ Definition global_definitions : list (ident * globdef fundef type) :=
  (___builtin_memcpy_aligned,
    Gfun(External (EF_builtin "__builtin_memcpy_aligned"
                    (mksignature
-                     (AST.Tint :: AST.Tint :: AST.Tint :: AST.Tint :: nil)
-                     AST.Tvoid cc_default))
+                     (AST.Tlong :: AST.Tlong :: AST.Tlong :: AST.Tlong ::
+                      nil) AST.Tvoid cc_default))
      (Tcons (tptr tvoid)
-       (Tcons (tptr tvoid) (Tcons tuint (Tcons tuint Tnil)))) tvoid
+       (Tcons (tptr tvoid) (Tcons tulong (Tcons tulong Tnil)))) tvoid
      cc_default)) ::
  (___builtin_sel,
    Gfun(External (EF_builtin "__builtin_sel"
@@ -915,13 +922,13 @@ Definition global_definitions : list (ident * globdef fundef type) :=
      {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
  (___builtin_annot,
    Gfun(External (EF_builtin "__builtin_annot"
-                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid
                      {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
      (Tcons (tptr tschar) Tnil) tvoid
      {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
  (___builtin_annot_intval,
    Gfun(External (EF_builtin "__builtin_annot_intval"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tint
                      cc_default)) (Tcons (tptr tschar) (Tcons tint Tnil))
      tint cc_default)) ::
  (___builtin_membar,
@@ -930,21 +937,21 @@ Definition global_definitions : list (ident * globdef fundef type) :=
      cc_default)) ::
  (___builtin_va_start,
    Gfun(External (EF_builtin "__builtin_va_start"
-                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
      (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
  (___builtin_va_arg,
    Gfun(External (EF_builtin "__builtin_va_arg"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
                      cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
      tvoid cc_default)) ::
  (___builtin_va_copy,
    Gfun(External (EF_builtin "__builtin_va_copy"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tvoid
                      cc_default))
      (Tcons (tptr tvoid) (Tcons (tptr tvoid) Tnil)) tvoid cc_default)) ::
  (___builtin_va_end,
    Gfun(External (EF_builtin "__builtin_va_end"
-                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
      (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
  (___builtin_unreachable,
    Gfun(External (EF_builtin "__builtin_unreachable"
@@ -952,8 +959,8 @@ Definition global_definitions : list (ident * globdef fundef type) :=
      cc_default)) ::
  (___builtin_expect,
    Gfun(External (EF_builtin "__builtin_expect"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
-                     cc_default)) (Tcons tint (Tcons tint Tnil)) tint
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
      cc_default)) ::
  (___builtin_fmax,
    Gfun(External (EF_builtin "__builtin_fmax"
@@ -995,21 +1002,21 @@ Definition global_definitions : list (ident * globdef fundef type) :=
      cc_default)) ::
  (___builtin_read16_reversed,
    Gfun(External (EF_builtin "__builtin_read16_reversed"
-                   (mksignature (AST.Tint :: nil) AST.Tint16unsigned
+                   (mksignature (AST.Tlong :: nil) AST.Tint16unsigned
                      cc_default)) (Tcons (tptr tushort) Tnil) tushort
      cc_default)) ::
  (___builtin_read32_reversed,
    Gfun(External (EF_builtin "__builtin_read32_reversed"
-                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
      (Tcons (tptr tuint) Tnil) tuint cc_default)) ::
  (___builtin_write16_reversed,
    Gfun(External (EF_builtin "__builtin_write16_reversed"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
                      cc_default)) (Tcons (tptr tushort) (Tcons tushort Tnil))
      tvoid cc_default)) ::
  (___builtin_write32_reversed,
    Gfun(External (EF_builtin "__builtin_write32_reversed"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
                      cc_default)) (Tcons (tptr tuint) (Tcons tuint Tnil))
      tvoid cc_default)) ::
  (___builtin_debug,
@@ -1018,53 +1025,53 @@ Definition global_definitions : list (ident * globdef fundef type) :=
                      {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
      (Tcons tint Tnil) tvoid
      {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
- (_malloc,
-   Gfun(External EF_malloc (Tcons tuint Tnil) (tptr tvoid) cc_default)) ::
- (_free, Gfun(External EF_free (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
  (_exit,
    Gfun(External (EF_external "exit"
                    (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
      (Tcons tint Tnil) tvoid cc_default)) ::
+ (_free, Gfun(External EF_free (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (_malloc,
+   Gfun(External EF_malloc (Tcons tulong Tnil) (tptr tvoid) cc_default)) ::
  (_makelock,
    Gfun(External (EF_external "makelock"
-                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
      (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
  (_acquire,
    Gfun(External (EF_external "acquire"
-                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
      (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
  (_freelock2,
    Gfun(External (EF_external "freelock2"
-                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
      (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
  (_release2,
    Gfun(External (EF_external "release2"
-                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
      (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
  (_spawn,
    Gfun(External (EF_external "spawn"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tvoid
                      cc_default))
      (Tcons
        (tptr (Tfunction (Tcons (tptr tvoid) Tnil) (tptr tvoid) cc_default))
        (Tcons (tptr tvoid) Tnil)) tvoid cc_default)) ::
  (_make_atomic,
    Gfun(External (EF_external "make_atomic"
-                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+                   (mksignature (AST.Tint :: nil) AST.Tlong cc_default))
      (Tcons tint Tnil) (tptr (Tstruct _atom_int noattr)) cc_default)) ::
  (_atom_load,
    Gfun(External (EF_external "atom_load"
-                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
      (Tcons (tptr (Tstruct _atom_int noattr)) Tnil) tint cc_default)) ::
  (_atom_store,
    Gfun(External (EF_external "atom_store"
-                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
                      cc_default))
      (Tcons (tptr (Tstruct _atom_int noattr)) (Tcons tint Tnil)) tvoid
      cc_default)) ::
  (_atom_CAS,
    Gfun(External (EF_external "atom_CAS"
-                   (mksignature (AST.Tint :: AST.Tint :: AST.Tint :: nil)
+                   (mksignature (AST.Tlong :: AST.Tlong :: AST.Tint :: nil)
                      AST.Tint cc_default))
      (Tcons (tptr (Tstruct _atom_int noattr))
        (Tcons (tptr tint) (Tcons tint Tnil))) tint cc_default)) ::
@@ -1082,8 +1089,8 @@ Definition public_idents : list ident :=
 (_main :: _f :: _init_table :: _add_item :: _get_item :: _set_item ::
  _integer_hash :: _surely_malloc :: _results :: _thread_locks ::
  _m_entries :: _atom_CAS :: _atom_store :: _atom_load :: _make_atomic ::
- _spawn :: _release2 :: _freelock2 :: _acquire :: _makelock :: _exit ::
- _free :: _malloc :: ___builtin_debug :: ___builtin_write32_reversed ::
+ _spawn :: _release2 :: _freelock2 :: _acquire :: _makelock :: _malloc ::
+ _free :: _exit :: ___builtin_debug :: ___builtin_write32_reversed ::
  ___builtin_write16_reversed :: ___builtin_read32_reversed ::
  ___builtin_read16_reversed :: ___builtin_fnmsub :: ___builtin_fnmadd ::
  ___builtin_fmsub :: ___builtin_fmadd :: ___builtin_fmin ::
@@ -1095,12 +1102,12 @@ Definition public_idents : list ident :=
  ___builtin_fabs :: ___builtin_ctzll :: ___builtin_ctzl :: ___builtin_ctz ::
  ___builtin_clzll :: ___builtin_clzl :: ___builtin_clz ::
  ___builtin_bswap16 :: ___builtin_bswap32 :: ___builtin_bswap ::
- ___builtin_bswap64 :: ___compcert_i64_umulh :: ___compcert_i64_smulh ::
- ___compcert_i64_sar :: ___compcert_i64_shr :: ___compcert_i64_shl ::
- ___compcert_i64_umod :: ___compcert_i64_smod :: ___compcert_i64_udiv ::
- ___compcert_i64_sdiv :: ___compcert_i64_utof :: ___compcert_i64_stof ::
- ___compcert_i64_utod :: ___compcert_i64_stod :: ___compcert_i64_dtou ::
- ___compcert_i64_dtos :: ___compcert_va_composite ::
+ ___builtin_bswap64 :: ___builtin_ais_annot :: ___compcert_i64_umulh ::
+ ___compcert_i64_smulh :: ___compcert_i64_sar :: ___compcert_i64_shr ::
+ ___compcert_i64_shl :: ___compcert_i64_umod :: ___compcert_i64_smod ::
+ ___compcert_i64_udiv :: ___compcert_i64_sdiv :: ___compcert_i64_utof ::
+ ___compcert_i64_stof :: ___compcert_i64_utod :: ___compcert_i64_stod ::
+ ___compcert_i64_dtou :: ___compcert_i64_dtos :: ___compcert_va_composite ::
  ___compcert_va_float64 :: ___compcert_va_int64 :: ___compcert_va_int32 ::
  nil).
 

--- a/atomics/verif_hashtable_atomic.v
+++ b/atomics/verif_hashtable_atomic.v
@@ -1295,7 +1295,7 @@ Proof.
     pose proof size_pos.
     rewrite Z.max_r; lia.
 Qed.
-Hint Resolve f_pred_exclusive.
+Hint Resolve f_pred_exclusive : exclusive.
 
 Lemma apply_hist_app : forall h1 h2 H, apply_hist H (h1 ++ h2) =
   match apply_hist H h1 with Some H' => apply_hist H' h2 | None => None end.

--- a/atomics/verif_hashtable_atomic.v
+++ b/atomics/verif_hashtable_atomic.v
@@ -34,17 +34,18 @@ Definition atom_store_spec := DECLARE _atom_store (atomic_store_spec atomic_int 
 Definition atom_CAS_spec := DECLARE _atom_CAS (atomic_CAS_spec atomic_int atomic_int_at).
 
 Definition surely_malloc_spec :=
- DECLARE _surely_malloc
-   WITH t : type, gv : globals
-   PRE [ tuint ]
-       PROP (0 <= sizeof t <= Int.max_unsigned; complete_legal_cosu_type t = true;
-             natural_aligned natural_alignment t = true)
-       PARAMS (Vint (Int.repr (sizeof t))) GLOBALS (gv)
+  DECLARE _surely_malloc
+   WITH t:type, gv: globals
+   PRE [ size_t ]
+       PROP (0 <= sizeof t <= Int.max_unsigned;
+                complete_legal_cosu_type t = true;
+                natural_aligned natural_alignment t = true)
+       PARAMS (Vptrofs (Ptrofs.repr (sizeof t))) GLOBALS (gv)
        SEP (mem_mgr gv)
     POST [ tptr tvoid ] EX p:_,
        PROP ()
        RETURN (p)
-       SEP (mem_mgr gv; malloc_token Ews t p; data_at_ Ews t p).
+       SEP (mem_mgr gv; malloc_token Ews t p * data_at_ Ews t p).
 
 Definition integer_hash_spec :=
  DECLARE _integer_hash
@@ -72,6 +73,11 @@ Qed.
 Next Obligation.
   - apply Z_mod_lt; rewrite (proj2_sig has_size); computable.
   - apply Z_mod_lt; rewrite (proj2_sig has_size); computable.
+Qed.
+
+Lemma size_signed : size <= Int.max_signed.
+Proof.
+  unfold size; simpl. rewrite (proj2_sig has_size). rep_lia.
 Qed.
 
 (* We don't need histories, but we do need to know that a non-zero key is persistent. *)
@@ -307,8 +313,8 @@ Lemma failed_entries : forall k i i1 keys lg T entries (Hk : k <> 0) (Hi : 0 <= 
 Proof.
   intros.
   rewrite -> Forall_forall, prop_forall; apply allp_right; intros (k', v').
-  rewrite prop_forall; apply allp_right; intro Hin. apply elem_of_list_In in Hin.
-  apply In_Znth in Hin; destruct Hin as (j & Hj & Hjth).
+  rewrite prop_forall; apply allp_right; intro Hin.
+  apply In_Znth in Hin as (j & Hj & Hjth).
   pose proof (hash_range k).
   erewrite Zlength_sublist in Hj by (rewrite ?Zlength_rebase; lia).
   rewrite -> Znth_sublist, Znth_rebase in Hjth by lia.
@@ -394,7 +400,7 @@ Proof.
   set (AS := ashift _ _ _ _ _ _).
   forward.
   forward_call k.
-  pose proof size_pos.
+  pose proof size_pos as Hsize; pose proof size_signed as Hsigned.
   forward_loop (EX i : Z, EX i1 : Z, EX keys : list Z,
     PROP (i1 mod size = (i + hash k) mod size; 0 <= i < size; Zlength keys = size;
           Forall (fun z => z <> 0 /\ z <> k) (sublist 0 i (rebase keys (hash k))))
@@ -475,10 +481,9 @@ Proof.
         rewrite -> Z2Nat.inj_add, upto_app, iter_sepcon_app by lia.
         change (upto (Z.to_nat 1)) with [0]; simpl iter_sepcon; rewrite -> Z2Nat.id, Z.add_0_r by lia.
         replace ((i + hash k) mod size) with (i1 mod size); rewrite -> Zmod_mod, upd_Znth_same by lia; entailer!.
-        { assert (Int.min_signed <= i1 mod size < Int.max_signed).
-          { split; etransitivity; try apply Z_mod_lt; auto; try computable.
-            setoid_rewrite (proj2_sig has_size); computable. }
-          rewrite -> Int.signed_repr by lia; auto. }
+        { split; auto.
+          split; etransitivity; try apply Z_mod_lt; auto; try computable.
+          setoid_rewrite (proj2_sig has_size); computable. }
         erewrite iter_sepcon_func_strong; [apply derives_refl|]; simpl; intros.
         rewrite upd_Znth_diff'; auto; try lia.
         replace (i1 mod size) with ((i + hash k) mod size); intro X; apply Zmod_plus_inv in X; auto.
@@ -586,10 +591,9 @@ Proof.
           rewrite -> Zmod_mod, Z2Nat.inj_add, upto_app, iter_sepcon_app by lia.
           change (upto (Z.to_nat 1)) with [0]; simpl iter_sepcon; rewrite -> Z2Nat.id, Z.add_0_r by lia.
           replace ((i + hash k) mod size) with (i1 mod size); rewrite -> upd_Znth_same by lia; entailer!.
-          { assert (Int.min_signed <= i1 mod size < Int.max_signed).
-            { split; etransitivity; try apply Z_mod_lt; auto; try computable.
-              setoid_rewrite (proj2_sig has_size); computable. }
-            rewrite -> Int.signed_repr by lia; auto. }
+          { split; auto.
+            split; etransitivity; try apply Z_mod_lt; auto; try computable.
+            setoid_rewrite (proj2_sig has_size); computable. }
           erewrite iter_sepcon_func_strong; [apply derives_refl|]; simpl; intros.
           rewrite upd_Znth_diff'; auto; try lia.
           replace (i1 mod size) with ((i + hash k) mod size); intro X; apply Zmod_plus_inv in X; auto.
@@ -684,7 +688,7 @@ Proof.
   unfold atomic_shift; Intros P.
   set (AS := ashift _ _ _ _ _ _).
   forward_call k.
-  pose proof size_pos.
+  pose proof size_pos as Hsize; pose proof size_signed as Hsigned.
   forward_loop (EX i : Z, EX i1 : Z, EX keys : list Z,
     PROP (i1 mod size = (i + hash k) mod size; 0 <= i < size; Zlength keys = size;
           Forall (fun z => z <> 0 /\ z <> k) (sublist 0 i (rebase keys (hash k))))
@@ -841,10 +845,8 @@ Proof.
         Intros; rewrite -> if_false by auto.
         replace ((i + hash k) mod size) with (i1 mod size); rewrite -> upd_Znth_same by lia; entailer!.
         { split.
-          { assert (Int.min_signed <= i1 mod size < Int.max_signed).
-            { split; etransitivity; try apply Z_mod_lt; auto; try computable.
-              setoid_rewrite (proj2_sig has_size); computable. }
-            rewrite -> Int.signed_repr by lia; auto. }
+          { split; etransitivity; try apply Z_mod_lt; auto; try computable.
+            setoid_rewrite (proj2_sig has_size); computable. }
           split; [rewrite Zmod_mod; auto|].
           split; [rewrite upd_Znth_Zlength; auto; lia|].
           replace (i1 mod size) with ((i + hash k) mod size); replace size with (Zlength keys);
@@ -880,7 +882,7 @@ Proof.
   set (AS := ashift _ _ _ _ _ _).
   forward.
   forward_call k.
-  pose proof size_pos.
+  pose proof size_pos as Hsize; pose proof size_signed as Hsigned.
   forward_loop (EX i : Z, EX i1 : Z, EX keys : list Z,
     PROP (i1 mod size = (i + hash k) mod size; 0 <= i < size; Zlength keys = size;
           Forall (fun z => z <> 0 /\ z <> k) (sublist 0 i (rebase keys (hash k))))
@@ -961,10 +963,9 @@ Proof.
         change (upto (Z.to_nat 1)) with [0]; simpl iter_sepcon.
         rewrite -> Z2Nat.id, Z.add_0_r by lia.
         replace ((i + hash k) mod size) with (i1 mod size); rewrite -> upd_Znth_same by lia; entailer!.
-        { assert (Int.min_signed <= i1 mod size < Int.max_signed).
-          { split; etransitivity; try apply Z_mod_lt; auto; try computable.
-            setoid_rewrite (proj2_sig has_size); computable. }
-          rewrite -> Int.signed_repr by lia; auto. }
+        { split; auto.
+          split; etransitivity; try apply Z_mod_lt; auto; try computable.
+          setoid_rewrite (proj2_sig has_size); computable. }
         erewrite iter_sepcon_func_strong; [apply derives_refl|]; intros; simpl.
         rewrite upd_Znth_diff'; auto; try lia.
         replace (i1 mod size) with ((i + hash k) mod size); intro X; apply Zmod_plus_inv in X; auto.
@@ -1071,10 +1072,9 @@ Proof.
           change (upto (Z.to_nat 1)) with [0]; simpl iter_sepcon.
           rewrite -> Z2Nat.id, Z.add_0_r by lia.
           replace ((i + hash k) mod size) with (i1 mod size); rewrite -> upd_Znth_same by lia; entailer!.
-          { assert (Int.min_signed <= i1 mod size < Int.max_signed).
-          { split; etransitivity; try apply Z_mod_lt; auto; try computable.
+          { assert (Int.min_signed <= i1 mod size < Int.max_signed); auto.
+            split; etransitivity; try apply Z_mod_lt; auto; try computable.
             setoid_rewrite (proj2_sig has_size); computable. }
-          rewrite -> Int.signed_repr by lia; auto. }
           erewrite iter_sepcon_func_strong; [apply derives_refl|]; intros; simpl.
           rewrite upd_Znth_diff'; auto; try lia.
           replace (i1 mod size) with ((i + hash k) mod size); intro X; apply Zmod_plus_inv in X; auto.
@@ -1207,6 +1207,7 @@ Proof.
     forward_call (vint 0).
     Intros pk.
     rewrite iter_sepcon_map; Intros.
+    pose proof size_signed as Hsigned.
     forward.
     forward_call (vint 0).
     Intros pv.
@@ -1391,8 +1392,7 @@ Proof.
           iSplit; auto; iPureIntro.
           apply (add_events_snoc _ nil); [constructor|].
           apply hist_incl_lt; auto. }
-    { repeat (split; auto); try rep_lia. eapply Forall_impl. apply H2. intros.
-      destruct x. auto. }
+    { repeat (split; auto); try rep_lia. eapply Forall_impl, H2. intros (?, ?); auto. }
     Intros b h'.
     forward_if (temp _total (vint (Zlength (List.filter id (ls ++ [b]))))).
     + pose proof (Zlength_filter id ls).
@@ -1718,9 +1718,6 @@ Axiom mem_mgr_dup : forall gv, mem_mgr gv = mem_mgr gv * mem_mgr gv.
 
 Lemma body_main : semax_body Vprog Gprog f_main main_spec.
 Proof.
-  name m_entries _m_entries.
-  name locksp _thread_locks.
-  name resp _results.
   start_function.
   replace 16384 with size by (setoid_rewrite (proj2_sig has_size); auto).
   sep_apply (create_mem_mgr gv).
@@ -1996,11 +1993,10 @@ Proof.
   repeat match goal with H : sepalg_list.list_join _ (sublist 3 3 _) _ |- _ =>
     rewrite sublist_nil in H; inv H end.
   gather_SEP (ghost_hist _ _ _) (|> invariant _ _).
-  replace_SEP 0 (|={inv i1}=> !!(Zlength (List.filter id (concat (map snd lr))) = 3) : mpred)%I.
+  replace_SEP 0 (|> |={inv i1}=> !!(Zlength (List.filter id (concat (map snd lr))) = 3) : mpred)%I.
   { go_lower.
     iIntros "(hist & inv)".
-    iPoseProof (timeless with "inv") as ">inv".
-    { admit. } (* This isn't true; we need something to get rid of the later earlier. *)
+    iNext.
     iMod (inv_open (inv i1) with "inv") as "[>inv Hclose]"; [auto|].
     unfold hashtable_inv.
     iDestruct "inv" as (HT) "[hashtable ref]"; iDestruct "ref" as (hr) "[% ref]".
@@ -2019,6 +2015,6 @@ Proof.
   (* Without including fupd in semax, it's not clear how to extract the result
      from the fupd. In a larger application, maybe there would be another view shift. *)
   forward.
-Admitted.
+Qed.
 
 End Proofs.

--- a/concurrency/fupd.v
+++ b/concurrency/fupd.v
@@ -22,8 +22,8 @@ Proof.
   unfold Timeless; intros; simpl.
   constructor; change (predicates_hered.derives (|>P) (|>FF || P)); intros ? HP.
   destruct (level a) eqn: Ha.
-  - left; intros ? ?%laterR_level.
-    rewrite Ha in H0; apply Nat.nlt_0_r in H0; contradiction H0.
+  - left; intros ? Hl%laterR_level.
+    rewrite Ha in Hl; apply Nat.nlt_0_r in Hl; contradiction Hl.
   - right.
     destruct (levelS_age a n) as [b [Hb]]; auto.
     specialize (HP _ (semax_lemmas.age_laterR Hb)).
@@ -419,8 +419,8 @@ Proof.
   destruct (level a) eqn: Hl.
   + left.
     change ((|> FF)%pred a).
-    intros ??%laterR_level.
-    rewrite Hl in H0; apply Nat.nlt_0_r in H0; contradiction H0.
+    intros ? Hl'%laterR_level.
+    rewrite Hl in Hl'; apply Nat.nlt_0_r in Hl'; contradiction Hl'.
   + right.
     rewrite <- Hl in *.
     intros ? J; specialize (H _ J) as (? & ? & a' & ? & ? & ? & HP); subst.

--- a/concurrency/invariants.v
+++ b/concurrency/invariants.v
@@ -215,7 +215,7 @@ Proof.
   destruct b.
   erewrite ghost_list_nth with (n := i) by (erewrite nth_map' with (d' := None), Hi'; eauto; lia).
   iDestruct "dis" as "[token dis]".
-  rewrite -> @iter_sepcon_eq, iter_sepcon_Znth with (i := Z.of_nat i)
+  rewrite -> @iter_sepcon_eq, @iter_sepcon_Znth with (d := _)(i := Z.of_nat i)
     by (rewrite Zlength_upto; split; [|apply Nat2Z.inj_lt]; lia).
   erewrite Znth_upto, Hi by lia.
   iDestruct "I" as "((agree' & HP) & I)".

--- a/veric/bi.v
+++ b/veric/bi.v
@@ -248,10 +248,8 @@ Proof.
   - unfold persistently.
     unseal_derives; intros ??; simpl.
     apply core_identity.
-  - intros.
-    unseal_derives; intros ??; simpl in *.
-    change (` (predicates_hered.andp P Q) (core a)).
-    apply H.
+  - unfold persistently; intros.
+    unseal_derives; intros ??; auto.
   - intros.
     unseal_derives; intros ??; simpl in *.
     destruct H as [b ?].

--- a/veric/bi.v
+++ b/veric/bi.v
@@ -291,7 +291,7 @@ Qed.
 Lemma mpred_bi_later_mixin : BiLaterMixin
   derives prop orp imp (@allp _ _) (@exp _ _) sepcon persistently seplog.later.
 Proof.
-  split.  
+  split.
   - repeat intro. hnf. rewrite !approx_later. destruct n.
     + rewrite !approx_0; auto.
     + apply dist_S in H; f_equal; auto.

--- a/veric/fupd.v
+++ b/veric/fupd.v
@@ -168,7 +168,7 @@ Proof.
   intros a0 (? & ? & J & HP & [? Hemp]).
   destruct (join_level _ _ _ J).
   apply join_comm, Hemp in J; subst.
-  eapply Himp in HP; try apply necR_refl; auto; omega.
+  eapply Himp in HP; try apply necR_refl; auto; lia.
 Qed.
 
 Lemma fupd_mono' : forall E1 E2 P Q (a : rmap) (Himp : (P >=> Q)%pred (level a)),
@@ -185,7 +185,7 @@ Proof.
   intros a0 (? & ? & J & HP & [? Hemp]).
   destruct (join_level _ _ _ J).
   apply join_comm, Hemp in J; subst.
-  eapply Himp in HP; try apply necR_refl; auto; omega.
+  eapply Himp in HP; try apply necR_refl; auto; lia.
 Qed.
 
 Lemma fupd_bupd : forall E1 E2 P Q, (P |-- (|==> (|={E1,E2}=> Q))) -> P |-- |={E1,E2}=> Q.


### PR DESCRIPTION
Should now work in either 32-bit or 64-bit mode, and with newer versions of Coq, Iris, and VST.