### PR TITLE
Adapt 'make all' testcases to Coq 8.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -678,19 +678,24 @@ endif
 
 # ########## Targets ##########
 
-default_target: _CoqProject msl veric floyd $(PROGSDIR)
-
+default_target: vst $(PROGSDIR)
+vst: _CoqProject msl veric floyd simpleconc
 all: default_target files travis io hmacdrbg tweetnacl aes
 
 ifeq ($(BITSIZE),64)
-travis: default_target progs
+test: default_target progs
+tests: test
 else
-travis: default_target progs sha hmac mailbox VSUpile
-travisx: default_target progs sha hmac mailbox
+test: default_target progs
+test2: sha hmac 
+test3: mailbox 
+test4: VSUpile
+tests: test test2 test3 test4
 endif
 
 files: _CoqProject $(FILES:.v=.vo)
 
+simpleconc: concurrency/conclib.vo concurrency/ghosts.vo
 msl:     _CoqProject $(MSL_FILES:%.v=msl/%.vo)
 sepcomp: _CoqProject $(CC_TARGET) $(SEPCOMP_FILES:%.v=sepcomp/%.vo)
 concurrency: _CoqProject $(CC_TARGET) $(SEPCOMP_FILES:%.v=sepcomp/%.vo) $(CONCUR_FILES:%.v=concurrency/%.vo)

--- a/Makefile
+++ b/Makefile
@@ -680,7 +680,7 @@ endif
 
 default_target: vst $(PROGSDIR)
 vst: _CoqProject msl veric floyd simpleconc
-all: default_target files travis io hmacdrbg tweetnacl aes
+all: default_target files tests io hmacdrbg tweetnacl aes
 
 ifeq ($(BITSIZE),64)
 test: default_target progs

--- a/Makefile
+++ b/Makefile
@@ -680,17 +680,22 @@ endif
 
 default_target: vst $(PROGSDIR)
 vst: _CoqProject msl veric floyd simpleconc
-all: default_target files tests io hmacdrbg tweetnacl aes
 
 ifeq ($(BITSIZE),64)
-test: default_target progs
-tests: test
+test: vst progs64
+	@# need this tab here to turn of special behavior of 'test' target
+test2: io
+tests: test test2
+all: tests
 else
-test: default_target progs
-test2: sha hmac 
-test3: mailbox 
-test4: VSUpile
-tests: test test2 test3 test4
+test: vst progs
+	@# need this tab here to turn of special behavior of 'test' target
+test2: io
+test3: sha hmac 
+test4: mailbox 
+test5: VSUpile
+tests: test test2 test3 test4 test5
+all: vst files tests hmacdrbg tweetnacl aes
 endif
 
 files: _CoqProject $(FILES:.v=.vo)

--- a/Makefile
+++ b/Makefile
@@ -810,7 +810,6 @@ endif
 # 	$(COQDEP) -Q coq-ext-lib/theories ExtLib coq-ext-lib/theories >>.depend
 # endif
 ifneq ($(wildcard InteractionTrees/theories),)
-	$(warning foo)
 #	$(COQDEP) -Q coq-ext-lib/theories ExtLib -Q paco/src Paco -Q InteractionTrees/theories ITree InteractionTrees/theories >>.depend
 	$(COQDEP) -Q paco/src Paco -Q InteractionTrees/theories ITree InteractionTrees/theories >>.depend
 endif

--- a/aes/verif_encryption_LL_after_loop.v
+++ b/aes/verif_encryption_LL_after_loop.v
@@ -110,6 +110,9 @@ intros.
    rewrite !(Int.unsigned_repr 255) in *|-* by computable .
     rewrite !Int.unsigned_repr by
      match goal with |- context [Z.land ?A] => clear - H0; specialize (H0 A); rep_lia end.
+  change (52+1) with 53. (* Became necessary in Coq 8.14 or 8.15 *)
+  change (53+1) with 54. (* Became necessary in Coq 8.14 or 8.15 *)
+  change (54+1) with 55. (* Became necessary in Coq 8.14 or 8.15 *)
   rewrite EqY0, EqY1, EqY2, EqY3; clear EqY0 EqY1 EqY2 EqY3.
 
   (* last AES round: special (uses S-box instead of forwarding tables) *)
@@ -139,6 +142,10 @@ intros.
    rewrite !(Int.unsigned_repr 255) in *|-* by computable .
     rewrite !Int.unsigned_repr by
      match goal with |- context [Z.land ?A] => clear - H0; specialize (H0 A); rep_lia end.
+  change (55+1) with 56. (* Became necessary in Coq 8.14 or 8.15 *)
+  change (56+1) with 57. (* Became necessary in Coq 8.14 or 8.15 *)
+  change (57+1) with 58. (* Became necessary in Coq 8.14 or 8.15 *)
+  change (58+1) with 59. (* Became necessary in Coq 8.14 or 8.15 *)
   rewrite EqX0, EqX1, EqX2, EqX3; clear EqX0 EqX1 EqX2 EqX3.
 
  remember_temp_Vints (@nil localdef).

--- a/floyd/printf.v
+++ b/floyd/printf.v
@@ -130,6 +130,7 @@ Proof.
 Defined.
 Next Obligation.
 Proof.
+  rewrite ?Zaux.Zdiv_eucl_unique in *. (* for Coq 8.15 *)
   rewrite <- Heq_anonymous0.
   destruct (Z.ltb_spec n 0); try discriminate.
   pose proof (Z.div_pos _ 10 H).

--- a/hmacdrbg/HMAC_DRBG_common_lemmas.v
+++ b/hmacdrbg/HMAC_DRBG_common_lemmas.v
@@ -18,7 +18,7 @@ Lemma da_emp_isptrornull sh t v p :
  Proof. unfold da_emp; apply pred_ext.
   + apply orp_left.
     - apply derives_extract_prop; intros; subst; simpl. entailer. apply orp_right1. auto.
-    - rewrite data_at_isptr with (p0:=p) at 1. normalize.
+    - rewrite (data_at_isptr _ _ _ p) at 1. normalize.
       destruct p; simpl in *; try contradiction. entailer. apply orp_right2. entailer.
   + entailer.
 Qed.

--- a/hmacdrbg/verif_hmac_drbg_NISTseed.v
+++ b/hmacdrbg/verif_hmac_drbg_NISTseed.v
@@ -243,8 +243,9 @@ Proof.
   thaw ALLSEP. thaw FIELDS2. forward.
 
   assert (FOURTYEIGHT: Int.unsigned (Int.mul (Int.repr 32) (Int.repr 3)) / 2 = 48).
-  { rewrite mul_repr. simpl.
-    rewrite Int.unsigned_repr. reflexivity. rep_lia. }
+  { rewrite mul_repr. simpl; auto.
+    all: rewrite Int.unsigned_repr by rep_lia; reflexivity. (* for Coq 8.13 and before *)
+  }
   set (myABS := HMAC256DRBGabs initial_key initial_value rc 48 pr_flag 10000) in *.
   assert (myST: exists ST:hmac256drbgstate, ST =
     ((info, (M2, p)), (map Vint (repeat Int.one 32), (Vint (Int.repr rc),
@@ -496,8 +497,9 @@ Proof.
   thaw ALLSEP. thaw FIELDS2. forward.
 
   assert (FOURTYEIGHT: Int.unsigned (Int.mul (Int.repr 32) (Int.repr 3)) / 2 = 48).
-  { rewrite mul_repr. simpl.
-    rewrite Int.unsigned_repr. reflexivity. rep_lia. }
+  { rewrite mul_repr. simpl; auto.
+    all: rewrite Int.unsigned_repr by rep_lia; reflexivity. (* for Coq 8.13 and before *)
+  }
   set (myABS := HMAC256DRBGabs initial_key initial_value rc 48 pr_flag 10000) in *.
   assert (myST: exists ST:hmac256drbgstate, ST =
     ((info, (M2, p)), (map Vint (repeat Int.one 32), (Vint (Int.repr rc),
@@ -793,8 +795,9 @@ Proof.
   thaw ALLSEP. thaw FIELDS2. forward.
 
   assert (FOURTYEIGHT: Int.unsigned (Int.mul (Int.repr 32) (Int.repr 3)) / 2 = 48).
-  { rewrite mul_repr. simpl.
-    rewrite Int.unsigned_repr. reflexivity. rep_lia. }
+  { rewrite mul_repr. simpl; auto.
+    all: rewrite Int.unsigned_repr by rep_lia; reflexivity. (* for Coq 8.13 and before *)
+  }
 
   set (myABS := HMAC256DRBGabs VV (repeat Byte.one 32) rc 48 pr 10000) in *.
   assert (myST: exists ST:hmac256drbgstate, ST =

--- a/hmacdrbg/verif_hmac_drbg_seed.v
+++ b/hmacdrbg/verif_hmac_drbg_seed.v
@@ -108,8 +108,9 @@ Proof.
   thaw ALLSEP. thaw FIELDS2. forward.
 
   assert (FOURTYEIGHT: Int.unsigned (Int.mul (Int.repr 32) (Int.repr 3)) / 2 = 48).
-  { rewrite mul_repr. simpl.
-    rewrite Int.unsigned_repr. reflexivity. rep_lia. }
+  { rewrite mul_repr. simpl; auto.
+    all: rewrite Int.unsigned_repr by rep_lia; reflexivity. (* for Coq 8.13 and before *)
+  }
   set (myABS := HMAC256DRBGabs initial_key initial_value rc 48 pr_flag 10000) in *.
   assert (myST: exists ST:hmac256drbgstate, ST =
     ((info, (M2, p)), (map Vint (repeat Int.one 32), (Vint (Int.repr rc),

--- a/mailbox/verif_mailbox_init.v
+++ b/mailbox/verif_mailbox_init.v
@@ -209,12 +209,13 @@ Proof.
       { intro X; contradiction unreadable_bot.
         rewrite <- X; auto. } }
     fold (ghost_var Tsh (vint 1) g0') (ghost_var Tsh (vint 0) g1') (ghost_var Tsh (vint 1) g2').
-    erewrite <- !ghost_var_share_join with (sh0 := Tsh) by eauto.
+    rewrite <- !(ghost_var_share_join gsh1 gsh2 Tsh) by auto.
     match goal with H : sepalg_list.list_join sh1 (sublist i N shs) sh |- _ =>
       erewrite sublist_next in H; try lia; inversion H as [|????? Hj1 Hj2] end.
     apply sepalg.join_comm in Hj1; eapply sepalg_list.list_join_assoc1 in Hj2; eauto.
     destruct Hj2 as (sh' & ? & Hsh').
-    erewrite <- data_at_share_join with (sh0 := sh) by (apply Hsh').
+    rewrite <- (data_at_share_join (Znth i shs) sh' sh) by (apply Hsh').
+    Intros.
     forward_call (l, Ews, AE_inv c g' (vint 0) (comm_R bufs (Znth i shs) gsh2 g0' g1' g2')).
     { lock_props.
       fast_cancel.

--- a/mailbox/verif_mailbox_write.v
+++ b/mailbox/verif_mailbox_write.v
@@ -268,7 +268,7 @@ Proof.
     destruct shs.
     { rewrite Zlength_nil, !Zlength_correct in *; lia. }
     rewrite Zlength_cons in *; simpl; rewrite IHl1; [|lia].
-    rewrite sublist_S_cons with (i0 := Z.succ _); [|rewrite Zlength_correct; lia].
+    rewrite (sublist_S_cons (Z.succ _)); [|rewrite Zlength_correct; lia].
     unfold Z.succ; rewrite !Z.add_simpl_r.
     destruct (eq_dec a i); auto.
 Qed.
@@ -966,7 +966,7 @@ Proof.
      apply ENTAIL_refl.
     + forward. rewrite neg_repr in H18.
       rename H18 into n1.
-      erewrite upd_Znth_triv with (i0 := i).
+      erewrite (upd_Znth_triv i).
       apply ENTAIL_refl.
       * rewrite !Zlength_map, Zlength_upto; auto.
       * rewrite !Znth_map, Znth_upto; try (simpl; unfold N in *; lia).

--- a/progs/VSUpile/Makefile
+++ b/progs/VSUpile/Makefile
@@ -22,7 +22,7 @@ VST_LOC ?= ../..
 
 ifdef COMPCERT_LOC
 CLIGHTGEN ?= $(COMPCERT_LOC)/clightgen
-COMPCERT_FLAGS= -R $(COMPCERT_LOC)
+COMPCERT_FLAGS= -R $(COMPCERT_LOC) compcert
 endif 
 
 ifdef CLIGHTGEN

--- a/progs/dry_mem_lemmas.v
+++ b/progs/dry_mem_lemmas.v
@@ -383,7 +383,7 @@ Proof.
     destruct mv; try discriminate.
     unfold decode_val in Hdecode; simpl in *.
     rewrite Z.sub_0_r in *.
-    apply Forall_Znth with (i0 := lo) in Hdef; try lia.
+    apply (Forall_Znth _ _ lo) in Hdef; try lia.
     setoid_rewrite <- Hdecode in Hdef.
     destruct m; try contradiction; clear Hdef.
     destruct mv; try discriminate; simpl in *.
@@ -423,7 +423,7 @@ Proof.
     * unfold Ptrofs.add.
       setoid_rewrite Ptrofs.unsigned_repr at 2; [|rep_lia].
       rewrite Ptrofs.unsigned_repr; rep_lia.
-    * apply Forall_Znth with (i0 := lo - 0) in Hdef; try lia; contradiction.
+    * apply (Forall_Znth _ _ (lo - 0)) in Hdef; try lia; contradiction.
     * rewrite Z.add_assoc in *.
       replace (1 + Z.of_nat n + lo) with (Z.of_nat n + (lo + 1)) by lia; auto.
     * eapply join_sub_trans; [eexists|]; eauto.

--- a/progs/io_combine.v
+++ b/progs/io_combine.v
@@ -114,7 +114,7 @@ Proof.
       destruct (sys_getc_spec) eqn:Hspec; inv H3.
       assert (sig_res (ef_sig e) <> AST.Tvoid).
       { destruct e; inv H4; discriminate. }
-      eapply sys_getc_correct with (m1 := m) in Hspec as (? & -> & [? Hpost ? ?]); eauto.
+      eapply (sys_getc_correct _ _ m) in Hspec as (? & -> & [? Hpost ? ?]); eauto.
       * split; auto; do 2 eexists; eauto.
         unfold getchar_post, getchar_post' in *.
         destruct Hpost as [? Hpost]; split; auto; split; auto.

--- a/progs/verif_io.v
+++ b/progs/verif_io.v
@@ -55,6 +55,7 @@ Program Fixpoint chars_of_Z (n : Z) { measure (Z.to_nat n) } : list byte :=
   match n' <=? 0 with true => [Byte.repr (n + char0)] | false => chars_of_Z n' ++ [Byte.repr (n mod 10 + char0)] end.
 Next Obligation.
 Proof.
+  rewrite ?Zaux.Zdiv_eucl_unique in *.  (* Coq 8.15 and after *)
   apply div_10_dec.
   symmetry in Heq_anonymous; apply Z.leb_nle in Heq_anonymous.
   eapply Z.lt_le_trans, Z_mult_div_ge with (b := 10); lia.
@@ -68,6 +69,7 @@ Program Fixpoint intr n { measure (Z.to_nat n) } : list byte :=
   end.
 Next Obligation.
 Proof.
+  rewrite ?Zaux.Zdiv_eucl_unique in *.  (* Coq 8.15 and after *)
   apply div_10_dec.
   symmetry in Heq_anonymous; apply Z.leb_nle in Heq_anonymous; lia.
 Defined.
@@ -239,6 +241,7 @@ Proof.
   rewrite chars_of_Z_eq, intr_eq.
   destruct (n <=? 0) eqn: Hn; [apply Zle_bool_imp_le in Hn; lia|].
   simpl.
+  rewrite ?Zaux.Zdiv_eucl_unique in *.  (* Coq 8.15 and after *)
   destruct (n / 10 <=? 0) eqn: Hdiv.
   - apply Zle_bool_imp_le in Hdiv.
     assert (0 <= n / 10).
@@ -372,9 +375,17 @@ Ltac alloc_block m n := match n with
   | S ?n' => let m' := fresh "m" in let Hm' := fresh "Hm" in
     destruct (dry_mem_lemmas.drop_alloc m) as [m' Hm']; alloc_block m' n'
   end.
-  alloc_block Mem.empty 60%nat.
-  eexists; repeat match goal with H : ?a = _ |- match ?a with Some m' => _ | None => None end = _ => rewrite H end.
-  reflexivity.
+try first [
+  (* This version works in Coq 8.15, CompCert 3.10 *)
+  alloc_block Mem.empty 62%nat;
+  eexists; repeat match goal with H : ?a = _ |- match ?a with Some m' => _ | None => None end = _ => rewrite H end;
+  reflexivity
+ | 
+  (* This version worked in Coq 8.13, CompCert 3.9 *)
+  alloc_block Mem.empty 60%nat;
+  eexists; repeat match goal with H : ?a = _ |- match ?a with Some m' => _ | None => None end = _ => rewrite H end;
+  reflexivity
+].
 Qed.
 
 Definition init_mem := proj1_sig init_mem_exists.

--- a/progs/verif_io_mem.v
+++ b/progs/verif_io_mem.v
@@ -29,6 +29,7 @@ Program Fixpoint chars_of_Z (n : Z) { measure (Z.to_nat n) } : list byte :=
   match n' <=? 0 with true => [Byte.repr (n + char0)] | false => chars_of_Z n' ++ [Byte.repr (n mod 10 + char0)] end.
 Next Obligation.
 Proof.
+  rewrite ?Zaux.Zdiv_eucl_unique in *.  (* Coq 8.15 and after *)
   apply div_10_dec.
   symmetry in Heq_anonymous; apply Z.leb_nle in Heq_anonymous.
   eapply Z.lt_le_trans, Z_mult_div_ge with (b := 10); lia.
@@ -235,6 +236,7 @@ Proof.
   intros.
   destruct (Z.leb_spec n 0).
   { rewrite chars_of_Z_eq; simpl.
+  rewrite ?Zaux.Zdiv_eucl_unique in *.  (* Coq 8.15 and after *)
     apply Zdiv_le_compat_r with (p := 10) in H; try lia.
     rewrite Zdiv_0_l in H.
     destruct (Z.leb_spec (n / 10) 0); auto; lia. }
@@ -242,6 +244,7 @@ Proof.
   rewrite chars_of_Z_eq, intr_eq.
   destruct (n <=? 0) eqn: Hn; [apply Zle_bool_imp_le in Hn; lia|].
   simpl.
+  rewrite ?Zaux.Zdiv_eucl_unique in *.  (* Coq 8.15 and after *)
   destruct (n / 10 <=? 0) eqn: Hdiv.
   - apply Zle_bool_imp_le in Hdiv.
     assert (0 <= n / 10).
@@ -549,9 +552,17 @@ Ltac alloc_block m n := match n with
   | S ?n' => let m' := fresh "m" in let Hm' := fresh "Hm" in
     destruct (dry_mem_lemmas.drop_alloc m) as [m' Hm']; alloc_block m' n'
   end.
-  alloc_block Mem.empty 61%nat.
-  eexists; repeat match goal with H : ?a = _ |- match ?a with Some m' => _ | None => None end = _ => rewrite H end.
-  reflexivity.
+try first [
+  (* This version works in Coq 8.15, CompCert 3.10 *)
+  alloc_block Mem.empty 63%nat;
+  eexists; repeat match goal with H : ?a = _ |- match ?a with Some m' => _ | None => None end = _ => rewrite H end;
+  reflexivity
+ | 
+  (* This version worked in Coq 8.13, CompCert 3.9 *)
+  alloc_block Mem.empty 61%nat;
+  eexists; repeat match goal with H : ?a = _ |- match ?a with Some m' => _ | None => None end = _ => rewrite H end;
+  reflexivity
+].
 Qed.
 
 Definition init_mem := proj1_sig init_mem_exists.

--- a/sha/HMAC256_spec_list.v
+++ b/sha/HMAC256_spec_list.v
@@ -10,8 +10,6 @@ Require Import sha.HMAC_spec_list.
 Require Import sha.HMAC_spec_concat.
 Require Import sha.ShaInstantiation.
 
-Require Import Omega.
-
 (*
 Definition ltb (n m:nat):bool := if beq_nat n m then false else leb n m.
 Lemma ltb_char n m: ltb n m = true <-> (n<m)%nat.

--- a/sha/general_lemmas.v
+++ b/sha/general_lemmas.v
@@ -53,7 +53,7 @@ rewrite <- H1.
 assert (b=1 \/ b>1) by lia.
 destruct H2.
 subst b. simpl. lia.
-rewrite (Z_div_nz_opp_full 1) by (rewrite Z.mod_small; lia).
+rewrite (Z_div_nz_opp_full 1) by (rewrite ?Z.mod_small; lia).
 rewrite  Z.div_small by lia.
 lia.
 rewrite H4.

--- a/sha/pure_lemmas.v
+++ b/sha/pure_lemmas.v
@@ -317,7 +317,8 @@ Theorem Zmod_mod_mult :
   Zmod (Zmod n (a * b)) b = Zmod n b.
 Proof.
 intros n a [|b|b] Ha Hb.
-now rewrite 2!Zmod_0_r.
+rewrite ?Z.mul_0_r.
+now rewrite 2!Zmod_0_r.  
 rewrite (Zmod_eq n (a * Zpos b)).
 rewrite Zmult_assoc.
 unfold Zminus.

--- a/sha/verif_addlength.v
+++ b/sha/verif_addlength.v
@@ -19,7 +19,10 @@ Lemma Z_div_mul: forall a b, b <> 0 ->
       (a/b*b = a - a mod b)%Z.
 Proof.
 intros.
-pose proof (Z_div_mod_eq_full a b H).
+first  [
+    pose proof (Z_div_mod_eq_full a b H)  (* for Coq 8.13 *)
+  | pose proof (Z_div_mod_eq_full a b) (* for Coq 8.15 *)
+].
 rewrite H0 at 2.
 rewrite Z.mul_comm; lia.
 Qed.
@@ -150,11 +153,6 @@ Qed.
 Lemma body_SHA256_addlength: semax_body Vprog Gtot f_SHA256_addlength SHA256_addlength_spec.
 Proof.
 start_function.
-name c_ _c.
-name len_ _len.
-name l_ _l.
-name Nl _cNl.
-name Nh _cNh.
 rename H into BOUND.
 rename H1 into Hn.
 assert (MN: Int.modulus <> 0) by (intro Hx; inv Hx).

--- a/sha/verif_sha_bdo7.v
+++ b/sha/verif_sha_bdo7.v
@@ -296,7 +296,8 @@ rewrite <- Sigma_0_eq, <- Maj_eq.
 repeat forward.
 rewrite Z.add_simpl_r.
 rewrite Z2Nat.inj_add by lia.
-entailer!. 2: apply derives_refl.
+entailer!. 
+all: try apply derives_refl.  (* to support Coq 8.13 *)
 clear - H H0 H1.
 rewrite Round_equation.
 forget (W (nthi bb) i) as Wbbi.

--- a/tweetnacl20140427/tweetNaclBase.v
+++ b/tweetnacl20140427/tweetNaclBase.v
@@ -124,7 +124,7 @@ Proof. intros.
   assert (HH: Z.to_nat (Zlength l1) = Z.to_nat (Zlength l2)).
     rewrite H; trivial.
   do 2 rewrite Zlength_correct, Nat2Z.id in HH.
-  eapply nth_extensional with (d0:=d). trivial.
+  eapply (nth_extensional _ _ HH d).
   intros.
   assert (I: 0 <= (Z.of_nat i) < Zlength l1).
     split. apply (Nat2Z.inj_le 0). apply H1. rewrite Zlength_correct. apply Nat2Z.inj_lt. apply H1.

--- a/tweetnacl20140427/verif_ld_st.v
+++ b/tweetnacl20140427/verif_ld_st.v
@@ -329,10 +329,13 @@ Time forward_for_simple_bound 4 (EX i:Z,
         destruct (zeq i 1); subst; simpl. f_equal. f_equal. f_equal.
         { rewrite Byte.unsigned_repr.
           2:{ assert (0 <= (Int.unsigned u mod Z.pow_pos 2 24) mod Z.pow_pos 2 16 / Z.pow_pos 2 8 < Byte.modulus).
-                   2:{ unfold Byte.max_unsigned. lia. }
+                   2: unfold Byte.max_unsigned; 
+                         rewrite ?Zaux.Zdiv_eucl_unique; (* for Coq 8.15 *)
+                         lia.
                    split. apply Z_div_pos. cbv; trivial. apply Z_mod_lt. cbv; trivial.
                    apply Zdiv_lt_upper_bound. cbv; trivial. apply Z_mod_lt. cbv; trivial.
           }
+          rewrite ?Zaux.Zdiv_eucl_unique; (* for Coq 8.15 *)
           apply Int.same_bits_eq. rewrite ZW; intros.
           rewrite Int.bits_zero_ext, Int.testbit_repr; try apply H.
           rewrite (Z.div_pow2_bits _ 8); try lia.
@@ -346,10 +349,13 @@ Time forward_for_simple_bound 4 (EX i:Z,
           f_equal.
         { rewrite Byte.unsigned_repr.
           2:{ assert (0 <= Int.unsigned u mod Z.pow_pos 2 24 / Z.pow_pos 2 16 < Byte.modulus).
-                   2: unfold Byte.max_unsigned; lia.
+                   2: unfold Byte.max_unsigned; 
+                         rewrite ?Zaux.Zdiv_eucl_unique; (* for Coq 8.15 *)
+                         lia.
                    split. apply Z_div_pos. cbv; trivial. apply Z_mod_lt. cbv; trivial.
                    apply Zdiv_lt_upper_bound. cbv; trivial. apply Z_mod_lt. cbv; trivial.
           }
+          rewrite ?Zaux.Zdiv_eucl_unique; (* for Coq 8.15 *)
           apply Int.same_bits_eq. rewrite ZW; intros.
           rewrite Int.bits_zero_ext, Int.testbit_repr; try apply H.
           rewrite Int.bits_shru; try lia. rewrite EIGHT, ZW.
@@ -365,7 +371,9 @@ Time forward_for_simple_bound 4 (EX i:Z,
           f_equal.
           rewrite Byte.unsigned_repr.  
           2:{ assert (0 <= Int.unsigned u / Z.pow_pos 2 24 < Byte.modulus).
-                   2: unfold Byte.max_unsigned; lia.
+                   2: unfold Byte.max_unsigned; 
+                         rewrite ?Zaux.Zdiv_eucl_unique; (* for Coq 8.15 *)
+                         lia.
                    split. apply Z_div_pos. cbv; trivial. apply Int.unsigned_range. 
                    apply Zdiv_lt_upper_bound. cbv; trivial. apply Int.unsigned_range. 
           }
@@ -378,6 +386,7 @@ Time forward_for_simple_bound 4 (EX i:Z,
           2: apply div_bound; cbv; trivial.
           replace (two_p 16 * two_p 8)%Z with (two_p 24) by reflexivity.
           apply zero_ext_inrange.
+          rewrite ?Zaux.Zdiv_eucl_unique; (* for Coq 8.15 *)
           rewrite (Int.unsigned_repr (Int.unsigned u / Z.pow_pos 2 24)).
           2: apply div_bound; cbv; trivial. 
           assert (Int.unsigned u / Z.pow_pos 2 24 < two_p 8). 2: lia.


### PR DESCRIPTION
Many fixes to test cases in sha,hmacdrbg,aes,mailbox,progs,tweetnacl, etc. so that now everything builds in Coq 8.15 and (probably) still builds in Coq 8.13.