### PR TITLE
Nontrivial Iris-style persistency

### DIFF
--- a/atomics/general_atomics.v
+++ b/atomics/general_atomics.v
@@ -6,6 +6,9 @@ Require Import VST.concurrency.invariants.
 Require Import VST.concurrency.fupd.
 Require Import VST.floyd.library.
 Require Import VST.floyd.sublist.
+(* trying to import Iris's definition directly *)
+Require Export iris.bi.lib.atomic.
+
 
 Set Bullet Behavior "Strict Subproofs".
 
@@ -29,22 +32,27 @@ Set Bullet Behavior "Strict Subproofs".
 
 Section atomics.
 
-Context {CS : compspecs} {inv_names : invG}.
+Context {inv_names : invG}.
 
 Section atomicity.
 
 (* The logical atomicity of Iris. *)
 (* We use the cored predicate to mimic Iris's persistent modality. *)
-Definition ashift {A B} P (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) :=
+(*Definition ashift {A B} P (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) :=
   ((|> P -* |={Eo,Ei}=> (EX x : A, a x *
     ((a x -* |={Ei,Eo}=> |> P) &&
-     ALL y : B, b x y -* |={Ei,Eo}=> Q y))))%I.
+     ALL y : B, b x y -* |={Ei,Eo}=> Q y))))%I.*)
 
-(* switch to Ralf's? *)
-Locate atomic_update.
+(*Definition atomic_shift {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) :=
+  EX P : mpred, |> P * (ashift P a Ei Eo b Q && cored).*)
 
-Definition atomic_shift {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) :=
-  EX P : mpred, |> P * (ashift P a Ei Eo b Q && cored).
+Definition tele_unwrap {A} (x : tele_arg (TeleS (fun _ : A => TeleO))) :=
+  match x with
+  | TargS _ _ x _ => x
+  end.
+
+Definition atomic_shift {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) : mpred :=
+  atomic_update Eo Ei (λ.. x, a (tele_unwrap x)) (λ.. x y, b (tele_unwrap x) (tele_unwrap y)) (λ.. x y, Q (tele_unwrap y)).
 
 Lemma atomic_commit_fupd : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
   (forall x, R * a x |-- (|==> (EX y, b x y * R' y))%I) ->
@@ -52,11 +60,10 @@ Lemma atomic_commit_fupd : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mp
 Proof.
   intros.
   iIntros "[AS R]".
-  unfold atomic_shift, ashift.
-  iDestruct "AS" as (P) "[P AS]".
-  iMod ("AS" with "P") as (x) "[a [_ H]]".
-  iMod (H with "[$R $a]") as (y) "[b R']".
-  iExists y; iMod ("H" with "b") as "$"; auto.
+  unfold atomic_shift.
+  iMod "AS" as (x) "[a [_ commit]]"; simpl.
+  iMod (H with "[$R $a]") as (y) "[b Q]".
+  iExists y; iMod ("commit" with "b") as "$"; auto.
 Qed.
 
 Corollary atomic_commit_elim : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
@@ -85,13 +92,10 @@ Lemma atomic_rollback_fupd : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> 
 Proof.
   intros.
   iIntros "[AS R]".
-  unfold atomic_shift, ashift.
-  iDestruct "AS" as (P) "[P AS]".
-  rewrite cored_dup; iDestruct "AS" as "[AS AS1]".
-  iMod ("AS" with "P") as (x) "[a H]".
-  iMod (H with "[$R $a]") as "[a $]".
-  iMod ("H" with "a").
-  iIntros "!>"; iExists P; iFrame.
+  unfold atomic_shift.
+  iMod "AS" as (x) "[a [rollback _]]"; simpl.
+  iMod (H with "[$R $a]") as "[a R]".
+  iMod ("rollback" with "a") as "$"; auto.
 Qed.
 
 Corollary atomic_rollback_elim : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
@@ -117,17 +121,8 @@ Lemma atomic_shift_mask_weaken {A B} Eo1 Eo2 Ei a (b : A -> B -> mpred) Q :
   Eo1 ⊆ Eo2 ->
   atomic_shift a Ei Eo1 b Q |-- atomic_shift a Ei Eo2 b Q.
 Proof.
-  intros; unfold atomic_shift, ashift.
-  Intros P; Exists P; cancel.
-  apply andp_derives; auto.
-  apply wand_derives; auto.
-  iIntros "H".
-  iMod (fupd_mask_subseteq _ H) as "mask".
-  iMod"H" as (x) "[Ha Hb]".
-  iExists x; iFrame.
-  iIntros "!>"; iSplit.
-  - iIntros "a"; iMod ("Hb" with "a") as "$"; auto.
-  - iIntros (y) "b"; iMod ("Hb" with "b") as "$"; auto.
+  intros; unfold atomic_shift.
+  apply atomic_update_mask_weaken; auto.
 Qed.
 
 Lemma inv_atomic_shift : forall {A B} a Ei Eo (b : A -> B -> mpred) Q i R P
@@ -137,6 +132,7 @@ Lemma inv_atomic_shift : forall {A B} a Ei Eo (b : A -> B -> mpred) Q i R P
   invariant i R * P |-- atomic_shift a Ei Eo b Q.
 Proof.
   intros; unfold atomic_shift.
+  iIntros "
   Exists P; cancel.
   apply andp_right, invariant_cored.
   unfold ashift.
@@ -156,7 +152,7 @@ Proof.
     iApply "Hclose"; auto.
 Qed.
 
-Lemma ashift_nonexpansive : forall {A B} P n a Ei Eo (b : A -> B -> mpred) Q,
+(*Lemma ashift_nonexpansive : forall {A B} P n a Ei Eo (b : A -> B -> mpred) Q,
   approx n (ashift P a Ei Eo b Q) =
   approx n (ashift P (fun x => approx n (a x)) Ei Eo (fun x y => approx n (b x y)) (fun y => approx n (Q y))).
 Proof.
@@ -168,18 +164,21 @@ Proof.
   * setoid_rewrite fview_shift_nonexpansive; rewrite !approx_idem; f_equal; f_equal; auto.
   * rewrite allp_nonexpansive; setoid_rewrite allp_nonexpansive at 2; f_equal; f_equal; extensionality.
     setoid_rewrite fview_shift_nonexpansive; rewrite !approx_idem; auto.
-Qed.
+Qed.*)
 
 Lemma atomic_shift_nonexpansive : forall {A B} n a Ei Eo (b : A -> B -> mpred) Q,
   approx n (atomic_shift a Ei Eo b Q) =
   approx n (atomic_shift (fun x => approx n (a x)) Ei Eo (fun x y => approx n (b x y)) (fun y => approx n (Q y))).
 Proof.
   intros; unfold atomic_shift.
-  rewrite !approx_exp; f_equal; extensionality.
-  rewrite !approx_sepcon !approx_andp ashift_nonexpansive; auto.
-Qed.
+  apply approx_Sn_eq_weaken.
+  unshelve eapply (atomic_update_ne _ _ n (λ.. x : [tele _ : A], a (tele_unwrap x))).
+  { intros a1; simpl. hnf. simpl. (*destruct a1.*) admit. }
+  { admit. }
+  { admit. }
+Admitted.
 
-Lemma atomic_shift_derives_frame_cored : forall {A A' B B'} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
+(*Lemma atomic_shift_derives_frame_cored : forall {A A' B B'} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
   (b : A -> B -> mpred) (b' : A' -> B' -> mpred) (Q : B -> mpred) (Q' : B' -> mpred) F R
   (HF : F |-- cored)
   (Ha : (forall x, a x * F * |>R |-- |={Ei}=> EX x' : A', a' x' *
@@ -247,7 +246,7 @@ Proof.
     iMod ("Hb" $! y' with "[$b $AS]") as (y) "[b HQ]".
     iMod ("H" with "b").
     iApply "HQ"; auto.
-Qed.
+Qed.*)
 
 Lemma atomic_shift_derives : forall {A A' B B'} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
   (b : A -> B -> mpred) (b' : A' -> B' -> mpred) (Q : B -> mpred) (Q' : B' -> mpred)
@@ -255,16 +254,19 @@ Lemma atomic_shift_derives : forall {A A' B B'} (a : A -> mpred) (a' : A' -> mpr
     ((a' x' -* |={Ei}=> a x) && ALL y' : _, b' x' y' -* |={Ei}=> EX y : _, b x y * (Q y -* |={Eo}=> Q' y')))%I),
   atomic_shift a Ei Eo b Q |-- atomic_shift a' Ei Eo b' Q'.
 Proof.
-  intros; eapply derives_trans, atomic_shift_derives_frame.
-  { rewrite <- sepcon_emp at 1; apply sepcon_derives; [apply derives_refl | apply now_later]. }
-  iIntros (x) "[a >_]".
-  iMod (Ha with "a") as (x') "[? H]".
-  iExists x'; iFrame; iIntros "!>"; iSplit.
-  - iIntros "a"; iMod ("H" with "a") as "$"; auto.
-  - iDestruct "H" as "[_ H]"; auto.
+  intros.
+  unfold atomic_shift; iIntros "AS".
+  iAuIntro.
+  iApply (aacc_aupd with "AS"); first auto.
+  iIntros (x) "a".
+  iMod (Ha with "a") as (x') "[a' H']".
+  iAaccIntro with "a'".
+  - iIntros "a'". iMod ("H'" with "a'") as "$"; auto.
+  - iIntros (y') "b'". iMod ("H'" with "b'") as (y) "[b H]".
+    iRight; iExists y; iFrame; auto.
 Qed.
 
-Lemma atomic_shift_derives_cored : forall {A A' B B'} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
+(*Lemma atomic_shift_derives_cored : forall {A A' B B'} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
   (b : A -> B -> mpred) (b' : A' -> B' -> mpred) (Q : B -> mpred) (Q' : B' -> mpred) F
   (HF : F |-- cored)
   (Ha : (forall x, a x * F |-- |={Ei}=> EX x' : A', a' x' *
@@ -278,7 +280,7 @@ Proof.
   iExists x'; iFrame; iIntros "!>"; iSplit.
   - iIntros "a"; iMod ("H" with "a") as "$"; auto.
   - iDestruct "H" as "[_ H]"; auto.
-Qed.
+Qed.*)
 
 Lemma atomic_shift_derives' : forall {A A' B} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
   (b : A -> B -> mpred) (b' : A' -> B -> mpred) (Q : B -> mpred)
@@ -297,7 +299,7 @@ Proof.
     iIntros "!> $"; auto.
 Qed.
 
-Lemma atomic_shift_derives'_cored : forall {A A' B} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
+(*Lemma atomic_shift_derives'_cored : forall {A A' B} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
   (b : A -> B -> mpred) (b' : A' -> B -> mpred) (Q : B -> mpred) F
   (HF : F |-- cored)
   (Ha : (forall x, a x * F |-- |={Ei}=> EX x' : A', a' x' *
@@ -313,7 +315,7 @@ Proof.
     iDestruct "H" as "[_ H]".
     iMod ("H" with "b") as "$".
     iIntros "!> $"; auto.
-Qed.
+Qed.*)
 
 Lemma atomic_shift_derives_simple : forall {A B} (a a' : A -> mpred) Ei Eo (b b' : A -> B -> mpred) (Q : B -> mpred)
   (Ha1 : (forall x, a x |-- |={Ei}=> a' x)%I)
@@ -328,7 +330,7 @@ Proof.
   - iIntros (?); iApply Hb.
 Qed.
 
-Lemma atomic_shift_exists : forall {A B} a Ei Eo (b : A -> B -> mpred) Q,
+(*Lemma atomic_shift_exists : forall {A B} a Ei Eo (b : A -> B -> mpred) Q,
   atomic_shift (fun (_ : unit) => EX x : A, a x) Ei Eo (fun (_ : unit) => EX x : A, b x) Q |-- atomic_shift a Ei Eo b Q.
 Proof.
   intros; unfold atomic_shift.
@@ -342,13 +344,13 @@ Proof.
     iExists x; auto.
   - iIntros (y) "b"; iApply "H".
     simpl; iExists x; auto.
-Qed.
+Qed.*)
 
 End atomicity.
 
 End atomics.
 
-Hint Resolve empty_subseteq : core.
+Global Hint Resolve empty_subseteq : core.
 
 Definition atomic_spec_type W T := ProdType (ProdType W (ArrowType (ConstType T) Mpred)) (ConstType invG).
 
@@ -716,6 +718,29 @@ Definition tcurry_rev (A : tlist) : tuple_type_rev A -> tuple_type A
 Definition rev_curry {A B} (f : tuple_type A -> B) : tuple_type_rev A -> B
   := fun v => f (tcurry_rev _ v).
 
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x : A 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+  (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type W T)
+   (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (inv_names : invG) (_ : tuple_type tnil) =>
+     PROPx (cons Px%type .. (cons Py%type nil) ..)
+     (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
+     (SEPx (cons (atomic_shift(inv_names := inv_names) (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+   (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (inv_names : invG) (_ : tuple_type tnil) =>
+    @exp (environ -> mpred) _ T (fun r =>
+     PROP () (LOCALx (cons LQx .. (cons LQy nil) ..) ((SEPx (Q r :: cons SPx .. (cons SPy nil) ..))))))))) ..)))
+   (@atomic_spec_nonexpansive_pre' (fun _ => A) T _ W
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Px%type .. (cons Py%type nil) ..))) ..)))
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
+      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
+     _ _ _ _ _ _)
+  (atomic_spec_nonexpansive_post' W
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons LQx%assert3 .. (cons LQy%assert3 nil) ..))) ..)))
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert3 .. (cons SPy%assert3 nil) ..))) ..))) _ _))
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+
 Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (inv_names : invG) (_ : tuple_type tnil) =>
@@ -1075,29 +1100,6 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
   (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
-
-Notation "'ATOMIC' 'TYPE' W 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
-  (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type0 W)
-   (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (inv_names : invG) (_ : tuple_type tnil) =>
-     PROPx (cons Px%type .. (cons Py%type nil) ..)
-     (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit)(inv_names := inv_names) (fun _ : unit => S2) Ei Eo (fun _ _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
-   (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (inv_names : invG) (_ : tuple_type tnil) =>
-     PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
-   (@atomic_spec_nonexpansive_pre0 _ W
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Px%type .. (cons Py%type nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) (_:unit) => S2)) ..)))
-      Ei Eo
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) _ _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
-     _ _ _ _ _ _)
-  (atomic_spec_nonexpansive_post0 W
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, Ei at level 0, Eo at level 0, S2 at level 0).
-
 Ltac atomic_nonexpansive_tac := try (let x := fresh "x" in intros ?? x;
   try match type of x with list Type => (let ts := fresh "ts" in rename x into ts; intros x) end;
   repeat destruct x as [x ?]; unfold rev_curry, tcurry; simpl; auto); repeat constructor.
@@ -1157,7 +1159,7 @@ Ltac start_function1 ::=
    unfold NDmk_funspec'
  end;
  let DependedTypeList := fresh "DependedTypeList" in
- unfold NDmk_funspec;
+ unfold NDmk_funspec; 
  match goal with |- semax_body _ _ _ (pair _ (mk_funspec _ _ _ ?Pre _ _ _)) =>
 
    split3; [check_parameter_types' | check_return_type | ];
@@ -1169,8 +1171,8 @@ Ltac start_function1 ::=
    end;
    simpl fn_body; simpl fn_params; simpl fn_return
  end;
- try match goal with |- semax _ (fun rho => ?A rho * ?B rho) _ _ =>
-     change (fun rho => ?A rho * ?B rho) with (A * B)
+ try match goal with |- semax _ (fun rho => ?A rho * ?B rho)%logic _ _ =>
+     change (fun rho => ?A rho * ?B rho)%logic with (A * B)%logic
   end;
  simpl functors.MixVariantFunctor._functor in *;
  simpl rmaps.dependent_type_functor_rec;

--- a/atomics/general_atomics.v
+++ b/atomics/general_atomics.v
@@ -1198,6 +1198,7 @@ Ltac start_function1 ::=
 *)
  try start_func_convert_precondition.
 
+(* can we not do this? *)
 Ltac start_function2 ::=
   first [ setoid_rewrite (* changed from erewrite *) compute_close_precondition_eq; [ | reflexivity | reflexivity]
         | rewrite close_precondition_main ].

--- a/atomics/general_atomics.v
+++ b/atomics/general_atomics.v
@@ -2,12 +2,11 @@ Require Import VST.veric.rmaps.
 Require Import VST.veric.compcert_rmaps.
 Require Import VST.concurrency.ghosts.
 Require Import VST.concurrency.conclib.
+Require Export iris.bi.lib.atomic.
 Require Import VST.concurrency.invariants.
 Require Import VST.concurrency.fupd.
 Require Import VST.floyd.library.
-Require Import VST.floyd.sublist.
-(* trying to import Iris's definition directly *)
-Require Export iris.bi.lib.atomic.
+Require Export VST.floyd.sublist.
 Require Import Program.Equality.
 
 

--- a/atomics/general_locks.v
+++ b/atomics/general_locks.v
@@ -7,6 +7,8 @@ Require Export VST.concurrency.invariants.
 Require Export VST.concurrency.fupd.
 Require Export VST.atomics.general_atomics.
 
+Open Scope logic.
+
 Section locks.
 
 Context {P : Ghost}.
@@ -46,14 +48,14 @@ Proof.
   iApply (ref_update(P := P)); eauto.
 Qed.
 
-Lemma public_part_update : forall g sh (a b a' b' : G) (Ha' : forall c, sepalg.join a c b -> sepalg.join a' c b'),
+Lemma public_part_update : forall g sh (a b a' b' : G) (Ha' : forall c, sepalg.join a c b -> sepalg.join a' c b' /\ (a = b -> a' = b')),
   my_half g sh a * public_half g b |-- !!(if eq_dec sh Tsh then a = b else exists x, sepalg.join a x b) && (|==> my_half g sh a' * public_half g b')%I.
 Proof.
   intros.
   iIntros "H".
   iSplit; [iApply (ref_sub with "H")|].
   rewrite !ghost_part_ref_join.
-  iApply (part_ref_update(P := P)); eauto.
+  iApply (part_ref_update(P := P) with "H"); auto.
 Qed.
 
 Definition sync_inv g sh R := EX a : G, R g a * my_half g sh a.
@@ -100,7 +102,7 @@ Qed.
 
 Lemma sync_commit_gen : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> mpred) Q R R' g sh (x0 : G)
   (Ha : forall x, R * a x |-- (|==> EX x1, public_half g x1 * (!!(if eq_dec sh Tsh then x0 = x1 else exists x, sepalg.join x0 x x1) -->
-    |==> (EX x0' x1' : G, !!(forall b, sepalg.join x0 b x1 -> sepalg.join x0' b x1') && (my_half g sh x0' * public_half g x1' -* |==> (EX y, b x y * R' y))))%I)%I),
+    |==> (EX x0' x1' : G, !!(forall b, sepalg.join x0 b x1 -> sepalg.join x0' b x1' /\ (x0 = x1 -> x0' = x1')) && (my_half g sh x0' * public_half g x1' -* |==> (EX y, b x y * R' y))))%I)%I),
   (atomic_shift a Ei Eo b Q * my_half g sh x0 * R |-- |==> EX y, Q y * R' y)%I.
 Proof.
   intros; rewrite sepcon_assoc.
@@ -129,7 +131,7 @@ Qed.
 
 Lemma sync_commit_gen1 : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> mpred) Q R R' g sh (x0 : G)
   (Ha : forall x, R * a x |-- (|==> EX x1, public_half g x1 * (!!(if eq_dec sh Tsh then x0 = x1 else exists x, sepalg.join x0 x x1) -->
-    |==> (EX x0' x1' : G, !!(forall b, sepalg.join x0 b x1 -> sepalg.join x0' b x1') && (my_half g sh x0' * public_half g x1' -* |==> (EX y, b x y) * R')))%I)%I),
+    |==> (EX x0' x1' : G, !!(forall b, sepalg.join x0 b x1 -> sepalg.join x0' b x1' /\ (x0 = x1 -> x0' = x1')) && (my_half g sh x0' * public_half g x1' -* |==> (EX y, b x y) * R')))%I)%I),
   (atomic_shift a Ei Eo b (fun _ => Q) * my_half g sh x0 * R |-- |==> Q * R')%I.
 Proof.
   intros; rewrite sepcon_assoc; eapply derives_trans; [apply @atomic_commit with
@@ -193,7 +195,7 @@ Qed.
 Lemma two_sync_commit : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> mpred) Q R R' g1 g2 sh1 sh2 (x1 x2 : G)
   (Ha : forall x, R * a x |-- (|==> EX y1 y2, public_half g1 y1 * public_half g2 y2 *
     (!!((if eq_dec sh1 Tsh then x1 = y1 else exists z, sepalg.join x1 z y1) /\ (if eq_dec sh2 Tsh then x2 = y2 else exists z, sepalg.join x2 z y2)) -->
-    |==> (EX x1' x2' y1' y2' : G, !!((forall z, sepalg.join x1 z y1 -> sepalg.join x1' z y1') /\ (forall z, sepalg.join x2 z y2 -> sepalg.join x2' z y2')) &&
+    |==> (EX x1' x2' y1' y2' : G, !!((forall z, sepalg.join x1 z y1 -> sepalg.join x1' z y1' /\ (x1 = y1 -> x1' = y1')) /\ (forall z, sepalg.join x2 z y2 -> sepalg.join x2' z y2' /\ (x2 = y2 -> x2' = y2'))) &&
       (my_half g1 sh1 x1' * public_half g1 y1' * my_half g2 sh2 x2' * public_half g2 y2' -* |==> (EX y, b x y * R' y))))%I)%I),
   (atomic_shift a Ei Eo b Q * my_half g1 sh1 x1 * my_half g2 sh2 x2 * R |-- |==> EX y, Q y * R' y)%I.
 Proof.
@@ -213,7 +215,7 @@ Qed.
 Lemma two_sync_commit1 : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> mpred) Q R R' g1 g2 sh1 sh2 (x1 x2 : G)
   (Ha : forall x, R * a x |-- (|==> EX y1 y2, public_half g1 y1 * public_half g2 y2 *
     (!!((if eq_dec sh1 Tsh then x1 = y1 else exists z, sepalg.join x1 z y1) /\ (if eq_dec sh2 Tsh then x2 = y2 else exists z, sepalg.join x2 z y2)) -->
-    |==> (EX x1' x2' y1' y2' : G, !!((forall z, sepalg.join x1 z y1 -> sepalg.join x1' z y1') /\ (forall z, sepalg.join x2 z y2 -> sepalg.join x2' z y2')) &&
+    |==> (EX x1' x2' y1' y2' : G, !!((forall z, sepalg.join x1 z y1 -> sepalg.join x1' z y1' /\ (x1 = y1 -> x1' = y1')) /\ (forall z, sepalg.join x2 z y2 -> sepalg.join x2' z y2' /\ (x2 = y2 -> x2' = y2'))) &&
       (my_half g1 sh1 x1' * public_half g1 y1' * my_half g2 sh2 x2' * public_half g2 y2' -* |==> ((EX y, b x y) * R'))))%I)%I),
   (atomic_shift a Ei Eo b (fun _ => Q) * my_half g1 sh1 x1 * my_half g2 sh2 x2 * R |-- |==> Q * R')%I.
 Proof.

--- a/atomics/general_locks.v
+++ b/atomics/general_locks.v
@@ -9,7 +9,6 @@ Require Export VST.atomics.general_atomics.
 
 Section locks.
 
-Context {CS : compspecs}.
 Context {P : Ghost}.
 
 Definition my_half g sh (a : G) := ghost_part(P := P) sh a g.
@@ -105,7 +104,7 @@ Lemma sync_commit_gen : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> m
   (atomic_shift a Ei Eo b Q * my_half g sh x0 * R |-- |==> EX y, Q y * R' y)%I.
 Proof.
   intros; rewrite sepcon_assoc.
-  apply (@atomic_commit CS) with (R' := fun y => R' y).
+  apply @atomic_commit with (R' := fun y => R' y).
   intros; iIntros "((my & R) & a)".
   iMod (Ha with "[$]") as (?) "[public a']".
   iPoseProof (ref_sub(P := P) with "[$my $public]") as "%".
@@ -120,7 +119,7 @@ Lemma sync_commit_same : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> 
   (atomic_shift a Ei Eo b Q * my_half g sh x0 * R |-- |==> EX y, Q y * R' y)%I.
 Proof.
   intros; rewrite sepcon_assoc.
-  apply (@atomic_commit CS) with (R' := fun y => R' y).
+  apply @atomic_commit with (R' := fun y => R' y).
   intros; iIntros "((my & R) & a)".
   iMod (Ha with "[$]") as (?) "[public a']".
   iPoseProof (ref_sub(P := P) with "[$my $public]") as "%".
@@ -133,7 +132,7 @@ Lemma sync_commit_gen1 : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> 
     |==> (EX x0' x1' : G, !!(forall b, sepalg.join x0 b x1 -> sepalg.join x0' b x1') && (my_half g sh x0' * public_half g x1' -* |==> (EX y, b x y) * R')))%I)%I),
   (atomic_shift a Ei Eo b (fun _ => Q) * my_half g sh x0 * R |-- |==> Q * R')%I.
 Proof.
-  intros; rewrite sepcon_assoc; eapply derives_trans; [apply (@atomic_commit CS) with
+  intros; rewrite sepcon_assoc; eapply derives_trans; [apply @atomic_commit with
       (R' := fun _ => R')|].
   - intros; iIntros "((my & R) & a)".
     iMod (Ha with "[$]") as (?) "[public a']".
@@ -150,7 +149,7 @@ Lemma sync_commit_same1 : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B ->
     |==> (my_half g sh x0 * public_half g x1 -* |==> (EX y, b x y * R')))%I)%I),
   (atomic_shift a Ei Eo b (fun _ => Q) * my_half g sh x0 * R |-- |==> Q * R')%I.
 Proof.
-  intros; rewrite sepcon_assoc; eapply derives_trans; [apply (@atomic_commit CS) with
+  intros; rewrite sepcon_assoc; eapply derives_trans; [apply @atomic_commit with
       (R' := fun _ => R')|].
   intros; iIntros "((my & R) & a)".
   iMod (Ha with "[$]") as (?) "[public a']".
@@ -199,7 +198,7 @@ Lemma two_sync_commit : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> m
   (atomic_shift a Ei Eo b Q * my_half g1 sh1 x1 * my_half g2 sh2 x2 * R |-- |==> EX y, Q y * R' y)%I.
 Proof.
   intros; rewrite -> 2sepcon_assoc.
-  apply (@atomic_commit CS) with (R' := fun y => R' y).
+  apply @atomic_commit with (R' := fun y => R' y).
   intros; iIntros "((my1 & my2 & R) & a)".
   iMod (Ha with "[$]") as (??) "((public1 & public2) &  a')".
   iPoseProof (ref_sub(P := P) with "[$my1 $public1]") as "%".
@@ -219,7 +218,7 @@ Lemma two_sync_commit1 : forall {A B} {inv_names : invG} a Ei Eo (b : A -> B -> 
   (atomic_shift a Ei Eo b (fun _ => Q) * my_half g1 sh1 x1 * my_half g2 sh2 x2 * R |-- |==> Q * R')%I.
 Proof.
   intros; rewrite -> 2sepcon_assoc.
-  eapply derives_trans; [apply (@atomic_commit CS) with (R' := fun _ => R')|].
+  eapply derives_trans; [apply @atomic_commit with (R' := fun _ => R')|].
   intros; iIntros "((my1 & my2 & R) & a)".
   iMod (Ha with "[$]") as (??) "((public1 & public2) &  a')".
   iPoseProof (ref_sub(P := P) with "[$my1 $public1]") as "%".

--- a/atomics/verif_hashtable_atomic.v
+++ b/atomics/verif_hashtable_atomic.v
@@ -440,7 +440,7 @@ Proof.
     { rewrite !sepcon_assoc; apply sepcon_derives; [|cancel].
       iIntros ">AS".
       iDestruct ("AS") as (HT) "[hashtable Hclose]"; simpl.
-      iDestruct "hashtable" as (T) "((% & excl) & entries)". (* why is this slow now? *)
+      iDestruct "hashtable" as (T) "((% & excl) & entries)".
       rewrite -> @iter_sepcon_Znth' with (d := Inhabitant_Z) (i := i1 mod size)
           by (rewrite -> ?Zlength_map, Zlength_upto, Z2Nat.id; lia).
       erewrite Znth_upto by (rewrite -> ?Zlength_upto, Z2Nat.id; lia).

--- a/concurrency/ghosts.v
+++ b/concurrency/ghosts.v
@@ -500,7 +500,7 @@ Section PVar.
 
 Global Program Instance nat_PCM: Ghost := { valid a := True; Join_G a b c := c = Nat.max a b }.
 Next Obligation.
-  exists (fun _ => O); auto; intros.
+  exists id; auto; intros.
   apply Nat.max_0_l.
 Defined.
 Next Obligation.

--- a/concurrency/ghosts.v
+++ b/concurrency/ghosts.v
@@ -34,7 +34,7 @@ Proof.
   exact own_alloc.
 Qed.
 
-Lemma own_dealloc : forall g (a : G) (pp : preds), own g a pp |-- |==> emp.
+Lemma own_dealloc : forall g (a : G) (pp : preds), own g a pp |-- emp.
 Proof.
   exact own_dealloc.
 Qed.
@@ -84,18 +84,16 @@ Qed.
 
 Lemma own_list_dealloc : forall {A} f (l : list A),
   (forall b, exists g a pp, f b |-- own g a pp) ->
-  iter_sepcon f l |-- |==> emp.
+  iter_sepcon f l |-- emp.
 Proof.
-  intros; induction l; simpl.
-  - apply bupd_intro.
-  - eapply derives_trans; [apply sepcon_derives, IHl|].
-    + destruct (H a) as (? & ? & ? & Hf).
-      eapply derives_trans; [apply Hf | apply own_dealloc].
-    + eapply derives_trans, bupd_mono; [apply bupd_sepcon | cancel].
+  intros; induction l; simpl; auto.
+  eapply derives_trans; [apply sepcon_derives, IHl | rewrite emp_sepcon; auto].
+  destruct (H a) as (? & ? & ? & Hf).
+  eapply derives_trans; [apply Hf | apply own_dealloc].
 Qed.
 
 Lemma own_list_dealloc' : forall {A} g a p (l : list A),
-  iter_sepcon (fun x => own (g x) (a x) (p x)) l |-- |==> emp.
+  iter_sepcon (fun x => own (g x) (a x) (p x)) l |-- emp.
 Proof.
   intros; apply own_list_dealloc.
   do 3 eexists; apply derives_refl.
@@ -379,7 +377,7 @@ Proof.
 Qed.
 
 Lemma part_ref_update : forall g sh a r a' r' pp
-  (Ha' : forall b, join a b r -> join a' b r'),
+  (Ha' : forall b, join a b r -> join a' b r' /\ (a = r -> a' = r')),
   own(RA := ref_PCM P) g (Some (sh, a), Some r) pp |-- |==>
   own(RA := ref_PCM P) g (Some (sh, a'), Some r') pp.
 Proof.
@@ -393,6 +391,7 @@ Proof.
       + destruct Hvalid as (? & ? & ? & ?); eexists; eauto.
       + inv Hvalid; apply join_sub_refl. }
     destruct (join_assoc Hx J) as (b & Jc & Jb%Ha').
+    destruct Jb as [Jb Heq].
     destruct (join_assoc (join_comm Jc) (join_comm Jb)) as (x' & Hx' & Hr').
     exists (Some (shx, x'), Some r'); repeat (split; auto); try constructor; simpl.
     + destruct Hvalid as (d & Hvalid); hnf in Hvalid.
@@ -403,12 +402,14 @@ Proof.
         eapply join_eq; [apply Ha'|]; eauto.
   - inv J1.
     exists (Some (sh, a'), Some r'); repeat split; simpl; auto; try constructor.
+    unfold completable in *.
     destruct Hvalid as (d & Hvalid); hnf in Hvalid.
     exists d; destruct d as [(shd, d)|]; hnf.
     + destruct Hvalid as (? & ? & ? & Hd); repeat (split; auto).
-    + inv Hvalid; f_equal.
-      symmetry; eapply core_identity.
-      apply join_comm, Ha', join_comm, core_unit.
+      eapply Ha'; auto.
+    + inv Hvalid. f_equal.
+      symmetry; eapply Ha'; auto.
+      apply join_comm, core_unit.
 Qed.
 
 Corollary ref_add : forall g sh a r b a' r' pp
@@ -419,6 +420,8 @@ Proof.
   intros; apply part_ref_update; intros c J.
   destruct (join_assoc (join_comm J) Hr) as (? & ? & ?).
   eapply join_eq in Ha; eauto; subst; auto.
+  split; auto; intros; subst.
+  eapply join_eq; eauto.
 Qed.
 
 End Reference.
@@ -500,8 +503,9 @@ Section PVar.
 
 Global Program Instance nat_PCM: Ghost := { valid a := True; Join_G a b c := c = Nat.max a b }.
 Next Obligation.
-  exists id; auto; intros.
-  apply Nat.max_0_l.
+  exists (id _); auto; intros.
+  - hnf. symmetry; apply Nat.max_id.
+  - eexists; eauto.
 Defined.
 Next Obligation.
   constructor.
@@ -524,7 +528,7 @@ Proof.
     split; [apply Nat.le_max_l | apply Nat.le_max_r].
   - hnf.
     rewrite Nat.max_l; auto.
-Defined.
+Qed.
 
 Lemma ghost_snap_join_N : forall v1 v2 p, ghost_snap v1 p * ghost_snap v2 p = ghost_snap (Nat.max v1 v2) p.
 Proof.
@@ -1001,8 +1005,10 @@ Qed.
 Global Program Instance map_disj_PCM : Ghost := { valid a := True; Join_G := map_disj_join }.
 Next Obligation.
   exists (fun _ => empty_map); auto; repeat intro.
-  simpl.
-  destruct (t k); auto.
+  - simpl.
+    destruct (t k); auto.
+  - exists empty_map; hnf.
+    intros; simpl; auto.
 Defined.
 Next Obligation.
   constructor.
@@ -1682,15 +1688,15 @@ Lemma wand_nonexpansive_l: forall P Q n,
 Proof.
   repeat intro.
   apply (nonexpansive_super_non_expansive (fun P => predicates_sl.wand P Q)).
-  split; intros ?? Hshift ??????.
+  split; intros ???? Hshift ??????.
   - eapply Hshift; eauto.
-    apply necR_level in H1; apply necR_level in H2.
-    apply join_level in H3 as [].
-    apply (H y0); auto; lia.
+    apply necR_level in H1; apply ext_level in H2; apply necR_level in H3.
+    apply join_level in H4 as [].
+    eapply (H y0); auto; lia.
   - eapply Hshift; eauto.
-    apply necR_level in H1; apply necR_level in H2.
-    apply join_level in H3 as [].
-    apply (H y0); auto; lia.
+    apply necR_level in H1; apply ext_level in H2; apply necR_level in H3.
+    apply join_level in H4 as [].
+    eapply (H y0); auto; lia.
 Qed.
 
 Lemma wand_nonexpansive_r: forall P Q n,
@@ -1698,15 +1704,15 @@ Lemma wand_nonexpansive_r: forall P Q n,
 Proof.
   repeat intro.
   apply (nonexpansive_super_non_expansive (fun Q => predicates_sl.wand P Q)).
-  split; intros ?? Hshift ??????.
-  - eapply Hshift in H4; eauto.
-    apply necR_level in H1; apply necR_level in H2.
-    apply join_level in H3 as [].
-    apply (H z); auto; lia.
-  - eapply Hshift in H4; eauto.
-    apply necR_level in H1; apply necR_level in H2.
-    apply join_level in H3 as [].
-    apply (H z); auto; lia.
+  split; intros ???? Hshift ??????.
+  - eapply Hshift in H5; eauto.
+    apply necR_level in H1; apply ext_level in H2; apply necR_level in H3.
+    apply join_level in H4 as [].
+    eapply (H z); auto; lia.
+  - eapply Hshift in H5; eauto.
+    apply necR_level in H1; apply ext_level in H2; apply necR_level in H3.
+    apply join_level in H4 as [].
+    eapply (H z); auto; lia.
 Qed.
 
 Lemma approx_bupd: forall P n, (approx n (own.bupd P) = (own.bupd (approx n P)))%logic.

--- a/concurrency/ghostsI.v
+++ b/concurrency/ghostsI.v
@@ -22,10 +22,8 @@ Proof.
   exact own_alloc.
 Qed.
 
-Lemma own_dealloc : forall g (a : G) (pp : preds), own g a pp |-- (|==> emp)%I.
-Proof.
-  exact own_dealloc.
-Qed.
+Instance own_dealloc g a pp : Affine (own g a pp) := own_dealloc.
+
 
 Lemma own_update : forall g a b pp, fp_update a b -> own g a pp |-- (|==> own g b pp)%I.
 Proof.
@@ -63,10 +61,10 @@ Proof.
   intros; apply own_list_dealloc'.
 Qed.
 
-(*Lemma own_persistent : forall g a p, join a a a -> Persistent (own g a p).
+Lemma own_persistent : forall g a p, a = core a -> Persistent (own g a p).
 Proof.
   exact own_persistent.
-Qed.*)
+Qed.
 
 End ghost.
 
@@ -105,12 +103,12 @@ Proof.
   exact snap_master_update1.
 Qed.
 
-(*Global Instance snap_persistent v p : Persistent (ghost_snap v p).
+Global Instance snap_persistent v p : Persistent (ghost_snap v p).
 Proof.
   apply own_persistent; hnf; simpl.
   rewrite !eq_dec_refl; split; auto.
   apply join_refl.
-Qed.*)
+Qed.
 
 End Snapshot.
 

--- a/concurrency/ghostsI.v
+++ b/concurrency/ghostsI.v
@@ -196,3 +196,6 @@ Proof.
 Qed.
 
 End GHist.
+
+(* speed up destructs of the form [% H] *)
+Existing Instance class_instances.into_sep_and_persistent_l.

--- a/concurrency/invariants.v
+++ b/concurrency/invariants.v
@@ -36,7 +36,7 @@ Context {inv_names : invG}.
 Global Instance agree_persistent g P : Persistent (agree g P : mpred).
 Proof.
   apply core_persistent; auto.
-Admitted.
+Qed.
 
 Global Instance inv_persistent i P : Persistent (invariant i P).
 Proof.
@@ -45,17 +45,8 @@ Qed.
 
 Global Instance inv_affine i P : Affine (invariant i P).
 Proof.
-(* apply _. unfold invariant.
-  apply @bi.exist_affine; intros.
-  apply @bi.sep_affine.
-
-2: { apply _.
-  Search Affine bi_exist.
-  constructor.
-  intros ? (g & ?).
-  (* this isn't true *)
-Abort.*)
-Admitted.
+  apply _.
+Qed.
 
 Lemma wsat_alloc : forall P, wsat * |> P |-- (|==> wsat * EX i : _, invariant i P)%I.
 Proof.
@@ -313,6 +304,21 @@ Qed.
 
 (* Consider putting rules for invariants and fancy updates in msl (a la ghost_seplog), and proofs
    in veric (a la own). *)
+
+(*
+
+need to do namespaces if we want to use iInv!
+
+Global Instance into_inv_inv N P : IntoInv (invariant N P) N := {}.
+
+Global Instance into_acc_inv N P E:
+  IntoAcc (X := unit) (inv N P)
+          (↑N ⊆ E) True (fupd E (E ∖ ↑N)) (fupd (E ∖ ↑N) E)
+          (λ _ : (), (▷ P)%I) (λ _ : (), (▷ P)%I) (λ _ : (), None).
+Proof.
+  rewrite inv_eq /IntoAcc /accessor bi.exist_unit.
+  iIntros (?) "#Hinv _". iApply "Hinv"; done.
+Qed.*)
 
 End Invariants.
 

--- a/concurrency/invariants.v
+++ b/concurrency/invariants.v
@@ -48,6 +48,11 @@ Proof.
   apply _.
 Qed.
 
+Lemma invariant_dup : forall i P, invariant i P = invariant i P * invariant i P.
+Proof.
+  intros; apply pred_ext; rewrite <- (bi.persistent_sep_dup (invariant i P)); auto.
+Qed.
+
 Lemma wsat_alloc : forall P, wsat * |> P |-- (|==> wsat * EX i : _, invariant i P)%I.
 Proof.
   intros; iIntros "[wsat P]".

--- a/concurrency/invariants.v
+++ b/concurrency/invariants.v
@@ -8,7 +8,7 @@ Require Import VST.veric.bi.
 Require Import VST.msl.sepalg.
 Require Import List.
 
-Definition cored : mpred := own.cored.
+(*Definition cored : mpred := own.cored.
 
 Lemma cored_dup : forall P, P && cored |-- (P && cored) * (P && cored).
 Proof.
@@ -48,7 +48,7 @@ Qed.
 Lemma emp_cored : (emp |-- cored)%I.
 Proof.
   constructor; apply own.emp_cored.
-Qed.
+Qed.*)
 
 Lemma iter_sepcon_eq : forall A, @invariants.iter_sepcon A = @iter_sepcon mpred A _ _.
 Proof.
@@ -74,6 +74,29 @@ Qed.
 Section Invariants.
 
 Context {inv_names : invG}.
+
+Global Instance inv_persistent i P : Persistent (invariant i P).
+Proof.
+  unfold Persistent, invariant.
+  constructor.
+  intros ? (g & ?).
+
+  (* need to prove that the snap is present in the core,
+     which is currently not true *)
+Abort.
+
+Global Instance inv_affine i P : Affine (invariant i P).
+Proof.
+  unfold Affine, invariant.
+  constructor.
+  intros ? (g & ?).
+  (* this isn't true *)
+Abort.
+(* Even if we could prove that inv is persistent, it still wouldn't
+   be intuitionistic (which is what Iris needs for its contexts),
+   because our emp distinguishes between presence and absence of
+   duplicable ghost state. Not sure we can change emp to fix that,
+   but maybe we can. *)
 
 Lemma invariant_dup : forall i P, invariant i P = invariant i P * invariant i P.
 Proof.

--- a/concurrency/invariants.v
+++ b/concurrency/invariants.v
@@ -8,48 +8,6 @@ Require Import VST.veric.bi.
 Require Import VST.msl.sepalg.
 Require Import List.
 
-(*Definition cored : mpred := own.cored.
-
-Lemma cored_dup : forall P, P && cored |-- (P && cored) * (P && cored).
-Proof.
-  constructor; apply own.cored_dup.
-Qed.
-
-Lemma cored_dup_cored : forall P, P && cored |-- ((P && cored) * (P && cored)) && cored.
-Proof.
-  constructor; apply cored_dup_cored.
-Qed.
-
-Lemma cored_duplicable : cored = cored * cored.
-Proof.
-  apply own.cored_duplicable.
-Qed.
-
-Lemma own_cored: forall {RA: Ghost} g a pp, join a a a -> own g a pp |-- cored.
-Proof.
-  intros; constructor; apply own.own_cored; auto.
-Qed.
-
-Lemma cored_sepcon: forall P Q, (P && cored) * (Q && cored) |-- (P * Q) && cored.
-Proof.
-  constructor; apply cored_sepcon.
-Qed.
-
-Lemma cored_dup_gen : forall P, (P |-- cored) -> P |-- P * P.
-Proof.
-  unseal_derives; exact cored_dup_gen.
-Qed.
-
-Lemma cored_emp: (cored |-- (|==> emp)%I)%I.
-Proof.
-  constructor; apply own.cored_emp.
-Qed.
-
-Lemma emp_cored : (emp |-- cored)%I.
-Proof.
-  constructor; apply own.emp_cored.
-Qed.*)
-
 Lemma iter_sepcon_eq : forall A, @invariants.iter_sepcon A = @iter_sepcon mpred A _ _.
 Proof.
   intros; extensionality f; extensionality l.
@@ -75,38 +33,29 @@ Section Invariants.
 
 Context {inv_names : invG}.
 
+Global Instance agree_persistent g P : Persistent (agree g P : mpred).
+Proof.
+  apply core_persistent; auto.
+Admitted.
+
 Global Instance inv_persistent i P : Persistent (invariant i P).
 Proof.
-  unfold Persistent, invariant.
-  constructor.
-  intros ? (g & ?).
-
-  (* need to prove that the snap is present in the core,
-     which is currently not true *)
-Abort.
+  apply _.
+Qed.
 
 Global Instance inv_affine i P : Affine (invariant i P).
 Proof.
-  unfold Affine, invariant.
+(* apply _. unfold invariant.
+  apply @bi.exist_affine; intros.
+  apply @bi.sep_affine.
+
+2: { apply _.
+  Search Affine bi_exist.
   constructor.
   intros ? (g & ?).
   (* this isn't true *)
-Abort.
-(* Even if we could prove that inv is persistent, it still wouldn't
-   be intuitionistic (which is what Iris needs for its contexts),
-   because our emp distinguishes between presence and absence of
-   duplicable ghost state. Not sure we can change emp to fix that,
-   but maybe we can. *)
-
-Lemma invariant_dup : forall i P, invariant i P = invariant i P * invariant i P.
-Proof.
-  exact invariant_dup.
-Qed.
-
-Lemma invariant_cored : forall i P, invariant i P |-- cored.
-Proof.
-  constructor; apply invariant_cored.
-Qed.
+Abort.*)
+Admitted.
 
 Lemma wsat_alloc : forall P, wsat * |> P |-- (|==> wsat * EX i : _, invariant i P)%I.
 Proof.
@@ -231,7 +180,7 @@ Proof.
     erewrite nth_map' with (d' := 0) in H0 by (rewrite upto_length; lia).
     erewrite nth_upto in H0 by lia.
     destruct (Znth (Z.of_nat i) lb); inv H0; iPureIntro; eauto. }
-  iMod (@own_dealloc (snap_PCM(ORD := list_order _)) with "snap").
+  iDestruct "snap" as "_".
   iModIntro.
   destruct Hi as (? & ? & b & Hi).
   assert (nth i lb None = Some b) as Hi' by (rewrite <- nth_Znth' in Hi; auto).
@@ -303,7 +252,7 @@ Proof.
     erewrite nth_map' with (d' := 0) in H0 by (rewrite upto_length; lia).
     erewrite nth_upto in H0 by lia.
     destruct (Znth (Z.of_nat i) lb); inv H0; eauto. }
-  iMod (@own_dealloc (snap_PCM(ORD := list_order _)) with "snap").
+  iDestruct "snap" as "_".
   iModIntro.
   destruct Hi as (? & ? & b & Hi).
   assert (nth i lb None = Some b) as Hi' by (rewrite <- nth_Znth' in Hi; auto).
@@ -360,11 +309,6 @@ Proof.
     intro; subst.
     apply in_app in Hin as [?%In_sublist_upto | ?%In_sublist_upto]; lia.
   - unfold Ensembles.In; auto.
-Qed.
-
-Lemma invariant_dealloc : forall i P, invariant i P |-- |==> emp.
-Proof.
-  constructor; apply invariant_dealloc.
 Qed.
 
 (* Consider putting rules for invariants and fancy updates in msl (a la ghost_seplog), and proofs

--- a/concurrency/semax_conc.v
+++ b/concurrency/semax_conc.v
@@ -877,7 +877,8 @@ variables [globals].
 For now, the specification of the spawned function has to be exactly
 of the form that you can see below (inside the "match ...").
 Cao Qinxiang is working on a notion of sub-specification that might
-enable us to have smoother specifications.
+enable us to have smoother specifications. (Now that Lennart has added
+this, can we make it better? -WM)
 
 The postcondition might not be emp, so we have potential memory leaks
 when a thread exists (those maps are still handled by the concurrent
@@ -913,7 +914,7 @@ Definition spawn_pre :=
                PROP ()
                (*(LOCALx (temp _y y :: gvars (gv x) :: nil)*) PARAMS (y) GLOBALS (gv x)
                (SEP   (pre x y)) (*)*)
-             POST [tptr tvoid]
+             POST [tptr tvoid] (* should be tvoid, since no one sees its return value *)
                PROP  ()
                LOCAL ()
                SEP   ())

--- a/concurrency/semax_conc.v
+++ b/concurrency/semax_conc.v
@@ -78,26 +78,26 @@ Qed.
 Lemma selflock'_eq Q sh p : selflock' Q sh p =
   selflock_fun Q sh p (selflock' Q sh p).
 Proof.
-  apply HORec_fold_unfold, prove_HOcontractive.
+  apply HORec_fold_unfold, prove_HOcontractive'.
   intros P1 P2 u.
   apply subp_sepcon; [ apply subp_refl | ].
-  rewrite <- subp_later.
+  eapply derives_trans, subp_later1.
   constructor; repeat intro.
-  match goal with |- app_pred (?P >=> ?Q)%logic ?a => change (subtypes.fash (P --> Q) a) end.
+  match goal with |- app_pred (?P >=> ?Q)%logic ?a => change (subtypes.fash (P --> Q)%pred a) end.
   unfold lock_inv; repeat intro.
-  destruct H3 as (b & ofs & ? & Hl & ?); exists b, ofs; split; auto; split; auto.
+  destruct H4 as (b & ofs & ? & Hl); exists b, ofs; split; auto.
   intro l; specialize (Hl l); simpl in *.
   if_tac; auto.
   destruct Hl as [rsh Hl]; exists rsh; rewrite Hl; repeat f_equal.
   extensionality.
-  specialize (H tt); rewrite <- eqp_later in H.
+  specialize (H tt).
   specialize (H _ H0).
-  apply necR_level in H2.
+  apply necR_level in H2. apply ext_level in H3.
   apply predicates_hered.pred_ext; intros ? []; split; auto.
   - destruct (H a0) as [X _]; [lia|].
-    specialize (X _ (necR_refl _)); auto.
+    specialize (X _ _ (necR_refl _) (ext_refl _)); auto.
   - destruct (H a0) as [_ X]; [lia|].
-    specialize (X _ (necR_refl _)); auto.
+    specialize (X _ _ (necR_refl _) (ext_refl _)); auto.
 Qed.
 
 Lemma selflock_eq Q sh p : selflock Q sh p = (Q * |>lock_inv sh p (selflock Q sh p))%logic.
@@ -147,7 +147,7 @@ Lemma lock_inv_nonexpansive2 : forall {A} (P Q : A -> mpred) sh p x, (ALL x : _,
 Proof.
   intros.
   apply allp_left with x.
-  rewrite <- eqp_later; apply later_derives.
+  eapply derives_trans, eqp_later1; apply later_derives.
   apply nonexpansive_entail; apply nonexpansive_lock_inv.
 Qed.
 
@@ -261,9 +261,9 @@ Lemma fash_equiv_approx: forall n (R: pred rmap),
   (|> (R <=> approx n R))%pred n.
 Proof.
   intros.
-  intros m ? x ?; split; intros y ? ?.
+  intros m ? x ?; split; intros ? y ? ? ?.
   + apply approx_lt; auto.
-    apply necR_level in H1.
+    apply necR_level in H1. apply ext_level in H2.
     apply later_nat in H; lia.
   + eapply approx_p; eauto.
 Qed.

--- a/concurrency/semax_conc_pred.v
+++ b/concurrency/semax_conc_pred.v
@@ -161,7 +161,7 @@ Program Definition weak_exclusive_mpred (P: mpred): mpred :=
 
 Lemma corable_weak_exclusive R : seplog.corable (weak_exclusive_mpred R).
 Proof.
-  apply assert_lemmas.corable_unfash.
+  apply assert_lemmas.corable_unfash, _.
 Qed.
 
 Lemma exclusive_mpred_nonexpansive:
@@ -351,7 +351,6 @@ Proof.
   apply @const_nonexpansive.
 
   unfold LKspec.
-  apply conj_nonexpansive, const_nonexpansive.
   apply forall_nonexpansive; intros.
   hnf; intros.
   intros n ?.
@@ -360,30 +359,32 @@ Proof.
     clear - H.
     intros; specialize (H y H0).
     destruct H.
-    specialize (H y). spec H; [auto |].
-    specialize (H1 y). spec H1; [auto |].
+    specialize (H _ _ (necR_refl _) (ext_refl _)).
+    specialize (H1 _ _ (necR_refl _) (ext_refl _)).
     tauto.
   }
   simpl; split; intros.
   + if_tac; auto.
-    destruct H3 as [p0 ?].
+    destruct H4 as [p0 ?].
     exists p0.
-    rewrite H3; f_equal.
+    rewrite H4; f_equal.
     f_equal.
     extensionality ts; clear ts.
-    clear H3 H4 p0.
+    clear H4 H5 p0.
+    apply ext_level in H3 as <-.
     apply predicates_hered.pred_ext; hnf; intros ? [? ?]; split; auto.
     - apply necR_level in H2.
       rewrite <- H0 by lia; auto.
     - apply necR_level in H2.
       rewrite H0 by lia; auto.
   + if_tac; auto.
-    destruct H3 as [p0 ?].
+    destruct H4 as [p0 ?].
     exists p0.
-    rewrite H3; f_equal.
+    rewrite H4; f_equal.
     f_equal.
     extensionality ts; clear ts.
-    clear H3 H4 p0.
+    clear H4 H5 p0.
+    apply ext_level in H3 as <-.
     apply predicates_hered.pred_ext; hnf; intros ? [? ?]; split; auto.
     - apply necR_level in H2.
       rewrite H0 by lia; auto.
@@ -397,7 +398,7 @@ Proof.
   unfold weak_rec_inv, nonexpansive; intros.
   apply eqp_unfash, eqp_eqp; auto.
   apply eqp_sepcon; [apply eqp_refl|].
-  rewrite <- subtypes.eqp_later.
+  eapply predicates_hered.derives_trans, subtypes.eqp_later1.
   eapply predicates_hered.derives_trans, predicates_hered.now_later.
   apply nonexpansive_lock_inv.
 Qed.
@@ -408,7 +409,7 @@ Proof.
   unfold weak_rec_inv, nonexpansive; intros.
   apply eqp_unfash, eqp_eqp; [apply eqp_refl|].
   apply eqp_sepcon; auto.
-  rewrite <- subtypes.eqp_later.
+  eapply predicates_hered.derives_trans, subtypes.eqp_later1.
   eapply predicates_hered.derives_trans, predicates_hered.now_later.
   apply eqp_refl.
 Qed.
@@ -418,7 +419,7 @@ Lemma exclusive_weak_exclusive: forall R,
   TT |-- weak_exclusive_mpred R.
 Proof.
   intros.
-  constructor; intros ???????.
+  constructor; intros ?????????.
   eapply H; auto.
 Qed.
 
@@ -428,7 +429,7 @@ Lemma rec_inv_weak_rec_inv: forall sh v Q R,
 Proof.
   intros.
   unfold weak_rec_inv.
-  constructor. intros ? _ ??; split; intros ???.
+  constructor. intros ? _ ??; split; intros ?????.
   - rewrite H in * |-; auto.
   - rewrite H; auto.
 Qed.

--- a/concurrency/semax_conc_pred.v
+++ b/concurrency/semax_conc_pred.v
@@ -164,62 +164,6 @@ Proof.
   apply assert_lemmas.corable_unfash.
 Qed.
 
-(* up *)
-Lemma eqp_unfash : forall G P Q, predicates_hered.derives G (P <=> Q)%pred ->
-  predicates_hered.derives G ((!P : mpred) <=> !Q)%pred.
-Proof.
-  intros.
-  eapply predicates_hered.derives_trans; [apply H|].
-  intros ????.
-  split; intros ???; eapply H0; eauto; apply necR_level in H2; simpl; unfold natLevel; lia.
-Qed.
-
-Lemma eqp_subp_subp : forall G (P Q R S : mpred),
-  predicates_hered.derives G (P <=> R)%pred -> predicates_hered.derives G (Q <=> S)%pred ->
-  predicates_hered.derives G ((P >=> Q) <=> (R >=> S))%pred.
-Proof.
-  intros.
-  change (subtypes.fash(NA := ag_nat)) with (fash(RecIndir := TrivRecIndir)); rewrite fash_triv.
-  apply predicates_hered.andp_right;
-    rewrite <- (predicates_hered.imp_andp_adjoint);
-    eapply subtypes.subp_trans, subtypes.subp_trans.
-  - apply predicates_hered.andp_left1, eqp_subp2, H.
-  - apply predicates_hered.andp_left2, predicates_hered.derives_refl.
-  - apply predicates_hered.andp_left1, subtypes.eqp_subp, H0.
-  - apply predicates_hered.andp_left1, subtypes.eqp_subp, H.
-  - apply predicates_hered.andp_left2, predicates_hered.derives_refl.
-  - apply predicates_hered.andp_left1, eqp_subp2, H0.
-Qed.
-
-Lemma eqp_trans : forall G (P Q R : mpred),
-  predicates_hered.derives G (P <=> Q)%pred -> predicates_hered.derives G (Q <=> R)%pred ->
-  predicates_hered.derives G (P <=> R)%pred.
-Proof.
-  intros.
-  eapply subp_eqp; eapply subtypes.subp_trans; eapply subtypes.eqp_subp.
-  - apply H.
-  - apply H0.
-  - rewrite eqp_comm; apply H0.
-  - rewrite eqp_comm; apply H.
-Qed.
-
-Lemma eqp_eqp : forall G (P Q R S : mpred),
-  predicates_hered.derives G (P <=> R)%pred -> predicates_hered.derives G (Q <=> S)%pred ->
-  predicates_hered.derives G ((P <=> Q) <=> (R <=> S))%pred.
-Proof.
-  intros.
-  change (subtypes.fash(NA := ag_nat)) with (fash(RecIndir := TrivRecIndir)); rewrite fash_triv.
-  apply predicates_hered.andp_right;
-    rewrite <- (predicates_hered.imp_andp_adjoint);
-    eapply eqp_trans, eqp_trans.
-  - apply predicates_hered.andp_left1; rewrite eqp_comm; apply H.
-  - apply predicates_hered.andp_left2, predicates_hered.derives_refl.
-  - apply predicates_hered.andp_left1, H0.
-  - apply predicates_hered.andp_left1, H.
-  - apply predicates_hered.andp_left2, predicates_hered.derives_refl.
-  - apply predicates_hered.andp_left1; rewrite eqp_comm; apply H0.
-Qed.
-
 Lemma exclusive_mpred_nonexpansive:
   nonexpansive weak_exclusive_mpred.
 Proof.

--- a/floyd/data_at_lemmas.v
+++ b/floyd/data_at_lemmas.v
@@ -112,7 +112,6 @@ apply exp_right with v';
 unfold address_mapsto;
 apply exp_left; intro bl; 
 apply exp_right with bl;
-apply andp_derives; auto;
 apply prop_andp_left; intros [? [? ?]];
 destruct bl as [| ? [|]]; try solve [inv H];
 (rewrite prop_true_andp; [auto | 
@@ -216,7 +215,7 @@ destruct (zlt i (Zlength bytes)).
  unfold res_predicates.address_mapsto; simpl;
  f_equal;
  extensionality bl;
- f_equal; f_equal; f_equal;
+ f_equal; f_equal;
  apply prop_ext; intuition;
  destruct bl as [| ? [|]]; inv H3;
  destruct m; inv H; reflexivity.
@@ -225,7 +224,6 @@ forget (Znth i bytes) as c.
 unfold res_predicates.address_mapsto; simpl.
 f_equal.
 extensionality bl.
-f_equal.
 f_equal.
 f_equal.
  apply prop_ext; intuition;

--- a/floyd/field_at.v
+++ b/floyd/field_at.v
@@ -1760,12 +1760,7 @@ intros.
 destruct q; auto.
 eapply derives_trans; try eassumption.
 simpl valid_pointer.
-match goal with
-| |- context [Int64.zero] =>
-    constructor; change (@predicates_hered.derives compcert_rmaps.R.rmap _ predicates_hered.FF (predicates_hered.prop (i = Int64.zero)))
-| |- context [Int.zero] =>
-    constructor; change (@predicates_hered.derives compcert_rmaps.R.rmap _ predicates_hered.FF (predicates_hered.prop (i = Int.zero)))
-end.
+constructor.
 intros ? ?. contradiction H0.
 rewrite offset_val_zero_Vptr in H.
 auto.

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -823,7 +823,7 @@ Proof.
   rewrite <- !sepcon_andp_prop'.
   specialize (H rho).
   eapply derives_trans; [apply sepcon_derives; [exact H1 | apply derives_refl] |].
-  constructor; apply (@predicates_sl.extend_sepcon _ _ _ _ compcert_rmaps.R.Age_rmap); auto.
+  constructor; apply predicates_sl.extend_sepcon; auto.
 Qed.
 
 Ltac delete_FRZR_from_SEP :=

--- a/floyd/forward_lemmas.v
+++ b/floyd/forward_lemmas.v
@@ -105,11 +105,11 @@ split3.
 { clear Hyp3. red; intros j fd J. destruct J; [ inv H | auto].
   exists b; split; trivial. }
 intros. specialize (Hyp3 _ Gfs Gffp n).
-intros v sig cc A P Q m NM CL. simpl in CL. red in CL.
+intros v sig cc A P Q ? m NM EM CL. simpl in CL. red in CL.
 destruct CL as [j [Pne [Qne [J GJ]]]]. simpl in J.
 rewrite PTree.gsspec in J.
 destruct (peq j id); subst.
-+ specialize (Hyp3 v sig cc A P Q m NM).
++ specialize (Hyp3 v sig cc A P Q _ _ NM EM).
   clear Hyp3.
   destruct GJ as [bb [BB VV]]. inv J. 
   assert (bb = b). 
@@ -122,7 +122,7 @@ destruct (peq j id); subst.
   destruct ifunc; trivial.
   destruct ifunc; trivial.
   intros until b2; intros Impos; inv Impos.
-+ apply (Hyp3 v sig cc A P Q m NM).
++ apply (Hyp3 v sig cc A P Q _ _ NM EM).
   simpl. exists j; do 2 eexists; split. apply J. apply GJ.
 Qed. 
 

--- a/msl/age_sepalg.v
+++ b/msl/age_sepalg.v
@@ -271,7 +271,7 @@ intros.
 unfold identity in *.
 intros.
 destruct (unage_join _ H1 H) as [y [? [? [? ?]]]].
-specialize ( H0 y x H2).
+specialize (H0 y x H2).
 subst.
 unfold age in *. congruence.
 Qed.

--- a/msl/age_sepalg.v
+++ b/msl/age_sepalg.v
@@ -7,7 +7,7 @@ Require Import VST.msl.ageable.
 Require Import VST.msl.sepalg.
 Require Import VST.msl.sepalg_generators.
 
-Class Age_alg (A:Type) {JOIN: Join A}{as_age : ageable A} :=
+Class Age_alg (A:Type) {JOIN: Join A}{as_age : ageable A}{SA: Sep_alg A} :=
 mkAge {
   age1_join : forall x {y z x'}, join x y z -> age x x' ->
     exists y':A, exists z':A, join x' y' z' /\ age y y' /\ age z z'
@@ -17,9 +17,10 @@ mkAge {
     exists y:A, exists z:A, join x y z /\ age y y' /\ age z z'
 ; unage_join2 : forall z {x' y' z'}, join x' y' z' -> age z z' ->
     exists x:A, exists y:A, join x y z /\ age x x' /\ age y y'
+; age_core : forall x y : A, age x y -> age (core x) (core y)
 }.
 
-Lemma age1_None_joins {A}{JA: Join A}{PA: Perm_alg A}{agA: ageable A}{XA: Age_alg A}: forall phi1 phi2, joins phi1 phi2 -> age1 phi1 = None -> age1 phi2 = None.
+Lemma age1_None_joins {A}{JA: Join A}{PA: Perm_alg A}{agA: ageable A}{SA: Sep_alg A}{XA: Age_alg A}: forall phi1 phi2, joins phi1 phi2 -> age1 phi1 = None -> age1 phi2 = None.
 Proof.
   intros.
   destruct H.
@@ -28,7 +29,7 @@ Proof.
   unfold age in *; rewrite H0 in H3; inv H3.
 Qed.
 
-Lemma age1_joins_eq {A} {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{XA: Age_alg A}: forall phi1 phi2,
+Lemma age1_joins_eq {A} {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{SA: Sep_alg A}{XA: Age_alg A}: forall phi1 phi2,
         joins phi1 phi2 ->
         forall phi1', age1 phi1 = Some phi1' ->
         forall phi2', age1 phi2 = Some phi2' ->
@@ -47,6 +48,7 @@ Section BIJECTION.
   Variable PA: Perm_alg A.
   Variable ag: ageable A.
   Variable bijAB: bijection A B.
+  Variable SA: Sep_alg A.
   Variable asa : Age_alg A.
 
   Existing Instance PA.
@@ -55,7 +57,7 @@ Section BIJECTION.
 
 (*  Instance PA_B:  @Perm_alg B (Join_bij _ _ _ bijAB ) := @Perm_bij A JA PA B bijAB. *)
 
-  Theorem asa_bijection : @Age_alg B (Join_bij _ _ _ bijAB) agB.
+  Theorem asa_bijection : @Age_alg B (Join_bij _ _ _ bijAB) agB (Sep_bij _ _ _ bijAB).
   Proof.
     constructor; unfold age, Join_bij; simpl;     destruct bijAB as [f g fg gf]; simpl  in *; intros.
 
@@ -102,6 +104,11 @@ Section BIJECTION.
     repeat rewrite gf.
     rewrite H2; rewrite H3.
     repeat rewrite fg; split; auto.
+
+    (* core *)
+    rewrite gf. destruct (age1 (g x)) eqn: Hage; [|discriminate].
+    inv H. apply age_core in Hage; rewrite Hage.
+    rewrite gf; reflexivity.
   Qed.
 End BIJECTION.
 
@@ -109,13 +116,15 @@ Section PROD.
   Variable A : Type.
   Variable J_A: Join A.
   Variable saA : Perm_alg A.
+  Variable SA : Sep_alg A.
   Variable agA : ageable A.
   Variable B: Type.
   Variable J_B: Join B.
   Variable saB : Perm_alg B.
+  Variable SB : Sep_alg B.
   Variable asa : Age_alg A.
 
-  Theorem asa_prod : @Age_alg (prod A B) _ (ag_prod A B agA).
+  Theorem asa_prod : @Age_alg (prod A B) _ (ag_prod A B agA) (Sep_prod SA SB).
   Proof.
     constructor; unfold age; simpl; unfold Join_prod.
 
@@ -150,6 +159,12 @@ Section PROD.
     destruct (unage_join2 _ H H1) as [xa [ya [? [? ?]]]].
     exists (xa,xb'); exists (ya,yb'); simpl.
     rewrite H3; rewrite H4; repeat split; auto.
+
+    (* core *)
+    intros (?, ?) ?; simpl.
+    destruct (age1 a) eqn: Hage; [|discriminate].
+    intros X; inv X.
+    apply age_core in Hage; rewrite Hage. reflexivity.
   Qed.
 End PROD.
 
@@ -157,14 +172,16 @@ Section PROD'.
   Variable A : Type.
   Variable J_A: Join A.
   Variable saA : Perm_alg A.
+  Variable SA : Sep_alg A.
   Variable B: Type.
   Variable J_B: Join B.
   Variable saB : Perm_alg B.
+  Variable SB : Sep_alg B.
   Variable agB : ageable B.
   Variable asb : Age_alg B.
 
 
-  Theorem asa_prod' : @Age_alg (prod A B) _ (ag_prod' A B agB).
+  Theorem asa_prod' : @Age_alg (prod A B) _ (ag_prod' A B agB) (Sep_prod SA SB).
   Proof.
     constructor; unfold age; simpl; unfold Join_prod.
 
@@ -199,11 +216,17 @@ Section PROD'.
     destruct (unage_join2 _ H0 H1) as [xb [yb [? [? ?]]]].
     exists (xa',xb); exists (ya',yb); simpl.
     rewrite H3; rewrite H4; repeat split; auto.
+
+    (* core *)
+    intros (?, ?) ?; simpl.
+    destruct (age1 b) eqn: Hage; [|discriminate].
+    intros X; inv X.
+    apply age_core in Hage; rewrite Hage. reflexivity.
   Qed.
 End PROD'.
 
 
-Lemma joins_fashionR {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{XA: Age_alg A} : forall x y,
+Lemma joins_fashionR {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{SA: Sep_alg A}{XA: Age_alg A} : forall x y,
   joins x y -> fashionR x y.
 Proof.
   pose proof I.
@@ -253,7 +276,7 @@ subst.
 unfold age in *. congruence.
 Qed.
 
-Lemma age_comparable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A} {agA: ageable A}{asaA: Age_alg A}:
+Lemma age_comparable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{DA: Flat_alg A} {agA: ageable A}{asaA: Age_alg A}:
     forall phi1 phi2 phi1' phi2', age phi1 phi1' -> age phi2 phi2' ->
       comparable phi1 phi2 -> comparable phi1' phi2'.
 Proof.
@@ -269,7 +292,7 @@ Proof.
   split; apply join_comm; auto.
 Qed.
 
-  Lemma asa_nat : @Age_alg nat (Join_equiv nat) ag_nat.
+  Lemma asa_nat : @Age_alg nat (Join_equiv nat) ag_nat _.
   Proof.
     constructor.
     repeat intro. hnf in H; subst; auto.
@@ -284,6 +307,7 @@ Qed.
     exists x; exists x. intuition.
     intros. destruct H; subst.
     exists z; exists z; intuition.
+    intros; simpl; auto.
   Qed.
 
 Lemma nec_identity {A} `{asaA: Age_alg A}: forall phi phi', necR phi phi'->
@@ -291,6 +315,25 @@ Lemma nec_identity {A} `{asaA: Age_alg A}: forall phi phi', necR phi phi'->
 Proof.
   induction 1; auto.
   apply age_identity; auto.
+Qed.
+
+Lemma later_join2 {A} `{asaA : Age_alg A}: forall {x y z z' : A},
+       join x y z ->
+       laterR z z' ->
+       exists x',
+         exists y',
+           join x' y' z' /\ laterR x x' /\ laterR y y'.
+Proof.
+intros.
+revert x y H; induction H0; intros.
+edestruct (age1_join2) as [x' [y' [? [? ?]]]]; eauto.
+exists x'; exists y'; split; auto.
+split; constructor 1; auto.
+destruct (IHclos_trans1 _ _ H) as [x' [y' [? [? ?]]]].
+destruct (IHclos_trans2 _ _ H0) as [x'' [y'' [? [? ?]]]].
+exists x''; exists y''.
+split; auto.
+split; econstructor 2; eauto.
 Qed.
 
 Lemma nec_join2 {A} `{asaA : Age_alg A}: forall {x y z z' : A},
@@ -301,16 +344,28 @@ Lemma nec_join2 {A} `{asaA : Age_alg A}: forall {x y z z' : A},
            join x' y' z' /\ necR x x' /\ necR y y'.
 Proof.
 intros.
-revert x y H; induction H0; intros.
-edestruct (age1_join2) as [x' [y' [? [? ?]]]]; eauto.
-exists x'; exists y'; split; auto.
+apply nec_refl_or_later in H0 as [|]; [subst; eauto|].
+eapply later_join2 in H0 as (? & ? & ? & ? & ?); eauto.
+do 3 eexists; eauto; split; apply laterR_necR; auto.
+Qed.
+
+Lemma later_join {A} `{asaA : Age_alg A}: forall {x y z x' : A},
+       join x y z ->
+       laterR x x' ->
+       exists y' ,
+         exists z' ,
+           join x' y' z' /\ laterR y y' /\ laterR z z'.
+Proof.
+intros.
+revert y z H; induction H0; intros.
+edestruct age1_join as [y' [z' [? [? ?]]]]; eauto.
+exists y'; exists z'; split; auto.
 split; constructor 1; auto.
-exists x0; exists y; split; auto.
-destruct (IHclos_refl_trans1 _ _ H) as [x' [y' [? [? ?]]]].
-destruct (IHclos_refl_trans2 _ _ H0) as [x'' [y'' [? [? ?]]]].
-exists x''; exists y''.
+destruct (IHclos_trans1 _ _ H) as [y' [z' [? [? ?]]]].
+destruct (IHclos_trans2 _ _ H0) as [y'' [z'' [? [? ?]]]].
+exists y''; exists z''.
 split; auto.
-split; econstructor 3; eauto.
+split; econstructor 2; eauto.
 Qed.
 
 Lemma nec_join {A} `{asaA : Age_alg A}: forall {x y z x' : A},
@@ -321,16 +376,9 @@ Lemma nec_join {A} `{asaA : Age_alg A}: forall {x y z x' : A},
            join x' y' z' /\ necR y y' /\ necR z z'.
 Proof.
 intros.
-revert y z H; induction H0; intros.
-edestruct age1_join as [y' [z' [? [? ?]]]]; eauto.
-exists y'; exists z'; split; auto.
-split; constructor 1; auto.
-exists y; exists z; split; auto.
-destruct (IHclos_refl_trans1 _ _ H) as [y' [z' [? [? ?]]]].
-destruct (IHclos_refl_trans2 _ _ H0) as [y'' [z'' [? [? ?]]]].
-exists y''; exists z''.
-split; auto.
-split; econstructor 3; eauto.
+apply nec_refl_or_later in H0 as [|]; [subst; eauto|].
+eapply later_join in H0 as (? & ? & ? & ? & ?); eauto.
+do 3 eexists; eauto; split; apply laterR_necR; auto.
 Qed.
 
 Lemma nec_join4 {A} `{asaA : Age_alg A}: forall z x' y' z' : A,
@@ -357,8 +405,32 @@ split; auto.
 split; econstructor 3; eauto.
 Qed.
 
+Lemma nec_join3 {A} `{asaA : Age_alg A}: forall x x' y' z' : A,
+       join x' y' z' ->
+       necR x x' ->
+       exists y,
+         exists z,
+           join x y z /\ necR y y' /\ necR z z'.
+Proof.
+intros.
+revert y' z' H.
+induction H0; intros.
+destruct (unage_join _ H0 H) as  [y0 [z0 [? [? ?]]]].
+exists y0; exists z0; split; auto.
+split; constructor 1; auto.
+exists y'; exists z'; split; auto.
 
-Lemma join_level {A}{JA: Join A}{PA: Perm_alg A}{AG: ageable A}{AgeA: Age_alg A}:
+rename y into x1.
+rename z into x2.
+destruct (IHclos_refl_trans2 _ _ H) as [y'' [z'' [? [? ?]]]].
+destruct (IHclos_refl_trans1 _ _ H0) as [y0 [z0 [? [? ?]]]].
+exists y0; exists z0.
+split; auto.
+split; econstructor 3; eauto.
+Qed.
+
+
+Lemma join_level {A}{JA: Join A}{PA: Perm_alg A}{AG: ageable A}{SA: Sep_alg A}{AgeA: Age_alg A}:
   forall x y z, join x y z -> level x = level z /\ level y = level z.
 Proof.
   intros.
@@ -394,14 +466,9 @@ Lemma age_core_eq {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}
   forall x y x' y', age x x' -> age y y' -> core x = core y -> core x' = core y'.
 Proof.
  intros.
- generalize (core_unit x); unfold unit_for; intro. apply join_comm in H2.
- generalize (core_unit y); unfold unit_for; intro. apply join_comm in H3.
- destruct (age1_join _ H2 H) as [u [v [? [? ?]]]].
- destruct (age1_join _ H3 H0) as [i [j [? [? ?]]]].
- unfold age in *. rewrite H in H6. inv H6. rewrite H0 in H9; inv H9.
- rewrite H1 in *. rewrite H5 in H8; inv H8.
- apply join_core2 in H4. apply join_core2 in H7.
-  congruence.
+ pose proof (age_core _ _ H) as Hc1.
+ pose proof (age_core _ _ H0) as Hc2.
+ rewrite H1 in Hc1; unfold age in *; congruence.
 Qed.
 
 Lemma age_twin {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
@@ -437,7 +504,7 @@ rewrite H2.
 trivial.
 Qed.
 
-Lemma age1_join_eq {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A} : forall phi1 phi2 phi3,
+Lemma age1_join_eq {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{SA: Sep_alg A}{AgeA: Age_alg A} : forall phi1 phi2 phi3,
         join phi1 phi2 phi3 ->
         forall phi1', age1 phi1 = Some phi1' ->
         forall phi2', age1 phi2 = Some phi2' ->
@@ -460,22 +527,6 @@ Qed.
 Lemma strong_nat_ind (P : nat -> Prop) (IH : forall n, (forall i, lt i n -> P i) -> P n) n : P n.
 Proof.
   apply IH; induction n; intros i li; inversion li; eauto.
-Qed.
-
-Lemma age_core {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
-  forall x y : A, age x y -> age (core x) (core y).
-Proof.
- intros. unfold age in *.
- pose proof (core_unit x).
- unfold unit_for in H0.
- destruct (age1_join2 _ H0 H) as [a [b [? [? ?]]]].
- unfold age in H3. rewrite H3 in H; inv H.
- pose proof (core_unit y).
- assert (a = core y); [|subst; auto].
- eapply same_identity; eauto.
- - eapply age_identity; eauto.
-   apply core_identity.
- - apply core_identity.
 Qed.
 
 Lemma laterR_core {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:

--- a/msl/age_to.v
+++ b/msl/age_to.v
@@ -348,7 +348,7 @@ Proof.
   eapply age_identity. apply E. auto.
 Qed.
 
-Lemma age_to_join_eq {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A} :
+Lemma age_to_join_eq {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A} :
   forall k x1 x2 x3,
     join x1 x2 x3 ->
     k <= level x3 ->
@@ -367,7 +367,7 @@ Proof.
   destruct (age_to_lt _ x1 l1) as [x1' [E1 ->]].
   destruct (age_to_lt _ x2 l2) as [x2' [E2 ->]].
   destruct (age_to_lt _ x3 l3) as [x3' [E3 ->]].
-  pose proof @age1_join_eq A _ _ _ _ _ _ _ J _ E1 _ E2 _ E3.
+  pose proof @age1_join_eq A _ _ _ _ _ _ _ _ J _ E1 _ E2 _ E3.
   pose proof @af_level2 A level age1 (@age_facts _ agA) _ _ E1.
   pose proof @af_level2 A level age1 (@age_facts _ agA) _ _ E2.
   pose proof @af_level2 A level age1 (@age_facts _ agA) _ _ E3.

--- a/msl/age_to.v
+++ b/msl/age_to.v
@@ -226,7 +226,7 @@ Proof.
   apply necR_age_by_iff.
 Qed.
 
-Lemma age_to_pred {A} `{agA : ageable A} (P : pred A) x n :
+Lemma age_to_pred {A} `{agA : ageable A} {EO : Ext_ord A} (P : pred A) x n :
   app_pred P x ->
   app_pred P (age_to n x).
 Proof.
@@ -234,7 +234,7 @@ Proof.
   destruct P as [x h]. apply h.
 Qed.
 
-Lemma age_by_pred {A} `{agA : ageable A} (P : pred A) x n :
+Lemma age_by_pred {A} `{agA : ageable A} {EO : Ext_ord A} (P : pred A) x n :
   app_pred P x ->
   app_pred P (age_by n x).
 Proof.
@@ -242,13 +242,13 @@ Proof.
   destruct P as [x h]. apply h.
 Qed.
 
-Lemma pred_age1' {A} `{agA : ageable A} (R : pred A) x : app_pred R x -> app_pred R (age1' x).
+Lemma pred_age1' {A} `{agA : ageable A} {EO : Ext_ord A} (R : pred A) x : app_pred R x -> app_pred R (age1' x).
 Proof.
   unfold age1'. destruct (age1 x) as [phi' | ] eqn:Ephi'; auto.
-  destruct R as [R h]. apply h. apply Ephi'.
+  destruct R as [R [h ?]]. apply h. apply Ephi'.
 Qed.
 
-Lemma age_by_age_by_pred {A} `{agA : ageable A} (P : pred A) x n1 n2 :
+Lemma age_by_age_by_pred {A} `{agA : ageable A} {EO : Ext_ord A} (P : pred A) x n1 n2 :
   le n1 n2 ->
   app_pred P (age_by n1 x) ->
   app_pred P (age_by n2 x).
@@ -348,7 +348,7 @@ Proof.
   eapply age_identity. apply E. auto.
 Qed.
 
-Lemma age_to_join_eq {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A} :
+Lemma age_to_join_eq {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO : Ext_ord A}  :
   forall k x1 x2 x3,
     join x1 x2 x3 ->
     k <= level x3 ->

--- a/msl/alg_seplog.v
+++ b/msl/alg_seplog.v
@@ -70,7 +70,7 @@ Instance algSepLog (T: Type) {agT: ageable T}{JoinT: Join T}{PermT: Perm_alg T}{
   intros; simpl. apply ewand_conflict; auto.
 Defined.
 
-Instance algClassicalSep (T: Type) {agT: ageable T}{JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_alg T}{AgeT: Age_alg T}:
+Instance algClassicalSep (T: Type) {agT: ageable T}{JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_alg T}{FlatT: Flat_alg T}{AgeT: Age_alg T}:
      @ClassicalSep (pred T) (algNatDed T)(algSepLog T).
  constructor; intros. simpl. apply predicates_sl.sepcon_emp.
 Qed.
@@ -78,7 +78,7 @@ Qed.
 Definition Triv := predicates_hered.pred nat.
 Instance TrivNatDed: NatDed Triv := algNatDed nat.
 Instance TrivSeplog: SepLog Triv := @algSepLog nat _ _ _ _ (asa_nat).
-Instance TrivClassical: ClassicalSep Triv := @algClassicalSep _ _ _ _ _ asa_nat.
+Instance TrivClassical: ClassicalSep Triv := @algClassicalSep _ _ _ _ _ _ asa_nat.
 Instance TrivIntuitionistic: IntuitionisticSep Triv.
  constructor. intros. hnf. constructor. hnf. intros. destruct H as [w1 [w2 [? [? _]]]].
  destruct H; subst; auto.

--- a/msl/alg_seplog.v
+++ b/msl/alg_seplog.v
@@ -207,7 +207,7 @@ Instance algCorableSepLog (T: Type) {agT: ageable T}{JoinT: Join T}{PermT: Perm_
   + apply corable.corable_prop.
   + apply corable.corable_andp.
   + apply corable.corable_orp.
-(*  + apply corable.corable_imp.*)
+  + apply corable.corable_imp.
   + intros; apply corable.corable_allp; auto.
   + intros; apply corable.corable_exp; auto.
   + apply corable.corable_sepcon.

--- a/msl/alg_seplog_direct.v
+++ b/msl/alg_seplog_direct.v
@@ -56,7 +56,7 @@ Instance algClassicalSep (T: Type) {JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_
  constructor; intros. simpl. apply predicates_sa.sepcon_emp.
 Defined.
 
-Instance algCorableSepLog (T: Type){JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_alg T}:
+Instance algCorableSepLog (T: Type){JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_alg T}{FT: Flat_alg T}:
          @CorableSepLog (pred T) (algNatDed T) (algSepLog T).
   apply mkCorableSepLog with (corable := corable_direct.corable); unfold algNatDed, algSepLog; simpl.
   + apply corable_prop.

--- a/msl/alg_seplog_direct.v
+++ b/msl/alg_seplog_direct.v
@@ -45,9 +45,9 @@ Instance algSepLog (T: Type) {JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_alg T}
  intros. pose proof (wand_sepcon_adjoint P Q R). simpl. rewrite H; split; auto.
  intros. apply (predicates_sa.sepcon_andp_prop P Q R).
  intros; intro; apply sepcon_derives; auto.
- intros; apply predicates_sa.ewand_sepcon.
- intros; simpl. apply ewand_TT_sepcon; auto.
- intros; simpl. intros w [w1 [w2 [? [? ?]]]]. exists w1,w2; repeat split; auto. exists w2; exists w; repeat split; auto.
+(* intros; apply predicates_sa.ewand_sepcon.*)
+(* intros; simpl. apply ewand_TT_sepcon; auto.*)
+(* intros; simpl. intros w [w1 [w2 [? [? ?]]]]. exists w1,w2; repeat split; auto. exists w2; exists w; repeat split; auto.*)
  intros; simpl. apply ewand_conflict; auto.
 Defined.
 
@@ -62,7 +62,7 @@ Instance algCorableSepLog (T: Type){JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_
   + apply corable_prop.
   + apply corable_andp.
   + apply corable_orp.
-  + apply corable_imp.
+(*  + apply corable_imp.*)
   + intros. apply corable_allp; auto.
   + intros; apply corable_exp; auto.
   + apply corable_sepcon.

--- a/msl/alg_seplog_direct.v
+++ b/msl/alg_seplog_direct.v
@@ -62,7 +62,7 @@ Instance algCorableSepLog (T: Type){JoinT: Join T}{PermT: Perm_alg T}{SepT: Sep_
   + apply corable_prop.
   + apply corable_andp.
   + apply corable_orp.
-(*  + apply corable_imp.*)
+  + apply corable_imp.
   + intros. apply corable_allp; auto.
   + intros; apply corable_exp; auto.
   + apply corable_sepcon.

--- a/msl/boolean_alg.v
+++ b/msl/boolean_alg.v
@@ -843,9 +843,10 @@ Module BA_Facts (BA:BOOLEAN_ALGEBRA) <: BA_FACTS.
   Qed.
 
   Instance sa: Sep_alg t.
-  Proof.  apply mkSep with (fun _ => bot).
+  Proof.  exists (fun _ => bot).
     intros. unfold unit_for. constructor. rewrite glb_commute; apply glb_bot.
              rewrite lub_commute; apply lub_bot.
+    intros. exists bot; auto. split; [apply glb_bot | apply lub_bot].
     intros. reflexivity.
   Defined.
 

--- a/msl/combiner_sa.v
+++ b/msl/combiner_sa.v
@@ -318,7 +318,7 @@ Proof. constructor.
   eapply join_positivity; eauto.
 Qed.
 
-Instance Sep_combiner: Sep_alg combiner.
+Instance Sep_combiner: FSep_alg combiner.
 Proof.
   apply mkSep with (fun _ => CEmpty).
   intros. hnf.  destruct t; auto.
@@ -487,7 +487,7 @@ Section ParameterizedCombiner.
   Defined.
 
 
-  Instance Sep_fcombiner (A: Type): Sep_alg (fcombiner A).
+  Instance Sep_fcombiner (A: Type): FSep_alg (fcombiner A).
   Proof. apply Sep_combiner; auto.
   Defined.
 

--- a/msl/contractive.v
+++ b/msl/contractive.v
@@ -207,7 +207,7 @@ Proof.
 Qed.
 *)
 
-Lemma contractive_nonexpansive {A} `{ageable A} : forall F,
+Lemma contractive_nonexpansive {A} `{ageable A} {EO: Ext_ord A}: forall F,
   contractive F ->
   nonexpansive F.
 Proof.

--- a/msl/contractive.v
+++ b/msl/contractive.v
@@ -16,7 +16,7 @@ Require Import VST.msl.subtypes_sl.
 
 Local Open Scope pred.
 
-Lemma conj_nonexpansive {A} `{ageable A} : forall (F G:pred A -> pred A),
+Lemma conj_nonexpansive {A} `{ageable A} {EO : Ext_ord A} : forall (F G:pred A -> pred A),
   nonexpansive F ->
   nonexpansive G ->
   nonexpansive (fun x:pred A => F x && G x).
@@ -27,7 +27,7 @@ Proof.
   apply subp_andp; apply eqp_subp2; auto.
 Qed.
 
-Lemma conj_contractive {A} `{ageable A} : forall F G,
+Lemma conj_contractive {A} `{ageable A} {EO : Ext_ord A} : forall F G,
   contractive F ->
   contractive G ->
   contractive (fun x => F x && G x).
@@ -38,7 +38,7 @@ Proof.
   apply subp_andp; apply eqp_subp2; auto.
 Qed.
 
-Lemma impl_contractive {A} `{ageable A} : forall F G,
+Lemma impl_contractive {A} `{ageable A} {EO : Ext_ord A} : forall F G,
   contractive F ->
   contractive G ->
   contractive (fun x => F x --> G x).
@@ -53,7 +53,7 @@ Proof.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma impl_nonexpansive {A} `{ageable A} : forall F G,
+Lemma impl_nonexpansive {A} `{ageable A} {EO : Ext_ord A} : forall F G,
   nonexpansive F ->
   nonexpansive G ->
   nonexpansive (fun x => F x --> G x).
@@ -68,7 +68,7 @@ Proof.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma forall_contractive {A} `{ageable A} : forall B (X : pred A -> B -> pred A),
+Lemma forall_contractive {A} `{ageable A} {EO : Ext_ord A} : forall B (X : pred A -> B -> pred A),
   (forall x, (contractive (fun y => X y x))) ->
   contractive (fun x => (allp (X x))).
 Proof.
@@ -80,7 +80,7 @@ Proof.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma forall_nonexpansive {A} `{ageable A} : forall B (X : pred A -> B -> pred A),
+Lemma forall_nonexpansive {A} `{ageable A} {EO : Ext_ord A} : forall B (X : pred A -> B -> pred A),
   (forall x, (nonexpansive (fun y => X y x))) ->
   nonexpansive (fun x => (allp (X x))).
 Proof.
@@ -92,7 +92,7 @@ Proof.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma exists_contractive {A} `{ageable A} : forall B (X : pred A -> B -> pred A),
+Lemma exists_contractive {A} `{ageable A} {EO : Ext_ord A} : forall B (X : pred A -> B -> pred A),
   (forall x, (contractive (fun y => X y x))) ->
   contractive (fun x => (exp (X x))).
 Proof.
@@ -102,7 +102,7 @@ Proof.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma exists_nonexpansive {A} `{ageable A} : forall B (X : pred A -> B -> pred A),
+Lemma exists_nonexpansive {A} `{ageable A} {EO : Ext_ord A} : forall B (X : pred A -> B -> pred A),
   (forall x, (nonexpansive (fun y => X y x))) ->
   nonexpansive (fun x => (exp (X x))).
 Proof.
@@ -112,21 +112,21 @@ Proof.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma later_contractive {A} `{ageable A} : forall F,
+Lemma later_contractive {A} `{ageable A} {EO : Ext_ord A} : forall F,
   nonexpansive F ->
   contractive (fun X => (|>(F X))).
 Proof.
   unfold nonexpansive, contractive; intros.
   apply subp_eqp.
-  rewrite <- subp_later.
+  eapply derives_trans, subp_later1.
   apply box_positive; auto.
   apply eqp_subp; auto.
-  rewrite <- subp_later.
+  eapply derives_trans, subp_later1.
   apply box_positive; auto.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma const_nonexpansive {A: Type} {H: ageable A}: forall P: pred A,
+Lemma const_nonexpansive {A: Type} {H: ageable A} {EO : Ext_ord A} : forall P: pred A,
   nonexpansive (fun _ => P).
 Proof.
   intros.
@@ -136,7 +136,7 @@ Proof.
   hnf; split; intros ? ? ?; auto.
 Qed.
 
-Lemma const_contractive {A: Type} {H: ageable A}: forall P: pred A,
+Lemma const_contractive {A: Type} {H: ageable A} {EO : Ext_ord A} : forall P: pred A,
   contractive (fun _ => P).
 Proof.
   intros.
@@ -146,7 +146,7 @@ Proof.
   hnf; split; intros ? ? ?; auto.
 Qed.
 
-Lemma identity_nonexpansive {A: Type} {H: ageable A}:
+Lemma identity_nonexpansive {A: Type} {H: ageable A} {EO : Ext_ord A} :
   nonexpansive (fun P: pred A => P).
 Proof.
   hnf; intros.
@@ -216,7 +216,7 @@ Proof.
   apply now_later.
 Qed.
 
-Lemma sepcon_contractive {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall F G,
+Lemma sepcon_contractive {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A} : forall F G,
   contractive F ->
   contractive G ->
   contractive (fun x => F x * G x).
@@ -227,7 +227,7 @@ Proof.
   apply subp_sepcon; apply eqp_subp2; auto.
 Qed.
 
-Lemma sepcon_nonexpansive {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall F G,
+Lemma sepcon_nonexpansive {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A} : forall F G,
   nonexpansive F ->
   nonexpansive G ->
   nonexpansive (fun x => F x * G x).
@@ -238,7 +238,7 @@ Proof.
   apply subp_sepcon; apply eqp_subp2; auto.
 Qed.
 
-Lemma wand_contractive {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall F G,
+Lemma wand_contractive {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A} : forall F G,
   contractive F ->
   contractive G ->
   contractive (fun x => F x -* G x).
@@ -253,7 +253,7 @@ Proof.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma wand_nonexpansive {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall F G,
+Lemma wand_nonexpansive {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A} : forall F G,
   nonexpansive F ->
   nonexpansive G ->
   nonexpansive (fun x => F x -* G x).
@@ -268,7 +268,7 @@ Proof.
   apply eqp_subp2; auto.
 Qed.
 
-Lemma prove_contractive {A} `{ageable A} : forall F,
+Lemma prove_contractive {A} `{ageable A} {EO: Ext_ord A}: forall F,
   (forall P Q,
     |>(P >=> Q) |-- F P >=> F Q) ->
   contractive F.
@@ -289,7 +289,7 @@ Proof.
   auto.
 Qed.
 
-Lemma prove_HOcontractive1 {A} `{ageable A} : forall X F,
+Lemma prove_HOcontractive1 {A} `{ageable A} {EO: Ext_ord A}: forall X F,
   (forall P Q: X -> pred A,
     (ALL x:X, |>(P x >=> Q x) |--
         ALL x:X, F P x >=> F Q x)) ->
@@ -305,7 +305,7 @@ Proof.
 Qed.
 
 
-Lemma prove_HOcontractive {A} `{ageable A} : forall X F,
+Lemma prove_HOcontractive {A} `{ageable A} {EO: Ext_ord A}: forall X F,
   (forall (P Q: X -> pred A) (x: X),
     (ALL x:X, (|> P x <=> |> Q x) |-- F P x >=> F Q x)) ->
    HOcontractive F.
@@ -319,6 +319,20 @@ Proof.
   eapply H0; eauto.
   intro x; specialize (H1 x). rewrite eqp_comm.
   apply eqp_later1. auto.
+Qed.
+
+Lemma prove_HOcontractive' {A} `{ageable A} {EO: Ext_ord A}: forall X F,
+  (forall (P Q: X -> pred A) (x: X),
+    (ALL x:X, |>(P x <=> Q x) |-- F P x >=> F Q x)) ->
+   HOcontractive F.
+Proof.
+  unfold HOcontractive.
+  intros. apply allp_right. intros.
+  repeat intro.
+  split.
+  eapply H0; eauto.
+  eapply H0; eauto.
+  intro x; specialize (H1 x). rewrite eqp_comm. auto.
 Qed.
 
 Ltac sub_unfold :=
@@ -337,7 +351,7 @@ Ltac sub_unfold :=
   subp_allp subp_imp subp_refl subp_exp subp_andp subp_orp subp_subp
   allp_imp2_later_e1 allp_imp2_later_e2 : contractive.
 
-Lemma Rec_sub {A} `{ageable A} : forall G
+Lemma Rec_sub {A} `{ageable A} {EO: Ext_ord A}: forall G
   (F   : pred A -> pred A -> pred A)
   (HF1 : forall X, contractive (F X))
   (HF2 : forall R P Q, P >=> Q |-- F P R >=> F Q R)
@@ -356,14 +370,14 @@ Proof.
   specialize ( HF2 a H0 a').
   spec  HF2.  apply necR_level in H2; lia.
   eapply HF2; auto.
-  rewrite Rec_fold_unfold in H3 by auto.
-  generalize (HF3 (Rec (F P)) (Rec (F Q)) P); intros.
-  specialize ( H5 a H4 a').
-  spec H5.  apply necR_level in H2; lia.
-  eapply H5; auto.
+  rewrite Rec_fold_unfold in H4 by auto.
+  generalize (HF3 (Rec (F P)) (Rec (F Q)) P); intros Hrec.
+  specialize ( Hrec a H5 a').
+  spec Hrec.  apply necR_level in H2; lia.
+  eapply Hrec; auto.
 Qed.
 
-Lemma HORec_sub {A} `{ageable A} : forall G B
+Lemma HORec_sub {A} `{ageable A} {EO: Ext_ord A}: forall G B
   (F : pred A -> (B -> pred A) -> B -> pred A)
   (HF1 : forall X, HOcontractive (F X))
   (HF2 : forall R a P Q, P >=> Q |-- F P R a >=> F Q R a)
@@ -380,15 +394,15 @@ Proof.
   rewrite HORec_fold_unfold by auto.
   specialize ( HF2 (HORec (F Q)) b P Q a H0 a').
   spec HF2. apply necR_level in H2; lia.
-  apply HF2; auto.
-  rewrite HORec_fold_unfold in H3 by auto.
-  rewrite box_all in H4.
-  specialize ( HF3 (HORec (F P)) (HORec (F Q)) P a H4 b a').
+  eapply HF2; auto.
+  rewrite HORec_fold_unfold in H4 by auto.
+  rewrite box_all in H5.
+  specialize ( HF3 (HORec (F P)) (HORec (F Q)) P a H5 b a').
   spec HF3. apply necR_level in H2; lia.
-  apply HF3; auto.
+  eapply HF3; auto.
 Qed.
 
-Lemma Rec_contractive {A} `{ageable A} : forall
+Lemma Rec_contractive {A} `{ageable A} {EO: Ext_ord A}: forall
   (F   : pred A -> pred A -> pred A)
   (HF1 : forall X, contractive (F X))
   (HF2 : forall R, contractive (fun X => F X R)),
@@ -402,29 +416,29 @@ Proof.
   rewrite Rec_fold_unfold by auto.
   specialize ( HF2 (Rec (F Q)) P Q a H0 a').
   spec HF2. apply necR_level in H3; lia.
-  destruct HF2.
-  eapply H5; auto.
-  rewrite Rec_fold_unfold in H4 by auto.
-  generalize (HF1 P (Rec (F P)) (Rec (F Q))); intros.
-  specialize ( H7 a).
-  detach H7; auto.
-  specialize ( H7 a').  spec H7. apply necR_level in H3; lia.
-  destruct H7; eauto.
+  destruct HF2 as [HF2 _].
+  eapply HF2; auto.
+  rewrite Rec_fold_unfold in H5 by auto.
+  generalize (HF1 P (Rec (F P)) (Rec (F Q))); intros Hrec.
+  specialize ( Hrec a).
+  detach Hrec; auto.
+  specialize ( Hrec a').  spec Hrec. apply necR_level in H3; lia.
+  destruct Hrec; eauto.
 
   rewrite Rec_fold_unfold by auto.
   specialize ( HF2 (Rec (F P)) P Q a H0 a').
   spec HF2. apply necR_level in H3; lia.
-  destruct HF2.
-  eapply H6; auto.
-  rewrite Rec_fold_unfold in H4 by auto.
-  generalize (HF1 Q (Rec (F P)) (Rec (F Q))); intros.
-  specialize ( H7 a).
-  detach H7; auto.
-  specialize ( H7 a').  spec H7. apply necR_level in H3; lia.
-  destruct H7; eauto.
+  destruct HF2 as [_ HF2].
+  eapply HF2; auto.
+  rewrite Rec_fold_unfold in H5 by auto.
+  generalize (HF1 Q (Rec (F P)) (Rec (F Q))); intros Hrec.
+  specialize ( Hrec a).
+  detach Hrec; auto.
+  specialize ( Hrec a').  spec Hrec. apply necR_level in H3; lia.
+  destruct Hrec; eauto.
 Qed.
 
-Lemma Rec_nonexpansive {A} `{ageable A} : forall
+Lemma Rec_nonexpansive {A} `{ageable A} {EO: Ext_ord A}: forall
   (F   : pred A -> pred A -> pred A)
   (HF1 : forall X, contractive (F X))
   (HF2 : forall R, nonexpansive (fun X => F X R)),
@@ -438,30 +452,30 @@ Proof.
   rewrite Rec_fold_unfold by auto.
   specialize ( HF2 (Rec (F Q)) P Q a H0 a').
   spec HF2. apply necR_level in H3; lia.
-  destruct HF2.
-  eapply H5; auto.
-  rewrite Rec_fold_unfold in H4 by auto.
-  generalize (HF1 P (Rec (F P)) (Rec (F Q))); intros.
-  specialize ( H7 a).
-  detach H7; auto.
-  specialize ( H7 a').  spec H7. apply necR_level in H3; lia.
-  destruct H7; eauto.
+  destruct HF2 as [HF2 _].
+  eapply HF2; auto.
+  rewrite Rec_fold_unfold in H5 by auto.
+  generalize (HF1 P (Rec (F P)) (Rec (F Q))); intros Hrec.
+  specialize ( Hrec a).
+  detach Hrec; auto.
+  specialize ( Hrec a').  spec Hrec. apply necR_level in H3; lia.
+  destruct Hrec; eauto.
 
   rewrite Rec_fold_unfold by auto.
   specialize ( HF2 (Rec (F P)) P Q a H0 a').
   spec HF2. apply necR_level in H3; lia.
-  destruct HF2.
-  eapply H6; auto.
-  rewrite Rec_fold_unfold in H4 by auto.
-  generalize (HF1 Q (Rec (F P)) (Rec (F Q))); intros.
-  specialize ( H7 a).
-  detach H7; auto.
-  specialize ( H7 a').  spec H7. apply necR_level in H3; lia.
-  destruct H7; eauto.
+  destruct HF2 as [_ HF2].
+  eapply HF2; auto.
+  rewrite Rec_fold_unfold in H5 by auto.
+  generalize (HF1 Q (Rec (F P)) (Rec (F Q))); intros Hrec.
+  specialize ( Hrec a).
+  detach Hrec; auto.
+  specialize ( Hrec a').  spec Hrec. apply necR_level in H3; lia.
+  destruct Hrec; eauto.
 Qed.
 
 
-Lemma HORec_contractive {A} `{ageable A} : forall B
+Lemma HORec_contractive {A} `{ageable A} {EO: Ext_ord A}: forall B
   (F : pred A -> (B -> pred A) -> B -> pred A)
   (HF1 : forall X, HOcontractive (F X))
   (HF2 : forall R a, contractive (fun X => F X R a)),
@@ -481,33 +495,33 @@ Proof.
   rewrite HORec_fold_unfold by auto.
   specialize ( HF2 (HORec (F Q)) b P Q a H0 a').
   spec HF2. apply necR_level in H3; lia.
-  destruct HF2.
-  eapply H5; auto.
-  rewrite HORec_fold_unfold in H4 by auto.
-  generalize (HF1 P (HORec (F P)) (HORec (F Q))); intros.
-  specialize ( H7 a).
-  detach H7.
-  specialize ( H7 b a').  spec H7. apply necR_level in H3; lia.
-  destruct H7; eauto.
+  destruct HF2 as [HF2 _].
+  eapply HF2; auto.
+  rewrite HORec_fold_unfold in H5 by auto.
+  generalize (HF1 P (HORec (F P)) (HORec (F Q))); intros Hrec.
+  specialize ( Hrec a).
+  detach Hrec.
+  specialize ( Hrec b a').  spec Hrec. apply necR_level in H3; lia.
+  destruct Hrec; eauto.
   rewrite <- box_all.
   auto.
 
   rewrite HORec_fold_unfold by auto.
   specialize ( HF2 (HORec (F P)) b P Q a H0 a').
   spec HF2. apply necR_level in H3; lia.
-  destruct HF2.
-  eapply H6; auto.
-  rewrite HORec_fold_unfold in H4 by auto.
-  generalize (HF1 Q (HORec (F P)) (HORec (F Q))); intros.
-  specialize ( H7 a).
-  detach H7.
-  specialize ( H7 b a').  spec H7. apply necR_level in H3; lia.
-  destruct H7; eauto.
+  destruct HF2 as [_ HF2].
+  eapply HF2; auto.
+  rewrite HORec_fold_unfold in H5 by auto.
+  generalize (HF1 Q (HORec (F P)) (HORec (F Q))); intros Hrec.
+  specialize (Hrec a).
+  detach Hrec.
+  specialize (Hrec b a').  spec Hrec. apply necR_level in H3; lia.
+  destruct Hrec; eauto.
   rewrite <- box_all.
   auto.
 Qed.
 
-Lemma HORec_nonexpansive {A} `{ageable A} : forall B
+Lemma HORec_nonexpansive {A} `{ageable A} {EO: Ext_ord A}: forall B
   (F : pred A -> (B -> pred A) -> B -> pred A)
   (HF1 : forall X, HOcontractive (F X))
   (HF2 : forall R a, nonexpansive (fun X => F X R a)),
@@ -527,28 +541,28 @@ Proof.
   rewrite HORec_fold_unfold by auto.
   specialize ( HF2 (HORec (F Q)) b P Q a H0 a').
   spec HF2. apply necR_level in H3; lia.
-  destruct HF2.
-  eapply H5; auto.
-  rewrite HORec_fold_unfold in H4 by auto.
-  generalize (HF1 P (HORec (F P)) (HORec (F Q))); intros.
-  specialize ( H7 a).
-  detach H7.
-  specialize ( H7 b a').  spec H7. apply necR_level in H3; lia.
-  destruct H7; eauto.
+  destruct HF2 as [HF2 _].
+  eapply HF2; auto.
+  rewrite HORec_fold_unfold in H5 by auto.
+  generalize (HF1 P (HORec (F P)) (HORec (F Q))); intros Hrec.
+  specialize (Hrec a).
+  detach Hrec.
+  specialize (Hrec b a').  spec Hrec. apply necR_level in H3; lia.
+  destruct Hrec; eauto.
   rewrite <- box_all.
   auto.
 
   rewrite HORec_fold_unfold by auto.
   specialize ( HF2 (HORec (F P)) b P Q a H0 a').
   spec HF2. apply necR_level in H3; lia.
-  destruct HF2.
-  eapply H6; auto.
-  rewrite HORec_fold_unfold in H4 by auto.
-  generalize (HF1 Q (HORec (F P)) (HORec (F Q))); intros.
-  specialize ( H7 a).
-  detach H7.
-  specialize ( H7 b a').  spec H7. apply necR_level in H3; lia.
-  destruct H7; eauto.
+  destruct HF2 as [_ HF2].
+  eapply HF2; auto.
+  rewrite HORec_fold_unfold in H5 by auto.
+  generalize (HF1 Q (HORec (F P)) (HORec (F Q))); intros Hrec.
+  specialize (Hrec a).
+  detach Hrec.
+  specialize (Hrec b a').  spec Hrec. apply necR_level in H3; lia.
+  destruct Hrec; eauto.
   rewrite <- box_all.
   auto.
 Qed.
@@ -558,76 +572,75 @@ Module Trashcan.
 (* Note: This approach to proving HOcontractive doesn't automate
   as well as the methods above.*)
 
-Lemma orp_HOcontractive {A}{agA: ageable A}: forall X (P Q: (X -> pred A) -> (X -> pred A)),
+Lemma orp_HOcontractive {A}{agA: ageable A}{EO: Ext_ord A}: forall X (P Q: (X -> pred A) -> (X -> pred A)),
        HOcontractive P -> HOcontractive Q -> HOcontractive (fun R x => P R x || Q R x).
 Proof.
  intros.
  intros F G n H2 x y Hy.
  specialize (H F G n H2 x y Hy). specialize (H0 F G n H2 x y Hy).
  destruct H, H0.
- split; (intros z Hz [?|?]; [left|right]); auto.
+ split; (intros z ? Hz ? [?|?]; [left|right]); eauto.
 Qed.
-Lemma andp_HOcontractive {A}{agA: ageable A}: forall X (P Q: (X -> pred A) -> (X -> pred A)),
+Lemma andp_HOcontractive {A}{agA: ageable A}{EO: Ext_ord A}: forall X (P Q: (X -> pred A) -> (X -> pred A)),
        HOcontractive P -> HOcontractive Q -> HOcontractive (fun R x => P R x && Q R x).
 Proof.
  intros.
  intros F G n H2 x y Hy.
  specialize (H F G n H2 x y Hy). specialize (H0 F G n H2 x y Hy).
  destruct H, H0.
- split; (intros z Hz [? ?]); split; auto.
+ split; (intros z ? Hz ? [? ?]); split; eauto.
 Qed.
-Lemma sepcon_HOcontractive {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}: forall X (P Q: (X -> pred A) -> (X -> pred A)),
+Lemma sepcon_HOcontractive {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}: forall X (P Q: (X -> pred A) -> (X -> pred A)),
        HOcontractive P -> HOcontractive Q -> HOcontractive (fun R x => P R x * Q R x).
 Proof.
  intros.
  unfold HOcontractive in *|-.
- apply prove_HOcontractive; intros F G ?.
+ apply prove_HOcontractive'; intros F G ?.
  specialize (H F G). specialize (H0 F G).
  apply subp_sepcon.
  eapply derives_trans.
- apply allp_derives; intro. rewrite <- eqp_later. apply derives_refl.
+ apply allp_derives; intro. apply derives_refl.
  eapply derives_trans; [ apply H | ].
  apply allp_left with x.
  apply fash_derives. apply andp_left1. auto.
  eapply derives_trans.
- apply allp_derives; intro. rewrite <- eqp_later. apply derives_refl.
+ apply allp_derives; intro. apply derives_refl.
  eapply derives_trans; [ apply H0 | ].
  apply allp_left with x.
  apply fash_derives. apply andp_left1. auto.
 Qed.
 
-Lemma const_HOcontractive{A}{agA: ageable A}: forall X (P : X -> pred A), HOcontractive (fun _ => P).
+Lemma const_HOcontractive{A}{agA: ageable A}{EO: Ext_ord A}: forall X (P : X -> pred A), HOcontractive (fun _ => P).
 Proof.
  intros.
  apply prove_HOcontractive. intros. apply subp_refl.
 Qed.
 
-Lemma exp_HOcontractive {A}{agA: ageable A}:
+Lemma exp_HOcontractive {A}{agA: ageable A}{EO: Ext_ord A}:
   forall X Y (G: Y -> X -> X) (F: Y -> X -> pred A -> pred A),
    (forall y x, contractive (F y x)) ->
    HOcontractive (fun (R: X -> pred A) (x: X) => EX y: Y, F y x (R (G y x))).
 Proof.
  intros.
- apply prove_HOcontractive; intros.
+ apply prove_HOcontractive'; intros.
  apply subp_exp; intro y.
  specialize (H y x (P (G y x)) (Q (G y x))).
  eapply derives_trans; [ | apply eqp_subp; apply H].
- rewrite eqp_later.
  apply allp_left with (G y x). auto.
 Qed.
-Lemma const_contractive {A}{agA: ageable A}: forall P : pred A, contractive (fun _ => P).
+Lemma const_contractive {A}{agA: ageable A}{EO: Ext_ord A}: forall P : pred A, contractive (fun _ => P).
 Proof.
  intros.
  apply prove_contractive. intros. apply subp_refl.
 Qed.
-Lemma later_contractive' {A} `{ageable A} : contractive (box laterM).
+Lemma later_contractive' {A} `{ageable A} {EO: Ext_ord A}: contractive (box laterM).
 Proof.
   unfold contractive; intros.
   apply subp_eqp.
-  rewrite <- subp_later.
+  eapply derives_trans, subp_later1.
   apply box_positive; auto.
   apply eqp_subp; auto.
-  rewrite <- subp_later.
+  eapply derives_trans, subp_later1.
   apply box_positive; auto.
   apply eqp_subp2; auto.
 Qed.

--- a/msl/corable.v
+++ b/msl/corable.v
@@ -26,10 +26,10 @@ Proof.
 Qed.*)
 
 (* from Iris: "persistent and absorbing" *)
-Definition corable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
+Definition corable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}
          (P: pred A) := forall w, P w -> forall w', (join_sub w w' \/ join_sub w' w) -> P w'.
 
-Lemma corable_core : forall {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A} P w1 w2, corable P ->
+Lemma corable_core : forall {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A} P w1 w2, corable P ->
   core w1 = core w2 -> P w1 -> P w2.
 Proof.
   intros.
@@ -38,51 +38,54 @@ Proof.
   - left; rewrite H0; eexists; apply core_unit.
 Qed.
 
-Lemma corable_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
   forall P Q, corable P -> corable Q -> corable (P && Q).
 Proof.
  unfold corable; intros; simpl.
  destruct H1; eauto.
 Qed.
-Lemma corable_orp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_orp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
   forall P Q, corable P -> corable Q -> corable (P || Q).
 Proof.
  unfold corable; intros; simpl.
  destruct H1; eauto.
 Qed.
-Lemma corable_allp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_allp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
   forall {B: Type} (P:  B -> pred A) ,
       (forall b, corable (P b)) -> corable (allp P).
 Proof.
  unfold corable; simpl; intros.
  eauto.
 Qed.
-Lemma corable_exp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_exp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
   forall {B: Type} (P:  B -> pred A) ,
       (forall b, corable (P b)) -> corable (exp P).
 Proof.
  unfold corable; intros; simpl.
  destruct H0; eauto.
 Qed.
-Lemma corable_prop{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_prop{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
   forall P, corable (prop P).
 Proof.
  unfold corable, prop; intros.
  simpl in *; auto.
 Qed.
 
-Lemma corable_imp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A} {agA: ageable A}{AgeA: Age_alg A}:
+(*Lemma corable_imp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A} {agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
   forall P Q, corable P -> corable Q -> corable (P --> Q).
 Proof.
   unfold corable; simpl; intros.
   destruct H2 as [[? J] | [? J]].
   - eapply nec_join2 in J as (? & ? & ? & Hw & ?); eauto.
-    eapply H1 in Hw; eauto.
+    eapply ext_join_commut in H2 as (? & ? & ?); eauto.
+    eapply H1 in H2; eauto.
   - eapply nec_join in J as (? & ? & ? & ? & Hw); eauto.
-    eapply H1 in Hw; eauto.
-Qed.
+    eapply ext_join_commut in H2 as (? & ? & ?); eauto.
+    eapply H1 in H2; eauto.
 
-Lemma corable_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Qed.*)
+
+Lemma corable_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
   forall P Q, corable P -> corable Q -> corable (P * Q).
 Proof.
   unfold corable; simpl; intros.
@@ -101,7 +104,7 @@ Proof.
       * eauto.
 Qed.
 
-Lemma corable_wand: forall {A:Type} {agA:ageable A} {JA: Join A} {PA: Perm_alg A} {SaA: Sep_alg A} {XA: Age_alg A} (P Q: pred A), corable P -> corable Q -> corable (P -* Q).
+Lemma corable_wand: forall {A:Type} {agA:ageable A} {JA: Join A} {PA: Perm_alg A} {SaA: Sep_alg A} {XA: Age_alg A} {EO: Ext_ord A}{EA: Ext_alg A} (P Q: pred A), corable P -> corable Q -> corable (P -* Q).
 Proof.
   unfold corable; simpl; intros.
   destruct H2 as [[? J] | [? J]].
@@ -123,7 +126,7 @@ Proof.
       * right; eexists; apply core_unit.
 Qed.
 
-Lemma corable_later: forall {A:Type} {agA:ageable A} {JA: Join A} {PA: Perm_alg A} {SaA: Sep_alg A} {XA: Age_alg A} P, corable P -> corable (|> P).
+Lemma corable_later: forall {A:Type} {agA:ageable A} {JA: Join A} {PA: Perm_alg A} {SaA: Sep_alg A} {XA: Age_alg A} {EO: Ext_ord A}{EA: Ext_alg A} P, corable P -> corable (|> P).
 Proof.
   unfold corable; simpl; intros.
   destruct H1 as [[? J] | [? J]].
@@ -132,9 +135,9 @@ Proof.
 Qed.
 
 #[export] Hint Resolve corable_andp corable_orp corable_allp corable_exp
-                    corable_imp corable_prop corable_sepcon corable_wand corable_later : core.
+                    (*corable_imp*) corable_prop corable_sepcon corable_wand corable_later : core.
 
-Lemma corable_andp_sepcon1{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_andp_sepcon1{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
    forall P Q R, corable P ->  (P && Q) * R = P && (Q * R).
 Proof.
 intros.
@@ -148,19 +151,19 @@ split; eauto.
 Qed.
 
 (* The following 3 lemmas should not be necessary *)
-Lemma corable_andp_sepcon2{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_andp_sepcon2{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
    forall P Q R, corable P ->  (Q && P) * R = P && (Q * R).
 Proof.
 intros. rewrite andp_comm. apply corable_andp_sepcon1. auto.
 Qed.
 
-Lemma corable_sepcon_andp1 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_sepcon_andp1 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
    forall P Q R, corable P ->  Q  * (P && R) = P && (Q * R).
 Proof.
 intros. rewrite sepcon_comm. rewrite corable_andp_sepcon1; auto. rewrite sepcon_comm; auto.
 Qed.
 
-Lemma corable_sepcon_andp2 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma corable_sepcon_andp2 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
    forall P Q R, corable P ->  Q  * (R && P) = P && (Q * R).
 Proof.
 intros. rewrite sepcon_comm. rewrite andp_comm. rewrite corable_andp_sepcon1; auto. rewrite sepcon_comm; auto.

--- a/msl/corable.v
+++ b/msl/corable.v
@@ -8,7 +8,7 @@ Require Import VST.msl.predicates_sl.
 
 Local Open Scope pred.
 
-Definition corable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
+(*Definition corable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
          (P: pred A) := forall w, P w = P (core w).
 
 Lemma corable_spec: forall {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
@@ -23,125 +23,112 @@ Proof.
     pose proof (H _ _ H0).
     pose proof (H _ _ (eq_sym H0)).
     apply prop_ext; split; auto.
+Qed.*)
+
+(* from Iris: "persistent and absorbing" *)
+Definition corable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
+         (P: pred A) := forall w, P w -> forall w', (join_sub w w' \/ join_sub w' w) -> P w'.
+
+Lemma corable_core : forall {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A} P w1 w2, corable P ->
+  core w1 = core w2 -> P w1 -> P w2.
+Proof.
+  intros.
+  eapply H; [eapply H; [eassumption|]|].
+  - right; eexists; apply core_unit.
+  - left; rewrite H0; eexists; apply core_unit.
 Qed.
 
 Lemma corable_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall P Q, corable P -> corable Q -> corable (P && Q).
 Proof.
- unfold corable; intros.
- apply prop_ext; split; intros [? ?]; split; congruence.
+ unfold corable; intros; simpl.
+ destruct H1; eauto.
 Qed.
 Lemma corable_orp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall P Q, corable P -> corable Q -> corable (P || Q).
 Proof.
- unfold corable; intros.
- apply prop_ext; split; (intros [?|?]; [left|right]; congruence).
+ unfold corable; intros; simpl.
+ destruct H1; eauto.
 Qed.
 Lemma corable_allp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall {B: Type} (P:  B -> pred A) ,
       (forall b, corable (P b)) -> corable (allp P).
 Proof.
- unfold corable, allp; intros.
- apply prop_ext; split; simpl; intros.
- rewrite <- H; auto. rewrite H; auto.
+ unfold corable; simpl; intros.
+ eauto.
 Qed.
 Lemma corable_exp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall {B: Type} (P:  B -> pred A) ,
       (forall b, corable (P b)) -> corable (exp P).
 Proof.
- unfold corable, exp; intros.
- apply prop_ext; split; simpl; intros;  destruct H0 as [b ?]; exists b.
- rewrite <- H; auto. rewrite H; auto.
+ unfold corable; intros; simpl.
+ destruct H0; eauto.
 Qed.
 Lemma corable_prop{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall P, corable (prop P).
 Proof.
  unfold corable, prop; intros.
- apply prop_ext; split; simpl; intros; auto.
+ simpl in *; auto.
 Qed.
 
 Lemma corable_imp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A} {agA: ageable A}{AgeA: Age_alg A}:
   forall P Q, corable P -> corable Q -> corable (P --> Q).
 Proof.
-  intros.
-  rewrite corable_spec in H, H0 |- *.
-  unfold imp in *.
-  simpl in *.
-  intros.
-  rename a' into y'.
-  pose proof H3.
-  apply necR_power_age in H5.
-  destruct H5 as [n ?H].
-  destruct (power_age_parallel' _ y' _ n (eq_sym H1) H5) as [x' [?H ?H]].
-  apply (H0 _ _ (eq_sym H7)).
-  apply H2.
-  + apply necR_power_age; exists n; auto.
-  + apply (H _ _ H7); auto.
+  unfold corable; simpl; intros.
+  destruct H2 as [[? J] | [? J]].
+  - eapply nec_join2 in J as (? & ? & ? & Hw & ?); eauto.
+    eapply H1 in Hw; eauto.
+  - eapply nec_join in J as (? & ? & ? & ? & Hw); eauto.
+    eapply H1 in Hw; eauto.
 Qed.
 
 Lemma corable_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall P Q, corable P -> corable Q -> corable (P * Q).
 Proof.
-  intros.
-  rewrite corable_spec in H, H0 |- *.
-  unfold sepcon.
-  intros.
-  simpl in H2 |- *.
-  destruct H2 as [x' [x'' [? [? ?]]]].
-  pose proof join_core H2.
-  pose proof join_core (join_comm H2).
-  exists (core y), y.
-  repeat split.
-  + apply core_unit.
-  + apply H with x'; auto.
-    rewrite core_idem.
-    congruence.
-  + apply H0 with x''; auto.
-    congruence.
+  unfold corable; simpl; intros.
+  destruct H1 as (? & ? & J & HP & HQ).
+  destruct H2 as [[? J'] | [? J']].
+  - destruct (join_assoc J J') as (? & ? & ?).
+    do 3 eexists; eauto.
+  - do 3 eexists; [apply core_unit|].
+    split.
+    + eapply H; [eapply H; [eassumption|]|].
+      * left; eexists; apply J.
+      * right; eapply join_sub_trans; [|eexists; eauto].
+        eexists; apply core_unit.
+    + eapply H0; [eapply H0; [eassumption|]|].
+      * left; eexists; apply join_comm, J.
+      * eauto.
 Qed.
 
 Lemma corable_wand: forall {A:Type} {agA:ageable A} {JA: Join A} {PA: Perm_alg A} {SaA: Sep_alg A} {XA: Age_alg A} (P Q: pred A), corable P -> corable Q -> corable (P -* Q).
 Proof.
-  intros.
-  rewrite corable_spec in H, H0 |- *.
-  unfold wand in *.
-  simpl in *.
-  intros.
-  rename x' into y'.
-  rename y0 into w'.
-  rename z into z'.
-  apply necR_power_age in H3.
-  destruct H3 as [n ?H].
-  pose proof power_age_parallel' _ y' _ n (eq_sym H1) H3.
-  destruct H6 as [x' [?H ?H]].
-  pose proof join_core H4.
-  pose proof join_core (join_comm H4).
-  apply H0 with x'; [congruence |].
-  apply (H2  x' (core x') x').
-  + apply necR_power_age.
-    exists n; auto.
-  + apply join_comm, core_unit.
-  + apply H with w'; auto.
-    rewrite core_idem.
-    congruence.
+  unfold corable; simpl; intros.
+  destruct H2 as [[? J] | [? J]].
+  - eapply nec_join2 in J as (? & ? & J' & Hw & ?); eauto.
+    eapply H1 in Hw; try apply J'; eauto.
+    eapply H; [eapply H; [eapply H; [eassumption|]|]|].
+    + left; eexists; apply join_comm; eassumption.
+    + right; eexists; eauto.
+    + eauto.
+  - eapply nec_join in J as (? & ? & J' & ? & Hw); eauto.
+    eapply H1 in Hw; try apply join_comm, core_unit.
+    + eapply H0; [eapply H0; [eassumption|]|].
+      * right; eexists; eauto.
+      * left; eexists; eauto.
+    + eapply H; [eapply H; [eapply H; [eapply H; [eassumption|]|]|]|].
+      * left; eexists; eauto.
+      * right; eexists; eauto.
+      * left; eexists; eauto.  
+      * right; eexists; apply core_unit.
 Qed.
 
 Lemma corable_later: forall {A:Type} {agA:ageable A} {JA: Join A} {PA: Perm_alg A} {SaA: Sep_alg A} {XA: Age_alg A} P, corable P -> corable (|> P).
 Proof.
-  intros.
-  rewrite corable_spec in H |- *.
-  intros.
-  unfold box in *.
-  simpl in *.
-  intros.
-  apply laterR_power_age in H2.
-  destruct H2 as [n ?H].
-  rename a' into y'.
-  destruct (power_age_parallel' _ y' _ _ (eq_sym H0) H2) as [x' [? ?]].
-  apply H with x'; auto.
-  apply H1.
-  apply laterR_power_age.
-  exists n; auto.
+  unfold corable; simpl; intros.
+  destruct H1 as [[? J] | [? J]].
+  - eapply later_join2 in J as (? & ? & ? & ? & ?); eauto.
+  - eapply later_join in J as (? & ? & ? & ? & ?); eauto.
 Qed.
 
 #[export] Hint Resolve corable_andp corable_orp corable_allp corable_exp
@@ -153,15 +140,11 @@ Proof.
 intros.
 apply pred_ext.
 intros w [w1 [w2 [? [[? ?] ?]]]].
-split.
-apply join_core in H0.
-rewrite H in H1|-*. rewrite <- H0; auto.
-exists w1; exists w2; split; [| split]; auto.
+split; [eapply H; eauto|].
+exists w1, w2; auto.
 intros w [? [w1 [w2 [? [? ?]]]]].
 exists w1; exists w2; split; [|split]; auto.
-split; auto.
-apply join_core in H1.
-rewrite H in H0|-*. rewrite H1; auto.
+split; eauto.
 Qed.
 
 (* The following 3 lemmas should not be necessary *)

--- a/msl/corable_direct.v
+++ b/msl/corable_direct.v
@@ -67,7 +67,7 @@ Proof.
   eapply H0; eauto.
 Qed.
 
-Lemma corable_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma corable_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall P Q, corable P -> corable Q -> corable (P * Q).
 Proof.
   intros.
@@ -88,7 +88,7 @@ Proof.
     congruence.
 Qed.
 
-Lemma corable_wand: forall {A:Type} {JA: Join A} {PA: Perm_alg A} {SaA: Sep_alg A} (P Q: pred A), corable P -> corable Q -> corable (P -* Q).
+Lemma corable_wand: forall {A:Type} {JA: Join A} {PA: Perm_alg A} {SaA: Sep_alg A} {FA: Flat_alg A} (P Q: pred A), corable P -> corable Q -> corable (P -* Q).
 Proof.
   intros.
   rewrite corable_spec in H, H0 |- *.
@@ -105,7 +105,7 @@ Proof.
     congruence.
 Qed.
 
-Lemma corable_andp_sepcon1{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma corable_andp_sepcon1{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
    forall P Q R, corable P ->  (P && Q) * R = P && (Q * R).
 Proof.
 intros.

--- a/msl/env.v
+++ b/msl/env.v
@@ -103,7 +103,7 @@ Instance Join_env: Join (env key A) :=
     fun (rho1 rho2 rho3: env key A) => join (env_get rho1) (env_get rho2) (env_get rho3).
 Parameter Perm_env: forall {PA: Perm_alg A}, Perm_alg (env key A).  Existing Instance Perm_env.
 
-Instance Sep_env {SA: Sep_alg A}: Sep_alg (env key A).
+Instance Sep_env {SA: Sep_alg A}: FSep_alg (env key A).
  refine (mkSep Join_env (fun _ => empty_env) _ _).
  repeat intro; rewrite env_get_empty; constructor.
  auto.
@@ -303,13 +303,13 @@ Proof.
   rewrite Join_env_eq. apply Perm_fpm; auto with typeclass_instances.
 Qed.
 
-Instance Sep_env {SA: Sep_alg A}: @Sep_alg env Join_env.
+Instance Sep_env {SA: Sep_alg A}: @FSep_alg env Join_env.
  refine (mkSep Join_env (fun _ => empty_env) _ _).
  repeat intro; rewrite env_get_empty; constructor.
  auto.
 Defined.
 
-Instance Sing_env {SA: Sep_alg A}: @Sing_alg env Join_env Sep_env.
+Instance Sing_env {SA: Sep_alg A}: @Sing_alg env Join_env (fsep_sep Sep_env).
   refine (mkSing empty_env _). reflexivity.
 Defined.
 

--- a/msl/ghost_seplog.v
+++ b/msl/ghost_seplog.v
@@ -102,7 +102,8 @@ Proof.
   erewrite own_op by apply core_unit.
   eapply derives_trans; [apply own_valid_2|].
   apply prop_left; intros (a' & J & ?); apply prop_right.
-  apply core_identity in J; subst; auto.
+  assert (a = a') as ->; auto.
+  eapply join_eq; eauto; apply core_unit.
 Qed.
 
 Lemma own_sub: forall `{BupdSepLog} {RA: Ghost} g (a b: G) pp,

--- a/msl/ghost_seplog.v
+++ b/msl/ghost_seplog.v
@@ -25,7 +25,7 @@ Class BupdSepLog (A N D: Type) {ND: NatDed A}{SL: SepLog A} := mkBSL {
   own_update_ND: forall {RA: Ghost} g (a: G) B pp, fp_update_ND a B ->
     own g a pp |-- bupd (EX b : _, !!(B b) && own g b pp);
   own_dealloc: forall {RA: Ghost} g (a: G) pp,
-    own g a pp |-- bupd emp
+    own g a pp |-- emp
   }.
 
 Notation "|==> P" := (bupd P) (at level 99, P at level 200): logic.

--- a/msl/join_hom_lemmas.v
+++ b/msl/join_hom_lemmas.v
@@ -285,7 +285,7 @@ Lemma join_hom_bij {A: Type} `{Perm_alg A}
     unfold unit_for in *. auto.
   Qed.
 
-  Lemma join_hom_comparable {A}{B}`{Perm_alg A}{SA: Sep_alg A}`{Perm_alg B}{SB:Sep_alg B}:
+  Lemma join_hom_comparable {A}{B}`{Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}`{Perm_alg B}{SB:Sep_alg B}{FB: Flat_alg B}:
       forall (f: A -> B) a1 a2, comparable a1 a2 -> join_hom f -> comparable (f a1) (f a2).
   Proof.
     intros.
@@ -296,7 +296,7 @@ Lemma join_hom_bij {A: Type} `{Perm_alg A}
   Qed.
 
   Lemma join_hom2_comparable {A}{B}{C}
-          `{Perm_alg A}{SA: Sep_alg A}`{Perm_alg B}{SB: Sep_alg B}`{Perm_alg C}{SC: Sep_alg C}:
+          `{Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}`{Perm_alg B}{SB: Sep_alg B}{FB: Flat_alg B}`{Perm_alg C}{SC: Sep_alg C}{FC: Flat_alg C}:
    forall (g: A -> B -> C) a1 a2 b1 b2,
      comparable a1 a2
       -> comparable b1 b2

--- a/msl/knot_full_variant.v
+++ b/msl/knot_full_variant.v
@@ -1,6 +1,7 @@
 Require Import VST.msl.base.
 Require Import VST.msl.ageable.
 Require Import VST.msl.functors.
+Require Import VST.msl.predicates_hered.
 Import VST.msl.functors.MixVariantFunctor.
 Import VST.msl.functors.MixVariantFunctorLemmas.
 
@@ -78,6 +79,75 @@ Module Type KNOT__MIXVARIANT_HERED_T_OTH_REL.
       knot_rel  k' k'' ->
       ORel o o' ->
       T_rel (p (k,o)) (p (k'',o'))).
+
+  Program Instance ext_knot : Ext_ord knot := { ext_order := knot_rel }.
+  Next Obligation.
+  Proof.
+    unfold knot_rel. split.
+    - intros k.
+      destruct (unsquash k); split; auto.
+      apply Rel_refl.
+    - intros k1 k2 k3.
+      destruct (unsquash k1), (unsquash k2), (unsquash k3).
+      intros [] []; subst; split; auto.
+      eapply Rel_trans; eauto.
+  Qed.
+(*  Next Obligation.
+  Proof.
+    intros ?????.
+    unfold age, knot_rel in *. rewrite knot_age1 in H0.
+    destruct (unsquash z) eqn: Hz.
+    destruct n; inv H0.
+    rewrite unsquash_squash in H.
+    destruct (unsquash x) eqn: Hx.
+    destruct H as [? H]; subst.
+    exists (squash (S n0, _f0)); simpl.
+    - rewrite knot_age1, unsquash_squash.
+      f_equal; apply unsquash_inj.
+      rewrite unsquash_squash, Hx.
+      rewrite fmap_app, <- (approx_approx1 1), <- (approx_approx2 1), <- (unsquash_approx Hx).
+      reflexivity.
+    - rewrite unsquash_squash; split; auto.
+      rewrite (unsquash_approx Hz); rewrite (unsquash_approx Hx) in *.
+      rewrite fmap_app, <- (approx_approx1 1), <- (approx_approx2 1).
+      (* may not be true: the unaged pred may not be in Rel even if the aged one is *)
+      admit.
+  Admitted.*)
+  Next Obligation.
+  Proof.
+    intros ?????.
+    unfold age, knot_rel in *. rewrite knot_age1 in H.
+    destruct (unsquash y) eqn: Hy.
+    destruct n; inv H; simpl.
+    destruct (unsquash z) eqn: Hz.
+    destruct H0 as [? H0]; subst.
+    exists (squash (n, _f0)).
+    - rewrite !unsquash_squash.
+      split; auto.
+      apply Rel_fmap; auto.
+    - rewrite knot_age1, Hz; auto.
+  Qed.
+  Next Obligation.
+  Proof.
+    unfold age, knot_rel in *. rewrite knot_age1 in H0.
+    destruct (unsquash a) eqn: Ha.
+    destruct n; inv H0.
+    destruct (unsquash b) eqn: Hb.
+    destruct H as [? H]; subst.
+    exists (squash (n, _f0)).
+    split.
+    - rewrite knot_age1, Hb; auto.
+    - rewrite !unsquash_squash; split; auto.
+      apply Rel_fmap; auto.
+  Qed.
+  Next Obligation.
+  Proof.
+    rewrite !knot_level. unfold knot_rel in H.
+    destruct (unsquash a), (unsquash b), H; auto.
+  Qed.
+
+  Lemma knot_order : ext_order = knot_rel.
+  Proof. reflexivity. Qed.
 
 End KNOT__MIXVARIANT_HERED_T_OTH_REL.
 
@@ -890,6 +960,75 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     intros; reflexivity.
   Qed.
 
+  Program Instance ext_knot : Ext_ord knot := { ext_order := knot_rel }.
+  Next Obligation.
+  Proof.
+    unfold knot_rel. split.
+    - intros k.
+      destruct (unsquash k); split; auto.
+      apply Rel_refl.
+    - intros k1 k2 k3.
+      destruct (unsquash k1), (unsquash k2), (unsquash k3).
+      intros [] []; subst; split; auto.
+      eapply Rel_trans; eauto.
+  Qed.
+(*  Next Obligation.
+  Proof.
+    intros ?????.
+    unfold age, knot_rel in *. rewrite knot_age1 in H0.
+    destruct (unsquash z) eqn: Hz.
+    destruct n; inv H0.
+    rewrite unsquash_squash in H.
+    destruct (unsquash x) eqn: Hx.
+    destruct H as [? H]; subst.
+    exists (squash (S n0, _f0)); simpl.
+    - rewrite knot_age1, unsquash_squash.
+      f_equal; apply unsquash_inj.
+      rewrite unsquash_squash, Hx.
+      rewrite fmap_app, <- (approx_approx1 1), <- (approx_approx2 1), <- (unsquash_approx Hx).
+      reflexivity.
+    - rewrite unsquash_squash; split; auto.
+      rewrite (unsquash_approx Hz); rewrite (unsquash_approx Hx) in *.
+      rewrite fmap_app, <- (approx_approx1 1), <- (approx_approx2 1).
+      (* may not be true: the unaged pred may not be in Rel even if the aged one is *)
+      admit.
+  Admitted.*)
+  Next Obligation.
+  Proof.
+    intros ?????.
+    unfold age, knot_rel in *. rewrite knot_age1 in H.
+    destruct (unsquash y) eqn: Hy.
+    destruct n; inv H; simpl.
+    destruct (unsquash z) eqn: Hz.
+    destruct H0 as [? H0]; subst.
+    exists (squash (n, _f0)); simpl.
+    - split; auto.
+      do 2 apply Rel_fmap; auto.
+    - rewrite knot_age1, Hz; auto.
+  Qed.
+  Next Obligation.
+  Proof.
+    unfold age, knot_rel in *. rewrite knot_age1 in H0.
+    destruct (unsquash a) eqn: Ha.
+    destruct n; inv H0.
+    destruct (unsquash b) eqn: Hb.
+    destruct H as [? H]; subst.
+    exists (squash (n, _f0)).
+    split.
+    - rewrite knot_age1, Hb; auto.
+    - rewrite !unsquash_squash; split; auto.
+      rewrite fmap_app, unstrat_strat.
+      apply Rel_fmap; auto.
+  Qed.
+  Next Obligation.
+  Proof.
+    rewrite !knot_level. unfold knot_rel in H.
+    destruct (unsquash a), (unsquash b), H; auto.
+  Qed.
+
+  Lemma knot_order : ext_order = knot_rel.
+  Proof. reflexivity. Qed.
+
 End Knot_MixVariantHeredTOthRel.
 
 Module KnotLemmas1.
@@ -1084,10 +1223,17 @@ Module Type KNOT_FULL.
   Definition knot : Type := KO.K0.knot.
   Definition ageable_knot : ageable knot := KO.K0.ageable_knot.
   Existing Instance ageable_knot.
+  Definition ext_knot : Ext_ord knot := KO.K0.ext_knot.
+  Existing Instance ext_knot.
   Definition predicate: Type := KO.predicate.
 
-  Parameter squash : (nat * F predicate) -> knot.
-  Parameter unsquash : knot -> (nat * F predicate).
+  Definition squash : (nat * KI.F predicate) -> knot :=
+    fun k => KO.K0.squash
+     (fst k, fmap KI.F (bij_f _ _ KO.pkp) (bij_g _ _ KO.pkp) (snd k)).
+
+  Definition unsquash : knot -> (nat * KI.F predicate) :=
+    fun k => let (n, f) := KO.K0.unsquash k in
+      (n, fmap KI.F (bij_g _ _ KO.pkp) (bij_f _ _ KO.pkp) f).
 
   Parameter approx : nat -> predicate -> predicate.
 
@@ -1158,6 +1304,8 @@ Module KnotFull
   Definition knot: Type := KO.K0.knot.
   Definition ageable_knot : ageable knot := KO.K0.ageable_knot.
   Existing Instance ageable_knot.
+  Definition ext_knot : Ext_ord knot := KO.K0.ext_knot.
+  Existing Instance ext_knot.
   Definition predicate: Type := KO.predicate.
 
   Definition squash : (nat * KI.F predicate) -> knot :=

--- a/msl/knot_full_variant.v
+++ b/msl/knot_full_variant.v
@@ -92,27 +92,6 @@ Module Type KNOT__MIXVARIANT_HERED_T_OTH_REL.
       intros [] []; subst; split; auto.
       eapply Rel_trans; eauto.
   Qed.
-(*  Next Obligation.
-  Proof.
-    intros ?????.
-    unfold age, knot_rel in *. rewrite knot_age1 in H0.
-    destruct (unsquash z) eqn: Hz.
-    destruct n; inv H0.
-    rewrite unsquash_squash in H.
-    destruct (unsquash x) eqn: Hx.
-    destruct H as [? H]; subst.
-    exists (squash (S n0, _f0)); simpl.
-    - rewrite knot_age1, unsquash_squash.
-      f_equal; apply unsquash_inj.
-      rewrite unsquash_squash, Hx.
-      rewrite fmap_app, <- (approx_approx1 1), <- (approx_approx2 1), <- (unsquash_approx Hx).
-      reflexivity.
-    - rewrite unsquash_squash; split; auto.
-      rewrite (unsquash_approx Hz); rewrite (unsquash_approx Hx) in *.
-      rewrite fmap_app, <- (approx_approx1 1), <- (approx_approx2 1).
-      (* may not be true: the unaged pred may not be in Rel even if the aged one is *)
-      admit.
-  Admitted.*)
   Next Obligation.
   Proof.
     intros ?????.

--- a/msl/knot_hered.v
+++ b/msl/knot_hered.v
@@ -27,8 +27,12 @@ Module Type KNOT_HERED.
   Parameter ag_knot : ageable knot.
   Existing Instance ag_knot.
   Existing Instance ag_prod.
+  Parameter ext_knot : Ext_ord knot.
+  Existing Instance ext_knot.
+  Existing Instance Ext_prod.
 
-  Definition predicate := pred (knot * other).
+  Parameter hered : (knot * other -> Prop) -> Prop.
+  Definition predicate := { p:knot * other -> Prop | hered p }.
 
   Parameter squash : (nat * F predicate) -> knot.
   Parameter unsquash : knot -> (nat * F predicate).
@@ -108,7 +112,7 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
     end.
   Definition ko_age x y := ko_age1 x = Some y.
 
-
+  Definition hered := hereditary ko_age.
   Definition predicate := { p:knot * other -> Prop | hereditary ko_age p }.
 
   Definition app_sinv (n:nat) (p:sinv (S n)) (x:F (sinv n) * other) :=
@@ -414,12 +418,12 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
   Next Obligation.
     hnf; simpl; intros.
     intuition.
-    unfold level in *.
-    unfold unsquash in *.
-    destruct a0; simpl in H.
-    destruct x; try discriminate.
-    inv H.
-    simpl in *; lia.
+    unfold ko_age, ko_age1 in H.
+    destruct (k_age1 (fst a)) eqn: Hage; inv H; simpl.
+    assert (level k < level (fst a)); [|lia].
+    unfold level, unsquash.
+    destruct a as ((n', ?), ?); simpl in *.
+    destruct n'; inv Hage; simpl in *; lia.
     destruct p; simpl in *.
     eapply h; eauto.
   Qed.
@@ -683,6 +687,16 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
     auto.
     destruct k; simpl. destruct x. auto.
     intros. discriminate.
+  Qed.
+
+  Program Instance ext_knot : Ext_ord knot := { ext_order := eq }.
+  Next Obligation.
+  Proof.
+    intros ?????; subst; eauto.
+  Qed.
+  Next Obligation.
+  Proof.
+    eauto.
   Qed.
 
 End KnotHered.

--- a/msl/knot_shims.v
+++ b/msl/knot_shims.v
@@ -116,7 +116,7 @@ Module Type KNOT_INPUT__COVARIANT_HERED_PROP_OTH_REL.
 
 End KNOT_INPUT__COVARIANT_HERED_PROP_OTH_REL.
 
-Module Type KNOT__COVARIANT_HERED_PROP_OTH_REL.
+(*Module Type KNOT__COVARIANT_HERED_PROP_OTH_REL.
   Import CovariantFunctor.
   Declare Module KI : KNOT_INPUT__COVARIANT_HERED_PROP_OTH_REL.
   Import KI.
@@ -169,7 +169,7 @@ Module Type KNOT__COVARIANT_HERED_PROP_OTH_REL.
     | (S n,x) => Some (squash (n,x))
     end.
 
-End KNOT__COVARIANT_HERED_PROP_OTH_REL.
+End KNOT__COVARIANT_HERED_PROP_OTH_REL.*)
 
 Module Type KNOT_INPUT__COVARIANT_HERED_PROP_OTH.
 
@@ -179,7 +179,7 @@ Module Type KNOT_INPUT__COVARIANT_HERED_PROP_OTH.
 
 End KNOT_INPUT__COVARIANT_HERED_PROP_OTH.
 
-Module Type KNOT__COVARIANT_HERED_PROP_OTH.
+(*Module Type KNOT__COVARIANT_HERED_PROP_OTH.
   Declare Module KI : KNOT_INPUT__COVARIANT_HERED_PROP_OTH.
   Import CovariantFunctor.
   Import CovariantFunctorLemmas.
@@ -300,12 +300,21 @@ Module Type KNOT__COVARIANT_HERED_PROP.
   Axiom approx_approx2 : forall m n,
     approx n = approx (m+n) oo approx n.
 *)
-End KNOT__COVARIANT_HERED_PROP.
+End KNOT__COVARIANT_HERED_PROP.*)
 
 Module Type KNOT_INPUT__MIXVARIANT_HERED_PROP.
 
   Import MixVariantFunctor.
   Parameter F : functor.
+
+  Parameter Rel : forall A, relation (F A).
+
+  Parameter Rel_fmap : forall A B (f1: A->B) (f2:B->A) x y,
+    Rel A x y ->
+    Rel B (fmap F f1 f2 x) (fmap F f1 f2 y).
+  Axiom Rel_refl : forall A x, Rel A x x.
+  Axiom Rel_trans : forall A x y z,
+    Rel A x y -> Rel A y z -> Rel A x z.
 
 End KNOT_INPUT__MIXVARIANT_HERED_PROP.
 
@@ -319,6 +328,9 @@ Module Type KNOT__MIXVARIANT_HERED_PROP.
 
   Parameter ageable_knot : ageable knot.
   Existing Instance ageable_knot.
+
+  Parameter ext_knot : Ext_ord knot.
+  Existing Instance ext_knot.
 
   Definition predicate := pred knot.
   Parameter squash : (nat * F (pred knot)) -> knot.
@@ -343,6 +355,9 @@ Module Type KNOT__MIXVARIANT_HERED_PROP.
     | (O,_) => None
     | (S n,x) => Some (squash (n,x))
     end.
+
+  Axiom knot_order : forall k1 k2 : knot, ext_order k1 k2 <->
+    level k1 = level k2 /\ Rel predicate (snd (unsquash k1)) (snd (unsquash k2)).
 
 End KNOT__MIXVARIANT_HERED_PROP.
 
@@ -518,7 +533,7 @@ Module KnotLemmas_CoContraVariantHeredTOthRel
 
 End KnotLemmas_CoContraVariantHeredTOthRel.
 
-Module Knot_CovariantHeredPropOthRel (KI':KNOT_INPUT__COVARIANT_HERED_PROP_OTH_REL)
+(*Module Knot_CovariantHeredPropOthRel (KI':KNOT_INPUT__COVARIANT_HERED_PROP_OTH_REL)
   : KNOT__COVARIANT_HERED_PROP_OTH_REL with Module KI:=KI'.
 
   Module KI:=KI'.
@@ -1379,7 +1394,7 @@ Module KnotLemmas_CovariantHeredProp (K: KNOT__COVARIANT_HERED_PROP).
      (knot_full_variant.KnotLemmas2.Proof).
   Qed.
 
-End KnotLemmas_CovariantHeredProp.
+End KnotLemmas_CovariantHeredProp.*)
 
 Module Knot_MixVariantHeredProp (KI':KNOT_INPUT__MIXVARIANT_HERED_PROP)
   : KNOT__MIXVARIANT_HERED_PROP with Module KI:=KI'.
@@ -1393,24 +1408,15 @@ Module Knot_MixVariantHeredProp (KI':KNOT_INPUT__MIXVARIANT_HERED_PROP)
     Definition F: functor := KI.F.
     Definition other := unit.
 
-    Definition Rel A := @eq (F A).
-    Lemma Rel_fmap : forall A B (f:A -> B) (s:B -> A) x y,
+    Definition Rel A := KI.Rel A.
+    Definition Rel_fmap : forall A B (f:A -> B) (s:B -> A) x y,
       Rel A x y ->
-      Rel B (fmap F f s x) (fmap F f s y).
-    Proof.
-      unfold Rel; intuition; subst; auto.
-    Qed.
+      Rel B (fmap F f s x) (fmap F f s y) := KI.Rel_fmap.
 
-    Lemma Rel_refl : forall A x, Rel A x x.
-    Proof.
-      intros; hnf; auto.
-    Qed.
+    Definition Rel_refl : forall A x, Rel A x x := KI.Rel_refl.
 
-    Lemma Rel_trans : forall A x y z,
-      Rel A x y -> Rel A y z -> Rel A x z.
-    Proof.
-      unfold Rel; intuition congruence.
-    Qed.
+    Definition Rel_trans : forall A x y z,
+      Rel A x y -> Rel A y z -> Rel A x z := KI.Rel_trans.
 
     Definition ORel := @eq other.
     Lemma ORel_refl : reflexive other ORel.
@@ -1445,39 +1451,40 @@ Module Knot_MixVariantHeredProp (KI':KNOT_INPUT__MIXVARIANT_HERED_PROP)
   Module K0 := knot_full_variant.Knot_MixVariantHeredTOthRel(Input).
   Module KL0 := knot_full_variant.KnotLemmas_MixVariantHeredTOthRel(K0).
   Existing Instance K0.ageable_knot.
+  Existing Instance K0.ext_knot.
 
   Lemma hered_hereditary : forall (p: K0.knot -> Prop),
-    K0.hered (fun ko => p (fst ko)) <-> hereditary age p.
+    K0.hered (fun ko => p (fst ko)) <-> hereditary age p /\ hereditary K0.knot_rel p.
   Proof.
     intros; split; repeat intro.
     rewrite K0.hered_spec in H.
+    split; repeat intro.
     hnf in H0.
     simpl in H0.
-    specialize ( H a a' a').
-    specialize ( H tt tt).
+    specialize (H a a' a').
+    specialize (H tt tt).
     spec H.
     apply rt_step; auto.
     spec H.
     hnf.
     destruct (K0.unsquash a'); split; auto.
-    hnf; auto.
+    apply Input.Rel_refl.
     apply H; auto.
     hnf; auto.
 
+    eapply (H _ _ _ tt tt); eauto.
+    reflexivity.
+
     rewrite K0.hered_spec; intros.
-    assert (k' = k'').
-    apply KL0.unsquash_inj.
-    hnf in H1.
-    destruct (K0.unsquash k').
-    destruct (K0.unsquash k'').
-    destruct H1; hnf in H3.
-    subst; auto.
-    subst k''.
+    hnf; simpl.
+    intros Hp.
+    destruct H as [H Hrel].
+    eapply Hrel; eauto.
     hnf in H.
 
     hnf.
     simpl.
-    clear -H H0.
+    clear -H H0 Hp.
     induction H0; auto.
     eapply H; eauto.
   Qed.
@@ -1500,6 +1507,7 @@ Module Knot_MixVariantHeredProp (KI':KNOT_INPUT__MIXVARIANT_HERED_PROP)
 
   Definition knot := K.knot.
   Definition ageable_knot := K.ageable_knot.
+  Definition ext_knot := K.ext_knot.
   Definition predicate := pred knot.
   Definition squash: (nat * KI.F (pred knot)) -> knot := K.squash.
   Definition unsquash: knot -> (nat * KI.F (pred knot)) := K.unsquash.
@@ -1535,6 +1543,20 @@ Module Knot_MixVariantHeredProp (KI':KNOT_INPUT__MIXVARIANT_HERED_PROP)
   Definition knot_age1 := K.knot_age1.
 
   Definition knot_level := K.knot_level.
+
+  Lemma knot_order : forall k1 k2 : knot, ext_order k1 k2 <->
+    level k1 = level k2 /\ Input.Rel predicate (snd (unsquash k1)) (snd (unsquash k2)).
+  Proof.
+    intros; simpl.
+    unfold Output.K0.knot_rel, Output.K0.unsquash, unsquash, K.unsquash.
+    rewrite !K0.knot_level.
+    destruct (K0.unsquash k1) eqn: Hk1, (K0.unsquash k2) eqn: Hk2; unfold snd.
+    unfold Output.K0.KI.Rel.
+    split; intros [? H]; split; auto.
+    - apply KI.Rel_fmap; auto.
+    - apply (KI.Rel_fmap _ _ (bij_f _ _ Output.pkp) (bij_g _ _ Output.pkp)) in H.
+      rewrite !fmap_app, bij_fg_id, fmap_id in H; auto.
+  Qed.
 
 End Knot_MixVariantHeredProp.
 

--- a/msl/log_normalize.v
+++ b/msl/log_normalize.v
@@ -946,7 +946,7 @@ intros. rewrite sepcon_comm. rewrite andp_comm. rewrite corable_andp_sepcon1; au
 Qed.
 
 #[export] Hint Resolve corable_andp corable_orp corable_allp corable_exp
-                    corable_imp corable_prop corable_sepcon corable_wand corable_later : core.
+                    (*corable_imp*) corable_prop corable_sepcon corable_wand corable_later : core.
 #[export] Hint Resolve corable_prop : norm.
 
 (* The followings are not in auto-rewrite lib. *)
@@ -1299,31 +1299,32 @@ Lemma subp_later1 {A}  {NA: NatDed A}{IA: Indir A}{RA: RecIndir A} : forall P Q 
    |>(P >=> Q)  |--   |>P >=> |>Q.
 Proof.
 intros.
-rewrite later_fash. rewrite later_imp. auto.
+rewrite later_fash. apply fash_derives, later_K.
 Qed.
 
-Lemma subp_later {A}  {NA: NatDed A}{IA: Indir A}{RA: RecIndir A} : forall P Q : A,
+(*Lemma subp_later {A}  {NA: NatDed A}{IA: Indir A}{RA: RecIndir A} : forall P Q : A,
    |>(P >=> Q) = |>P >=> |>Q.
 Proof.
 intros.
 rewrite later_fash. rewrite later_imp. auto.
-Qed.
+Qed.*)
 
 Lemma eqp_later1 {A} {NA: NatDed A}{IA: Indir A}{RA: RecIndir A} : forall P Q : A,
    |>(P <=> Q)  |--   |>P <=> |>Q.
 Proof.
 intros.
 rewrite later_fash.
-rewrite later_andp; repeat rewrite later_imp; repeat  rewrite fash_andp. auto.
+rewrite later_andp.
+apply fash_derives, andp_derives; apply later_K.
 Qed.
 
-Lemma eqp_later {A}  {NA: NatDed A}{IA: Indir A}{RA: RecIndir A}  : forall P Q: A,
+(*Lemma eqp_later {A}  {NA: NatDed A}{IA: Indir A}{RA: RecIndir A}  : forall P Q: A,
     (|>(P <=> Q) = |>P <=> |>Q).
 Proof.
 intros.
 rewrite later_fash.
 rewrite later_andp; repeat rewrite later_imp; repeat  rewrite fash_andp. auto.
-Qed.
+Qed.*)
 
 Lemma subp_refl {A} {NA: NatDed A}{IA: Indir A}{RA: RecIndir A}  : forall G (P : A),
   G |-- P >=> P.
@@ -1494,18 +1495,11 @@ Lemma prove_HOcontractive {A} {NA: NatDed A}{IA: Indir A}{RA: RecIndir A} : fora
     (ALL x:X, (|> P x <=> |> Q x) |-- F P x >=> F Q x)) ->
    HOcontractive F.
 Proof.
-  intros.
   unfold HOcontractive.
-  intros.
-  apply allp_right; intro v.
+  intros. apply allp_right. intros.
   rewrite fash_andp.
-  apply andp_right.
-  eapply derives_trans; [ | apply H].
-  apply allp_derives; intro x.
-  rewrite eqp_later. auto.
-  eapply derives_trans; [ | apply H].
-  apply allp_derives; intro x.
-  rewrite eqp_later. rewrite andp_comm. auto.
+  apply andp_right; eapply derives_trans, H; apply allp_derives; intros;
+    [|rewrite andp_comm]; apply eqp_later1.
 Qed.
 
 Lemma sub_sepcon' {A}{NA: NatDed A}{SL: SepLog A}{IA: Indir A}{RA: RecIndir A}{SRA: SepRec A}:
@@ -1563,7 +1557,7 @@ Proof.
 intros.
 assert (TT |-- Q --> P).
 apply loeb.
-rewrite later_imp.
+eapply derives_trans; [apply later_K|].
 apply imp_andp_adjoint.
 eapply derives_trans; [ | apply H].
 apply andp_right.

--- a/msl/log_normalize.v
+++ b/msl/log_normalize.v
@@ -1502,6 +1502,20 @@ Proof.
     [|rewrite andp_comm]; apply eqp_later1.
 Qed.
 
+Lemma prove_HOcontractive' {A} {NA: NatDed A}{IA: Indir A}{RA: RecIndir A} : forall X F,
+  (forall (P Q: X -> A) (x: X),
+    (ALL x:X, |>(P x <=> Q x) |-- F P x >=> F Q x)) ->
+   HOcontractive F.
+Proof.
+  unfold HOcontractive.
+  intros. apply allp_right. intros v.
+  setoid_rewrite fash_andp at 2.
+  apply andp_right; auto.
+  eapply derives_trans, H.
+  apply allp_derives; intros.
+  rewrite andp_comm; auto.
+Qed.
+
 Lemma sub_sepcon' {A}{NA: NatDed A}{SL: SepLog A}{IA: Indir A}{RA: RecIndir A}{SRA: SepRec A}:
   forall P P' Q Q': A, (P >=> P') && (Q >=> Q') |-- (P * Q) >=> (P' * Q').
 Proof.

--- a/msl/log_normalize.v
+++ b/msl/log_normalize.v
@@ -946,7 +946,7 @@ intros. rewrite sepcon_comm. rewrite andp_comm. rewrite corable_andp_sepcon1; au
 Qed.
 
 #[export] Hint Resolve corable_andp corable_orp corable_allp corable_exp
-                    (*corable_imp*) corable_prop corable_sepcon corable_wand corable_later : core.
+                    corable_imp corable_prop corable_sepcon corable_wand corable_later : core.
 #[export] Hint Resolve corable_prop : norm.
 
 (* The followings are not in auto-rewrite lib. *)

--- a/msl/normalize.v
+++ b/msl/normalize.v
@@ -2,7 +2,7 @@ Require Import VST.msl.msl_standard.
 
 Local Open Scope pred.
 
-Lemma andp_TT {A}`{ageable A}: forall (P: pred A), P && TT = P.
+Lemma andp_TT {A}`{ageable A}{EO: Ext_ord A}: forall (P: pred A), P && TT = P.
 Proof.
 intros.
 apply pred_ext; intros w ?.
@@ -10,7 +10,7 @@ destruct H0; auto.
 split; auto.
 Qed.
 
-Lemma sepcon_andp_prop' {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall P Q R, (!!Q && P)*R = !!Q&&(P*R).
+Lemma sepcon_andp_prop' {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}: forall P Q R, (!!Q && P)*R = !!Q&&(P*R).
 Proof.
 intros.
 rewrite sepcon_comm. rewrite sepcon_andp_prop.
@@ -23,25 +23,28 @@ Hint Rewrite @sepcon_emp @emp_sepcon @TT_and @andp_TT
          @sepcon_andp_prop @sepcon_andp_prop'
         : normalize.
 
-Definition pure {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
+Definition pure {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}
      (P: pred A) : Prop :=
    P |-- emp.
 
-Lemma pure_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall (P : pred A), pure P -> P*P=P.
+(*Lemma pure_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}: forall (P : pred A), pure P -> P*P=P.
 Proof.
-pose proof I.
 intros.
 apply pred_ext; intros w ?.
-destruct H1 as (? & ? & J & HP & ?).
-apply H0 in HP; apply HP in J; subst; auto.
+destruct H0 as (? & ? & J & HP & ?).
+apply H in HP. destruct HP as (? & Hid & Hext).
+eapply join_ext_commut in Hext as (? & J1 & ?); eauto.
+apply Hid in J1; subst.
+eapply pred_upclosed; eauto.
+destruct (H _ H0) as (? & ? & ?).
 exists w; exists w.
 split; [|split]; auto.
 apply H0 in H1.
 do 3 red in H1. apply identity_unit' in H1.
 apply H1.
-Qed.
+Qed.*)
 
-Lemma pure_e {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall (P: pred A), pure P -> (P |-- emp).
+Lemma pure_e {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}: forall (P: pred A), pure P -> (P |-- emp).
 Proof.
 intros.
 apply H.
@@ -49,7 +52,7 @@ Qed.
 
 #[export] Hint Resolve pure_e : core.
 
-Lemma sepcon_pure_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+(*Lemma sepcon_pure_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
  forall P Q, pure P -> pure Q -> ((P * Q) = (P && Q)).
 Proof.
 intros.
@@ -74,9 +77,9 @@ clear dependent P. clear dependent Q.
 pose proof (core_unit w); unfold unit_for in *.
 pose proof (H1 _ _ (join_comm H)).
 rewrite H0 in H; auto.
-Qed.
+Qed.*)
 
-Lemma pure_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: pure emp.
+Lemma pure_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}: pure emp.
 Proof.
 intros. unfold pure; auto.
 Qed.
@@ -86,7 +89,7 @@ Lemma join_equiv_refl {A}: forall x:A, @join A (Join_equiv A) x x x.
 Proof. split; auto. Qed.
 #[export] Hint Resolve join_equiv_refl : core.
 
-Lemma pure_sepcon1'' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall P Q R, pure P -> (Q |-- R) -> P * Q |-- R.
+(*Lemma pure_sepcon1'' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall P Q R, pure P -> (Q |-- R) -> P * Q |-- R.
 Proof.
 pose proof I.
 intros.
@@ -94,10 +97,10 @@ intros w [w1 [w2 [? [? ?]]]].
 apply H0 in H3.
 apply join_unit1_e in H2; auto.
 subst; auto.
-Qed.
+Qed.*)
 
 
-Lemma pure_existential {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma pure_existential {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
    forall B (P: B -> pred A),    (forall x: B , pure (P x)) -> pure (exp P).
 Proof.
 intros.
@@ -108,22 +111,22 @@ Qed.
 
 #[export] Hint Resolve pure_existential : core.
 
-Lemma pure_core {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+(*Lemma pure_core {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
   forall P w, pure P -> P w -> P (core w).
 Proof.
 intros.
 rewrite <- identity_core; auto.
 apply H; auto.
-Qed.
+Qed.*)
 
-Lemma FF_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma FF_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
            forall P, FF * P = FF.
 Proof.
 intros.
 apply pred_ext; intros w ?; try contradiction.
 destruct H as [w1 [w2 [? [? ?]]]]; contradiction.
 Qed.
-Lemma sepcon_FF {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma sepcon_FF {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
             forall P, P * FF = FF.
 Proof.
 intros.
@@ -133,30 +136,30 @@ Hint Rewrite @FF_sepcon @sepcon_FF : normalize.
 
 Hint Rewrite @prop_true_andp using (solve [auto]) : normalize.
 
-Lemma true_eq {A} `{ageable A}:  forall P: Prop, P -> (!! P) = (TT: pred A).
+Lemma true_eq {A} `{ageable A} {EO: Ext_ord A}:  forall P: Prop, P -> (!! P) = (TT: pred A).
 Proof.
 intros. apply pred_ext; intros ? ?; simpl in *; intuition.
 Qed.
 Hint Rewrite @true_eq using (solve [auto]) : normalize.
 
 
-Lemma pure_con' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma pure_con' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
       forall P Q, pure P -> pure Q -> pure (P*Q).
 Proof.
 intros.
 unfold pure in *.
-rewrite <- emp_emp_sepcon.
+rewrite <- emp_sepcon.
 apply sepcon_derives; auto.
 Qed.
 #[export] Hint Resolve pure_con' : core.
 
-Lemma pure_intersection1: forall {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
+Lemma pure_intersection1: forall {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}
        (P Q: pred A), pure P -> pure (P && Q).
 Proof.
 unfold pure; intros; auto.
 intros w [? ?]; auto.
 Qed.
-Lemma pure_intersection2: forall {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}
+Lemma pure_intersection2: forall {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}
      (P Q: pred A), pure Q -> pure (P && Q).
 Proof.
 unfold pure; intros; auto.
@@ -164,11 +167,11 @@ intros w [? ?]; auto.
 Qed.
 #[export] Hint Resolve pure_intersection1 pure_intersection2 : core.
 
-Lemma FF_andp {A} `{ageable A}:  forall P: pred A, FF && P = FF.
+Lemma FF_andp {A} `{ageable A}{EO: Ext_ord A}:  forall P: pred A, FF && P = FF.
 Proof.
 unfold FF, prop, andp; intros; apply pred_ext; intros ? ?; simpl in *; intuition.
 Qed.
-Lemma andp_FF {A}`{ageable A}:  forall P: pred A, P && FF = FF.
+Lemma andp_FF {A}`{ageable A}{EO: Ext_ord A}:  forall P: pred A, P && FF = FF.
 Proof.
 unfold FF, prop, andp; intros; apply pred_ext; intros ? ?; simpl in *; intuition.
 Qed.
@@ -176,7 +179,7 @@ Hint Rewrite @FF_andp @andp_FF : normalize.
 
 Hint Rewrite @andp_dup : normalize.
 
-Lemma andp_emp_sepcon_TT {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{FA: Flat_alg A}{AgeA: Age_alg A}:
+Lemma andp_emp_sepcon_TT {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{FA: Flat_alg A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
  forall (Q: pred A),
      (forall w1 w2, core w1 = core w2 -> Q w1 -> Q w2) ->
       (Q && emp * TT = Q).
@@ -195,7 +198,7 @@ apply H with w; auto.
 symmetry; eapply join_core2; eauto.
 Qed.
 
-Lemma sepcon_TT {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma sepcon_TT {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
    forall (P: pred A), P |-- (P * TT).
 Proof.
 intros.
@@ -205,7 +208,7 @@ apply join_comm, core_unit.
 Qed.
 #[export] Hint Resolve sepcon_TT : core.
 
-Lemma imp_extract_exp_left {B A: Type} `{ageable A}:
+Lemma imp_extract_exp_left {B A: Type} `{ageable A}{EO: Ext_ord A}:
     forall    (p : B -> pred A) (q: pred A),
   (forall x, p x |-- q) ->
    exp p |-- q.
@@ -215,7 +218,7 @@ intros w [x ?].
 eapply H0; eauto.
 Qed.
 
-Lemma pure_sepcon_TT_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+(*Lemma pure_sepcon_TT_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
   forall P Q, pure P -> (P * TT) && Q = (P*Q).
 Proof.
  pose proof I.
@@ -235,7 +238,7 @@ subst; auto.
 apply H0 in H2; auto.
 Qed.
 
-Lemma pure_sepcon_TT_andp' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma pure_sepcon_TT_andp' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
   forall P Q, pure P -> Q && (P * TT) = (Q*P).
 Proof.
 intros. rewrite andp_comm.
@@ -243,25 +246,25 @@ rewrite pure_sepcon_TT_andp; auto.
 apply sepcon_comm.
 Qed.
 
-Hint Rewrite @pure_sepcon_TT_andp @pure_sepcon_TT_andp' using (solve [auto]): normalize.
+Hint Rewrite @pure_sepcon_TT_andp @pure_sepcon_TT_andp' using (solve [auto]): normalize.*)
 
-Lemma pure_sepcon1' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+(*Lemma pure_sepcon1' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
 
   forall P Q R, pure P -> (P * Q |-- P * R) -> P * Q |-- R.
 Proof.
 intros.
 eapply derives_trans; try apply H0.
 apply pure_sepcon1''; auto.
-Qed.
+Qed.*)
 
-Lemma pull_right {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma pull_right {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
  forall P Q R,
    (Q * P * R) = (Q * R * P).
 Proof.
 intros. repeat rewrite sepcon_assoc. rewrite (sepcon_comm P); auto.
 Qed.
 
-Lemma pull_right0 {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall P Q,
+Lemma pull_right0 {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}: forall P Q,
    (P * Q) = (Q * P).
 Proof.
 intros. rewrite (sepcon_comm P); auto.
@@ -271,16 +274,16 @@ Ltac pull_left A := repeat (rewrite <- (pull_right A) || rewrite <- (pull_right0
 
 Ltac pull_right A := repeat (rewrite (pull_right A) || rewrite (pull_right0 A)).
 
-Lemma pure_modus {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+(*Lemma pure_modus {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}:
   forall P Q,  (P |-- Q) -> pure Q -> P |-- Q && P.
 Proof.
 intros.
 intros w ?.
 split; auto.
-Qed.
+Qed.*)
 
 
-Lemma imp_exp_right {B A : Type} `{saA: ageable A}:
+Lemma imp_exp_right {B A : Type} `{saA: ageable A}{EO: Ext_ord A}:
   forall (x: B) (p: pred A) (q: B -> pred A),
     (p |-- q x) ->
     p |-- exp q.
@@ -290,14 +293,14 @@ eapply derives_trans; try apply H.
 intros w ?; exists x; auto.
 Qed.
 
-Lemma derives_extract_prop {A} `{ageable A}:
+Lemma derives_extract_prop {A} `{ageable A}{EO: Ext_ord A}:
   forall (P: Prop) (Q R: pred A), (P -> Q |-- R) ->  !!P && Q |-- R.
 Proof.
 unfold derives, prop, andp; hnf in *; intuition.
 hnf in H1; intuition.
 Qed.
 
-Lemma derives_extract_prop' {A} `{ageable A}:
+Lemma derives_extract_prop' {A} `{ageable A}{EO: Ext_ord A}:
   forall (P: Prop) (Q R: pred A), (P -> Q |-- R) ->  Q && !!P|-- R.
 Proof.
 unfold derives, prop, andp; intuition; hnf in *; intuition.
@@ -353,7 +356,7 @@ Tactic Notation "normalize" "in" hyp(H) := repeat (normalize1_in H).
 
 Definition mark {A: Type} (i: nat) (j: A) := j.
 
-Lemma swap_mark1 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma swap_mark1 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
   forall i j Pi Pj B, (i<j)%nat -> B * mark i Pi * mark j Pj = B * mark j Pj * mark i Pi.
 Proof.
 intros.
@@ -362,7 +365,7 @@ f_equal.
 apply sepcon_comm.
 Qed.
 
-Lemma swap_mark0 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma swap_mark0 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}:
   forall i j Pi Pj,  (i<j)%nat -> mark i Pi * mark j Pj = mark j Pj * mark i Pi.
 Proof.
 intros.
@@ -390,7 +393,7 @@ Ltac markem n P :=
   end.
 
 Ltac prove_assoc_commut :=
- clear;
+ match goal with H : Perm_alg _ |- _ => clear - H end;
  try (match goal with |- ?F _ -> ?G _ => replace G with F; auto end);
   (repeat rewrite <- sepcon_assoc;
    match goal with |- ?P = _ => markem O P end;
@@ -401,7 +404,7 @@ Ltac prove_assoc_commut :=
      reflexivity
    end).
 
-Lemma test_prove_assoc_commut {T}{JA: Join T}{PA: Perm_alg T}{SA: Sep_alg T}{agA: ageable T}{AgeA: Age_alg T} : forall A B C D E : pred T,
+Lemma test_prove_assoc_commut {T}{JA: Join T}{PA: Perm_alg T}{SA: Sep_alg T}{agA: ageable T}{AgeA: Age_alg T}{EO: Ext_ord T}{EA: Ext_alg T} : forall A B C D E : pred T,
    D * E * A * C * B = A * B * C * D * E.
 Proof.
 intros.

--- a/msl/normalize.v
+++ b/msl/normalize.v
@@ -32,10 +32,8 @@ Proof.
 pose proof I.
 intros.
 apply pred_ext; intros w ?.
-assert ((emp * P)%pred w).
-eapply sepcon_derives; try apply H1; auto.
-rewrite emp_sepcon in H2.
-auto.
+destruct H1 as (? & ? & J & HP & ?).
+apply H0 in HP; apply HP in J; subst; auto.
 exists w; exists w.
 split; [|split]; auto.
 apply H0 in H1.
@@ -147,7 +145,7 @@ Lemma pure_con' {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{
 Proof.
 intros.
 unfold pure in *.
-rewrite <- sepcon_emp.
+rewrite <- emp_emp_sepcon.
 apply sepcon_derives; auto.
 Qed.
 #[export] Hint Resolve pure_con' : core.
@@ -178,7 +176,7 @@ Hint Rewrite @FF_andp @andp_FF : normalize.
 
 Hint Rewrite @andp_dup : normalize.
 
-Lemma andp_emp_sepcon_TT {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma andp_emp_sepcon_TT {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{FA: Flat_alg A}{AgeA: Age_alg A}:
  forall (Q: pred A),
      (forall w1 w2, core w1 = core w2 -> Q w1 -> Q w2) ->
       (Q && emp * TT = Q).
@@ -201,8 +199,9 @@ Lemma sepcon_TT {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{
    forall (P: pred A), P |-- (P * TT).
 Proof.
 intros.
-rewrite <- (sepcon_emp P) at 1.
-eapply sepcon_derives; try apply H0; auto.
+intros ??.
+exists a, (core a); repeat split; auto.
+apply join_comm, core_unit.
 Qed.
 #[export] Hint Resolve sepcon_TT : core.
 
@@ -354,7 +353,7 @@ Tactic Notation "normalize" "in" hyp(H) := repeat (normalize1_in H).
 
 Definition mark {A: Type} (i: nat) (j: A) := j.
 
-Lemma swap_mark1 {A} {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma swap_mark1 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall i j Pi Pj B, (i<j)%nat -> B * mark i Pi * mark j Pj = B * mark j Pj * mark i Pi.
 Proof.
 intros.
@@ -363,7 +362,7 @@ f_equal.
 apply sepcon_comm.
 Qed.
 
-Lemma swap_mark0 {A} {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma swap_mark0 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall i j Pi Pj,  (i<j)%nat -> mark i Pi * mark j Pj = mark j Pj * mark i Pi.
 Proof.
 intros.
@@ -402,7 +401,7 @@ Ltac prove_assoc_commut :=
      reflexivity
    end).
 
-Lemma test_prove_assoc_commut {T}{JA: Join T}{PA: Perm_alg T}{agA: ageable T}{AgeA: Age_alg T} : forall A B C D E : pred T,
+Lemma test_prove_assoc_commut {T}{JA: Join T}{PA: Perm_alg T}{SA: Sep_alg T}{agA: ageable T}{AgeA: Age_alg T} : forall A B C D E : pred T,
    D * E * A * C * B = A * B * C * D * E.
 Proof.
 intros.

--- a/msl/op_classes.v
+++ b/msl/op_classes.v
@@ -20,7 +20,7 @@ Require Import VST.msl.predicates_rec.
 
 Class StarOp A := {  starOp : A -> A -> A }.
 
-Instance baseStarOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{AgeA: Age_alg A}
+Instance baseStarOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AgeA: Age_alg A}
  : StarOp (pred A) := {| starOp := sepcon |}.
 
 Instance funStarOp (B: Type)(A: Type)(StarA: StarOp A) : StarOp (B -> A) :=
@@ -47,7 +47,7 @@ Open Scope logic_derives.
 
 Class WandOp A := {  wandOp : A -> A -> A }.
 
-Instance baseWandOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{AgeA: Age_alg A}
+Instance baseWandOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AgeA: Age_alg A}
  : WandOp (pred A) := {| wandOp := wand |}.
 
 Instance funWandOp (B: Type)(A: Type)(WandA: WandOp A) : WandOp (B -> A) :=
@@ -74,7 +74,7 @@ Variables (rmap : Type)
       (Canc_rmap: @Canc_alg rmap Join_rmap)
       (Disj_rmap: @Disj_alg rmap Join_rmap)
       (ag_rmap: ageable rmap)
-      (Age_rmap: @Age_alg rmap Join_rmap ag_rmap).
+      (Age_rmap: @Age_alg rmap Join_rmap ag_rmap Sep_rmap).
 Existing Instance  Join_rmap.
 Existing Instance  Perm_rmap.
 Existing Instance  Sep_rmap.

--- a/msl/op_classes.v
+++ b/msl/op_classes.v
@@ -20,7 +20,7 @@ Require Import VST.msl.predicates_rec.
 
 Class StarOp A := {  starOp : A -> A -> A }.
 
-Instance baseStarOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AgeA: Age_alg A}
+Instance baseStarOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}
  : StarOp (pred A) := {| starOp := sepcon |}.
 
 Instance funStarOp (B: Type)(A: Type)(StarA: StarOp A) : StarOp (B -> A) :=
@@ -33,8 +33,8 @@ Set Warnings "notation-overridden".
 
 Class DerivesOp A := {  derivesOp : A -> A -> Prop }.
 
-Instance baseDerivesOp {A}{agA: ageable A}
- : DerivesOp (pred A) := {| derivesOp := @derives A agA|}.
+Instance baseDerivesOp {A}{agA: ageable A}{EO: Ext_ord A}
+ : DerivesOp (pred A) := {| derivesOp := @derives A agA EO|}.
 
 Instance funDerivesOp (B: Type)(A: Type)(DerivesA: DerivesOp A) : DerivesOp (B -> A)
  := {| derivesOp := fun (P Q : B -> A)  => forall b, derivesOp (P b) (Q b) |}.
@@ -47,7 +47,7 @@ Open Scope logic_derives.
 
 Class WandOp A := {  wandOp : A -> A -> A }.
 
-Instance baseWandOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AgeA: Age_alg A}
+Instance baseWandOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AgeA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A}
  : WandOp (pred A) := {| wandOp := wand |}.
 
 Instance funWandOp (B: Type)(A: Type)(WandA: WandOp A) : WandOp (B -> A) :=
@@ -60,8 +60,8 @@ Set Warnings "notation-overridden".
 
 Class EmpOp A := { Emp: A}.
 
-Instance baseEmpOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AgeA: Age_alg A}
-  : EmpOp (pred A) := {| Emp := @emp A JA PA SA agA AgeA |}.
+Instance baseEmpOp {A}{agA: ageable A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AgeA: Age_alg A}{EO: Ext_ord A}
+  : EmpOp (pred A) := {| Emp := @emp A JA SA agA AgeA EO |}.
 
 Instance funEmpOp  (B: Type)(A: Type)(EmpA: EmpOp A) : EmpOp (B -> A) :=
    {| Emp := fun (b : B) =>  Emp  |}.
@@ -74,7 +74,9 @@ Variables (rmap : Type)
       (Canc_rmap: @Canc_alg rmap Join_rmap)
       (Disj_rmap: @Disj_alg rmap Join_rmap)
       (ag_rmap: ageable rmap)
-      (Age_rmap: @Age_alg rmap Join_rmap ag_rmap Sep_rmap).
+      (Age_rmap: @Age_alg rmap Join_rmap ag_rmap Sep_rmap)
+      (Ext_rmap: @Ext_ord rmap ag_rmap)
+      (ExtA_rmap: @Ext_alg rmap ag_rmap Ext_rmap Join_rmap Sep_rmap).
 Existing Instance  Join_rmap.
 Existing Instance  Perm_rmap.
 Existing Instance  Sep_rmap.
@@ -82,6 +84,8 @@ Existing Instance  Canc_rmap.
 Existing Instance  Disj_rmap.
 Existing Instance  ag_rmap.
 Existing Instance  Age_rmap.
+Existing Instance  Ext_rmap.
+Existing Instance  ExtA_rmap.
 
 Lemma test1: forall (P : environ -> pred rmap) (Q: pred rmap),
    P * Emp |-- P.

--- a/msl/predicates_hered.v
+++ b/msl/predicates_hered.v
@@ -5,6 +5,7 @@
 
 Require Import VST.msl.base.
 Require Import VST.msl.ageable.
+Require Import RelationClasses.
 
 Declare Scope pred.
 Delimit Scope pred with pred.
@@ -17,9 +18,84 @@ Local Open Scope pred.
 Definition hereditary {A} (R:A->A->Prop) (p:A->Prop) :=
   forall a a':A, R a a' -> p a -> p a'.
 
-(* A predicate is a hereditary pre-predicate *)
-Definition pred (A:Type) {AG:ageable A} :=
-  { p:A -> Prop | hereditary age p }.
+(* Following the ordered RA approach of "MoSeL: A General, Extensible Modal Framework for
+   Interactive Proofs in Separation Logic", Krebbers et al.,
+   our algebra is equipped with an order, and predicates must be
+   upward-closed w.r.t. that order. In VeriC, this order is
+   "adding more ghost state".
+   Most importantly, "emp" will be true of anything above the empty element
+   in this order. *)
+Class Ext_ord (A : Type) {AG : ageable A} :=
+  { ext_order : relation A;
+    ext_preorder :> PreOrder ext_order;
+(*    ext_age_commut : commut A ext_order age;*)
+    (* This may not be true, since non-ordered elements may age to ordered elements *)
+    age_ext_commut : commut A age ext_order;
+    ext_age_compat : forall a b a', ext_order a b -> age a a' -> exists b', age b b' /\ ext_order a' b';
+    ext_level : forall a b, ext_order a b -> level a = level b
+  }.
+
+Lemma ext_refl : forall `{Ext_ord} a, ext_order a a.
+Proof.
+  reflexivity.
+Qed.
+
+#[export] Hint Resolve ext_refl : core.
+
+Program Instance Ext_prod A B `(Ext_ord A) (relB : relation B) {P : PreOrder relB} : @Ext_ord (A * B) (ag_prod A B _) :=
+  { ext_order := fun a b => ext_order (fst a) (fst b) /\ relB (snd a) (snd b) }.
+Next Obligation.
+Proof.
+  split.
+  - intros (?, ?); split; reflexivity.
+  - intros (?, ?) (?, ?) (?, ?) [] []; split; etransitivity; eauto.
+Qed.
+(*Next Obligation.
+Proof.
+  intros (?, ?) (?, ?) [] (?, ?) Hage.
+  hnf in Hage; simpl in Hage.
+  destruct (age1 a1) eqn: Hage1; [|discriminate].
+  inv Hage.
+  eapply ext_age_commut in Hage1 as [? Hage]; eauto.
+  eexists (_, _); hnf; simpl; eauto.
+  rewrite Hage; auto.
+Qed.*)
+Next Obligation.
+Proof.
+  intros (?, ?) (?, ?) Hage (?, ?) [].
+  simpl in *.
+  hnf in Hage; simpl in Hage.
+  destruct (age1 a0) eqn: Hage1; [|discriminate].
+  inv Hage.
+  eapply age_ext_commut in Hage1 as [? ? Hage]; eauto.
+  eexists (_, _); hnf; simpl; eauto.
+  rewrite Hage; auto.
+Qed.
+Next Obligation.
+Proof.
+  simpl in *.
+  hnf in H1; simpl in H1.
+  destruct (age1 a) eqn: Hage1; [|discriminate].
+  inv H1.
+  eapply ext_age_compat in H0 as (? & Hage & ?); eauto.
+  eexists (_, _); split; hnf; simpl; eauto.
+  rewrite Hage; auto.
+Qed.
+Next Obligation.
+Proof.
+  simpl in *.
+  eapply ext_level; eauto.
+Qed.
+
+Section Order.
+
+Context {A : Type} {AG : ageable A}.
+Context {EO : Ext_ord A}.
+
+
+(* A predicate is a hereditary pre-predicate that is upward-closed
+   according to the extension order. *)
+Definition pred := { p:A -> Prop | hereditary age p /\ hereditary ext_order p }.
 
 Bind Scope pred with pred.
 
@@ -28,136 +104,115 @@ Bind Scope pred with pred.
    see it is a subset type.  The coercion is sugar that allows us to use
    predicates easily.
  *)
-Definition app_pred {A} `{ageable A} (p:pred A) : A -> Prop := proj1_sig p.
-Definition pred_hereditary `{ageable} (p:pred A) := proj2_sig p.
+Definition app_pred (p:pred) : A -> Prop := proj1_sig p.
+Definition pred_hereditary (p:pred) := proj1 (proj2_sig p).
+Definition pred_upclosed (p:pred) := proj2 (proj2_sig p).
 Coercion app_pred : pred >-> Funclass.
 Global Opaque pred.
 
-#[export] Hint Resolve pred_hereditary : core.
+#[local] Hint Resolve pred_hereditary : core.
 
-Lemma nec_hereditary {A} `{ageable A} (p: A -> Prop) : hereditary age p ->
+Lemma nec_hereditary (p: A -> Prop) : hereditary age p ->
   forall a a':A, necR a a' -> p a -> p a'.
 Proof.
   intros.
-  induction H1; auto.
-  apply H0 with x; auto.
+  induction H0; auto.
+  apply H with x; auto.
 Qed.
 
-Lemma pred_nec_hereditary {A} `{ageable A} (p:pred A) :
+Lemma pred_nec_hereditary (p:pred) :
   forall a a':A, necR a a' -> p a -> p a'.
 Proof.
   apply nec_hereditary, pred_hereditary.
 Qed.
 
-Program Definition mkPred {A} `{ageable A} (p:A -> Prop) : pred A :=
-  fun x => forall x', necR x x' -> p x'.
-Next Obligation.
+(*Lemma ext_later_commut : commut A ext_order laterR.
+Proof.
   repeat intro.
-  apply H1.
-  apply rt_trans with a'; auto.
-  apply rt_step; auto.
+  revert dependent x; induction H0; intros.
+  - eapply ext_age_commut in H as []; eauto.
+    eexists; [|apply H1].
+    apply t_step; auto.
+  - apply IHclos_trans2 in H as [? ? Hext].
+    apply IHclos_trans1 in Hext as [? ? Hext].
+    eexists; [|apply Hext].
+    eapply t_trans; eauto.
+Qed.
+
+Lemma ext_nec_commut : commut A ext_order necR.
+Proof.
+  repeat intro.
+  apply nec_refl_or_later in H0 as [|]; subst; eauto.
+  destruct (ext_later_commut _ _ H _ H0).
+  eexists; [|apply H2].
+  apply laterR_necR; auto.
+Qed.*)
+
+Lemma later_ext_commut : commut A laterR ext_order.
+Proof.
+  repeat intro.
+  revert dependent z; induction H; intros.
+  - eapply age_ext_commut in H as []; eauto.
+    eexists; [apply H|].
+    apply t_step; auto.
+  - apply IHclos_trans1 in H1 as [? Hext ?].
+    apply IHclos_trans2 in Hext as [? Hext ?].
+    eexists; [apply Hext|].
+    eapply t_trans; eauto.
+Qed.
+
+Lemma nec_ext_commut : commut A necR ext_order.
+Proof.
+  repeat intro.
+  apply nec_refl_or_later in H as [|]; subst; eauto.
+  destruct (later_ext_commut _ _ H _ H0).
+  eexists; [apply H1|].
+  apply laterR_necR; auto.
+Qed.
+
+Program Definition mkPred (p:A -> Prop) : pred :=
+  fun x => forall x' x'', necR x x' -> ext_order x' x'' -> p x''.
+Next Obligation.
+  split; repeat intro.
+  - eapply H0, H2.
+    apply rt_trans with a'; auto.
+    apply rt_step; auto.
+  - eapply nec_ext_commut in H as [? ? ?]; [|apply H1].
+    eapply H0; eauto.
+    etransitivity; eauto.
 Qed.
 
 (* The semantic notion of entailment.
  *)
-Definition derives {A} `{ageable A} (P Q:pred A) := forall a:A, P a -> Q a.
-Arguments derives [A] [H] _ _.
+Definition derives (P Q:pred) := forall a:A, P a -> Q a.
 
-(* "valid" relations are those that commute with aging.  These
-   relations are the ones that can be turned into modalities.
+(* "valid" relations are those that commute with aging and extension.
+   These relations are the ones that can be turned into modalities.
  *)
-Definition valid_rel {A} `{ageable A} (R:relation A) : Prop :=
-  commut A age R /\ commut A R age.
+Definition valid_rel (R:relation A) : Prop :=
+  commut A age R /\ commut A R age /\ commut A R ext_order (*/\ commut A ext_order R*).
 
-(* A modaility is a valid relation *)
-Definition modality {A} `{ageable A} := { R:relation A | valid_rel R }.
+(* A modality is a valid relation *)
+Definition modality := { R:relation A | valid_rel R }.
 
-(* More black magic to make the definition of modaility mostly opaque. *)
-Definition app_mode {A} `{ageable A} (m:modality) : A -> A -> Prop := proj1_sig m.
-Definition mode_valid {A} `{ageable A} (m:modality) := proj2_sig m.
+(* More black magic to make the definition of modality mostly opaque. *)
+Definition app_mode (m:modality) : A -> A -> Prop := proj1_sig m.
+Definition mode_valid (m:modality) := proj2_sig m.
 Global Opaque modality.
 Coercion app_mode : modality >-> Funclass.
 
 (* commutivity facts for the basic relations *)
 
-Lemma valid_rel_commut_later1 {A} `{ageable A} : forall R,
+Lemma valid_rel_commut_later1 : forall R,
   valid_rel R ->
   commut A laterR R.
 Proof.
   intros; hnf; intros.
-  revert z H2.
-  induction H1; intros.
-  destruct H0.
-  destruct (H0 _ _ H1 _ H2).
-  exists x0; auto.
-  apply t_step; auto.
-  destruct (IHclos_trans1 _ H2).
-  destruct (IHclos_trans2 _ H1).
-  exists x1; auto.
-  eapply t_trans; eauto.
-Qed.
-
-Lemma valid_rel_commut_later2 {A} `{ageable A} : forall R,
-  valid_rel R ->
-  commut A R laterR.
-Proof.
-  intros; hnf; intros.
-  revert x H1.
-  induction H2; intros.
-  destruct H0.
-  destruct (H3 _ _ H2 _ H1).
-  exists x1; auto.
-  apply t_step; auto.
-  destruct (IHclos_trans2 _ H1).
-  destruct (IHclos_trans1 _ H3).
-  exists x2; auto.
-  eapply t_trans; eauto.
-Qed.
-
-Lemma valid_rel_commut_nec1 {A} `{ageable A} : forall R,
-  valid_rel R ->
-  commut A necR R.
-Proof.
-  intros; hnf; intros.
-  apply nec_refl_or_later in H1; destruct H1; subst.
-  exists z; auto.
-  destruct (valid_rel_commut_later1 R H0 x y H1 z H2).
-  exists x0; auto.
-  apply Rt_Rft; auto.
-Qed.
-
-Lemma valid_rel_commut_nec2 {A} `{ageable A} : forall R,
-  valid_rel R ->
-  commut A R necR.
-Proof.
-  intros; hnf; intros.
-  apply nec_refl_or_later in H2; destruct H2; subst.
-  exists x; auto.
-  destruct (valid_rel_commut_later2 R H0 x y H1 z H2).
-  exists x0; auto.
-  apply Rt_Rft; auto.
-Qed.
-
-Lemma valid_rel_age {A} `{ageable A} : valid_rel age.
-Proof.
-  intros; split; hnf; intros; firstorder.
-Qed.
-
-Lemma valid_rel_later {A} `{ageable A} : valid_rel laterR.
-Proof.
-  intros; split; hnf; intros.
-  revert x H0.
-  induction H1; intros.
-  exists y; auto.
-  apply t_step; auto.
-  destruct (IHclos_trans2 _ H0).
-  destruct (IHclos_trans1 _ H2).
-  exists x2; auto.
-  eapply t_trans; eauto.
-
   revert z H1.
   induction H0; intros.
-  exists x; auto.
+  destruct H.
+  destruct (H _ _ H0 _ H1).
+  exists x0; auto.
   apply t_step; auto.
   destruct (IHclos_trans1 _ H1).
   destruct (IHclos_trans2 _ H0).
@@ -165,88 +220,185 @@ Proof.
   eapply t_trans; eauto.
 Qed.
 
-Lemma valid_rel_nec {A} `{ageable A} : valid_rel necR.
+Lemma valid_rel_commut_later2 : forall R,
+  valid_rel R ->
+  commut A R laterR.
 Proof.
-  intros; split; hnf; intros.
+  intros; hnf; intros.
   revert x H0.
   induction H1; intros.
+  destruct H as (_ & H & _).
+  destruct (H _ _ H1 _ H0).
+  exists x1; auto.
+  apply t_step; auto.
+  destruct (IHclos_trans2 _ H0).
+  destruct (IHclos_trans1 _ H2).
+  exists x2; auto.
+  eapply t_trans; eauto.
+Qed.
+
+Lemma valid_rel_commut_nec1 : forall R,
+  valid_rel R ->
+  commut A necR R.
+Proof.
+  intros; hnf; intros.
+  apply nec_refl_or_later in H0; destruct H0; subst.
+  exists z; auto.
+  destruct (valid_rel_commut_later1 R H x y H0 z H1).
+  exists x0; auto.
+  apply Rt_Rft; auto.
+Qed.
+
+Lemma valid_rel_commut_nec2 : forall R,
+  valid_rel R ->
+  commut A R necR.
+Proof.
+  intros; hnf; intros.
+  apply nec_refl_or_later in H1; destruct H1; subst.
+  exists x; auto.
+  destruct (valid_rel_commut_later2 R H x y H0 z H1).
+  exists x0; auto.
+  apply Rt_Rft; auto.
+Qed.
+
+(*Lemma valid_rel_commut_ext1 : forall R,
+  valid_rel R ->
+  commut A ext_order R.
+Proof.
+  intros ? H; apply H.
+Qed.*)
+
+Lemma valid_rel_commut_ext2 : forall R,
+  valid_rel R ->
+  commut A R ext_order.
+Proof.
+  intros ? H; apply H.
+Qed.
+
+Lemma valid_rel_age : valid_rel age.
+Proof.
+  intros; split; hnf; intros; eauto.
+  split; [|(*split; [*)apply age_ext_commut (*| apply ext_age_commut]*)].
+  unfold commut; eauto.
+Qed.
+
+Lemma valid_rel_later : valid_rel laterR.
+Proof.
+  intros; split; hnf; intros.
+  revert dependent x.
+  induction H0; intros.
+  exists y; auto.
+  apply t_step; auto.
+  destruct (IHclos_trans2 _ H).
+  destruct (IHclos_trans1 _ H1).
+  exists x2; auto.
+  eapply t_trans; eauto.
+
+  split; [|(*split; [*)apply later_ext_commut (*| apply ext_later_commut]*)].
+  intros ???.
+  induction H; intros.
+  exists x; auto.
+  apply t_step; auto.
+  destruct (IHclos_trans1 _ H1).
+  destruct (IHclos_trans2 _ H2).
+  exists x1; auto.
+  eapply t_trans; eauto.
+Qed.
+
+Lemma valid_rel_nec : valid_rel necR.
+Proof.
+  intros; split; hnf; intros.
+  revert dependent x.
+  induction H0; intros.
   exists y; auto.
   apply rt_step; auto.
   exists x0; auto.
-  destruct (IHclos_refl_trans2 _ H0).
-  destruct (IHclos_refl_trans1 _ H2).
+  destruct (IHclos_refl_trans2 _ H).
+  destruct (IHclos_refl_trans1 _ H1).
   exists x2; auto.
   eapply rt_trans; eauto.
 
-  revert z H1.
-  induction H0; intros.
+  split; [|(*split; [*)apply nec_ext_commut (*| apply ext_nec_commut]*)].
+  intros ???.
+  induction H; intros.
   exists x; auto.
   apply rt_step; auto.
   exists z; auto.
 
   destruct (IHclos_refl_trans1 _ H1).
-  destruct (IHclos_refl_trans2 _ H0).
+  destruct (IHclos_refl_trans2 _ H2).
   exists x1; auto.
   eapply rt_trans; eauto.
 Qed.
 
 (* Definitions of the basic modalities.
  *)
-Definition ageM {A} `{ageable A} : modality
+Definition ageM : modality
   := exist _ age valid_rel_age.
-Definition laterM {A} `{ageable A} : modality
+Definition laterM : modality
   := exist _ laterR valid_rel_later.
 (*
-Definition necM {A} `{ageable A} : modality
+Definition necM  : modality
   := exist _ necR valid_rel_nec.
 *)
 
-#[export] Hint Resolve rt_refl rt_trans t_trans : core.
-#[export] Hint Unfold necR : core.
+#[local] Hint Resolve rt_refl rt_trans t_trans : core.
+#[local] Hint Unfold necR : core.
 Obligation Tactic := unfold hereditary; intuition;
-    first [eapply pred_hereditary; eauto; fail | eauto ].
+    first [eapply pred_hereditary; eauto; fail | eapply pred_upclosed; eauto; fail | eauto ].
 
 (* Definitions of the basic propositional conectives.
  *)
 
 (* Lifting pure mathematical facts to predicates *)
 
-Program Definition prop {A} `{ageable A}  (P: Prop) : pred A := (fun _  => P).
+Program Definition prop (P: Prop) : pred := (fun _  => P).
 
-Definition TT {A} `{ageable A}: pred A := prop True.
-Definition FF  {A} `{ageable A}: pred A := prop False.
+Definition TT : pred := prop True.
+Definition FF  : pred := prop False.
 
-Program Definition imp {A} `{ageable A} (P Q:pred A) : pred A :=
-   fun a:A => forall a':A, necR a a' -> P a' -> Q a'.
+Program Definition imp  (P Q:pred) : pred :=
+   fun a:A => forall a' a'':A, necR a a' -> ext_order a' a'' -> P a'' -> Q a''.
 Next Obligation.
-  apply H1; auto.
+  apply H0 with a'0; auto.
   apply rt_trans with a'; auto.
   apply rt_step; auto.
+
+  eapply nec_ext_commut in H1 as [? ? ?]; eauto.
+  eapply H0; eauto.
+  etransitivity; eauto.
 Qed.
-Program Definition orp {A} `{ageable A} (P Q:pred A) : pred A :=
+Program Definition orp  (P Q:pred) : pred :=
    fun a:A => P a \/ Q a.
 Next Obligation.
   left; eapply pred_hereditary; eauto.
   right; eapply pred_hereditary; eauto.
+  left; eapply pred_upclosed; eauto.
+  right; eapply pred_upclosed; eauto.
 Qed.
 
-Program Definition andp {A} `{ageable A} (P Q:pred A) : pred A :=
+Program Definition andp  (P Q:pred) : pred :=
    fun a:A => P a /\ Q a.
 
 (* Universal and exp quantification
  *)
 
-Program Definition allp {A} `{ageable A} {B: Type} (f: B -> pred A) : pred A
+Program Definition allp  {B: Type} (f: B -> pred) : pred
   := fun a => forall b, f b a.
 Next Obligation.
   apply pred_hereditary with a; auto.
-  apply H1.
+  apply H0.
+
+  apply pred_upclosed with a; auto.
+  apply H0.
 Qed.
 
-Program Definition exp {A} `{ageable A} {B: Type} (f: B -> pred A) : pred A
+Program Definition exp  {B: Type} (f: B -> pred) : pred
   := fun a => exists b, f b a.
 Next Obligation.
-  destruct H1; exists x; eapply pred_hereditary; eauto.
+  destruct H0; exists x; eapply pred_hereditary; eauto.
+
+  destruct H0; exists x; eapply pred_upclosed; eauto.
 Qed.
 
 
@@ -254,13 +406,18 @@ Qed.
    modalities (relations) into a "necessarily" type operator.
  *)
 
-Program Definition box {A} `{ageable A} (M:modality) (P:pred A) : pred A :=
+Program Definition box  (M:modality) (P:pred) : pred :=
   fun a:A => forall a', M a a' -> P a'.
 Next Obligation.
-  destruct M as [M [H3 H4]]; simpl in *.
-  destruct (H4 _ _ H2 _ H0).
+  destruct M as [M [? [H4 ?]]]; simpl in *.
+  destruct (H4 _ _ H1 _ H).
   apply pred_hereditary with x; auto.
-  apply H1; auto.
+  apply H0; auto.
+
+  destruct M as [M [? [? (*[*)H4 (*?]*)]]]; simpl in *.
+  destruct (H4 _ _ H1 _ H).
+  apply pred_upclosed with x; auto.
+  apply H0; auto.
 Qed.
 
 (* Definition of the "diamond" modal operator.  This operator
@@ -271,17 +428,23 @@ Qed.
    to Substructural Logic" (2000).
  *)
 
-Program Definition diamond {A} `{ageable A} (M:modality) (P:pred A) : pred A :=
+(*Program Definition diamond  (M:modality) (P:pred) : pred :=
   fun a:A => exists a', M a' a /\ P a'.
 Next Obligation.
-  destruct M as [M [H3 H4]]; simpl in *.
-  destruct H1 as [x [? ?]].
-  destruct (H3 _ _ H0 _ H1).
+  destruct M as [M [H3 ?]]; simpl in *.
+  destruct H0 as [x [? ?]].
+  destruct (H3 _ _ H _ H0).
   exists x0; split; auto.
   apply pred_hereditary with x; auto.
-Qed.
 
-Definition boxy {A} `{ageable A} (m: modality) (p: pred A): Prop :=  box m p = p.
+  destruct M as [M [? [? (*[*)? (*H3]*)]]]; simpl in *.
+  destruct H0 as [x [? ?]].
+  destruct (H3 _ _ H _ H0).
+  exists x0; split; auto.
+  apply pred_upclosed with x; auto.
+Qed.*)
+
+Definition boxy  (m: modality) (p: pred): Prop :=  box m p = p.
 
 (* A pile of notations for the operators we have defined *)
 Declare Scope pred_derives.
@@ -300,15 +463,16 @@ Notation "'|>' e" := (box laterM e) (at level 20, right associativity): pred.
 Notation "'!!' e" := (prop e) (at level 15) : pred.
 
 (* Rules for the propositional connectives *)
-Lemma modus_ponens {A} `{ageable A} : forall (X P Q:pred A),
+Lemma modus_ponens  : forall (X P Q:pred),
   (X |-- P) ->
   (X |-- (P --> Q)) ->
   X |-- Q.
 Proof.
-  unfold derives, imp; simpl; intuition eauto.
+  unfold derives, imp; simpl; intros.
+  eapply H0 in H1; eauto.
 Qed.
 
-Lemma andp_right {A} `{ageable A} : forall (X P Q:pred A),
+Lemma andp_right  : forall (X P Q:pred),
   (X |-- P) ->
   (X |-- Q) ->
   X |-- P && Q.
@@ -317,64 +481,63 @@ Proof.
 Qed.
 
 
-  Lemma pred_ext' {A} `{ageable A}: forall (p1 p2:pred A),
-    app_pred p1 = app_pred p2 ->
-    p1 = p2.
-  Proof.
-    intros; destruct p1; destruct p2; simpl in H.
-   simpl in H0.
-    subst x0.
-    replace h0 with h by apply proof_irr.
-    auto.
-  Qed.
+Lemma pred_ext' : forall (p1 p2:pred),
+  app_pred p1 = app_pred p2 ->
+  p1 = p2.
+Proof.
+  intros; destruct p1; destruct p2; simpl in H.
+  subst x0.
+  replace a0 with a by apply proof_irr.
+  auto.
+Qed.
 
-Lemma pred_ext : forall A `{ageable A} (P Q:pred A),
+Lemma pred_ext : forall (P Q:pred),
   derives P Q -> derives Q P -> P = Q.
 Proof.
   intros.
   destruct P as [P HP].
   destruct Q as [Q HQ].
   unfold derives in *. simpl in *.
-   apply (exist_ext (A->Prop) (fun p => hereditary (@age _ H) p)).
+  apply (exist_ext (A->Prop) (fun p => hereditary (@age _ AG) p /\ hereditary (@ext_order _ AG EO) p)).
   extensionality a.
   apply prop_ext; intuition.
 Qed.
 
-Lemma andp_dup {A}{agA: ageable A}: forall P: pred A, P && P = P.
+Lemma andp_dup : forall P: pred, P && P = P.
 Proof. intros. apply pred_ext; intros w ?. destruct H; auto. split; auto.
 Qed.
 
-Lemma andp_left1{A}{agA: ageable A}: forall P Q R: pred A,  (P |-- R) -> P && Q |-- R.
+Lemma andp_left1: forall P Q R: pred,  (P |-- R) -> P && Q |-- R.
 Proof. repeat intro. destruct H0; auto.
 Qed.
 
-Lemma andp_left2{A}{agA: ageable A}: forall P Q R: pred A,  (Q |-- R) -> P && Q |-- R.
+Lemma andp_left2: forall P Q R: pred,  (Q |-- R) -> P && Q |-- R.
 Proof. repeat intro. destruct H0; auto.
 Qed.
 
-Lemma orp_left{A}{agA: ageable A}: forall P Q R: pred A,  (P |-- R) -> (Q |-- R) -> P || Q |-- R.
+Lemma orp_left: forall P Q R: pred,  (P |-- R) -> (Q |-- R) -> P || Q |-- R.
 Proof. repeat intro. destruct H1; auto.
 Qed.
 
-Lemma orp_right1{A}{agA: ageable A}: forall P Q R: pred A,  (P |-- Q) -> P |-- Q || R.
+Lemma orp_right1: forall P Q R: pred,  (P |-- Q) -> P |-- Q || R.
 Proof. repeat intro. left; auto.
 Qed.
 
-Lemma orp_right2{A}{agA: ageable A}: forall P Q R: pred A,  (P |-- R) -> P |-- Q || R.
+Lemma orp_right2: forall P Q R: pred,  (P |-- R) -> P |-- Q || R.
 Proof. repeat intro. right; auto.
 Qed.
 
-Lemma orp_assoc {A} `{ageable A} : forall P Q R: pred A, (P || Q) || R = P || (Q || R).
+Lemma orp_assoc  : forall P Q R: pred, (P || Q) || R = P || (Q || R).
 Proof.
   intros; apply pred_ext; auto; unfold derives, andp; simpl; intuition.
 Qed.
 
-Lemma derives_trans {A}`{ageable A}:
-    forall P Q R: pred A, (P |-- Q) -> (Q |-- R) -> P |-- R.
+Lemma derives_trans :
+    forall P Q R: pred, (P |-- Q) -> (Q |-- R) -> P |-- R.
 Proof. firstorder. Qed.
 
 Lemma exp_right:
-  forall {B A: Type}{agA: ageable A}(x:B) p (q: B -> pred A),
+  forall {B}(x:B) p (q: B -> pred),
     (p |-- q x) ->
     p |-- exp q.
 Proof.
@@ -384,7 +547,7 @@ intros w ?; exists x; auto.
 Qed.
 
 Lemma exp_left:
-  forall {B A: Type}{agA: ageable A}(p: B -> pred A) q,
+  forall {B: Type}(p: B -> pred) q,
   (forall x, p x |-- q) ->
    exp p |-- q.
 Proof.
@@ -393,90 +556,99 @@ intros w [x' ?].
 eapply H; eauto.
 Qed.
 
-Lemma and1 {A} `{ageable A} : forall (X P Q:pred A),
+Lemma and1  : forall (X P Q:pred),
   X |-- P && Q --> P.
 Proof.
   unfold derives, imp, andp; simpl; intuition eauto.
 Qed.
 
-Lemma and2 {A} `{ageable A} : forall (X P Q:pred A),
+Lemma and2  : forall (X P Q:pred),
   X |-- P && Q --> Q.
 Proof.
   unfold derives, imp, andp; simpl; intuition eauto.
 Qed.
 
-Lemma and3 {A} `{ageable A} : forall (X P Q R:pred A),
+Lemma and3  : forall (X P Q R:pred),
   X |-- (P --> Q) --> (P --> R) --> (P --> Q && R).
 Proof.
   unfold derives, imp, andp; simpl; intuition eauto.
+  eapply nec_ext_commut in H4 as [? ? ?]; [|eauto].
+  eapply H2.
+  - eapply rt_trans; eauto.
+  - etransitivity; eauto.
+  - auto.
 Qed.
 
-Lemma or1 {A} `{ageable A} : forall (X P Q:pred A),
+Lemma or1  : forall (X P Q:pred),
   X |-- P --> P || Q.
 Proof.
   unfold derives, imp, orp; simpl; intuition.
 Qed.
 
-Lemma or2 {A} `{ageable A} : forall (X P Q:pred A),
+Lemma or2  : forall (X P Q:pred),
   X |-- Q --> P || Q.
 Proof.
   unfold derives, imp, orp; simpl; intuition.
 Qed.
 
-Lemma or3 {A} `{ageable A} : forall (X P Q R:pred A),
+Lemma or3  : forall (X P Q R:pred),
   X |-- (P --> R) --> (Q --> R) --> (P || Q --> R).
 Proof.
   unfold derives, imp, orp; simpl; intuition eauto.
+  eapply nec_ext_commut in H4 as [? ? ?]; [|eauto].
+  eapply H2.
+  - eapply rt_trans; eauto.
+  - etransitivity; eauto.
+  - auto.
 Qed.
 
-Lemma TTrule {A} `{ageable A} : forall X P,
+Lemma TTrule  : forall X P,
   X |-- P --> TT.
 Proof.
   unfold derives, imp, TT; simpl; intuition.
 Qed.
 
-Lemma FFrule {A} `{ageable A} : forall X P,
+Lemma FFrule  : forall X P,
   X |-- FF --> P.
 Proof.
   unfold derives, imp, FF; simpl; intuition.
 Qed.
 
-Lemma distribution {A} `{ageable A} : forall (X P Q R:pred A),
+Lemma distribution  : forall (X P Q R:pred),
   X |-- P && (Q || R) --> (P && Q) || (P && R).
 Proof.
   unfold derives, imp, orp, andp; simpl; intuition.
 Qed.
 
 (* Characterize the relation between conjunction and implication *)
-Lemma imp_andp_adjoint {A} `{ageable A} : forall (P Q R:pred A),
+Lemma imp_andp_adjoint  : forall (P Q R:pred),
   ((P && Q) |-- R) <-> (P |-- (Q --> R)).
 Proof.
   split; intros.
   hnf; intros; simpl; intros.
-  apply H0.
+  apply H.
   split; auto.
-  apply pred_nec_hereditary with a; auto.
+  eapply pred_nec_hereditary, pred_upclosed in H0; eauto.
   hnf; intros.
-  hnf in H0.
-  unfold imp in H0; simpl in H0.
-  destruct H1.
-  apply H0 with a; auto.
+  hnf in H.
+  unfold imp in H; simpl in H.
+  destruct H0.
+  eapply H; eauto.
 Qed.
 
 (* Some facts about modalities *)
 
-Lemma box_e0 {A} `{ageable A}: forall (M: modality) Q,
+Lemma box_e0 : forall (M: modality) Q,
             reflexive _ M -> box M Q  |-- Q.
 Proof.
 intros.
 intro; intros.
-apply H1; simpl.
-apply H0.
+apply H0; simpl.
+apply H.
 Qed.
-Arguments box_e0 [A] _ _ _ _ _ _.
 
-Lemma boxy_i {A} `{ageable A}:
-  forall (Q: pred A) (M: modality),
+Lemma boxy_i :
+  forall (Q: pred) (M: modality),
     reflexive _ M ->
     (forall w w', M w w' -> Q w -> Q w') ->
     boxy M Q.
@@ -486,11 +658,11 @@ unfold boxy.
 apply pred_ext; hnf; intros.
 eapply box_e0; eauto.
 hnf; intros.
-eapply H1; eauto.
+eapply H0; eauto.
 Qed.
 
 (*
-Lemma necM_refl {A} `{ageable A}: reflexive _ necM.
+Lemma necM_refl : reflexive _ necM.
 Proof.
 intros; intro; simpl.
 unfold necR.
@@ -501,55 +673,56 @@ Qed.
 *)
 
 (* relationship between box and diamond *)
-Lemma box_diamond {A} `{ageable A} : forall M (P Q:pred A),
+(*Lemma box_diamond  : forall M (P Q:pred),
   ((diamond M P) |-- Q) <-> (P |-- (box M Q)).
 Proof.
   unfold derives; intuition.
   hnf; intros.
-  apply H0.
+  apply H.
   hnf; eauto.
-  destruct H1 as [a' [? ?]].
-  apply H0 with a'; auto.
+  destruct H0 as [a' [? ?]].
+  apply H with a'; auto.
 Qed.
 
 (* Box is a normal modal operator *)
 
-Lemma ruleNec {A} `{ageable A} : forall M (P:pred A),
+Lemma ruleNec  : forall M (P:pred),
   derives TT P ->
   derives TT (box M P).
 Proof.
   intros.
   rewrite <- box_diamond.
   hnf; intros.
-  apply H0; hnf; auto.
-Qed.
+  apply H; hnf; auto.
+Qed.*)
 
-Lemma axiomK {A} `{ageable A}: forall M (P Q:pred A),
+Lemma axiomK : forall M (P Q:pred),
   (box M (P --> Q)) |-- (box M P --> box M Q).
 Proof.
   intros; do 3 (hnf; intros).
   destruct M as [R HR]; simpl in *.
-  destruct (valid_rel_commut_nec2 R HR _ _ H3 _ H1).
-  apply H0 with x; auto.
+  destruct (valid_rel_commut_ext2 R HR _ _ H3 _ H1) as [? ? HR'].
+  destruct (valid_rel_commut_nec2 R HR _ _ HR' _ H0).
+  eauto.
 Qed.
 
 (* Box and diamond are positive modal operators *)
 
-Lemma box_positive {A} `{ageable A} : forall M (P Q:pred A),
+Lemma box_positive  : forall M (P Q:pred),
   (P |-- Q) ->
   box M P |-- box M Q.
 Proof.
   unfold derives, box; simpl; intuition.
 Qed.
 
-Lemma diamond_positive {A} `{ageable A} : forall M (P Q:pred A),
+(*Lemma diamond_positive  : forall M (P Q:pred),
   (P |-- Q) ->
   diamond M P |-- diamond M Q.
 Proof.
   unfold derives, diamond; simpl; firstorder.
-Qed.
+Qed.*)
 
-Lemma box_refl_trans {A} `{ageable A}: forall (m:modality) p,
+Lemma box_refl_trans : forall (m:modality) p,
   reflexive _ m ->
   transitive _ m ->
   box m (box m p) = box m p.
@@ -558,37 +731,37 @@ Proof.
   apply pred_ext.
   repeat intro.
   assert (box m p a').
-  apply H2; auto.
-  apply H4.
-  apply H0.
+  apply H1; auto.
+  apply H3.
+  apply H.
   repeat intro.
-  apply H2.
-  eapply H1; eauto.
+  apply H1.
+  eapply H0; eauto.
 Qed.
 
 (* Disribuitivity of box over various connectives *)
 
-Lemma box_and {A} `{ageable A}: forall R (P Q:pred A),
+Lemma box_and : forall R (P Q:pred),
   box R (P && Q) = box R P && box R Q.
 Proof.
   intros; apply pred_ext; hnf; intuition;
     unfold andp, box in *; simpl in *; firstorder.
 Qed.
 
-Lemma box_all {A} `{ageable A} : forall B R (F:B -> pred A),
+Lemma box_all  : forall B R (F:B -> pred),
   box R (allp F) = ALL x:B, box R (F x).
 Proof.
   intros; apply pred_ext; hnf; intuition;
     unfold allp, box in *; simpl in *; firstorder.
 Qed.
 
-Lemma box_ex {A} `{ageable A} : forall B R (F:B->pred A),
+Lemma box_ex  : forall B R (F:B->pred),
   EX x:B, box R (F x) |-- box R (exp F).
 Proof.
   unfold derives, exp, box; simpl; firstorder.
 Qed.
 
-Lemma box_or {A} `{ageable A} : forall R (P Q:pred A),
+Lemma box_or  : forall R (P Q:pred),
    box R P || box R Q |-- box R (P || Q).
 Proof.
   unfold derives, orp, box; simpl; firstorder.
@@ -596,37 +769,37 @@ Qed.
 
 (* Distributivity of diamond over various operators *)
 
-Lemma diamond_or {A} `{ageable A} : forall R (P Q:pred A),
+(*Lemma diamond_or  : forall R (P Q:pred),
   diamond R (P || Q) = diamond R P || diamond R Q.
 Proof.
   intros; apply pred_ext; hnf; intuition;
     unfold diamond, orp in *; simpl in *; firstorder.
 Qed.
 
-Lemma diamond_ex {A} `{ageable A} : forall B R (F:B -> pred A),
+Lemma diamond_ex  : forall B R (F:B -> pred),
   diamond R (exp F) = EX x:B, diamond R (F x).
 Proof.
   intros; apply pred_ext; hnf; intuition;
     unfold diamond, exp in *; simpl in *; firstorder.
 Qed.
 
-Lemma diamond_and {A} `{ageable A} : forall R (P Q:pred A),
+Lemma diamond_and  : forall R (P Q:pred),
   diamond R (P && Q) |-- diamond R P && diamond R Q.
 Proof.
   unfold derives, andp, diamond; simpl; firstorder.
 Qed.
 
-Lemma diamond_all {A} `{ageable A} : forall B R (F:B->pred A),
+Lemma diamond_all  : forall B R (F:B->pred),
   diamond R (allp F) |-- ALL x:B, diamond R (F x).
 Proof.
   unfold derives, allp, diamond; simpl; firstorder.
-Qed.
+Qed.*)
 
 
 (* Lemmas about aging and the later operator *)
 
 (*
-Lemma nec_useless {A} `{ageable A} :
+Lemma nec_useless  :
   forall P, []P = P.
 intros.
   apply pred_ext; intros.
@@ -638,21 +811,21 @@ intros.
 Qed.
 *)
 
-Lemma later_age {A} `{ageable A} : forall P,
+Lemma later_age  : forall P,
   |>P = box ageM P.
 Proof.
   intros; apply pred_ext; do 2 (hnf; intros).
-  simpl in H0.
-  apply H0.
+  simpl in H.
+  apply H.
   apply t_step; auto.
-  revert H0; induction H1; intros.
-  apply H1; auto.
+  revert H; induction H0; intros.
+  apply H0; auto.
   apply pred_nec_hereditary with y.
   apply Rt_Rft; auto.
   apply IHclos_trans1; auto.
 Qed.
 
-Lemma now_later {A} `{ageable A} : forall P,
+Lemma now_later  : forall P,
   P |-- |>P.
 Proof.
   repeat intro.
@@ -660,7 +833,7 @@ Proof.
   apply Rt_Rft; auto.
 Qed.
 
-Lemma now_later2 {A} `{ageable A} : forall G P,
+Lemma now_later2  : forall G P,
   (G |-- P) ->
   G |-- |>P.
 Proof.
@@ -670,22 +843,22 @@ Qed.
 
 (* The "induction" rule for later *)
 
-Lemma goedel_loeb {A} `{ageable A} : forall (P Q:pred A),
+Lemma goedel_loeb  : forall (P Q:pred),
   (Q && |>P |-- P) ->
   Q |-- P.
 Proof.
   intros; hnf; intro a.
   induction a using age_induction.
-  intros; simpl in H0.
-  eapply H0; auto.
+  intros; simpl in H.
+  eapply H; auto.
   split; auto.
   rewrite later_age.
   simpl; intros.
-  apply H1; auto.
+  apply H0; auto.
   apply pred_hereditary with x; auto.
 Qed.
 
-Lemma loeb {A} `{ageable A} : forall (P:pred A),
+Lemma loeb  : forall (P:pred),
      (|>P |-- P)    ->     TT |-- P.
 Proof.
   intros. apply goedel_loeb.
@@ -694,41 +867,41 @@ Qed.
 
 (* Later distributes over almost everything! *)
 
-Lemma later_commute_dia {A} `{ageable A} : forall M (P:pred A),
+(*Lemma later_commute_dia  : forall M (P:pred),
   diamond M (|> P) |-- |> (diamond M P).
 Proof.
   intros.
   repeat rewrite later_age.
   do 3 (hnf; intros).
-  simpl in H0.
+  simpl in H.
   firstorder.
   destruct M as [R HR].
   simpl in *.
-  destruct HR.
-  destruct (H3 _ _ H1 _ H0).
+  destruct HR as (H3 & _).
+  destruct (H3 _ _ H0 _ H).
   exists x0; split; auto.
-Qed.
+Qed.*)
 
-Lemma later_commute {A} `{ageable A} : forall M (P:pred A),
+Lemma later_commute  : forall M (P:pred),
   box M (|>P) = |>(box M P).
 Proof.
   intros.
   apply pred_ext; do 3 (hnf; intros).
   destruct M as [R HR].
-  destruct (valid_rel_commut_later2 R HR _ _ H2 _ H1).
-  apply H0 with x; simpl; auto.
+  destruct (valid_rel_commut_later2 R HR _ _ H1 _ H0).
+  apply H with x; simpl; auto.
   destruct M as [R HR].
-  destruct (valid_rel_commut_later1 R HR _ _ H2 _ H1).
-  apply H0 with x; auto.
+  destruct (valid_rel_commut_later1 R HR _ _ H1 _ H0).
+  apply H with x; auto.
 Qed.
 
-Lemma later_and {A} `{ageable A} : forall P Q,
+Lemma later_and  : forall P Q,
   |>(P && Q) = |>P && |> Q.
 Proof.
   intros; apply box_and.
 Qed.
 
-Lemma later_or {A} `{ageable A} : forall (P Q:pred A),
+Lemma later_or  : forall (P Q:pred),
   |>(P || Q) = |>P || |>Q.
 Proof.
   intros.
@@ -736,9 +909,9 @@ Proof.
   apply pred_ext.
   2: apply box_or.
   hnf; intros.
-  simpl in H0.
+  simpl in H.
   case_eq (age1 a); intros.
-  destruct (H0 a0); auto.
+  destruct (H a0); auto.
   left; simpl; intros.
   replace a' with a0; auto.
   congruence.
@@ -747,11 +920,11 @@ Proof.
   congruence.
   left.
   hnf; simpl; intros.
-  hnf in H2.
-  rewrite H1 in H2; discriminate.
+  hnf in H1.
+  rewrite H0 in H1; discriminate.
 Qed.
 
-Lemma later_ex {A} `{ageable A} : forall B (F:B->pred A),
+Lemma later_ex  : forall B (F:B->pred),
   B ->
   |>(exp F) = EX x:B, |>(F x).
 Proof.
@@ -759,9 +932,9 @@ Proof.
   apply pred_ext.
   2: apply box_ex.
   hnf; intros.
-  rewrite later_age in H0.
+  rewrite later_age in H.
   case_eq (age1 a); intros.
-  destruct (H0 a0); auto.
+  destruct (H a0); auto.
   exists x.
   rewrite later_age; simpl; intros.
   replace a' with a0; auto.
@@ -769,36 +942,36 @@ Proof.
   exists X.
   rewrite later_age.
   hnf; simpl; intros.
-  unfold age in H2.
-  rewrite H1 in H2; discriminate.
+  unfold age in H1.
+  rewrite H0 in H1; discriminate.
 Qed.
 
-Lemma later_ex'' {A} `{ageable A} : forall B (F:B->pred A),
+Lemma later_ex''  : forall B (F:B->pred),
   |>(exp F) |-- (EX x:B, |>(F x)) || |> FF.
 Proof.
   intros.
   unfold derives; intros.
   simpl in H |- *.
   destruct (age1 a) eqn:?H; [left | right].
-  + simpl in H0.
-    pose proof H0 a0.
-    destruct H2 as [b ?].
+  + simpl in H.
+    pose proof H a0.
+    destruct H1 as [b ?].
     {
       constructor.
       auto.
     }
     exists b.
     intros.
-    revert H2; apply pred_nec_hereditary.
+    eapply pred_nec_hereditary, H1.
     eapply age_later_nec; eauto.
   + intros.
-    clear - H2 H1.
-    induction H2.
-    - hnf in H0; congruence.
+    clear - H1 H0.
+    induction H1.
+    - hnf in H; congruence.
     - auto.
 Qed.
 
-Lemma later_imp {A} `{ageable A} : forall P Q,
+(*Lemma later_imp  : forall P Q,
   |>(P --> Q) = |>P --> |>Q.
 Proof.
   intros; repeat rewrite later_age.
@@ -806,104 +979,107 @@ Proof.
   apply axiomK.
   hnf; intros.
   simpl; intros.
-  simpl in H0.
-  destruct valid_rel_nec.
-  destruct (H5 _ _ H2 _ H1).
-  apply H0 with x; auto.
+  simpl in H. 
+  destruct valid_rel_nec as (_ & H4 & _).
+  destruct (H4 _ _ H1 _ H0) as [? Hage ?].
+  lapply (H x x).
+  intros X.
+  eapply ext_age_commut in Hage as []; eauto.
+  eapply H; eauto.
   intros.
-  replace a'1 with a'0; auto.
+  replace a'1 with a''; auto.
   congruence.
-Qed.
+Qed.*)
 
-Lemma TT_boxy {A} `{ageable A} : forall M,
+Lemma TT_boxy  : forall M,
   boxy M TT.
 Proof.
   intros; hnf.
   apply pred_ext; repeat intro; simpl; auto.
 Qed.
 
-Lemma positive_boxy {A} `{ageable A} : forall P Q M,
+Lemma positive_boxy  : forall P Q M,
   boxy M P ->
   (P |-- Q) ->
   P |-- box M Q.
 Proof.
   intros.
-  rewrite <- H0.
+  rewrite <- H.
   apply box_positive.
   auto.
 Qed.
 
-Lemma forallI {A} `{ageable A} : forall A G X,
+Lemma forallI  : forall A G X,
   (forall x:A, G |-- X x) ->
   G |-- allp X.
 Proof.
   repeat intro.
-  eapply H0; auto.
+  eapply H; auto.
 Qed.
 
-Lemma TT_and {A} `{ageable A} : forall P,
+Lemma TT_and  : forall P,
   TT && P = P.
 Proof.
   intros; apply pred_ext; repeat intro.
-  destruct H0; auto.
+  destruct H; auto.
   split; simpl; auto.
 Qed.
 
-Lemma andp_comm {A} `{ageable A} : forall P Q,
+Lemma andp_comm  : forall P Q,
   P && Q = Q && P.
 Proof.
   intros; apply pred_ext; unfold andp; repeat intro; simpl in *; intuition.
 Qed.
 
-Lemma andp_assoc {A} `{ageable A} : forall P Q R,
+Lemma andp_assoc  : forall P Q R,
   (P && Q) && R = P && (Q && R).
 Proof.
   intros; apply pred_ext; auto; unfold derives, andp; simpl; intuition.
 Qed.
 
-Lemma ex_and : forall {A} `{ageable A} B (P:B->pred A) Q,
+Lemma ex_and : forall  B (P:B->pred) Q,
   (exp P) && Q = EX x:B, P x && Q.
 Proof.
   intros. apply pred_ext.
-  repeat intro. destruct H0. destruct H0.
+  repeat intro. destruct H. destruct H.
   exists x. split; auto.
   repeat intro.
-  destruct H0. destruct H0.
+  destruct H. destruct H.
   split; auto. exists x; auto.
 Qed.
 
-Lemma FF_and : forall {A} `{ageable A} (P:pred A),
+Lemma FF_and : forall  (P:pred),
   FF && P = FF.
 Proof.
   intros. apply pred_ext; repeat intro.
-  destruct H0; auto.
-  elim H0.
+  destruct H; auto.
+  elim H.
 Qed.
 
 
-Lemma boxy_e {A} `{H : ageable A}: forall (M: modality) P,  boxy M P ->
+Lemma boxy_e : forall (M: modality) P,  boxy M P ->
            forall w w', app_mode M w w' -> P w -> P w'.
 Proof.
 intros.
-rewrite <- H0 in H2; eauto.
+rewrite <- H in H1; eauto.
 Qed.
 
-Lemma boxy_andp {A} `{H : ageable A}:
-     forall (M: modality) , reflexive _ (app_mode M) ->
+Lemma boxy_andp :
+     forall (M: modality), reflexive _ (app_mode M) ->
       forall P Q, boxy M P -> boxy M Q -> boxy M (P && Q).
 Proof.
 destruct M;
 intros.
 simpl in *.
 apply boxy_i; intros; auto.
-destruct H4.
+destruct H3.
 simpl.
 split; eapply boxy_e; eauto.
 Qed.
 
-#[export] Hint Resolve boxy_andp : core.
+#[local] Hint Resolve boxy_andp : core.
 
-Lemma boxy_disjunction {A} `{H : ageable A}:
+Lemma boxy_disjunction :
      forall (M: modality) , reflexive _ (app_mode M) ->
       forall P Q, boxy M P -> boxy M Q -> boxy M (P || Q).
 Proof.
@@ -911,15 +1087,15 @@ destruct M;
 intros.
 simpl in *.
 apply boxy_i; intros; auto.
-destruct H4.
+destruct H3.
 left.  eapply boxy_e; eauto.
 right. eapply boxy_e; eauto.
 Qed.
 
-#[export] Hint Resolve boxy_disjunction : core.
+#[local] Hint Resolve boxy_disjunction : core.
 
-Lemma boxy_exp {A} `{agA : ageable A}:
-    forall (M: modality) T (P: T -> pred A),
+Lemma boxy_exp :
+    forall (M: modality) T (P: T -> pred),
      reflexive _ (app_mode M) ->
      (forall x, boxy M (P x)) -> boxy M (exp P).
 Proof.
@@ -931,47 +1107,47 @@ specialize ( H2 w' H1).
 econstructor; eauto.
 Qed.
 
-#[export] Hint Resolve boxy_exp : core.
+#[local] Hint Resolve boxy_exp : core.
 
-Lemma boxy_prop {A} `{H : ageable A}:  forall (M: modality) P, reflexive _ (app_mode M) -> boxy M (prop P).
+Lemma boxy_prop :  forall (M: modality) P, reflexive _ (app_mode M) -> boxy M (prop P).
 Proof.
 intros.
 apply boxy_i; auto.
 Qed.
 
-Lemma boxy_TT {A} `{H : ageable A}:  forall (M: modality), reflexive _ (app_mode M) -> boxy M TT.
+Lemma boxy_TT :  forall (M: modality), reflexive _ (app_mode M) -> boxy M TT.
 Proof.
 intros.
 apply boxy_i; intros; auto.
 Qed.
 
-Lemma boxy_FF {A} `{H : ageable A}:  forall (M: modality), reflexive _ (app_mode M) -> boxy M FF.
+Lemma boxy_FF :  forall (M: modality), reflexive _ (app_mode M) -> boxy M FF.
 Proof.
 intros; apply boxy_i; intros; auto; contradiction.
 Qed.
 
-#[export] Hint Resolve boxy_TT : core.
-#[export] Hint Resolve boxy_FF : core.
+#[local] Hint Resolve boxy_TT : core.
+#[local] Hint Resolve boxy_FF : core.
 
-Lemma TT_i  {A} `{ageable A}: forall w: A,  app_pred TT w.
+Lemma TT_i  : forall w: A,  app_pred TT w.
 Proof.
 unfold TT, prop; simpl; auto.
 Qed.
 
-#[export] Hint Resolve TT_i : core.
+#[local] Hint Resolve TT_i : core.
 
-Lemma prop_andp_left {A}{agA: ageable A}: forall (P: Prop) Q R, (P -> Q |-- R) -> !!P && Q |-- R.
+Lemma prop_andp_left : forall (P: Prop) Q R, (P -> Q |-- R) -> !!P && Q |-- R.
 Proof.
  repeat intro. destruct H0; auto. apply H; auto.
 Qed.
 
-Lemma prop_andp_right {A}{agA: ageable A}: forall (P: Prop) Q R, P -> (Q |-- R) -> Q |-- !!P && R.
+Lemma prop_andp_right : forall (P: Prop) Q R, P -> (Q |-- R) -> Q |-- !!P && R.
 Proof.
  repeat intro. split; auto.
 Qed.
 
 Lemma prop_true_andp:
-  forall (P: Prop) A `{ageable A} (Q: pred A), P -> (!! P && Q = Q).
+  forall (P: Prop) (Q: pred), P -> (!! P && Q = Q).
 Proof.
 intros.
 apply pred_ext.
@@ -980,8 +1156,7 @@ unfold derives; intros; split; auto.
 Qed.
 
 Lemma prop_false_andp:
-  forall (P: Prop) A `{ageable A} (Q: pred A),
-   ~P -> !! P && Q = FF.
+  forall (P: Prop) (Q: pred), ~P -> !! P && Q = FF.
 Proof.
 intros.
 apply pred_ext.
@@ -989,25 +1164,25 @@ unfold derives; intros ? [? ?]; tauto.
 unfold derives. intros ? [].
 Qed.
 
-Lemma prop_andp_e {A} `{ageable A}:  forall P Q (w:A), (!! P && Q) w -> P /\ Q w.
+Lemma prop_andp_e :  forall P Q (w:A), (!! P && Q) w -> P /\ Q w.
 Proof.
-intuition; destruct H0; auto.
+intuition; destruct H; auto.
 Qed.
 
-Lemma prop_andp_i {A} `{ageable A}:  forall P Q (w:A), P /\ app_pred Q w -> (!! P && Q) w.
+Lemma prop_andp_i :  forall P Q (w:A), P /\ app_pred Q w -> (!! P && Q) w.
 Proof.
 intuition.
 split; auto.
 Qed.
 
-Lemma later_derives {A} `{agA : ageable A}: forall {P Q}, (P |-- Q) -> (|> P |-- |> Q).
+Lemma later_derives : forall {P Q}, (P |-- Q) -> (|> P |-- |> Q).
 Proof.
 unfold derives; intros.
 intro; intros; eapply H.
 eauto.
 Qed.
 
-Lemma boxy_allp {A} `{agA : ageable A}:
+Lemma boxy_allp :
   forall (M: modality) (B: Type) F,
      reflexive _ (app_mode M) ->
      (forall (x:B), boxy M (F x)) -> boxy M (allp F).
@@ -1019,20 +1194,20 @@ apply boxy_i; auto.
 intros.
 simpl in *.
 intro.
-specialize ( H2 b).
+specialize (H2 b).
 rewrite <- H0 in H2.
 apply H2; auto.
 Qed.
-#[export] Hint Resolve boxy_allp : core.
+#[local] Hint Resolve boxy_allp : core.
 
-Lemma later_allp {A} `{agA : ageable A}:
+Lemma later_allp :
        forall B P, |> (allp P) = allp (fun x:B => |> (P x)).
 Proof.
 intros.
 apply pred_ext; unfold derives; simpl; intros; eapply H; eauto.
 Qed.
 
-Lemma later_prop {A} `{agA : ageable A}:
+Lemma later_prop :
        forall P: Prop, |> (prop P) |-- prop P || |> FF.
 Proof.
   intros.
@@ -1050,12 +1225,12 @@ Proof.
     - auto.
 Qed.
 
-Lemma box_derives {A} `{ageable A} : forall M (P Q:pred A),
+Lemma box_derives  : forall M (P Q:pred),
   (P |-- Q) ->  box M P |-- box M Q.
 Proof. exact box_positive. Qed.
 
 Lemma allp_derives:
-       forall {A: Type} `{agA: ageable A} (B: Type) (P Q: B -> pred A),
+       forall (B: Type) (P Q: B -> pred),
                (forall x:B, P x |-- Q x) -> (allp P |-- allp Q).
 Proof.
 intros.
@@ -1063,76 +1238,94 @@ intros w b ?.
 eapply H; eauto.
 Qed.
 
-Lemma forall_pred_ext  {A} `{agA : ageable A}: forall B (P Q: B -> pred A),
+Lemma forall_pred_ext  : forall B (P Q: B -> pred),
  (ALL x : B, (P x <--> Q x)) |-- (ALL x : B, P x) <--> (ALL x: B, Q x) .
 Proof.
 intros.
 intros w ?.
-split; intros ? ? ? ?;  destruct (H b); eauto.
+split; intros ? ? ? ? ? ?; destruct (H b); eauto.
 Qed.
 
-Lemma exists_pred_ext  {A} `{agA : ageable A}: forall B (P Q: B -> pred A),
+Lemma exists_pred_ext  : forall B (P Q: B -> pred),
  (ALL x : B, (P x <--> Q x)) |-- (EX x : B, P x) <--> (EX x: B, Q x) .
 Proof.
 intros.
 intros w ?.
-split; intros w' ? [? ?]; exists x; eapply H; eauto.
+split; intros w' ? ? ? [? ?]; exists x; eapply H; eauto.
 Qed.
 
-Lemma imp_pred_ext  {A} `{agA : ageable A}: forall B B' P Q,
+Lemma imp_pred_ext  : forall B B' P Q,
        (B <--> B') && (B --> (P <--> Q))
  |-- (B --> P) <-->  (B' --> Q).
 Proof.
 intros.
 intros w [? ?].
-split; intros w'' ? ? w3 ? ?.
+split; intros ? w'' ? Hext ? ? w3 Hnec' ? ?.
+eapply nec_ext_commut in Hext as []; [|eauto].
 eapply H0.
-4: eapply H2; eauto.
-2: eapply H; try apply H4.
-econstructor 3; eauto.
-econstructor 3; eauto.
-constructor 2.
-eapply H; eauto.
+eapply rt_trans; eauto.
+etransitivity; eauto.
+eapply H.
+eapply rt_trans; eauto.
+etransitivity; eauto.
+auto.
+apply rt_refl.
+reflexivity.
+eapply H2; eauto.
+eapply H.
+eapply rt_trans; eauto.
+etransitivity; eauto.
+auto.
+eapply nec_ext_commut in Hext as []; [|eauto].
 eapply H0.
-4: eapply H2; eauto.
-2: eapply H; try apply H4.
-econstructor 3; eauto.
-econstructor 3; eauto.
-eapply H; eauto.
-econstructor 3; eauto.
-eapply H; eauto.
+eapply rt_trans; eauto.
+etransitivity; eauto.
+eapply H.
+eapply rt_trans; eauto.
+etransitivity; eauto.
+eapply H.
+eapply rt_trans; eauto.
+etransitivity; eauto.
+auto.
+apply rt_refl.
+reflexivity.
+eapply H2; eauto.
+eapply H.
+eapply rt_trans; eauto.
+etransitivity; eauto.
+auto.
 Qed.
 
-Lemma derives_refl {A: Type} `{ageable A}:
-  forall (P: pred A), (P |-- P).
+Lemma derives_refl:
+  forall (P: pred), (P |-- P).
 Proof. firstorder.
 Qed.
 
-#[export] Hint Resolve derives_refl : core.
+#[local] Hint Resolve derives_refl : core.
 
-Lemma andp_derives {A} `{ageable A}:
-  forall P Q P' Q': pred A, (P |-- P') -> (Q |-- Q') -> P && Q |-- P' && Q'.
+Lemma andp_derives :
+  forall P Q P' Q': pred, (P |-- P') -> (Q |-- Q') -> P && Q |-- P' && Q'.
 Proof.
 intros.
 intros w [? ?]; split; auto.
 Qed.
 
-Lemma orp_derives {A} `{ageable A}:
-  forall P Q P' Q': pred A, (P |-- P') -> (Q |-- Q') -> P || Q |-- P' || Q'.
+Lemma orp_derives :
+  forall P Q P' Q': pred, (P |-- P') -> (Q |-- Q') -> P || Q |-- P' || Q'.
 Proof.
 intros.
  apply orp_left. apply orp_right1; auto. apply orp_right2; auto.
 Qed.
 
-Lemma exp_derives {A} `{HA : ageable A}:
-       forall B (P: B -> pred A) Q , (forall x:B, P x |-- Q x) -> (exp P |-- exp Q).
+Lemma exp_derives :
+       forall B (P: B -> pred) Q , (forall x:B, P x |-- Q x) -> (exp P |-- exp Q).
 Proof.
 intros.
 intros w [b ?].
 exists b; eapply H; eauto.
 Qed.
 
-Lemma box_ext {A} `{agA : ageable A}: forall (M: modality) P Q,
+Lemma box_ext : forall (M: modality) P Q,
     box M (P <--> Q) |--  box M P <--> box M Q.
 Proof.
 intros.
@@ -1141,63 +1334,70 @@ apply andp_right;
 eapply derives_trans; try apply axiomK; intros ? [? ?]; auto.
 Qed.
 
-Lemma andp_pred_ext {A} `{agA : ageable A}: forall P Q P' Q',
+Lemma andp_pred_ext : forall P Q P' Q',
        (P <--> P') && (Q <--> Q') |--  (P && Q) <--> (P' && Q').
 Proof.
 intros.
 intros w [? ?].
-split; (intros w' ? [? ?]; split; [eapply H; eauto | eapply H0; eauto]).
+split; (intros w' ? ? ? [? ?]; split; [eapply H; eauto | eapply H0; eauto]).
 Qed.
 
-Program Definition exactly {A} `{ageable A} (x: A) : pred A := necR x.
+Program Definition exactly  (x: A) : pred := fun w => exists y, necR x y /\ ext_order y w.
 Next Obligation.
-constructor 3 with a; auto.
-constructor 1; auto.
+destruct H0 as (? & Hnec & Hext).
+eapply age_ext_commut in Hext as [? Hext ?]; eauto.
+do 2 eexists; [|apply Hext].
+eapply rt_trans; eauto.
+apply rt_step; auto.
+
+destruct H0 as (? & Hnec & Hext).
+do 2 eexists; eauto.
+etransitivity; eauto.
 Qed.
 
-Lemma derives_TT {A} `{ageable A}: forall (P: pred A), P |-- TT.
+Lemma derives_TT : forall (P: pred), P |-- TT.
 Proof.
 intros.
 intros ? ?; auto.
 Qed.
-#[export] Hint Resolve derives_TT : core.
+#[local] Hint Resolve derives_TT : core.
 
-Lemma FF_derives {A} `{ageable A}: forall P, FF |-- P.
+Lemma FF_derives : forall P, FF |-- P.
 Proof.
-intros. intros ? ?. hnf in H0; contradiction.
+intros. intros ? ?. hnf in H; contradiction.
 Qed.
-#[export] Hint Immediate FF_derives : core.
+#[local] Hint Immediate FF_derives : core.
 
-Lemma necR_level' {A} `{H : ageable A}: forall {w w': A}, necR w w' ->
+Lemma necR_level' : forall {w w': A}, necR w w' ->
        @necR _ ag_nat (level w) (level w').
 Proof.
 induction 1; simpl; intros.
-apply age_level in H0. constructor 1.  unfold age, age1; simpl.  rewrite H0; reflexivity.
+apply age_level in H. constructor 1.  unfold age, age1; simpl.  rewrite H; reflexivity.
 constructor 2.
 constructor 3 with (level y); auto.
 Qed.
 
-Lemma derives_imp {A} `{agA : ageable A}:
+Lemma derives_imp :
   forall P Q w, (P |-- Q) -> (P --> Q) w.
 Proof.
 intros.
-intros ? _; auto.
+intros ????; auto.
 Qed.
 
-Lemma exp_andp1 {A} `{ageable A}:
- forall B (p: B -> pred A) q, (exp p && q)%pred = (exp (fun x => p x && q))%pred.
+Lemma exp_andp1 :
+ forall B (p: B -> pred) q, (exp p && q)%pred = (exp (fun x => p x && q))%pred.
 Proof.
 intros; apply pred_ext; intros w ?.
-destruct H0.
-destruct H0.
+destruct H.
+destruct H.
 exists x; split; auto.
-destruct H0. destruct H0.
+destruct H. destruct H.
 split; auto.
 exists x; auto.
 Qed.
 
-Lemma exp_andp2 {A} `{HA: ageable A}:
- forall B p (q: B -> pred A), (p && exp q)%pred = (exp (fun x => p && q x))%pred.
+Lemma exp_andp2 :
+ forall B p (q: B -> pred), (p && exp q)%pred = (exp (fun x => p && q x))%pred.
 Proof.
 intros; apply pred_ext; intros w ?.
 destruct H.
@@ -1208,108 +1408,86 @@ split; auto.
 exists x; auto.
 Qed.
 
-Lemma exp_imp_left {A} `{agA : ageable A}:  forall B (p: B -> pred A) q,
+Lemma exp_imp_left :  forall B (p: B -> pred) q,
      (exp p --> q)%pred = allp (fun x => p x --> q)%pred.
 Proof.
 intros; apply pred_ext; intros w ?.
 intro.
-intros ?w ? ?.
-eapply H.
-apply necR_trans with w0; auto.
+intros ? ?w ? ? ?.
+eapply H; eauto.
 exists b; auto.
-intros ?w ? [? ?].
+intros ?w ? ? ? [? ?].
 eapply H; eauto.
 Qed.
 
-Lemma app_ext  {A: Type} `{ageable A} : forall (F G: A -> Prop) p1 p2 w,
+Lemma app_ext  : forall (F G: A -> Prop) p1 p2 w,
          (F w = G w) ->
-         app_pred (exist (hereditary age) F p1) w = app_pred (exist (hereditary age) G p2) w.
+         app_pred (exist (fun P => hereditary age P /\ hereditary ext_order P) F p1) w = app_pred (exist (fun P => hereditary age P /\ hereditary ext_order P) G p2) w.
 Proof.
 simpl; auto.
 Qed.
 
-Lemma imp_derives {A} `{agA : ageable A}:
+Lemma imp_derives :
   forall P P' Q Q',
     (P' |-- P) ->
     (Q |-- Q') ->
     P --> Q |-- P' --> Q'.
 Proof.
 intros.
-intros w ? w'' ? ?.
+intros w ? ? w'' ? ? ?.
 apply H0.
 eapply H1; eauto.
 Qed.
 
 
-Lemma imp_lem0  {A} `{agA : ageable A}:  forall P st, (TT --> P) st -> P st.
+Lemma imp_lem0  :  forall P st, (TT --> P) st -> P st.
 Proof.
 intros; eauto.
 Qed.
 
-Lemma conjoin_hyp0  {A} `{H : ageable A}:
-      forall (P Q: pred A) w,  P w -> (P --> Q) w -> (TT --> Q) w.
+Lemma conjoin_hyp0  :
+      forall (P Q: pred) w,  P w -> (P --> Q) w -> (TT --> Q) w.
 Proof.
 intros.
-intros w' ? ?.
-eapply H1;
+intros w' ? ? ? ?.
+eapply H0;
 eauto.
-eapply pred_nec_hereditary; eauto.
+eapply pred_nec_hereditary, pred_upclosed in H; eauto.
 Qed.
 
-Lemma conjoin_hyp1 {A} `{agA : ageable A}: forall (P Q R: pred A)  w,
+Lemma conjoin_hyp1 : forall (P Q R: pred)  w,
             P w -> (P&&Q --> R) w -> (Q --> R) w.
 Proof.
 intros.
-intros w' ? ?.
-eapply H0; auto.
+intros w' ? ? ? ?.
+eapply H0; try eassumption.
 split; eauto.
-eapply pred_nec_hereditary; eauto.
+eapply pred_nec_hereditary, pred_upclosed in H; eauto.
 Qed.
 
-Lemma derives_e {A: Type} `{agA : ageable A}: forall p q (st: A),
+Lemma derives_e : forall p q (st: A),
       (p |-- q) -> p st -> q st.
 Proof.
 auto.
 Qed.
 
-Ltac slurp :=
- apply imp_lem0;
-  match goal with |-  app_pred (_ --> _)  ?st =>
-        repeat match goal with
-                   | H: app_pred ?P st |- app_pred (?b --> ?c) st =>
-                       (apply (@conjoin_hyp0 _ _ P c st H) ||
-                        (apply (@conjoin_hyp1 _ _ P b c st H)));
-                       clear H
-                   end;
-        try (revert st; apply derives_e)
-  end.
-
-Lemma test_slurp {A} `{agA : ageable A} :  forall  (P Q R S : pred A) w ,
-        (P && (Q && R) --> S) w -> P w -> Q w -> R w -> S w.
-Proof.
-intros.
-remember (app_pred (P && (Q && R) --> S) w) as hide.
-slurp.
-subst hide. assumption.
-Qed.
-
-Lemma later_andp {A} `{H : ageable A}:
+Lemma later_andp :
   forall P Q, |> (P && Q) = |>P && |>Q.
 Proof.
 intros.
 apply pred_ext; intros w ?.
-split; intros w' ?; destruct (H0 _ H1); auto.
-destruct H0.
+split; intros w' ?; destruct (H _ H0); auto.
+destruct H.
 intros w' ?; split; eauto.
 Qed.
 
-Lemma True_andp_eq {A}`{ageable A}:
-  forall (P: Prop) (Q: pred A), P -> (!!P && Q)%pred = Q.
+Lemma True_andp_eq :
+  forall (P: Prop) (Q: pred), P -> (!!P && Q)%pred = Q.
 intros.
 apply pred_ext; intros w ?; hnf in *; simpl; intros; intuition.
 Qed.
 
-Lemma distrib_orp_andp {A}{agA: ageable A}:
+Lemma distrib_orp_andp :
    forall P Q R, (P||Q)&&R = (P&&R)||(Q&&R).
 Proof.
   intros. apply pred_ext.
@@ -1317,23 +1495,77 @@ Proof.
   intros w [[? ?]|[? ?]]; split; auto. left; auto. right; auto.
 Qed.
 
-Lemma allp_right {B A: Type}{agA: ageable A}:
-  forall (P: pred A) (Q: B -> pred A),
+Lemma allp_right {B: Type}:
+  forall (P: pred) (Q: B -> pred),
   (forall v, P |-- Q v) ->
    P |-- allp Q.
 Proof.
  intros. intros w ? v; apply (H v); auto.
 Qed.
 
-Lemma allp_left {B}{A}{agA: ageable A}:
-   forall (P: B -> pred A) x Q, (P x |-- Q) -> allp P |-- Q.
+Lemma allp_left {B}:
+   forall (P: B -> pred) x Q, (P x |-- Q) -> allp P |-- Q.
  Proof.
    intros. intros ? ?. apply H. apply H0.
 Qed.
 
-Lemma later_imp2 {A}{agA: ageable A}: forall P Q: pred A,
+(*Lemma later_imp2 : forall P Q: pred,
                  |> (P <--> Q) = |> P <--> |> Q.
 Proof.
  intros.
   repeat rewrite <- later_imp. rewrite <- later_andp; auto.
+Qed.*)
+
+End Order.
+
+Arguments pred A {AG EO}.
+
+#[export] Hint Resolve pred_hereditary : core.
+#[export] Hint Resolve rt_refl rt_trans t_trans : core.
+#[export] Hint Unfold necR : core.
+#[export] Hint Resolve boxy_andp : core.
+#[export] Hint Resolve boxy_disjunction : core.
+#[export] Hint Resolve boxy_exp : core.
+#[export] Hint Resolve boxy_TT : core.
+#[export] Hint Resolve boxy_FF : core.
+#[export] Hint Resolve TT_i : core.
+#[export] Hint Resolve boxy_allp : core.
+#[export] Hint Resolve derives_refl : core.
+#[export] Hint Resolve derives_TT : core.
+#[export] Hint Immediate FF_derives : core.
+
+Declare Scope pred_derives.
+Notation "P '|--' Q" := (derives P%pred Q%pred) (at level 80, no associativity) : pred_derives.
+Open Scope pred_derives.
+Notation "'EX' x .. y , P " :=
+  (exp (fun x => .. (exp (fun y => P%pred)) ..)) (at level 65, x binder, y binder, right associativity) : pred.
+Notation "'ALL' x .. y , P " :=
+  (allp (fun x => .. (allp (fun y => P%pred)) ..)) (at level 65, x binder, y binder, right associativity) : pred.
+Infix "||" := orp (at level 50, left associativity) : pred.
+Infix "&&" := andp (at level 40, left associativity) : pred.
+Notation "P '-->' Q" := (imp P Q) (at level 55, right associativity) : pred.
+Notation "P '<-->' Q" := (andp (imp P Q) (imp Q P)) (at level 57, no associativity) : pred.
+(* Notation "'[]' e" := (box necM e) (at level 30, right associativity): pred. *)
+Notation "'|>' e" := (box laterM e) (at level 20, right associativity): pred.
+Notation "'!!' e" := (prop e) (at level 15) : pred.
+
+Ltac slurp :=
+ apply imp_lem0;
+  match goal with |-  app_pred (_ --> _)  ?st =>
+        repeat match goal with
+                   | H: app_pred ?P st |- app_pred (?b --> ?c) st =>
+                       (apply (@conjoin_hyp0 _ _ _ P c st H) ||
+                        (apply (@conjoin_hyp1 _ _ _ P b c st H)));
+                       clear H
+                   end;
+        try (revert st; apply derives_e)
+  end.
+
+Lemma test_slurp {A} {agA : ageable A} {EO : Ext_ord A} :  forall (P Q R S : pred A) w ,
+        (P && (Q && R) --> S) w -> P w -> Q w -> R w -> S w.
+Proof.
+intros.
+remember (app_pred (P && (Q && R) --> S) w) as hide.
+slurp.
+subst hide. assumption.
 Qed.

--- a/msl/predicates_hered_simple.v
+++ b/msl/predicates_hered_simple.v
@@ -1,0 +1,1339 @@
+(*
+ * Copyright (c) 2009-2010, Andrew Appel, Robert Dockins and Aquinas Hobor.
+ *
+ *)
+
+Require Import VST.msl.base.
+Require Import VST.msl.ageable.
+
+Declare Scope pred.
+Delimit Scope pred with pred.
+Local Open Scope pred.
+
+(* A "pre-predicate" is hereditary iff whenever it is
+   true at world a, it is also true at all worlds
+   accessable from a via R.
+ *)
+Definition hereditary {A} (R:A->A->Prop) (p:A->Prop) :=
+  forall a a':A, R a a' -> p a -> p a'.
+
+(* A predicate is a hereditary pre-predicate *)
+Definition pred (A:Type) {AG:ageable A} :=
+  { p:A -> Prop | hereditary age p }.
+
+Bind Scope pred with pred.
+
+(* Here is some junk that makes the definition of "pred" opaque
+   to most tactics but still allows the "Program" extension to
+   see it is a subset type.  The coercion is sugar that allows us to use
+   predicates easily.
+ *)
+Definition app_pred {A} `{ageable A} (p:pred A) : A -> Prop := proj1_sig p.
+Definition pred_hereditary `{ageable} (p:pred A) := proj2_sig p.
+Coercion app_pred : pred >-> Funclass.
+Global Opaque pred.
+
+#[export] Hint Resolve pred_hereditary : core.
+
+Lemma nec_hereditary {A} `{ageable A} (p: A -> Prop) : hereditary age p ->
+  forall a a':A, necR a a' -> p a -> p a'.
+Proof.
+  intros.
+  induction H1; auto.
+  apply H0 with x; auto.
+Qed.
+
+Lemma pred_nec_hereditary {A} `{ageable A} (p:pred A) :
+  forall a a':A, necR a a' -> p a -> p a'.
+Proof.
+  apply nec_hereditary, pred_hereditary.
+Qed.
+
+Program Definition mkPred {A} `{ageable A} (p:A -> Prop) : pred A :=
+  fun x => forall x', necR x x' -> p x'.
+Next Obligation.
+  repeat intro.
+  apply H1.
+  apply rt_trans with a'; auto.
+  apply rt_step; auto.
+Qed.
+
+(* The semantic notion of entailment.
+ *)
+Definition derives {A} `{ageable A} (P Q:pred A) := forall a:A, P a -> Q a.
+Arguments derives [A] [H] _ _.
+
+(* "valid" relations are those that commute with aging.  These
+   relations are the ones that can be turned into modalities.
+ *)
+Definition valid_rel {A} `{ageable A} (R:relation A) : Prop :=
+  commut A age R /\ commut A R age.
+
+(* A modaility is a valid relation *)
+Definition modality {A} `{ageable A} := { R:relation A | valid_rel R }.
+
+(* More black magic to make the definition of modaility mostly opaque. *)
+Definition app_mode {A} `{ageable A} (m:modality) : A -> A -> Prop := proj1_sig m.
+Definition mode_valid {A} `{ageable A} (m:modality) := proj2_sig m.
+Global Opaque modality.
+Coercion app_mode : modality >-> Funclass.
+
+(* commutivity facts for the basic relations *)
+
+Lemma valid_rel_commut_later1 {A} `{ageable A} : forall R,
+  valid_rel R ->
+  commut A laterR R.
+Proof.
+  intros; hnf; intros.
+  revert z H2.
+  induction H1; intros.
+  destruct H0.
+  destruct (H0 _ _ H1 _ H2).
+  exists x0; auto.
+  apply t_step; auto.
+  destruct (IHclos_trans1 _ H2).
+  destruct (IHclos_trans2 _ H1).
+  exists x1; auto.
+  eapply t_trans; eauto.
+Qed.
+
+Lemma valid_rel_commut_later2 {A} `{ageable A} : forall R,
+  valid_rel R ->
+  commut A R laterR.
+Proof.
+  intros; hnf; intros.
+  revert x H1.
+  induction H2; intros.
+  destruct H0.
+  destruct (H3 _ _ H2 _ H1).
+  exists x1; auto.
+  apply t_step; auto.
+  destruct (IHclos_trans2 _ H1).
+  destruct (IHclos_trans1 _ H3).
+  exists x2; auto.
+  eapply t_trans; eauto.
+Qed.
+
+Lemma valid_rel_commut_nec1 {A} `{ageable A} : forall R,
+  valid_rel R ->
+  commut A necR R.
+Proof.
+  intros; hnf; intros.
+  apply nec_refl_or_later in H1; destruct H1; subst.
+  exists z; auto.
+  destruct (valid_rel_commut_later1 R H0 x y H1 z H2).
+  exists x0; auto.
+  apply Rt_Rft; auto.
+Qed.
+
+Lemma valid_rel_commut_nec2 {A} `{ageable A} : forall R,
+  valid_rel R ->
+  commut A R necR.
+Proof.
+  intros; hnf; intros.
+  apply nec_refl_or_later in H2; destruct H2; subst.
+  exists x; auto.
+  destruct (valid_rel_commut_later2 R H0 x y H1 z H2).
+  exists x0; auto.
+  apply Rt_Rft; auto.
+Qed.
+
+Lemma valid_rel_age {A} `{ageable A} : valid_rel age.
+Proof.
+  intros; split; hnf; intros; firstorder.
+Qed.
+
+Lemma valid_rel_later {A} `{ageable A} : valid_rel laterR.
+Proof.
+  intros; split; hnf; intros.
+  revert x H0.
+  induction H1; intros.
+  exists y; auto.
+  apply t_step; auto.
+  destruct (IHclos_trans2 _ H0).
+  destruct (IHclos_trans1 _ H2).
+  exists x2; auto.
+  eapply t_trans; eauto.
+
+  revert z H1.
+  induction H0; intros.
+  exists x; auto.
+  apply t_step; auto.
+  destruct (IHclos_trans1 _ H1).
+  destruct (IHclos_trans2 _ H0).
+  exists x1; auto.
+  eapply t_trans; eauto.
+Qed.
+
+Lemma valid_rel_nec {A} `{ageable A} : valid_rel necR.
+Proof.
+  intros; split; hnf; intros.
+  revert x H0.
+  induction H1; intros.
+  exists y; auto.
+  apply rt_step; auto.
+  exists x0; auto.
+  destruct (IHclos_refl_trans2 _ H0).
+  destruct (IHclos_refl_trans1 _ H2).
+  exists x2; auto.
+  eapply rt_trans; eauto.
+
+  revert z H1.
+  induction H0; intros.
+  exists x; auto.
+  apply rt_step; auto.
+  exists z; auto.
+
+  destruct (IHclos_refl_trans1 _ H1).
+  destruct (IHclos_refl_trans2 _ H0).
+  exists x1; auto.
+  eapply rt_trans; eauto.
+Qed.
+
+(* Definitions of the basic modalities.
+ *)
+Definition ageM {A} `{ageable A} : modality
+  := exist _ age valid_rel_age.
+Definition laterM {A} `{ageable A} : modality
+  := exist _ laterR valid_rel_later.
+(*
+Definition necM {A} `{ageable A} : modality
+  := exist _ necR valid_rel_nec.
+*)
+
+#[export] Hint Resolve rt_refl rt_trans t_trans : core.
+#[export] Hint Unfold necR : core.
+Obligation Tactic := unfold hereditary; intuition;
+    first [eapply pred_hereditary; eauto; fail | eauto ].
+
+(* Definitions of the basic propositional conectives.
+ *)
+
+(* Lifting pure mathematical facts to predicates *)
+
+Program Definition prop {A} `{ageable A}  (P: Prop) : pred A := (fun _  => P).
+
+Definition TT {A} `{ageable A}: pred A := prop True.
+Definition FF  {A} `{ageable A}: pred A := prop False.
+
+Program Definition imp {A} `{ageable A} (P Q:pred A) : pred A :=
+   fun a:A => forall a':A, necR a a' -> P a' -> Q a'.
+Next Obligation.
+  apply H1; auto.
+  apply rt_trans with a'; auto.
+  apply rt_step; auto.
+Qed.
+Program Definition orp {A} `{ageable A} (P Q:pred A) : pred A :=
+   fun a:A => P a \/ Q a.
+Next Obligation.
+  left; eapply pred_hereditary; eauto.
+  right; eapply pred_hereditary; eauto.
+Qed.
+
+Program Definition andp {A} `{ageable A} (P Q:pred A) : pred A :=
+   fun a:A => P a /\ Q a.
+
+(* Universal and exp quantification
+ *)
+
+Program Definition allp {A} `{ageable A} {B: Type} (f: B -> pred A) : pred A
+  := fun a => forall b, f b a.
+Next Obligation.
+  apply pred_hereditary with a; auto.
+  apply H1.
+Qed.
+
+Program Definition exp {A} `{ageable A} {B: Type} (f: B -> pred A) : pred A
+  := fun a => exists b, f b a.
+Next Obligation.
+  destruct H1; exists x; eapply pred_hereditary; eauto.
+Qed.
+
+
+(* Definition of the "box" modal operator.  This operator turns
+   modalities (relations) into a "necessarily" type operator.
+ *)
+
+Program Definition box {A} `{ageable A} (M:modality) (P:pred A) : pred A :=
+  fun a:A => forall a', M a a' -> P a'.
+Next Obligation.
+  destruct M as [M [H3 H4]]; simpl in *.
+  destruct (H4 _ _ H2 _ H0).
+  apply pred_hereditary with x; auto.
+  apply H1; auto.
+Qed.
+
+(* Definition of the "diamond" modal operator.  This operator
+   turns modalities into a "possibly" type operator.  _However_,
+   note that this is NOT the boolean dual to "box", as usually
+   found in accounts of modal logic. Instead, this is the
+   "proof-theoretic" dual as found in Restall's "A Introduction
+   to Substructural Logic" (2000).
+ *)
+
+Program Definition diamond {A} `{ageable A} (M:modality) (P:pred A) : pred A :=
+  fun a:A => exists a', M a' a /\ P a'.
+Next Obligation.
+  destruct M as [M [H3 H4]]; simpl in *.
+  destruct H1 as [x [? ?]].
+  destruct (H3 _ _ H0 _ H1).
+  exists x0; split; auto.
+  apply pred_hereditary with x; auto.
+Qed.
+
+Definition boxy {A} `{ageable A} (m: modality) (p: pred A): Prop :=  box m p = p.
+
+(* A pile of notations for the operators we have defined *)
+Declare Scope pred_derives.
+Notation "P '|--' Q" := (derives P%pred Q%pred) (at level 80, no associativity) : pred_derives.
+Open Scope pred_derives.
+Notation "'EX' x .. y , P " :=
+  (exp (fun x => .. (exp (fun y => P%pred)) ..)) (at level 65, x binder, y binder, right associativity) : pred.
+Notation "'ALL' x .. y , P " :=
+  (allp (fun x => .. (allp (fun y => P%pred)) ..)) (at level 65, x binder, y binder, right associativity) : pred.
+Infix "||" := orp (at level 50, left associativity) : pred.
+Infix "&&" := andp (at level 40, left associativity) : pred.
+Notation "P '-->' Q" := (imp P Q) (at level 55, right associativity) : pred.
+Notation "P '<-->' Q" := (andp (imp P Q) (imp Q P)) (at level 57, no associativity) : pred.
+(* Notation "'[]' e" := (box necM e) (at level 30, right associativity): pred. *)
+Notation "'|>' e" := (box laterM e) (at level 20, right associativity): pred.
+Notation "'!!' e" := (prop e) (at level 15) : pred.
+
+(* Rules for the propositional connectives *)
+Lemma modus_ponens {A} `{ageable A} : forall (X P Q:pred A),
+  (X |-- P) ->
+  (X |-- (P --> Q)) ->
+  X |-- Q.
+Proof.
+  unfold derives, imp; simpl; intuition eauto.
+Qed.
+
+Lemma andp_right {A} `{ageable A} : forall (X P Q:pred A),
+  (X |-- P) ->
+  (X |-- Q) ->
+  X |-- P && Q.
+Proof.
+  unfold derives, imp, andp; simpl; intuition.
+Qed.
+
+
+  Lemma pred_ext' {A} `{ageable A}: forall (p1 p2:pred A),
+    app_pred p1 = app_pred p2 ->
+    p1 = p2.
+  Proof.
+    intros; destruct p1; destruct p2; simpl in H.
+   simpl in H0.
+    subst x0.
+    replace h0 with h by apply proof_irr.
+    auto.
+  Qed.
+
+Lemma pred_ext : forall A `{ageable A} (P Q:pred A),
+  derives P Q -> derives Q P -> P = Q.
+Proof.
+  intros.
+  destruct P as [P HP].
+  destruct Q as [Q HQ].
+  unfold derives in *. simpl in *.
+   apply (exist_ext (A->Prop) (fun p => hereditary (@age _ H) p)).
+  extensionality a.
+  apply prop_ext; intuition.
+Qed.
+
+Lemma andp_dup {A}{agA: ageable A}: forall P: pred A, P && P = P.
+Proof. intros. apply pred_ext; intros w ?. destruct H; auto. split; auto.
+Qed.
+
+Lemma andp_left1{A}{agA: ageable A}: forall P Q R: pred A,  (P |-- R) -> P && Q |-- R.
+Proof. repeat intro. destruct H0; auto.
+Qed.
+
+Lemma andp_left2{A}{agA: ageable A}: forall P Q R: pred A,  (Q |-- R) -> P && Q |-- R.
+Proof. repeat intro. destruct H0; auto.
+Qed.
+
+Lemma orp_left{A}{agA: ageable A}: forall P Q R: pred A,  (P |-- R) -> (Q |-- R) -> P || Q |-- R.
+Proof. repeat intro. destruct H1; auto.
+Qed.
+
+Lemma orp_right1{A}{agA: ageable A}: forall P Q R: pred A,  (P |-- Q) -> P |-- Q || R.
+Proof. repeat intro. left; auto.
+Qed.
+
+Lemma orp_right2{A}{agA: ageable A}: forall P Q R: pred A,  (P |-- R) -> P |-- Q || R.
+Proof. repeat intro. right; auto.
+Qed.
+
+Lemma orp_assoc {A} `{ageable A} : forall P Q R: pred A, (P || Q) || R = P || (Q || R).
+Proof.
+  intros; apply pred_ext; auto; unfold derives, andp; simpl; intuition.
+Qed.
+
+Lemma derives_trans {A}`{ageable A}:
+    forall P Q R: pred A, (P |-- Q) -> (Q |-- R) -> P |-- R.
+Proof. firstorder. Qed.
+
+Lemma exp_right:
+  forall {B A: Type}{agA: ageable A}(x:B) p (q: B -> pred A),
+    (p |-- q x) ->
+    p |-- exp q.
+Proof.
+intros.
+eapply derives_trans; try apply H.
+intros w ?; exists x; auto.
+Qed.
+
+Lemma exp_left:
+  forall {B A: Type}{agA: ageable A}(p: B -> pred A) q,
+  (forall x, p x |-- q) ->
+   exp p |-- q.
+Proof.
+intros.
+intros w [x' ?].
+eapply H; eauto.
+Qed.
+
+Lemma and1 {A} `{ageable A} : forall (X P Q:pred A),
+  X |-- P && Q --> P.
+Proof.
+  unfold derives, imp, andp; simpl; intuition eauto.
+Qed.
+
+Lemma and2 {A} `{ageable A} : forall (X P Q:pred A),
+  X |-- P && Q --> Q.
+Proof.
+  unfold derives, imp, andp; simpl; intuition eauto.
+Qed.
+
+Lemma and3 {A} `{ageable A} : forall (X P Q R:pred A),
+  X |-- (P --> Q) --> (P --> R) --> (P --> Q && R).
+Proof.
+  unfold derives, imp, andp; simpl; intuition eauto.
+Qed.
+
+Lemma or1 {A} `{ageable A} : forall (X P Q:pred A),
+  X |-- P --> P || Q.
+Proof.
+  unfold derives, imp, orp; simpl; intuition.
+Qed.
+
+Lemma or2 {A} `{ageable A} : forall (X P Q:pred A),
+  X |-- Q --> P || Q.
+Proof.
+  unfold derives, imp, orp; simpl; intuition.
+Qed.
+
+Lemma or3 {A} `{ageable A} : forall (X P Q R:pred A),
+  X |-- (P --> R) --> (Q --> R) --> (P || Q --> R).
+Proof.
+  unfold derives, imp, orp; simpl; intuition eauto.
+Qed.
+
+Lemma TTrule {A} `{ageable A} : forall X P,
+  X |-- P --> TT.
+Proof.
+  unfold derives, imp, TT; simpl; intuition.
+Qed.
+
+Lemma FFrule {A} `{ageable A} : forall X P,
+  X |-- FF --> P.
+Proof.
+  unfold derives, imp, FF; simpl; intuition.
+Qed.
+
+Lemma distribution {A} `{ageable A} : forall (X P Q R:pred A),
+  X |-- P && (Q || R) --> (P && Q) || (P && R).
+Proof.
+  unfold derives, imp, orp, andp; simpl; intuition.
+Qed.
+
+(* Characterize the relation between conjunction and implication *)
+Lemma imp_andp_adjoint {A} `{ageable A} : forall (P Q R:pred A),
+  ((P && Q) |-- R) <-> (P |-- (Q --> R)).
+Proof.
+  split; intros.
+  hnf; intros; simpl; intros.
+  apply H0.
+  split; auto.
+  apply pred_nec_hereditary with a; auto.
+  hnf; intros.
+  hnf in H0.
+  unfold imp in H0; simpl in H0.
+  destruct H1.
+  apply H0 with a; auto.
+Qed.
+
+(* Some facts about modalities *)
+
+Lemma box_e0 {A} `{ageable A}: forall (M: modality) Q,
+            reflexive _ M -> box M Q  |-- Q.
+Proof.
+intros.
+intro; intros.
+apply H1; simpl.
+apply H0.
+Qed.
+Arguments box_e0 [A] _ _ _ _ _ _.
+
+Lemma boxy_i {A} `{ageable A}:
+  forall (Q: pred A) (M: modality),
+    reflexive _ M ->
+    (forall w w', M w w' -> Q w -> Q w') ->
+    boxy M Q.
+Proof.
+intros.
+unfold boxy.
+apply pred_ext; hnf; intros.
+eapply box_e0; eauto.
+hnf; intros.
+eapply H1; eauto.
+Qed.
+
+(*
+Lemma necM_refl {A} `{ageable A}: reflexive _ necM.
+Proof.
+intros; intro; simpl.
+unfold necR.
+constructor 2.
+Qed.
+
+#[export] Hint Resolve necM_refl.
+*)
+
+(* relationship between box and diamond *)
+Lemma box_diamond {A} `{ageable A} : forall M (P Q:pred A),
+  ((diamond M P) |-- Q) <-> (P |-- (box M Q)).
+Proof.
+  unfold derives; intuition.
+  hnf; intros.
+  apply H0.
+  hnf; eauto.
+  destruct H1 as [a' [? ?]].
+  apply H0 with a'; auto.
+Qed.
+
+(* Box is a normal modal operator *)
+
+Lemma ruleNec {A} `{ageable A} : forall M (P:pred A),
+  derives TT P ->
+  derives TT (box M P).
+Proof.
+  intros.
+  rewrite <- box_diamond.
+  hnf; intros.
+  apply H0; hnf; auto.
+Qed.
+
+Lemma axiomK {A} `{ageable A}: forall M (P Q:pred A),
+  (box M (P --> Q)) |-- (box M P --> box M Q).
+Proof.
+  intros; do 3 (hnf; intros).
+  destruct M as [R HR]; simpl in *.
+  destruct (valid_rel_commut_nec2 R HR _ _ H3 _ H1).
+  apply H0 with x; auto.
+Qed.
+
+(* Box and diamond are positive modal operators *)
+
+Lemma box_positive {A} `{ageable A} : forall M (P Q:pred A),
+  (P |-- Q) ->
+  box M P |-- box M Q.
+Proof.
+  unfold derives, box; simpl; intuition.
+Qed.
+
+Lemma diamond_positive {A} `{ageable A} : forall M (P Q:pred A),
+  (P |-- Q) ->
+  diamond M P |-- diamond M Q.
+Proof.
+  unfold derives, diamond; simpl; firstorder.
+Qed.
+
+Lemma box_refl_trans {A} `{ageable A}: forall (m:modality) p,
+  reflexive _ m ->
+  transitive _ m ->
+  box m (box m p) = box m p.
+Proof.
+  intros.
+  apply pred_ext.
+  repeat intro.
+  assert (box m p a').
+  apply H2; auto.
+  apply H4.
+  apply H0.
+  repeat intro.
+  apply H2.
+  eapply H1; eauto.
+Qed.
+
+(* Disribuitivity of box over various connectives *)
+
+Lemma box_and {A} `{ageable A}: forall R (P Q:pred A),
+  box R (P && Q) = box R P && box R Q.
+Proof.
+  intros; apply pred_ext; hnf; intuition;
+    unfold andp, box in *; simpl in *; firstorder.
+Qed.
+
+Lemma box_all {A} `{ageable A} : forall B R (F:B -> pred A),
+  box R (allp F) = ALL x:B, box R (F x).
+Proof.
+  intros; apply pred_ext; hnf; intuition;
+    unfold allp, box in *; simpl in *; firstorder.
+Qed.
+
+Lemma box_ex {A} `{ageable A} : forall B R (F:B->pred A),
+  EX x:B, box R (F x) |-- box R (exp F).
+Proof.
+  unfold derives, exp, box; simpl; firstorder.
+Qed.
+
+Lemma box_or {A} `{ageable A} : forall R (P Q:pred A),
+   box R P || box R Q |-- box R (P || Q).
+Proof.
+  unfold derives, orp, box; simpl; firstorder.
+Qed.
+
+(* Distributivity of diamond over various operators *)
+
+Lemma diamond_or {A} `{ageable A} : forall R (P Q:pred A),
+  diamond R (P || Q) = diamond R P || diamond R Q.
+Proof.
+  intros; apply pred_ext; hnf; intuition;
+    unfold diamond, orp in *; simpl in *; firstorder.
+Qed.
+
+Lemma diamond_ex {A} `{ageable A} : forall B R (F:B -> pred A),
+  diamond R (exp F) = EX x:B, diamond R (F x).
+Proof.
+  intros; apply pred_ext; hnf; intuition;
+    unfold diamond, exp in *; simpl in *; firstorder.
+Qed.
+
+Lemma diamond_and {A} `{ageable A} : forall R (P Q:pred A),
+  diamond R (P && Q) |-- diamond R P && diamond R Q.
+Proof.
+  unfold derives, andp, diamond; simpl; firstorder.
+Qed.
+
+Lemma diamond_all {A} `{ageable A} : forall B R (F:B->pred A),
+  diamond R (allp F) |-- ALL x:B, diamond R (F x).
+Proof.
+  unfold derives, allp, diamond; simpl; firstorder.
+Qed.
+
+
+(* Lemmas about aging and the later operator *)
+
+(*
+Lemma nec_useless {A} `{ageable A} :
+  forall P, []P = P.
+intros.
+  apply pred_ext; intros.
+  hnf; intros; apply H0.
+  simpl; apply necM_refl.
+  hnf; intros.
+  hnf; intros.
+  apply pred_nec_hereditary with a; auto.
+Qed.
+*)
+
+Lemma later_age {A} `{ageable A} : forall P,
+  |>P = box ageM P.
+Proof.
+  intros; apply pred_ext; do 2 (hnf; intros).
+  simpl in H0.
+  apply H0.
+  apply t_step; auto.
+  revert H0; induction H1; intros.
+  apply H1; auto.
+  apply pred_nec_hereditary with y.
+  apply Rt_Rft; auto.
+  apply IHclos_trans1; auto.
+Qed.
+
+Lemma now_later {A} `{ageable A} : forall P,
+  P |-- |>P.
+Proof.
+  repeat intro.
+  apply pred_nec_hereditary with a; auto.
+  apply Rt_Rft; auto.
+Qed.
+
+Lemma now_later2 {A} `{ageable A} : forall G P,
+  (G |-- P) ->
+  G |-- |>P.
+Proof.
+  intros; apply @derives_trans with P; auto.
+  apply now_later.
+Qed.
+
+(* The "induction" rule for later *)
+
+Lemma goedel_loeb {A} `{ageable A} : forall (P Q:pred A),
+  (Q && |>P |-- P) ->
+  Q |-- P.
+Proof.
+  intros; hnf; intro a.
+  induction a using age_induction.
+  intros; simpl in H0.
+  eapply H0; auto.
+  split; auto.
+  rewrite later_age.
+  simpl; intros.
+  apply H1; auto.
+  apply pred_hereditary with x; auto.
+Qed.
+
+Lemma loeb {A} `{ageable A} : forall (P:pred A),
+     (|>P |-- P)    ->     TT |-- P.
+Proof.
+  intros. apply goedel_loeb.
+  apply andp_left2. auto.
+Qed.
+
+(* Later distributes over almost everything! *)
+
+Lemma later_commute_dia {A} `{ageable A} : forall M (P:pred A),
+  diamond M (|> P) |-- |> (diamond M P).
+Proof.
+  intros.
+  repeat rewrite later_age.
+  do 3 (hnf; intros).
+  simpl in H0.
+  firstorder.
+  destruct M as [R HR].
+  simpl in *.
+  destruct HR.
+  destruct (H3 _ _ H1 _ H0).
+  exists x0; split; auto.
+Qed.
+
+Lemma later_commute {A} `{ageable A} : forall M (P:pred A),
+  box M (|>P) = |>(box M P).
+Proof.
+  intros.
+  apply pred_ext; do 3 (hnf; intros).
+  destruct M as [R HR].
+  destruct (valid_rel_commut_later2 R HR _ _ H2 _ H1).
+  apply H0 with x; simpl; auto.
+  destruct M as [R HR].
+  destruct (valid_rel_commut_later1 R HR _ _ H2 _ H1).
+  apply H0 with x; auto.
+Qed.
+
+Lemma later_and {A} `{ageable A} : forall P Q,
+  |>(P && Q) = |>P && |> Q.
+Proof.
+  intros; apply box_and.
+Qed.
+
+Lemma later_or {A} `{ageable A} : forall (P Q:pred A),
+  |>(P || Q) = |>P || |>Q.
+Proof.
+  intros.
+  repeat rewrite later_age.
+  apply pred_ext.
+  2: apply box_or.
+  hnf; intros.
+  simpl in H0.
+  case_eq (age1 a); intros.
+  destruct (H0 a0); auto.
+  left; simpl; intros.
+  replace a' with a0; auto.
+  congruence.
+  right; simpl; intros.
+  replace a' with a0; auto.
+  congruence.
+  left.
+  hnf; simpl; intros.
+  hnf in H2.
+  rewrite H1 in H2; discriminate.
+Qed.
+
+Lemma later_ex {A} `{ageable A} : forall B (F:B->pred A),
+  B ->
+  |>(exp F) = EX x:B, |>(F x).
+Proof.
+  intros.
+  apply pred_ext.
+  2: apply box_ex.
+  hnf; intros.
+  rewrite later_age in H0.
+  case_eq (age1 a); intros.
+  destruct (H0 a0); auto.
+  exists x.
+  rewrite later_age; simpl; intros.
+  replace a' with a0; auto.
+  congruence.
+  exists X.
+  rewrite later_age.
+  hnf; simpl; intros.
+  unfold age in H2.
+  rewrite H1 in H2; discriminate.
+Qed.
+
+Lemma later_ex'' {A} `{ageable A} : forall B (F:B->pred A),
+  |>(exp F) |-- (EX x:B, |>(F x)) || |> FF.
+Proof.
+  intros.
+  unfold derives; intros.
+  simpl in H |- *.
+  destruct (age1 a) eqn:?H; [left | right].
+  + simpl in H0.
+    pose proof H0 a0.
+    destruct H2 as [b ?].
+    {
+      constructor.
+      auto.
+    }
+    exists b.
+    intros.
+    revert H2; apply pred_nec_hereditary.
+    eapply age_later_nec; eauto.
+  + intros.
+    clear - H2 H1.
+    induction H2.
+    - hnf in H0; congruence.
+    - auto.
+Qed.
+
+Lemma later_imp {A} `{ageable A} : forall P Q,
+  |>(P --> Q) = |>P --> |>Q.
+Proof.
+  intros; repeat rewrite later_age.
+  apply pred_ext.
+  apply axiomK.
+  hnf; intros.
+  simpl; intros.
+  simpl in H0.
+  destruct valid_rel_nec.
+  destruct (H5 _ _ H2 _ H1).
+  apply H0 with x; auto.
+  intros.
+  replace a'1 with a'0; auto.
+  congruence.
+Qed.
+
+Lemma TT_boxy {A} `{ageable A} : forall M,
+  boxy M TT.
+Proof.
+  intros; hnf.
+  apply pred_ext; repeat intro; simpl; auto.
+Qed.
+
+Lemma positive_boxy {A} `{ageable A} : forall P Q M,
+  boxy M P ->
+  (P |-- Q) ->
+  P |-- box M Q.
+Proof.
+  intros.
+  rewrite <- H0.
+  apply box_positive.
+  auto.
+Qed.
+
+Lemma forallI {A} `{ageable A} : forall A G X,
+  (forall x:A, G |-- X x) ->
+  G |-- allp X.
+Proof.
+  repeat intro.
+  eapply H0; auto.
+Qed.
+
+Lemma TT_and {A} `{ageable A} : forall P,
+  TT && P = P.
+Proof.
+  intros; apply pred_ext; repeat intro.
+  destruct H0; auto.
+  split; simpl; auto.
+Qed.
+
+Lemma andp_comm {A} `{ageable A} : forall P Q,
+  P && Q = Q && P.
+Proof.
+  intros; apply pred_ext; unfold andp; repeat intro; simpl in *; intuition.
+Qed.
+
+Lemma andp_assoc {A} `{ageable A} : forall P Q R,
+  (P && Q) && R = P && (Q && R).
+Proof.
+  intros; apply pred_ext; auto; unfold derives, andp; simpl; intuition.
+Qed.
+
+Lemma ex_and : forall {A} `{ageable A} B (P:B->pred A) Q,
+  (exp P) && Q = EX x:B, P x && Q.
+Proof.
+  intros. apply pred_ext.
+  repeat intro. destruct H0. destruct H0.
+  exists x. split; auto.
+  repeat intro.
+  destruct H0. destruct H0.
+  split; auto. exists x; auto.
+Qed.
+
+Lemma FF_and : forall {A} `{ageable A} (P:pred A),
+  FF && P = FF.
+Proof.
+  intros. apply pred_ext; repeat intro.
+  destruct H0; auto.
+  elim H0.
+Qed.
+
+
+Lemma boxy_e {A} `{H : ageable A}: forall (M: modality) P,  boxy M P ->
+           forall w w', app_mode M w w' -> P w -> P w'.
+Proof.
+intros.
+rewrite <- H0 in H2; eauto.
+Qed.
+
+Lemma boxy_andp {A} `{H : ageable A}:
+     forall (M: modality) , reflexive _ (app_mode M) ->
+      forall P Q, boxy M P -> boxy M Q -> boxy M (P && Q).
+Proof.
+destruct M;
+intros.
+simpl in *.
+apply boxy_i; intros; auto.
+destruct H4.
+simpl.
+split; eapply boxy_e; eauto.
+Qed.
+
+#[export] Hint Resolve boxy_andp : core.
+
+Lemma boxy_disjunction {A} `{H : ageable A}:
+     forall (M: modality) , reflexive _ (app_mode M) ->
+      forall P Q, boxy M P -> boxy M Q -> boxy M (P || Q).
+Proof.
+destruct M;
+intros.
+simpl in *.
+apply boxy_i; intros; auto.
+destruct H4.
+left.  eapply boxy_e; eauto.
+right. eapply boxy_e; eauto.
+Qed.
+
+#[export] Hint Resolve boxy_disjunction : core.
+
+Lemma boxy_exp {A} `{agA : ageable A}:
+    forall (M: modality) T (P: T -> pred A),
+     reflexive _ (app_mode M) ->
+     (forall x, boxy M (P x)) -> boxy M (exp P).
+Proof.
+intros.
+apply boxy_i; auto; intros.
+destruct H2 as [x ?].
+rewrite <- H0 in H2.
+specialize ( H2 w' H1).
+econstructor; eauto.
+Qed.
+
+#[export] Hint Resolve boxy_exp : core.
+
+Lemma boxy_prop {A} `{H : ageable A}:  forall (M: modality) P, reflexive _ (app_mode M) -> boxy M (prop P).
+Proof.
+intros.
+apply boxy_i; auto.
+Qed.
+
+Lemma boxy_TT {A} `{H : ageable A}:  forall (M: modality), reflexive _ (app_mode M) -> boxy M TT.
+Proof.
+intros.
+apply boxy_i; intros; auto.
+Qed.
+
+Lemma boxy_FF {A} `{H : ageable A}:  forall (M: modality), reflexive _ (app_mode M) -> boxy M FF.
+Proof.
+intros; apply boxy_i; intros; auto; contradiction.
+Qed.
+
+#[export] Hint Resolve boxy_TT : core.
+#[export] Hint Resolve boxy_FF : core.
+
+Lemma TT_i  {A} `{ageable A}: forall w: A,  app_pred TT w.
+Proof.
+unfold TT, prop; simpl; auto.
+Qed.
+
+#[export] Hint Resolve TT_i : core.
+
+Lemma prop_andp_left {A}{agA: ageable A}: forall (P: Prop) Q R, (P -> Q |-- R) -> !!P && Q |-- R.
+Proof.
+ repeat intro. destruct H0; auto. apply H; auto.
+Qed.
+
+Lemma prop_andp_right {A}{agA: ageable A}: forall (P: Prop) Q R, P -> (Q |-- R) -> Q |-- !!P && R.
+Proof.
+ repeat intro. split; auto.
+Qed.
+
+Lemma prop_true_andp:
+  forall (P: Prop) A `{ageable A} (Q: pred A), P -> (!! P && Q = Q).
+Proof.
+intros.
+apply pred_ext.
+unfold derives; intros ? [? ?]; auto.
+unfold derives; intros; split; auto.
+Qed.
+
+Lemma prop_false_andp:
+  forall (P: Prop) A `{ageable A} (Q: pred A),
+   ~P -> !! P && Q = FF.
+Proof.
+intros.
+apply pred_ext.
+unfold derives; intros ? [? ?]; tauto.
+unfold derives. intros ? [].
+Qed.
+
+Lemma prop_andp_e {A} `{ageable A}:  forall P Q (w:A), (!! P && Q) w -> P /\ Q w.
+Proof.
+intuition; destruct H0; auto.
+Qed.
+
+Lemma prop_andp_i {A} `{ageable A}:  forall P Q (w:A), P /\ app_pred Q w -> (!! P && Q) w.
+Proof.
+intuition.
+split; auto.
+Qed.
+
+Lemma later_derives {A} `{agA : ageable A}: forall {P Q}, (P |-- Q) -> (|> P |-- |> Q).
+Proof.
+unfold derives; intros.
+intro; intros; eapply H.
+eauto.
+Qed.
+
+Lemma boxy_allp {A} `{agA : ageable A}:
+  forall (M: modality) (B: Type) F,
+     reflexive _ (app_mode M) ->
+     (forall (x:B), boxy M (F x)) -> boxy M (allp F).
+Proof.
+intros.
+destruct M as [R V].
+simpl in *.
+apply boxy_i; auto.
+intros.
+simpl in *.
+intro.
+specialize ( H2 b).
+rewrite <- H0 in H2.
+apply H2; auto.
+Qed.
+#[export] Hint Resolve boxy_allp : core.
+
+Lemma later_allp {A} `{agA : ageable A}:
+       forall B P, |> (allp P) = allp (fun x:B => |> (P x)).
+Proof.
+intros.
+apply pred_ext; unfold derives; simpl; intros; eapply H; eauto.
+Qed.
+
+Lemma later_prop {A} `{agA : ageable A}:
+       forall P: Prop, |> (prop P) |-- prop P || |> FF.
+Proof.
+  intros.
+  unfold derives; intros.
+  simpl in H |- *.
+  destruct (age1 a) eqn:?H; [left | right].
+  + apply (H a0).
+    unfold laterR.
+    constructor.
+    auto.
+  + intros.
+    clear - H0 H1.
+    induction H1.
+    - hnf in H; congruence.
+    - auto.
+Qed.
+
+Lemma box_derives {A} `{ageable A} : forall M (P Q:pred A),
+  (P |-- Q) ->  box M P |-- box M Q.
+Proof. exact box_positive. Qed.
+
+Lemma allp_derives:
+       forall {A: Type} `{agA: ageable A} (B: Type) (P Q: B -> pred A),
+               (forall x:B, P x |-- Q x) -> (allp P |-- allp Q).
+Proof.
+intros.
+intros w b ?.
+eapply H; eauto.
+Qed.
+
+Lemma forall_pred_ext  {A} `{agA : ageable A}: forall B (P Q: B -> pred A),
+ (ALL x : B, (P x <--> Q x)) |-- (ALL x : B, P x) <--> (ALL x: B, Q x) .
+Proof.
+intros.
+intros w ?.
+split; intros ? ? ? ?;  destruct (H b); eauto.
+Qed.
+
+Lemma exists_pred_ext  {A} `{agA : ageable A}: forall B (P Q: B -> pred A),
+ (ALL x : B, (P x <--> Q x)) |-- (EX x : B, P x) <--> (EX x: B, Q x) .
+Proof.
+intros.
+intros w ?.
+split; intros w' ? [? ?]; exists x; eapply H; eauto.
+Qed.
+
+Lemma imp_pred_ext  {A} `{agA : ageable A}: forall B B' P Q,
+       (B <--> B') && (B --> (P <--> Q))
+ |-- (B --> P) <-->  (B' --> Q).
+Proof.
+intros.
+intros w [? ?].
+split; intros w'' ? ? w3 ? ?.
+eapply H0.
+4: eapply H2; eauto.
+2: eapply H; try apply H4.
+econstructor 3; eauto.
+econstructor 3; eauto.
+constructor 2.
+eapply H; eauto.
+eapply H0.
+4: eapply H2; eauto.
+2: eapply H; try apply H4.
+econstructor 3; eauto.
+econstructor 3; eauto.
+eapply H; eauto.
+econstructor 3; eauto.
+eapply H; eauto.
+Qed.
+
+Lemma derives_refl {A: Type} `{ageable A}:
+  forall (P: pred A), (P |-- P).
+Proof. firstorder.
+Qed.
+
+#[export] Hint Resolve derives_refl : core.
+
+Lemma andp_derives {A} `{ageable A}:
+  forall P Q P' Q': pred A, (P |-- P') -> (Q |-- Q') -> P && Q |-- P' && Q'.
+Proof.
+intros.
+intros w [? ?]; split; auto.
+Qed.
+
+Lemma orp_derives {A} `{ageable A}:
+  forall P Q P' Q': pred A, (P |-- P') -> (Q |-- Q') -> P || Q |-- P' || Q'.
+Proof.
+intros.
+ apply orp_left. apply orp_right1; auto. apply orp_right2; auto.
+Qed.
+
+Lemma exp_derives {A} `{HA : ageable A}:
+       forall B (P: B -> pred A) Q , (forall x:B, P x |-- Q x) -> (exp P |-- exp Q).
+Proof.
+intros.
+intros w [b ?].
+exists b; eapply H; eauto.
+Qed.
+
+Lemma box_ext {A} `{agA : ageable A}: forall (M: modality) P Q,
+    box M (P <--> Q) |--  box M P <--> box M Q.
+Proof.
+intros.
+repeat rewrite box_and.
+apply andp_right;
+eapply derives_trans; try apply axiomK; intros ? [? ?]; auto.
+Qed.
+
+Lemma andp_pred_ext {A} `{agA : ageable A}: forall P Q P' Q',
+       (P <--> P') && (Q <--> Q') |--  (P && Q) <--> (P' && Q').
+Proof.
+intros.
+intros w [? ?].
+split; (intros w' ? [? ?]; split; [eapply H; eauto | eapply H0; eauto]).
+Qed.
+
+Program Definition exactly {A} `{ageable A} (x: A) : pred A := necR x.
+Next Obligation.
+constructor 3 with a; auto.
+constructor 1; auto.
+Qed.
+
+Lemma derives_TT {A} `{ageable A}: forall (P: pred A), P |-- TT.
+Proof.
+intros.
+intros ? ?; auto.
+Qed.
+#[export] Hint Resolve derives_TT : core.
+
+Lemma FF_derives {A} `{ageable A}: forall P, FF |-- P.
+Proof.
+intros. intros ? ?. hnf in H0; contradiction.
+Qed.
+#[export] Hint Immediate FF_derives : core.
+
+Lemma necR_level' {A} `{H : ageable A}: forall {w w': A}, necR w w' ->
+       @necR _ ag_nat (level w) (level w').
+Proof.
+induction 1; simpl; intros.
+apply age_level in H0. constructor 1.  unfold age, age1; simpl.  rewrite H0; reflexivity.
+constructor 2.
+constructor 3 with (level y); auto.
+Qed.
+
+Lemma derives_imp {A} `{agA : ageable A}:
+  forall P Q w, (P |-- Q) -> (P --> Q) w.
+Proof.
+intros.
+intros ? _; auto.
+Qed.
+
+Lemma exp_andp1 {A} `{ageable A}:
+ forall B (p: B -> pred A) q, (exp p && q)%pred = (exp (fun x => p x && q))%pred.
+Proof.
+intros; apply pred_ext; intros w ?.
+destruct H0.
+destruct H0.
+exists x; split; auto.
+destruct H0. destruct H0.
+split; auto.
+exists x; auto.
+Qed.
+
+Lemma exp_andp2 {A} `{HA: ageable A}:
+ forall B p (q: B -> pred A), (p && exp q)%pred = (exp (fun x => p && q x))%pred.
+Proof.
+intros; apply pred_ext; intros w ?.
+destruct H.
+destruct H0.
+exists x; split; auto.
+destruct H. destruct H.
+split; auto.
+exists x; auto.
+Qed.
+
+Lemma exp_imp_left {A} `{agA : ageable A}:  forall B (p: B -> pred A) q,
+     (exp p --> q)%pred = allp (fun x => p x --> q)%pred.
+Proof.
+intros; apply pred_ext; intros w ?.
+intro.
+intros ?w ? ?.
+eapply H.
+apply necR_trans with w0; auto.
+exists b; auto.
+intros ?w ? [? ?].
+eapply H; eauto.
+Qed.
+
+Lemma app_ext  {A: Type} `{ageable A} : forall (F G: A -> Prop) p1 p2 w,
+         (F w = G w) ->
+         app_pred (exist (hereditary age) F p1) w = app_pred (exist (hereditary age) G p2) w.
+Proof.
+simpl; auto.
+Qed.
+
+Lemma imp_derives {A} `{agA : ageable A}:
+  forall P P' Q Q',
+    (P' |-- P) ->
+    (Q |-- Q') ->
+    P --> Q |-- P' --> Q'.
+Proof.
+intros.
+intros w ? w'' ? ?.
+apply H0.
+eapply H1; eauto.
+Qed.
+
+
+Lemma imp_lem0  {A} `{agA : ageable A}:  forall P st, (TT --> P) st -> P st.
+Proof.
+intros; eauto.
+Qed.
+
+Lemma conjoin_hyp0  {A} `{H : ageable A}:
+      forall (P Q: pred A) w,  P w -> (P --> Q) w -> (TT --> Q) w.
+Proof.
+intros.
+intros w' ? ?.
+eapply H1;
+eauto.
+eapply pred_nec_hereditary; eauto.
+Qed.
+
+Lemma conjoin_hyp1 {A} `{agA : ageable A}: forall (P Q R: pred A)  w,
+            P w -> (P&&Q --> R) w -> (Q --> R) w.
+Proof.
+intros.
+intros w' ? ?.
+eapply H0; auto.
+split; eauto.
+eapply pred_nec_hereditary; eauto.
+Qed.
+
+Lemma derives_e {A: Type} `{agA : ageable A}: forall p q (st: A),
+      (p |-- q) -> p st -> q st.
+Proof.
+auto.
+Qed.
+
+Ltac slurp :=
+ apply imp_lem0;
+  match goal with |-  app_pred (_ --> _)  ?st =>
+        repeat match goal with
+                   | H: app_pred ?P st |- app_pred (?b --> ?c) st =>
+                       (apply (@conjoin_hyp0 _ _ P c st H) ||
+                        (apply (@conjoin_hyp1 _ _ P b c st H)));
+                       clear H
+                   end;
+        try (revert st; apply derives_e)
+  end.
+
+Lemma test_slurp {A} `{agA : ageable A} :  forall  (P Q R S : pred A) w ,
+        (P && (Q && R) --> S) w -> P w -> Q w -> R w -> S w.
+Proof.
+intros.
+remember (app_pred (P && (Q && R) --> S) w) as hide.
+slurp.
+subst hide. assumption.
+Qed.
+
+Lemma later_andp {A} `{H : ageable A}:
+  forall P Q, |> (P && Q) = |>P && |>Q.
+Proof.
+intros.
+apply pred_ext; intros w ?.
+split; intros w' ?; destruct (H0 _ H1); auto.
+destruct H0.
+intros w' ?; split; eauto.
+Qed.
+
+Lemma True_andp_eq {A}`{ageable A}:
+  forall (P: Prop) (Q: pred A), P -> (!!P && Q)%pred = Q.
+intros.
+apply pred_ext; intros w ?; hnf in *; simpl; intros; intuition.
+Qed.
+
+Lemma distrib_orp_andp {A}{agA: ageable A}:
+   forall P Q R, (P||Q)&&R = (P&&R)||(Q&&R).
+Proof.
+  intros. apply pred_ext.
+  intros w [[?|?] ?]; [left|right]; split; auto.
+  intros w [[? ?]|[? ?]]; split; auto. left; auto. right; auto.
+Qed.
+
+Lemma allp_right {B A: Type}{agA: ageable A}:
+  forall (P: pred A) (Q: B -> pred A),
+  (forall v, P |-- Q v) ->
+   P |-- allp Q.
+Proof.
+ intros. intros w ? v; apply (H v); auto.
+Qed.
+
+Lemma allp_left {B}{A}{agA: ageable A}:
+   forall (P: B -> pred A) x Q, (P x |-- Q) -> allp P |-- Q.
+ Proof.
+   intros. intros ? ?. apply H. apply H0.
+Qed.
+
+Lemma later_imp2 {A}{agA: ageable A}: forall P Q: pred A,
+                 |> (P <--> Q) = |> P <--> |> Q.
+Proof.
+ intros.
+  repeat rewrite <- later_imp. rewrite <- later_andp; auto.
+Qed.

--- a/msl/predicates_sa.v
+++ b/msl/predicates_sa.v
@@ -187,7 +187,7 @@ extensionality w; apply prop_ext; split; intros;
 (destruct H as [w1 [w2 [? [? ?]]]]; exists w2; exists w1; split ; [apply join_comm; auto | split; auto]).
 Qed.
 
-Lemma sepcon_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}: forall P, (P * emp) = P.
+Lemma sepcon_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}: forall P, (P * emp) = P.
 Proof.
 intros.
 extensionality w; apply prop_ext; split; intros.
@@ -204,11 +204,11 @@ apply join_comm.
 apply identity_unit; auto.
 Qed.
 
-Lemma emp_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma emp_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
     forall P, (emp*P) = P.
 Proof. intros. rewrite sepcon_comm; rewrite sepcon_emp; auto. Qed.
 
-Lemma precise_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma precise_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
      precise emp.
 Proof.
 repeat intro.
@@ -291,7 +291,7 @@ destruct H; auto.
 split; auto.
 Qed.
 
-Lemma emp_wand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma emp_wand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
     forall P, emp -* P = P.
 Proof.
 intros.
@@ -325,7 +325,7 @@ Definition ewand {A} {JA: Join A} (P Q: pred A) : pred A :=
 
 (* Notation "P '-o' Q" := (ewand P Q) (at level 60, right associativity). *)
 
-Lemma emp_ewand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:  forall P, ewand emp P = P.
+Lemma emp_ewand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:  forall P, ewand emp P = P.
 Proof.
 intros.
 extensionality w; apply prop_ext; split; intros.
@@ -405,7 +405,7 @@ Qed.
 Definition superprecise {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A} (P: pred A) :=
    forall w1 w2, P w1 -> P w2 -> comparable w1 w2 -> w1=w2.
 
-Lemma modus_ewand {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A} :  forall P Q, superprecise P -> P * (ewand P Q) |-- Q.
+Lemma modus_ewand {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA : Flat_alg A} :  forall P Q, superprecise P -> P * (ewand P Q) |-- Q.
 Proof.
 pose proof I.
 intros.

--- a/msl/predicates_sl.v
+++ b/msl/predicates_sl.v
@@ -26,10 +26,10 @@ Section Predicates.
 
 Context {A : Type} {JA : Join A} {PA : Perm_alg A} {SA : Sep_alg A} {AG : ageable A} {XA : Age_alg A} {EO : Ext_ord A} {EA : Ext_alg A}.
 
-(*Definition compareR : relation A := comparable.
+(*Definition compareR : relation A := comparable.*)
 Definition extendR : relation A := join_sub.
 
-Lemma valid_rel_compare {FA: Flat_alg A} : valid_rel compareR.
+(*Lemma valid_rel_compare {FA: Flat_alg A} : valid_rel compareR.
 Proof.
   split; hnf; intros.
 
@@ -73,28 +73,33 @@ Proof.
 
   split; hnf; intros.
   hnf in H.
-Qed.
+Qed.*)
 
 Lemma valid_rel_extend  : valid_rel extendR.
 Proof.
-  intros; split; hnf; intros.
+  split; hnf; intros.
   destruct H0 as [w ?].
   destruct (age1_join2 _ H0 H)
     as [u [v [? [? ?]]]].
   exists u; auto.
   exists v; auto.
 
+  split; hnf; intros.
   destruct H.
   destruct (unage_join _ H H0)
     as [u [v [? [? ?]]]].
   exists v; auto.
   exists u; auto.
+
+  destruct H.
+  eapply join_ext_commut in H as (? & ? & ?); eauto.
+  eexists; eauto; eexists; eauto.
 Qed.
 
-Definition compareM  : modality
-  := exist _ compareR valid_rel_compare.
+(*Definition compareM  : modality
+  := exist _ compareR valid_rel_compare.*)
 Definition extendM {A}{JA: Join A}{PA: Perm_alg A}{SA : Sep_alg A}{AG: ageable A}{XA: Age_alg A} : modality
-  := exist _ extendR valid_rel_extend.*)
+  := exist _ extendR valid_rel_extend.
 
 (* Definitions of the BI connectives. *)
 Obligation Tactic := unfold hereditary; intros; try solve [intuition].
@@ -145,21 +150,21 @@ Qed.
 
 Notation "P '*' Q" := (sepcon P Q) : pred.
 Notation "P '-*' Q" := (wand P Q) (at level 60, right associativity) : pred.
-(*Notation "'%' e"  := (box extendM e)(at level 30, right associativity): pred.*)
+Notation "'%' e"  := (box extendM e)(at level 30, right associativity): pred.
 
-(*Lemma extendM_refl : reflexive _ extendM.
+Lemma extendM_refl : reflexive _ extendM.
 Proof.
 intros; intro; simpl; apply join_sub_refl.
 Qed.
 
-Lemma compareM_refl {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A} : reflexive _ compareM.
+(*Lemma compareM_refl {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A} : reflexive _ compareM.
 Proof.
 intros; intro; simpl.
 apply comparable_refl.
-Qed.
+Qed.*)
 
-#[export] Hint Resolve extendM_refl : core.
-#[export] Hint Resolve compareM_refl : core.*)
+#[local] Hint Resolve extendM_refl : core.
+(*#[export] Hint Resolve compareM_refl : core.*)
 
 
 (* Rules for the BI connectives *)
@@ -393,16 +398,16 @@ split; auto.
 exists x; auto.
 Qed.
 
-(*Lemma extend_later : forall P, (%|>P = |>%P)%pred.
+Lemma extend_later : forall P, (%|>P = |>%P)%pred.
 Proof.
   intros; rewrite later_commute; auto.
 Qed.
 
-Lemma extend_later' {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall P, boxy extendM P -> boxy extendM (|> P).
+Lemma extend_later' : forall P, boxy extendM P -> boxy extendM (|> P)%pred.
 Proof.
 intros. unfold boxy in *. rewrite later_commute. rewrite H. auto.
 Qed.
-#[export] Hint Resolve extend_later' : core.*)
+#[local] Hint Resolve extend_later' : core.
 
 Lemma age_sepcon  :
       forall P Q, (box ageM (P * Q) = box ageM P * box ageM Q)%pred.
@@ -564,7 +569,7 @@ do 3 eexists; eauto.
 split; do 2 eexists; eauto.
 Qed.
 
-(*Lemma extend_sepcon_andp {FA:Flat_alg A}:
+Lemma extend_sepcon_andp :
   forall P Q R, boxy extendM Q -> P * (Q && R) |-- Q && (P * R).
 Proof.
 intros.
@@ -576,7 +581,7 @@ exists w0.
 apply join_comm; auto.
 exists w0; exists w1; auto.
 Qed.
-Arguments extend_sepcon_andp : clear implicits.*)
+Arguments extend_sepcon_andp : clear implicits.
 
 Lemma distrib_sepcon_andp :
   forall P Q R, P * (Q && R) |-- (P * Q) && (P * R).
@@ -594,7 +599,7 @@ intros w  [?w [?w [? [? ?]]]].
 eapply H1; eauto.
 Qed.
 
-(*Lemma extend_sepcon :
+Lemma extend_sepcon :
   forall {Q R: pred A}, boxy extendM Q ->  Q * R |-- Q.
 Proof.
 intros.
@@ -602,7 +607,7 @@ intros w [w1 [w2 [? [? _]]]].
 rewrite <- H in H1. eapply H1; eauto.
 simpl; eauto.
 exists w2; auto.
-Qed.*)
+Qed.
 
 Definition precise  (P: pred A) : Prop :=
      forall w w1 w2, P w1 -> P w2 -> join_sub w1 w -> join_sub w2 w -> w1=w2.
@@ -1117,6 +1122,9 @@ End Predicates.
 
 Notation "P '*' Q" := (sepcon P Q) : pred.
 Notation "P '-*' Q" := (wand P Q) (at level 60, right associativity) : pred.
+Notation "'%' e"  := (box extendM e)(at level 30, right associativity): pred.
 Notation "P '-o' Q" := (ewand P Q) (at level 60, right associativity).
 
 #[export] Hint Resolve id_emp : core.
+#[export] Hint Resolve extendM_refl : core.
+#[export] Hint Resolve extend_later' : core.

--- a/msl/predicates_sl.v
+++ b/msl/predicates_sl.v
@@ -1,4 +1,4 @@
-(*
+ (*
  * Copyright (c) 2009-2010, Andrew Appel, Robert Dockins and Aquinas Hobor.
  *
  *)
@@ -13,9 +13,9 @@ Require Import VST.msl.cross_split.
 
 Definition compareR {A} {JA: Join A}{SA: Sep_alg A}{AG: ageable A} : relation A
    := comparable.
-Definition extendR  {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A} : relation A := join_sub.
+Definition extendR  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A} : relation A := join_sub.
 
-Lemma valid_rel_compare {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : valid_rel compareR.
+Lemma valid_rel_compare {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A} : valid_rel compareR.
 Proof.
   split; hnf; intros.
 
@@ -57,7 +57,7 @@ Proof.
   auto.
 Qed.
 
-Lemma valid_rel_extend {A}  {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} : valid_rel extendR.
+Lemma valid_rel_extend {A}  {JA: Join A}{PA: Perm_alg A}{SA : Sep_alg A}{AG: ageable A}{XA: Age_alg A} : valid_rel extendR.
 Proof.
   intros; split; hnf; intros.
   destruct H0 as [w ?].
@@ -73,9 +73,9 @@ Proof.
   exists u; auto.
 Qed.
 
-Definition compareM {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : modality
+Definition compareM {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A} : modality
   := exist _ compareR valid_rel_compare.
-Definition extendM {A}{JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} : modality
+Definition extendM {A}{JA: Join A}{PA: Perm_alg A}{SA : Sep_alg A}{AG: ageable A}{XA: Age_alg A} : modality
   := exist _ extendR valid_rel_extend.
 
 (* Definitions of the BI connectives. *)
@@ -88,7 +88,7 @@ Next Obligation.
   apply H0 in H2. subst b'. unfold age in H3, H4. congruence.
 Qed.
 
-Program Definition sepcon {A}  {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} (p q:pred A) : pred A := fun x:A =>
+Program Definition sepcon {A}  {JA: Join A}{PA: Perm_alg A}{SA : Sep_alg A}{AG: ageable A}{XA: Age_alg A} (p q:pred A) : pred A := fun x:A =>
   exists y:A, exists z:A, join y z x /\ p y /\ q z.
 Next Obligation.
   destruct H0 as [y [z [? [? ?]]]].
@@ -99,7 +99,7 @@ Next Obligation.
   apply pred_hereditary with z; auto.
 Qed.
 
-Program Definition wand {A}  {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} (p q:pred A) : pred A := fun x =>
+Program Definition wand {A}  {JA: Join A}{PA: Perm_alg A}{SA : Sep_alg A}{AG: ageable A}{XA: Age_alg A} (p q:pred A) : pred A := fun x =>
   forall x' y z, necR x x' -> join x' y z -> p y -> q z.
 Next Obligation.
   apply H0 with x' y; auto.
@@ -116,7 +116,7 @@ Proof.
 intros; intro; simpl; apply join_sub_refl.
 Qed.
 
-Lemma compareM_refl {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : reflexive _ compareM.
+Lemma compareM_refl {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A} : reflexive _ compareM.
 Proof.
 intros; intro; simpl.
 apply comparable_refl.
@@ -128,7 +128,7 @@ Qed.
 
 (* Rules for the BI connectives *)
 
-Lemma wand_sepcon_adjoint {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q R:pred A),
+Lemma wand_sepcon_adjoint {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q R:pred A),
   ((P * Q) |-- R) = (P |-- (Q -* R)).
 Proof.
   intros. apply prop_ext.
@@ -145,7 +145,7 @@ Proof.
   eapply H; eauto.
 Qed.
 
-Lemma sepcon_assoc {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q R:pred A),
+Lemma sepcon_assoc {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q R:pred A),
   ((P * Q) * R = P * (Q * R))%pred.
 Proof.
   pose proof I.
@@ -164,7 +164,7 @@ Proof.
   exists x; exists z; intuition.
 Qed.
 
-Lemma sepcon_comm {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q:pred A),
+Lemma sepcon_comm {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q:pred A),
   (P * Q = Q * P)%pred.
 Proof.
   pose proof I.
@@ -175,7 +175,7 @@ Proof.
   exists y; exists x; intuition; apply join_comm; auto.
 Qed.
 
-Lemma split_sepcon {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q R S:pred A),
+Lemma split_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q R S:pred A),
   (P |-- Q) ->
   (R |-- S) ->
   (P * R) |-- (Q * S).
@@ -185,7 +185,7 @@ Proof.
   exists x; exists y; intuition.
 Qed.
 
-Lemma sepcon_cut {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q R S:pred A),
+Lemma sepcon_cut {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P Q R S:pred A),
   (P |-- (Q -* R)) ->
   (S |-- Q) ->
   (P * S) |-- R.
@@ -197,7 +197,17 @@ Proof.
   eapply H; eauto.
 Qed.
 
-Lemma emp_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P:pred A),
+Lemma emp_emp_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} :
+  (emp * emp = emp)%pred.
+Proof.
+  apply pred_ext; hnf; intros.
+  - destruct H as (? & ? & J & H & ?).
+    apply H in J; subst; auto.
+  - exists a, a; repeat split; auto.
+    apply identity_self_join; auto.
+Qed.
+
+Lemma emp_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A} : forall (P:pred A),
   (emp * P = P)%pred.
 Proof.
   intros; apply pred_ext; hnf; intros.
@@ -209,7 +219,7 @@ Proof.
   specialize (Hu _ _ Hj); subst; auto.
 Qed.
 
-Lemma sepcon_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}  : forall (P:pred A),
+Lemma sepcon_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A}  : forall (P:pred A),
   (P * emp = P)%pred.
 Proof.
   intros.
@@ -223,7 +233,7 @@ Lemma sepcon_emp : forall {A} `{Age_alg A} (P:pred A), P * emp = P.
 Proof. exact @sepcon_emp. Qed.
 *)
 	
-Lemma later_wand {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} : forall P Q,
+Lemma later_wand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} : forall P Q,
   (|>(P -* Q) = |>P -* |>Q)%pred.
 Proof.
   pose proof I.
@@ -307,7 +317,7 @@ Proof.
   exists w'; exists v'; intuition.
 Qed.
 
-Lemma FF_sepcon : forall {A}{JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} (P:pred A),
+Lemma FF_sepcon : forall {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} (P:pred A),
   (FF * P = FF)%pred.
 Proof.
   intros. apply pred_ext; repeat intro.
@@ -315,7 +325,7 @@ Proof.
   elim H.
 Qed.
 
-Lemma sepcon_derives {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma sepcon_derives {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall p q p' q', (p |-- p') -> (q |-- q') -> (p * q |-- p' * q').
 Proof.
 intros.
@@ -324,7 +334,7 @@ destruct H1 as [w1 [w2 [? [? ?]]]].
 exists w1; exists w2; repeat split ;auto.
 Qed.
 
-Lemma exp_sepcon1 {A}  {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma exp_sepcon1 {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall T (P: T ->  pred A) Q,  (exp P * Q = exp (fun x => P x * Q))%pred.
 Proof.
 intros.
@@ -337,7 +347,7 @@ split; auto.
 exists x; auto.
 Qed.
 
-Lemma exp_sepcon2 {A}  {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma exp_sepcon2 {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall T (P: pred A) (Q: T -> pred A),  (P * exp Q = exp (fun x => P * Q x))%pred.
 Proof.
 intros.
@@ -350,12 +360,12 @@ split; auto.
 exists x; auto.
 Qed.
 
-Lemma extend_later {A}  {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}: forall P, (%|>P = |>%P)%pred.
+Lemma extend_later {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}: forall P, (%|>P = |>%P)%pred.
 Proof.
   intros; rewrite later_commute; auto.
 Qed.
 
-Lemma extend_later' {A}{JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall P, boxy extendM P -> boxy extendM (|> P).
+Lemma extend_later' {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}: forall P, boxy extendM P -> boxy extendM (|> P).
 Proof.
 intros. unfold boxy in *. rewrite later_commute. rewrite H. auto.
 Qed.
@@ -402,7 +412,7 @@ Proof.
 Qed.
 
 
-Lemma age_twin {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma age_twin {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall phi1 phi2 n phi1',
   comparable phi1 phi2 ->
   ageN n phi1 = Some phi1' ->
@@ -438,7 +448,7 @@ rewrite H2.
 trivial.
 Qed.
 
-Lemma ageN_different {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}: forall n phi phi', ageN (S n) phi = Some phi' ->
+Lemma ageN_different {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A}: forall n phi phi', ageN (S n) phi = Some phi' ->
     ~ comparable phi phi'.
 Proof.
    intros.
@@ -462,7 +472,7 @@ Proof.
    unfold ageN in H9; simpl  in H9; rewrite H2 in H9; inv H9.
 Qed.
 
-Lemma necR_comparable{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma necR_comparable{A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall w w', necR w w' -> comparable w w' -> w=w'.
 Proof.
 intros.
@@ -496,7 +506,7 @@ exists x; exists w; split; auto.
 Qed.
 
 
-Lemma join_exactly {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma join_exactly {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall w1 w2 w3, join w1 w2 w3 ->  (exactly w1 * exactly w2 = exactly w3)%pred.
 Proof.
 pose proof I.
@@ -516,7 +526,7 @@ auto.
 eapply nec_join2; eauto.
 Qed.
 
-Lemma extend_sepcon_andp {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma extend_sepcon_andp {A} {JA: Join A} {PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall P Q R, boxy extendM Q -> P * (Q && R) |-- Q && (P * R).
 Proof.
 intros.
@@ -530,7 +540,7 @@ exists w0; exists w1; auto.
 Qed.
 Arguments extend_sepcon_andp : clear implicits.
 
-Lemma distrib_sepcon_andp {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma distrib_sepcon_andp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall P Q R, P * (Q && R) |-- (P * Q) && (P * R).
 Proof.
 intros. intros w [w1 [w2 [? [? ?]]]].
@@ -538,7 +548,7 @@ destruct H1.
 split; exists w1; exists w2; split; auto.
 Qed.
 
-Lemma modus_wand {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma modus_wand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall P Q,  P * (P -* Q) |-- Q.
 Proof.
 intros.
@@ -546,7 +556,7 @@ intros w  [?w [?w [? [? ?]]]].
 eapply H1; eauto.
 Qed.
 
-Lemma extend_sepcon {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma extend_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall {Q R: pred A}, boxy extendM Q ->  Q * R |-- Q.
 Proof.
 intros.
@@ -632,7 +642,7 @@ apply comparable_fashionR; auto.
 Qed.
 #[export] Hint Resolve superprecise_exactly : core.
 
-Lemma superprecise_precise {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}: forall (P: pred A) , superprecise P -> precise P.
+Lemma superprecise_precise {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A}: forall (P: pred A) , superprecise P -> precise P.
 Proof.
   pose proof I.
   unfold precise. unfold superprecise.
@@ -646,7 +656,7 @@ Qed.
 
 (* EXistential Magic Wand *)
 
-Program Definition ewand {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} (P Q: pred A) : pred A :=
+Program Definition ewand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} (P Q: pred A) : pred A :=
   fun w => exists w1, exists w2, join w1 w w2 /\ P w1 /\ Q w2.
 Next Obligation.
 destruct H0 as [w1 [w2 [? [? ?]]]].
@@ -703,7 +713,7 @@ Qed.
 
 (* Notation "P '-o' Q" := (ewand P Q) (at level 60, right associativity). *)
 
-Lemma emp_ewand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma emp_ewand {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{AG: ageable A}{XA: Age_alg A}:
       forall P, ewand emp P = P.
 Proof.
 intros.
@@ -869,7 +879,7 @@ split; auto.
 exists w3; exists w2; split; auto.
 Qed.
 
-Lemma ewand_derives {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma ewand_derives {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall P P' Q Q',  (P |-- P') -> (Q |-- Q') -> ewand P Q |-- ewand P' Q'.
 Proof.
 intros.
@@ -878,7 +888,7 @@ destruct H1 as [?w [?w [? [? ?]]]].
 exists w0; exists w1; split; auto.
 Qed.
 
-Lemma ewand_sepcon {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}: forall P Q R,
+Lemma ewand_sepcon {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}: forall P Q R,
       (ewand (P * Q) R = ewand P (ewand Q R))%pred.
 Proof.
 intros; apply pred_ext; intros w ?.
@@ -896,7 +906,7 @@ exists wf. exists w4. split; [|split]; auto.
 exists w1; exists w3; split; auto.
 Qed.
 
-Lemma ewand_sepcon_assoc {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{CrA: Cross_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma ewand_sepcon_assoc {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{CrA: Cross_alg A}{AG: ageable A}{XA: Age_alg A}:
   Trip_alg A ->
   forall P Q R: pred A,
       (forall w1 w2 w3, join w1 w2 w3 -> P w3 -> P w1) ->
@@ -978,7 +988,7 @@ subst wf.
 auto.
 Qed.
 
-Lemma sepcon_andp_prop2 {A} {JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A}:
+Lemma sepcon_andp_prop2 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
   forall P Q R,  (P * (!!Q && R) = !!Q && (P * R))%pred.
 Proof.
 intros.
@@ -991,13 +1001,13 @@ destruct H0 as [w1 [w2 [? [? ?]]]].
 exists w1; exists w2; repeat split; auto.
 Qed.
 
-Lemma sepcon_andp_prop1 {A}{JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma sepcon_andp_prop1 {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA:  ageable A}{AgeA: Age_alg A}:
    forall (P: Prop) (Q R: pred A) , ((!! P && Q) * R = !! P && (Q * R))%pred.
 Proof.
  intros. rewrite (sepcon_comm). rewrite sepcon_andp_prop2. rewrite sepcon_comm; auto.
 Qed.
 
-Lemma distrib_orp_sepcon {A : Type}{JA : Join A}{PA : Perm_alg A}{agA : ageable A}
+Lemma distrib_orp_sepcon {A : Type}{JA : Join A}  {PA : Perm_alg A}{SA : Sep_alg A}{agA : ageable A}
     {AgeA : Age_alg A}:
   forall (P Q R : pred A), ((P || Q) * R = P * R || Q * R)%pred.
 Proof.
@@ -1007,7 +1017,7 @@ Proof.
   left; auto. right; auto.
 Qed.
 
-Lemma distrib_orp_sepcon2{A : Type}{JA : Join A}{PA : Perm_alg A}{agA : ageable A}
+Lemma distrib_orp_sepcon2{A : Type}{JA : Join A}{PA : Perm_alg A}{SA : Sep_alg A}{agA : ageable A}
     {AgeA : Age_alg A}:
   forall (P Q R : pred A),
      (R * (P || Q) = R * P || R * Q)%pred.

--- a/msl/psepalg.v
+++ b/msl/psepalg.v
@@ -241,7 +241,7 @@ Section SA_LOWER.
     inv H; inv H0; auto. f_equal. apply (join_positivity H1 H4).
  Qed.
 
- Instance Sep_lower: @Sep_alg _ Join_lower.
+ Instance Sep_lower: @FSep_alg _ Join_lower.
  Proof. apply mkSep with (fun _ => None); intros.
    constructor. reflexivity.
  Defined.
@@ -324,7 +324,7 @@ Section SA_SMASH.
 
   Definition smashed : Type := option (lifted J_T).
   Definition Perm_smash :  Perm_alg smashed  := Perm_lower (lifted J_T). 
-  Definition Sep_smash : Sep_alg smashed := Sep_lower (lifted J_T).
+  Definition Sep_smash : FSep_alg smashed := Sep_lower (lifted J_T).
 
   Lemma smash_inv: forall a b c : smashed,
     join a b c ->
@@ -351,7 +351,7 @@ Proof. intros; apply None_identity. Qed.
 
  Instance Perm_option (T : Type)  : @Perm_alg (option T) (@Join_lower T (@Join_discrete T)) :=
     @Perm_lower T  (@Join_discrete T) (Perm_discrete T).
- Instance Sep_option (T: Type) : @Sep_alg (option T) (@Join_lower T (@Join_discrete T)) :=
+ Instance Sep_option (T: Type) : @FSep_alg (option T) (@Join_lower T (@Join_discrete T)) :=
     @Sep_lower T  (@Join_discrete T) .
 
 (** Often, once we have a Pos_alg, we want to product it with regular
@@ -429,7 +429,7 @@ Section FinitePartialMap.
     Perm_prop (A -> Rng) _ _ finMap finMap_join.
 
   Lemma finMap_core  x: finMap x -> 
-        finMap (@core _ _ (Sep_fun A (option B) Join_Rng _ ) x).
+        finMap (@core _ _ (Sep_fun A (option B) Join_Rng (Perm_lower _) (fsep_sep _)) x).
   Proof. intros. exists nil; intros; reflexivity. Qed.
 
   Definition empty_fpm : fpm.
@@ -437,9 +437,9 @@ Section FinitePartialMap.
     exists nil; auto.
   Defined.
 
-  Instance Sep_fpm : @Sep_alg fpm Join_fpm.
+  Instance Sep_fpm : @FSep_alg fpm Join_fpm.
   Proof. 
-    apply mkSep with (core := fun _ => empty_fpm).
+    apply mkSep with (fun _ => empty_fpm).
      intros. intro a. simpl. constructor. auto.
    Defined.
 

--- a/msl/sepalg_generators.v
+++ b/msl/sepalg_generators.v
@@ -26,7 +26,7 @@ Require Import VST.msl.sepalg.
   Qed.
 
   Instance Sep_unit: FSep_alg unit.
-  Proof. apply mkSep with (fun _ => tt); intros;  hnf; auto with typeclass_instances. Qed.
+  Proof. apply mkSep with (fun _ => tt); intros;  hnf; auto with typeclass_instances. Defined.
 
   Instance Sing_unit: Sing_alg unit.
   Proof. apply (mkSing tt); intros; hnf; simpl.
@@ -55,7 +55,7 @@ Require Import VST.msl.sepalg.
   Instance Sep_void: FSep_alg Void.
   Proof. apply mkSep with (fun x => x); intros.
       auto with typeclass_instances. destruct t. destruct a.
-  Qed.
+  Defined.
   Instance Canc_void: Canc_alg Void.
   Proof. repeat intro. destruct b. Qed.
   Instance Disj_void: Disj_alg Void.
@@ -425,7 +425,7 @@ Section SepAlgSigma.
    intros [i a]. constructor. apply core_unit.
    intros. inv H. eexists; constructor. eapply core_sub_join, join_core_sub, H0.
    intros. simpl. rewrite core_idem; reflexivity.
- Defined.
+  Defined.
 
   Instance Canc_sigma: (forall i, Canc_alg (Sigma i)) -> Canc_alg S.
   Proof. repeat intro.

--- a/msl/sepalg_list.v
+++ b/msl/sepalg_list.v
@@ -106,7 +106,7 @@ Qed.
 
 Definition age1_list {A} `{ageable A} := list_forall2 age.
 
-Lemma age1_list_join {A} {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma age1_list_join {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall l (phi phi' phi2: A),
         age phi phi' ->
         list_join phi l phi2 ->
@@ -125,7 +125,7 @@ exists phi2'.
 repeat split; auto; econstructor 2; eauto.
 Qed.
 
-Lemma age1_list_join2 {A} {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma age1_list_join2 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall (l: list A) phi phi2 phi2',  age1 phi2 = Some phi2' -> list_join phi l phi2 ->
         exists l', exists phi',  age1 phi = Some phi' /\ age1_list l l' /\ list_join phi' l' phi2'.
 Proof.
@@ -197,7 +197,7 @@ Qed.
 
 (*****************************)
 
-Lemma list_join_comparable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma list_join_comparable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall (phi1: A) l phi2, list_join phi1 l phi2 -> comparable phi1 phi2.
 Proof.
   intros; revert phi1 phi2 H; induction l; simpl; intros; inv H.
@@ -208,27 +208,27 @@ Proof.
   auto.
 Qed.
 
-Lemma join_comparable'  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma join_comparable'  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall phi1 phi2 phi3: A, join phi1 phi2 phi3 -> comparable phi2 phi3.
 Proof. intros; apply join_comparable with phi1; apply join_comm; auto. Qed.
 
-Lemma join_comparable2'  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma join_comparable2'  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall phi1 phi2 phi3: A, join phi1 phi2 phi3 -> comparable phi2 phi1.
 Proof. intros; apply comparable_sym; eapply join_comparable2; eauto. Qed.
 
-Lemma list_join_comparable'  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma list_join_comparable'  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall (phi1: A) l phi2, list_join phi1 l phi2 -> comparable phi2 phi1.
 Proof. intros; apply comparable_sym; eapply list_join_comparable; eauto. Qed.
 
-Lemma join_comparable''  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma join_comparable''  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall phi1 phi2 phi3: A, join phi1 phi2 phi3 -> comparable phi3 phi2.
 Proof. intros; apply comparable_sym; eapply join_comparable'; eauto. Qed.
 
-Lemma join_comparable'''  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma join_comparable'''  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall phi1 phi2 phi3: A, join phi1 phi2 phi3 -> comparable phi3 phi1.
 Proof. intros; apply comparable_sym; eapply join_comparable; eauto. Qed.
 
-Lemma joins_comparable  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma joins_comparable  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall phi1 phi2: A, joins phi1 phi2 -> comparable phi1 phi2.
 Proof.
   unfold joins; intros.
@@ -236,7 +236,7 @@ Proof.
   eapply join_comparable2; eauto.
 Qed.
 
-Lemma joins_comparable2 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma joins_comparable2 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
      forall phi1 phi2: A, joins phi2 phi1 -> comparable phi1 phi2.
 Proof.
 unfold joins; intros.
@@ -245,7 +245,7 @@ apply comparable_sym.
 eapply join_comparable2; eauto.
 Qed.
 
-Lemma join_sub_comparable  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma join_sub_comparable  {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
   forall phi1 phi2: A, join_sub phi1 phi2 -> comparable phi1 phi2.
 Proof.
 unfold joins; intros.
@@ -253,7 +253,7 @@ destruct H as [phi3 ?].
 eapply join_comparable; eauto.
 Qed.
 
-Lemma join_sub_comparable2 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
+Lemma join_sub_comparable2 {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}:
      forall phi1 phi2: A, join_sub phi2 phi1 -> comparable phi1 phi2.
 Proof.
 unfold joins; intros.
@@ -274,7 +274,7 @@ Proof.
 intros; subst; apply comparable_refl.
 Qed.
 
-Lemma ageN_join {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma ageN_join {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall n (w1 w2 w3 w1': A),
    join w1 w2 w3 ->
       ageN n w1 = Some w1' ->
@@ -293,7 +293,7 @@ exists w2''; exists w3''. rewrite H3; rewrite H4.
 repeat split; auto.
 Qed.
 
-Lemma ageN_join2 {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma ageN_join2 {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall n (w1 w2 w3 w3': A),
    join w1 w2 w3 ->
       ageN n w3 = Some w3' ->
@@ -312,7 +312,7 @@ exists w1''; exists w2''. rewrite H3; rewrite H4.
 repeat split; auto.
 Qed.
 
-Lemma ageN_comparable {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma ageN_comparable {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}{FA: Flat_alg A}:
   forall n (w1 w2 w1' w2': A),
         ageN n w1 = Some w1' -> ageN n w2 = Some w2' -> comparable w1 w2 -> comparable w1' w2'.
 Proof.
@@ -426,7 +426,7 @@ Lemma not_any_younger_refl {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: 
  forall phi : A, not_any_younger phi phi.
 Proof. intros; exists phi; split; auto. apply comparable_refl. Qed.
 
-Lemma not_any_younger_trans {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}:
+Lemma not_any_younger_trans {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{FA: Flat_alg A}{agA: ageable A}{AgeA: Age_alg A}:
   forall phi1 phi2 phi3, not_any_younger phi1 phi2 -> not_any_younger phi2 phi3 ->
             not_any_younger phi1 phi3.
 Proof.

--- a/msl/seplog.v
+++ b/msl/seplog.v
@@ -223,7 +223,7 @@ Class CorableSepLog (A: Type) {ND: NatDed A}{SL: SepLog A}:= mkCorableSepLog {
   corable_prop: forall P, corable (!! P);
   corable_andp: forall P Q, corable P -> corable Q -> corable (P && Q);
   corable_orp: forall P Q, corable P -> corable Q -> corable (P || Q);
-(*  corable_imp: forall P Q, corable P -> corable Q -> corable (P --> Q);*)
+  corable_imp: forall P Q, corable P -> corable Q -> corable (P --> Q);
   corable_allp: forall {B: Type} (P:  B -> A), (forall b, corable (P b)) -> corable (allp P);
   corable_exp: forall {B: Type} (P:  B -> A), (forall b, corable (P b)) -> corable (exp P);
   corable_sepcon: forall P Q, corable P -> corable Q -> corable (P * Q);
@@ -236,7 +236,7 @@ Instance LiftCorableSepLog (A: Type) (B: Type) {NB: NatDed B} {SB: SepLog B} {CS
   + apply corable_prop.
   + apply corable_andp; auto.
   + apply corable_orp; auto.
-(*  + apply corable_imp; auto.*)
+  + apply corable_imp; auto.
   + apply corable_allp; auto.
   + apply corable_exp; auto.
   + apply corable_sepcon; auto.

--- a/msl/seplog.v
+++ b/msl/seplog.v
@@ -124,11 +124,12 @@ Class SepLog (A: Type) {ND: NatDed A} := mkSepLog {
   wand_sepcon_adjoint: forall (P Q R: A),  (sepcon P Q |-- R) <-> (P |-- wand Q R);
   sepcon_andp_prop: forall P Q R, sepcon P (!!Q && R) = !!Q && (sepcon P R);
   sepcon_derives: forall P P' Q Q' : A, (P |-- P') -> (Q |-- Q') -> sepcon P Q |-- sepcon P' Q';
-  ewand_sepcon: forall (P Q R : A),  ewand (sepcon P Q) R = ewand P (ewand Q R);
+(* how necessary is ewand? *)
+(*  ewand_sepcon: forall (P Q R : A),  ewand (sepcon P Q) R = ewand P (ewand Q R);
   ewand_TT_sepcon: forall (P Q R: A),
                          andp (sepcon P Q) (ewand R TT) |--
                                sepcon (andp P (ewand R TT)) (andp Q (ewand R TT));
-  exclude_elsewhere: forall P Q: A, sepcon P Q |-- sepcon (andp P (ewand Q TT)) Q;
+  exclude_elsewhere: forall P Q: A, sepcon P Q |-- sepcon (andp P (ewand Q TT)) Q;*)
   ewand_conflict: forall P Q R, (sepcon P Q |-- FF) -> andp P (ewand Q R) |-- FF
 }.
 
@@ -146,9 +147,9 @@ Instance LiftSepLog (A B: Type) {NB: NatDed B}{SB: SepLog B} : SepLog (A -> B).
     intro. intro rho.     apply <- wand_sepcon_adjoint; auto.
  simpl; intros. extensionality x. apply sepcon_andp_prop.
  simpl; intros; apply sepcon_derives; auto.
- simpl; intros; extensionality x; apply ewand_sepcon.
+(* simpl; intros; extensionality x; apply ewand_sepcon.
  simpl; intros; eapply ewand_TT_sepcon.
- simpl; intros; eapply exclude_elsewhere.
+ simpl; intros; eapply exclude_elsewhere.*)
  simpl; intros; eapply ewand_conflict; eauto.
 Defined.
 
@@ -182,7 +183,7 @@ Class Indir (A: Type) {ND: NatDed A} := mkIndir {
   later_exp: forall T (F: T-> A), EX x:T, later (F x) |-- later (exp F);
   later_exp': forall T (any:T) F, later (exp F) = EX x:T, later (F x);
   later_exp'': forall T F, later (exp F) |-- (EX x:T, later (F x)) || later FF;
-  later_imp: forall P Q,  later(P --> Q) = later P --> later Q;
+(*  later_imp: forall P Q,  later(P --> Q) = later P --> later Q;*)
   later_prop: forall PP: Prop, later (!! PP) |-- !! PP || later FF;
   loeb: forall P,   (later P |-- P) ->  TT |-- P
 }.
@@ -198,15 +199,15 @@ Instance LiftIndir (A: Type) (B: Type)  {NB: NatDed B}{IXB: Indir B} :
  simpl; intros. apply later_exp.
  simpl; intros. extensionality rho. apply later_exp'; auto.
  simpl; intros. apply later_exp''.
- simpl; intros. extensionality rho. apply later_imp.
+(* simpl; intros. extensionality rho. apply later_imp.*)
  simpl; intros. apply later_prop.
  simpl; intros. apply loeb; auto.
 Defined.
 
 Class SepIndir (A: Type) {NA: NatDed A}{SA: SepLog A}{IA: Indir A} := mkSepIndir {
   later_sepcon: forall P Q, |> (P * Q) = |>P * |>Q;
-  later_wand: forall P Q, |> (P -* Q) = |>P -* |>Q;
-  later_ewand: forall P Q, |> (ewand P Q) = ewand (|>P) (|>Q)
+  later_wand: forall P Q, |> (P -* Q) = |>P -* |>Q(*;
+  later_ewand: forall P Q, |> (ewand P Q) = ewand (|>P) (|>Q)*)
 }.
 
 Instance LiftSepIndir  (A: Type) (B: Type)  {NB: NatDed B} {SB: SepLog B}{IB: Indir B}{SIB: SepIndir B} :
@@ -214,7 +215,7 @@ Instance LiftSepIndir  (A: Type) (B: Type)  {NB: NatDed B} {SB: SepLog B}{IB: In
  constructor.
  intros; simpl. extensionality rho.  apply later_sepcon.
  intros; simpl. extensionality rho.  apply later_wand.
- intros; simpl. extensionality rho.  apply later_ewand.
+(* intros; simpl. extensionality rho.  apply later_ewand.*)
 Defined.
 
 Class CorableSepLog (A: Type) {ND: NatDed A}{SL: SepLog A}:= mkCorableSepLog {
@@ -222,7 +223,7 @@ Class CorableSepLog (A: Type) {ND: NatDed A}{SL: SepLog A}:= mkCorableSepLog {
   corable_prop: forall P, corable (!! P);
   corable_andp: forall P Q, corable P -> corable Q -> corable (P && Q);
   corable_orp: forall P Q, corable P -> corable Q -> corable (P || Q);
-  corable_imp: forall P Q, corable P -> corable Q -> corable (P --> Q);
+(*  corable_imp: forall P Q, corable P -> corable Q -> corable (P --> Q);*)
   corable_allp: forall {B: Type} (P:  B -> A), (forall b, corable (P b)) -> corable (allp P);
   corable_exp: forall {B: Type} (P:  B -> A), (forall b, corable (P b)) -> corable (exp P);
   corable_sepcon: forall P Q, corable P -> corable Q -> corable (P * Q);
@@ -235,7 +236,7 @@ Instance LiftCorableSepLog (A: Type) (B: Type) {NB: NatDed B} {SB: SepLog B} {CS
   + apply corable_prop.
   + apply corable_andp; auto.
   + apply corable_orp; auto.
-  + apply corable_imp; auto.
+(*  + apply corable_imp; auto.*)
   + apply corable_allp; auto.
   + apply corable_exp; auto.
   + apply corable_sepcon; auto.

--- a/msl/shares.v
+++ b/msl/shares.v
@@ -529,7 +529,7 @@ Section SM.
   Definition map := fpm A (lifted Share.Join_ba * B).
   Instance Join_map : Join map := Join_fpm _.
   Instance pa_map : Perm_alg map := Perm_fpm _ _.
-  Instance sa_map : Sep_alg map := Sep_fpm _ _.
+  Instance sa_map : FSep_alg map := Sep_fpm _ _.
   Instance ca_map {CA: Canc_alg B} : Canc_alg map := Canc_fpm _.
   Instance da_map {DA: Disj_alg B} : Disj_alg map := @Disj_fpm _ _ _ _ _ _.
 

--- a/msl/subtypes_sl.v
+++ b/msl/subtypes_sl.v
@@ -28,14 +28,11 @@ Proof.
   clear G H2.
   destruct H5 as [w1 [w2 [? [? ?]]]].
   exists w1; exists w2; split; auto.
+  destruct (join_level _ _ _ H2); auto.
   split.
   eapply H0; auto.
-  assert (level w1 = level a').
-  apply comparable_fashionR.  eapply join_sub_comparable; eauto.
  apply necR_level in H4. lia.
   eapply H1; auto.
-  assert (level w2 = level a').
-  apply comparable_fashionR. eapply join_sub_comparable; eauto.
  apply necR_level in H4. lia.
 Qed.
 
@@ -49,12 +46,10 @@ Proof.
   specialize (H0 _ H2); specialize (H1 _ H2); clear G H2; pose (H2:=True).
   eapply H0 in H8; try apply necR_refl.
   eapply H1; try apply necR_refl.
-  apply necR_level in H4. apply necR_level in H6. apply join_comparable in H7.
-  apply comparable_fashionR in H7. unfold fashionR in H7. lia.
+  apply necR_level in H4. apply necR_level in H6. apply join_level in H7 as []. lia.
   eapply H5; eauto.
   apply necR_level in H4. apply necR_level in H6.
-   apply join_comparable2 in H7.
-  apply comparable_fashionR in H7. unfold fashionR in H7. lia.
+  apply join_level in H7 as []. lia.
 Qed.
 
 Lemma find_superprecise {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}:
@@ -83,16 +78,13 @@ Proof.
 intros.
 intros w' ? w'' ? [w1 [w2 [? [? ?]]]].
 destruct (nec_join4 _ _ _ _ H4 H3) as [w1' [w2' [? [? ?]]]].
+apply join_level in H7 as []; auto.
 exists w1; exists w2; repeat split; auto.
 eapply (H0 w1'); eauto.
 simpl in *.
 subst.
 replace (level w1') with (level w'); auto.
-symmetry; apply comparable_fashionR; eapply join_comparable; eauto.
-eapply (H1 w2'); eauto.
-replace (level w2') with (level w'); auto.
-symmetry. apply comparable_fashionR.
-eapply join_comparable; eauto.
+eapply (H1 w2'); eauto. lia.
 Qed.
 
 Lemma subp_refl'  {A} `{agA : ageable A} :  forall (Q: pred A) (st: nat), (Q >=> Q) st.
@@ -184,9 +176,7 @@ apply boxy_i; auto; intros.
 unfold unfash in *.
 simpl in H. destruct H.
 hnf in H0|-*.
-replace (level w') with (level w); auto.
-apply comparable_fashionR.
-eapply join_comparable; eauto.
+apply join_level in H as [<-]; auto.
 Qed.
 
 #[export] Hint Resolve extend_unfash : core.

--- a/msl/subtypes_sl.v
+++ b/msl/subtypes_sl.v
@@ -166,7 +166,7 @@ apply axiomK.
 Qed.
 *)
 
-(*Lemma extend_unfash {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}{EO: Ext_ord A} : forall (P: pred nat), boxy extendM (! P).
+Lemma extend_unfash {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A} : forall (P: pred nat), boxy extendM (! P).
 Proof.
 intros.
 apply boxy_i; auto; intros.
@@ -176,7 +176,7 @@ hnf in H0|-*.
 apply join_level in H as [<-]; auto.
 Qed.
 
-#[export] Hint Resolve extend_unfash : core.*)
+#[export] Hint Resolve extend_unfash : core.
 
 Lemma subp_unfash {A} `{Age_alg A} {EO: Ext_ord A}:
   forall (P Q : pred nat) (n: nat), (P >=> Q) n -> ( ! P >=> ! Q) n.

--- a/progs64/verif_incr.v
+++ b/progs64/verif_incr.v
@@ -51,7 +51,7 @@ Definition thread_lock_inv sh g1 g2 ctr lockc lockt :=
 Definition thread_func_spec :=
  DECLARE _thread_func
   WITH y : val, x : share * gname * gname * globals
-  PRE [ (*_args OF*) (tptr tvoid) ]
+  PRE [ tptr tvoid ]
          let '(sh, g1, g2, gv) := x in
          PROP  (readable_share sh)
          PARAMS (y) GLOBALS (gv)

--- a/progs64/verif_incr_atomic.v
+++ b/progs64/verif_incr_atomic.v
@@ -127,48 +127,39 @@ Proof.
   Exists n; entailer!.
 Qed.
 
-(* remove *)
-Require Import iris.bi.lib.atomic.
-
-(* this is missing -- unprovable? *)
-Instance inv_persistent {inv_names : invG} i R : Persistent (invariant i R).
-Proof.
-Admitted.
-
-Instance inv_affine {inv_names : invG} i R : Affine (invariant i R).
-Proof.
-Admitted.
-
 (* prove a lemma about our specific use pattern of incr *)
 Lemma incr_inv_shift : forall {inv_names : invG} i g g1 g2 gv, (gv = g1 \/ gv = g2) ->
   invariant i (cptr_inv g g1 g2) * ghost_var gsh2 0%nat gv |--
   atomic_shift (λ n : nat, public_half g n) ∅ ⊤
       (λ (n : nat) (_ : ()), fold_right_sepcon [public_half g (n + 1)%nat]) (λ _ : (), ghost_var gsh2 1%nat gv).
 Proof.
-  intros.
+  intros; unfold cptr_inv.
   iIntros "[#inv g]".
   iAuIntro.
-  intros; apply inv_atomic_shift; auto.
-  { apply empty_subseteq. }
-  unfold cptr_inv; iIntros "c".
-  iDestruct "c" as (x y0) "[[>g1 >g2] >c]"; iModIntro.
-  iExists (x + y0)%nat; iFrame; iSplit.
-  - iIntros "c !>".
-    iExists x, y0; iFrame; auto.
-  - iIntros (_) "(>g & c & _)".
+  rewrite /atomic_acc /=.
+  iMod (inv_open with "inv") as "[c Hclose]"; auto.
+  iDestruct "c" as (x y) "[[>g1 >g2] >c]".
+  iMod fupd_mask_subseteq as "Hclose'"; [|iModIntro]; first set_solver.
+  iExists (x + y)%nat; iFrame "c"; iSplit.
+  - iIntros "c". iFrame.
+    iMod "Hclose'" as "_"; iApply "Hclose".
+    iExists x, y; iFrame; auto.
+  - iIntros (_) "(c & _)".
     destruct H; subst.
     + iPoseProof (ghost_var_inj(A := nat) with "[$g1 $g]") as "%"; auto with share; subst.
       iMod (ghost_var_update with "[g1 g]") as "g1".
       { rewrite <- (ghost_var_share_join gsh1 gsh2 Tsh) by auto with share; iFrame. }
       rewrite <- (ghost_var_share_join gsh1 gsh2 Tsh) by auto with share.
       iDestruct "g1" as "[g1 $]".
-      iExists 1%nat, y0; iFrame; auto.
+      iMod "Hclose'" as "_"; iApply "Hclose".
+      iExists 1%nat, y; iFrame; auto.
       rewrite Nat.add_0_l Nat.add_comm; auto.
     + iPoseProof (ghost_var_inj(A := nat) with "[$g2 $g]") as "%"; auto with share; subst.
       iMod (ghost_var_update with "[g2 g]") as "g2".
       { rewrite <- (ghost_var_share_join gsh1 gsh2 Tsh) by auto with share; iFrame. }
       rewrite <- (ghost_var_share_join gsh1 gsh2 Tsh) by auto with share.
       iDestruct "g2" as "[g2 $]".
+      iMod "Hclose'" as "_"; iApply "Hclose".
       iExists x, 1%nat; iFrame; auto.
       rewrite Nat.add_0_r; auto.
 Qed.
@@ -212,9 +203,9 @@ Proof.
   { go_lower; apply make_wsat. }
   Intros inv_names.
   rewrite <- 2(ghost_var_share_join gsh1 gsh2 Tsh) by auto with share; Intros.
-  gather_SEP 0 2 3 5; viewshift_SEP 0 (EX i, |> (wsat * invariant i (cptr_inv g g1 g2))).
+  gather_SEP wsat (public_half _ _) (ghost_var gsh1 _ _) (ghost_var gsh1 _ _); viewshift_SEP 0 (EX i, |> (wsat * invariant i (cptr_inv g g1 g2))).
   { go_lower.
-    apply make_inv'.
+    rewrite !sepcon_assoc; apply make_inv'.
     unfold cptr_inv.
     Exists O O; simpl; cancel. }
   Intros i.
@@ -238,17 +229,16 @@ Proof.
   gather_SEP (invariant _ _) (ghost_var _ _ g1) (ghost_var _ _ g2).
   forward_call (sh2, g, gv, fun n => !!(n = 2)%nat && ghost_var gsh2 1%nat g1 * ghost_var gsh2 1%nat g2, inv_names).
   { rewrite -> 4sepcon_assoc; apply sepcon_derives; cancel.
-    unfold atomic_shift; Exists (ghost_var gsh2 1%nat g1 * ghost_var gsh2 1%nat g2);
-      rewrite later_sepcon; cancel.
-    erewrite (add_andp (invariant _ _)) by apply invariant_cored; apply andp_derives; auto.
-    iIntros "I >[g1 g2]".
+    unfold atomic_shift.
+    iIntros "[[#I g1] g2]"; iAuIntro.
+    rewrite /atomic_acc /=.
     iMod (inv_open with "I") as "[>c H]"; auto.
     iDestruct "c" as (x y) "[gs c]"; iExists (x + y)%nat; iFrame "c".
     iMod (fupd_mask_subseteq) as "mask".
     { apply empty_subseteq. }
     iIntros "!>"; iSplit.
     - iIntros "lock"; iMod "mask" as "_".
-      iMod ("H" with "[-g1 g2]"); last by rewrite later_sepcon; iFrame; auto.
+      iMod ("H" with "[-g1 g2]"); last by iFrame.
       unfold cptr_inv.
       iExists x, y; iFrame; auto.
     - iIntros (z) "[[% c] _]".

--- a/progs64/verif_incr_atomic.v
+++ b/progs64/verif_incr_atomic.v
@@ -127,12 +127,27 @@ Proof.
   Exists n; entailer!.
 Qed.
 
+(* remove *)
+Require Import iris.bi.lib.atomic.
+
+(* this is missing -- unprovable? *)
+Instance inv_persistent {inv_names : invG} i R : Persistent (invariant i R).
+Proof.
+Admitted.
+
+Instance inv_affine {inv_names : invG} i R : Affine (invariant i R).
+Proof.
+Admitted.
+
 (* prove a lemma about our specific use pattern of incr *)
 Lemma incr_inv_shift : forall {inv_names : invG} i g g1 g2 gv, (gv = g1 \/ gv = g2) ->
   invariant i (cptr_inv g g1 g2) * ghost_var gsh2 0%nat gv |--
   atomic_shift (λ n : nat, public_half g n) ∅ ⊤
       (λ (n : nat) (_ : ()), fold_right_sepcon [public_half g (n + 1)%nat]) (λ _ : (), ghost_var gsh2 1%nat gv).
 Proof.
+  intros.
+  iIntros "[#inv g]".
+  iAuIntro.
   intros; apply inv_atomic_shift; auto.
   { apply empty_subseteq. }
   unfold cptr_inv; iIntros "c".

--- a/progs64/verif_io.v
+++ b/progs64/verif_io.v
@@ -1,5 +1,5 @@
-Require Import VST.progs.io.
-Require Import VST.progs.io_specs.
+Require Import VST.progs64.io.
+Require Import VST.progs64.io_specs.
 Require Import VST.floyd.proofauto.
 
 Local Open Scope itree_scope.

--- a/progs64/verif_io_mem.v
+++ b/progs64/verif_io_mem.v
@@ -1,5 +1,5 @@
-Require Import VST.progs.io_mem.
-Require Import VST.progs.io_mem_specs.
+Require Import VST.progs64.io_mem.
+Require Import VST.progs64.io_mem_specs.
 Require Import VST.floyd.proofauto.
 Require Import VST.floyd.library.
 

--- a/progs64/verif_sumarray.v
+++ b/progs64/verif_sumarray.v
@@ -21,8 +21,7 @@ Definition sumarray_spec : ident * funspec :=
           PROP  (readable_share sh; 0 <= size <= Int.max_signed;
                  Forall (fun x => 0 <= x <= Int.max_unsigned) contents)
           PARAMS (a; Vint (Int.repr size))
-          GLOBALS () (*TODO: make this line optional, ie insert GLOBALx nil during parsing of notation.
-                          Currently, omitting the line leads to failaure of start_function, specifically of compute_close_precondition_eq *)
+          GLOBALS ()
           SEP   (data_at sh (tarray tuint size) (map Vint (map Int.repr contents)) a)
   POST [ tuint ]
         PROP () LOCAL(temp ret_temp  (Vint (Int.repr (sum_Z contents))))

--- a/veric/Clight_assert_lemmas.v
+++ b/veric/Clight_assert_lemmas.v
@@ -75,14 +75,14 @@ Lemma allp_fun_id_sigcc_sub: forall Delta Delta' rho,
 Proof.
   intros.
   apply allp_derives; intros id.
-  intros w W fs u WU FS.
+  intros w W fs u ? WU EU FS.
   destruct H as [_ [_ [_ [_ [? _]]]]].
   specialize (H id).
   hnf in H.
   rewrite FS in H. destruct H as [gs [GSA GSB]]. specialize (GSB u I).
-  destruct (W gs u WU GSA) as [b [B1 B2]].
-  exists b; split; [trivial | destruct fs; destruct gs].  
-  destruct GSB as [[GSBa GCBb] _]. subst c0 t0. trivial. 
+  destruct (W gs u _ WU EU GSA) as [b [B1 B2]].
+  exists b; split; [trivial | destruct fs; destruct gs].
+  destruct GSB as [[GSBa GCBb] _]. subst c0 t0. trivial.
 Qed.
 
 Lemma allp_fun_id_sub: forall Delta Delta' rho,
@@ -91,15 +91,15 @@ Lemma allp_fun_id_sub: forall Delta Delta' rho,
 Proof.
   intros.
   apply allp_derives; intros id.
-  intros w W fs u WU FS.
+  intros w W fs u ? WU EU FS.
   destruct H as [_ [_ [_ [_ [? _]]]]].
   specialize (H id).
   hnf in H.
   rewrite FS in H. destruct H as [gs [GSA GSB]]. specialize (GSB u I).
-  destruct (W gs u WU GSA) as [b [B1 [bb [X [hs [HS B2]]]]]]; clear W.
+  destruct (W gs u _ WU EU GSA) as [b [B1 [bb [X [hs [HS B2]]]]]]; clear W.
   simpl in X; inv X.
   exists bb; split; [trivial | ]. exists bb; split; [ reflexivity |].
-  exists hs; split; trivial. eapply funspec_sub_si_trans; split. apply HS. apply GSB.
+  exists hs; split; trivial. eapply funspec_sub_si_trans; split. apply HS. eapply pred_upclosed, GSB; auto.
 Qed.
 
 Lemma funassert_allp_fun_id Delta rho: funassert Delta rho |-- allp_fun_id Delta rho.
@@ -153,7 +153,7 @@ apply H.
 apply H0.
 Qed.
 *)
-Lemma prop_derives {A}{H: ageable A}:
+Lemma prop_derives {A}{H: ageable A}{EO: Ext_ord A}:
  forall (P Q: Prop), (P -> Q) -> prop P |-- prop Q.
 Proof.
 intros. intros w ?; apply H0; auto.

--- a/veric/Clight_initial_world.v
+++ b/veric/Clight_initial_world.v
@@ -370,6 +370,7 @@ rewrite <- core_resource_at.
 rewrite resource_at_make_rmap.
 unfold initial_core'.
 simpl in *.
+change fcore with (@core _ _ (fsep_sep Sep_resource)).
 if_tac; [ | rewrite core_NO; auto].
 case_eq (@Genv.invert_symbol (Ctypes.fundef function) type
        (@Genv.globalenv (Ctypes.fundef function) type prog) b);
@@ -550,6 +551,7 @@ rewrite <- core_resource_at.
 rewrite resource_at_make_rmap.
 unfold initial_core'.
 simpl in *.
+change fcore with (@core _ _ (fsep_sep Sep_resource)).
 if_tac; [ | rewrite core_NO; auto].
 case_eq (@Genv.invert_symbol (Ctypes.fundef function) type (@Genv.globalenv (Ctypes.fundef function) type prog) b);
    intros;  try now (rewrite core_NO; auto).
@@ -696,6 +698,7 @@ Proof.
     rewrite !resource_at_make_rmap.
     unfold inflate_initial_mem'.
     rewrite !resource_at_make_rmap.
+    change fcore with (@core _ _ (fsep_sep Sep_resource)).
     apply join_comm, core_unit.
   - unfold set_ghost; rewrite ghost_of_make_rmap.
     simpl.
@@ -843,13 +846,13 @@ Proof.
    exists (fmap (dependent_type_functor_rec ts A) (approx n oo approx n')
              (approx n' oo approx n) ftor).
   rewrite (approx_min n' n) in *.
-  exists emp. rewrite !emp_sepcon.
+  exists emp. rewrite !res_predicates.emp_sepcon.
   destruct H4.
   split. auto.
   intro rho.
   pose proof (equal_f HQ rho). simpl in H5.
   intros phi' Hphi'.
-  rewrite emp_sepcon.
+  rewrite res_predicates.emp_sepcon.
   intros phi'' Hphi''.
   intros [_ ?].
   rewrite (approx_min n n') in *.
@@ -928,13 +931,13 @@ Proof.
    exists (fmap (dependent_type_functor_rec ts A) (approx n oo approx n')
              (approx n' oo approx n) ftor).
   rewrite (approx_min n' n) in *.
-  exists emp. rewrite !emp_sepcon.
+  exists emp. rewrite !res_predicates.emp_sepcon.
   destruct H4.
   split. auto.
   intro rho.
   pose proof (equal_f HQ rho). simpl in H5.
   intros phi' Hphi'.
-  rewrite emp_sepcon.
+  rewrite res_predicates.emp_sepcon.
   intros phi'' Hphi''.
   intros [_ ?].
   rewrite (approx_min n n') in *.

--- a/veric/Clight_initial_world.v
+++ b/veric/Clight_initial_world.v
@@ -788,8 +788,10 @@ Lemma initial_jm_matchfunspecs prog m G n H H1 H2:
 Proof.
   intros b  [fsig cc A P Q ? ?].
   simpl m_phi.
-  intros phi' H0 FAT.
+  intros phi' ? H0 Hext FAT.
   simpl in FAT.
+  apply rmap_order in Hext as (Hl & Hr & _).
+  rewrite <- Hr in FAT; clear Hr.
   assert (H3 := proj2 (necR_PURE' _ _ (b,0) (FUN fsig cc) H0)).
   spec H3. eauto.
   destruct H3 as [pp H3].
@@ -818,14 +820,14 @@ Proof.
   clear H6 H5 i.
   rewrite later_unfash.
   do 3 red.
-  clear FAT. forget (level phi') as n'. clear phi'.
+  clear FAT. forget (level phi') as n'. rewrite <- Hl in *. clear phi'. clear dependent a''.
   intros n1' Hn1'. apply laterR_nat in Hn1'.
   intros ts ftor garg.
-  intros phi Hphi phi' Hphi'.
-  apply necR_level in Hphi'.
-  assert (n' > level phi')%nat by lia.
-  clear n1' Hphi phi Hphi' Hn1'.
-  rename phi' into phi.
+  intros phi Hphi phi' phi'' Hphi' Hext'.
+  apply necR_level in Hphi'. apply ext_level in Hext'.
+  assert (n' > level phi'')%nat by lia.
+  clear n1' Hphi phi Hphi' Hn1' phi' Hext'.
+  rename phi'' into phi.
   intros [_ ?].
   assert (approx n' (P ts ftor garg) phi).
   split; auto.
@@ -846,14 +848,14 @@ Proof.
    exists (fmap (dependent_type_functor_rec ts A) (approx n oo approx n')
              (approx n' oo approx n) ftor).
   rewrite (approx_min n' n) in *.
-  exists emp. rewrite !res_predicates.emp_sepcon.
+  exists emp. rewrite !emp_sepcon.
   destruct H4.
   split. auto.
   intro rho.
   pose proof (equal_f HQ rho). simpl in H5.
   intros phi' Hphi'.
-  rewrite res_predicates.emp_sepcon.
-  intros phi'' Hphi''.
+  rewrite emp_sepcon.
+  intros ? phi'' Hphi'' Hext''.
   intros [_ ?].
   rewrite (approx_min n n') in *.
   rewrite (Nat.min_comm n n') in *.
@@ -861,7 +863,7 @@ Proof.
        (fmap (dependent_type_functor_rec ts A) (approx (Init.Nat.min n' n))
           (approx (Init.Nat.min n' n)) ftor) rho) phi'').
   split; auto.
-  apply necR_level in Hphi''; lia.
+  apply necR_level in Hphi''; apply ext_level in Hext''; lia.
   rewrite <- H5 in H7; clear H5.
   rewrite <- Q_ne in H7.
   destruct H7.
@@ -873,8 +875,10 @@ Lemma initial_jm_ext_matchfunspecs {Z} (ora : Z) prog m G n H H1 H2:
 Proof.
   intros b  [fsig cc A P Q ? ?].
   simpl m_phi.
-  intros phi' H0 FAT.
+  intros ? phi' H0 Hext FAT.
   simpl in FAT.
+  apply rmap_order in Hext as (Hl & Hr & _).
+  rewrite <- Hr in FAT; clear Hr.
   assert (H3 := proj2 (necR_PURE' _ _ (b,0) (FUN fsig cc) H0)).
   spec H3. eauto.
   destruct H3 as [pp H3].
@@ -903,18 +907,18 @@ Proof.
   clear H6 H5 i.
   rewrite later_unfash.
   do 3 red.
-  clear FAT. forget (level phi') as n'. clear phi'.
+  clear FAT. forget (level phi') as n'. clear phi'. rewrite Hl in *. clear dependent a'.
   intros n1' Hn1'. apply laterR_nat in Hn1'.
   intros ts ftor garg.
-  intros phi Hphi phi' Hphi'.
-  apply necR_level in Hphi'.
+  intros phi Hphi ? phi' Hphi' Hext'.
+  apply necR_level in Hphi'. apply ext_level in Hext'.
   assert (n' > level phi')%nat by lia.
-  clear n1' Hphi phi Hphi' Hn1'.
+  clear n1' Hphi phi Hphi' Hn1' a' Hext'.
   rename phi' into phi.
   intros [_ ?].
   assert (approx n' (P ts ftor garg) phi).
   split; auto.
-  clear H3. 
+  clear H3.
   apply own.bupd_intro.
   exists ts.
   assert (H5 := equal_f_dep (equal_f_dep H8 ts) ftor). clear H8.
@@ -931,14 +935,14 @@ Proof.
    exists (fmap (dependent_type_functor_rec ts A) (approx n oo approx n')
              (approx n' oo approx n) ftor).
   rewrite (approx_min n' n) in *.
-  exists emp. rewrite !res_predicates.emp_sepcon.
+  exists emp. rewrite !emp_sepcon.
   destruct H4.
   split. auto.
   intro rho.
   pose proof (equal_f HQ rho). simpl in H5.
   intros phi' Hphi'.
-  rewrite res_predicates.emp_sepcon.
-  intros phi'' Hphi''.
+  rewrite emp_sepcon.
+  intros ? phi'' Hphi'' Hext''.
   intros [_ ?].
   rewrite (approx_min n n') in *.
   rewrite (Nat.min_comm n n') in *.
@@ -946,7 +950,7 @@ Proof.
        (fmap (dependent_type_functor_rec ts A) (approx (Init.Nat.min n' n))
           (approx (Init.Nat.min n' n)) ftor) rho) phi'').
   split; auto.
-  apply necR_level in Hphi''; lia.
+  apply necR_level in Hphi''; apply ext_level in Hext''; lia.
   rewrite <- H5 in H7; clear H5.
   rewrite <- Q_ne in H7.
   destruct H7.

--- a/veric/Clight_mapsto_memory_block.v
+++ b/veric/Clight_mapsto_memory_block.v
@@ -63,7 +63,7 @@ Proof.
      exact (conj H0 H1).
  }
  f_equal. f_equal; extensionality bl.
- f_equal. f_equal. f_equal.
+ f_equal. f_equal.
  simpl;  apply prop_ext; intuition.
  destruct bl; inv H0. destruct bl; inv H.
  unfold Memdata.decode_val in *. simpl in *.
@@ -101,7 +101,7 @@ Proof.
      exact H1.
  }
  f_equal; f_equal; extensionality bl.
- f_equal. f_equal. f_equal.
+ f_equal. f_equal.
  simpl;  apply prop_ext; intuition.
  destruct bl; inv H0. destruct bl; inv H3.
  unfold Memdata.decode_val in *. simpl in *.
@@ -138,7 +138,7 @@ Proof.
      exact (conj H0 H1).
  }
  apply equal_f. apply f_equal. apply f_equal. extensionality bl.
- apply equal_f. apply f_equal. apply equal_f. apply f_equal. apply f_equal.
+ apply equal_f. apply f_equal. apply f_equal.
  simpl;  apply prop_ext; intuition.
  destruct bl; inv H0. destruct bl; inv H3. destruct bl; inv H1.
  unfold Memdata.decode_val in *. simpl in *.
@@ -175,7 +175,7 @@ Proof.
      exact H1.
  }
  apply equal_f. apply f_equal. apply f_equal. extensionality bl.
- apply equal_f. apply f_equal. apply equal_f. apply f_equal. apply f_equal.
+ apply equal_f. apply f_equal. apply f_equal.
  simpl;  apply prop_ext; intuition.
  destruct bl; inv H0. destruct bl; inv H3. destruct bl; inv H1.
  unfold Memdata.decode_val in *. simpl in *.

--- a/veric/NullExtension.v
+++ b/veric/NullExtension.v
@@ -19,10 +19,13 @@ Definition dryspec : external_specification juicy_mem external_function unit
      (fun rv m z => False).
 
 Definition Espec : OracleKind.
- refine (Build_OracleKind unit (Build_juicy_ext_spec _ dryspec _ _ _)).
+ refine (Build_OracleKind unit (Build_juicy_ext_spec _ dryspec _ _ _ _ _ _)).
 Proof.
 simpl; intros; contradiction.
 simpl; intros; contradiction.
+simpl; intros; intros ? ? ? ?; contradiction.
+simpl; intros; contradiction.
+simpl; intros; intros ? ? ? ?; contradiction.
 simpl; intros; intros ? ? ? ?; contradiction.
 Defined.
 

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -43,7 +43,7 @@ Import Ctypes Clight expr.
 
 Instance Nveric: NatDed mpred := algNatDed compcert_rmaps.RML.R.rmap.
 Instance Sveric: SepLog mpred := algSepLog compcert_rmaps.RML.R.rmap.
-Instance Cveric: ClassicalSep mpred := algClassicalSep compcert_rmaps.RML.R.rmap.
+Instance Cveric: ClassicalSep mpred := mkCS _ _ _ res_predicates.sepcon_emp.
 Instance Iveric: Indir mpred := algIndir compcert_rmaps.RML.R.rmap.
 Instance Rveric: RecIndir mpred := algRecIndir compcert_rmaps.RML.R.rmap.
 Instance SIveric: SepIndir mpred := algSepIndir compcert_rmaps.RML.R.rmap.

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -43,7 +43,7 @@ Import Ctypes Clight expr.
 
 Instance Nveric: NatDed mpred := algNatDed compcert_rmaps.RML.R.rmap.
 Instance Sveric: SepLog mpred := algSepLog compcert_rmaps.RML.R.rmap.
-Instance Cveric: ClassicalSep mpred := mkCS _ _ _ res_predicates.sepcon_emp.
+Instance Cveric: ClassicalSep mpred := algClassicalSep compcert_rmaps.RML.R.rmap.
 Instance Iveric: Indir mpred := algIndir compcert_rmaps.RML.R.rmap.
 Instance Rveric: RecIndir mpred := algRecIndir compcert_rmaps.RML.R.rmap.
 Instance SIveric: SepIndir mpred := algSepIndir compcert_rmaps.RML.R.rmap.
@@ -51,7 +51,7 @@ Instance CSLveric: CorableSepLog mpred := algCorableSepLog compcert_rmaps.RML.R.
 Instance CIveric: CorableIndir mpred := algCorableIndir compcert_rmaps.RML.R.rmap.
 Instance SRveric: SepRec mpred := algSepRec compcert_rmaps.RML.R.rmap.
 
-Lemma derives_eq : @derives _ Nveric = predicates_hered.derives(A := compcert_rmaps.RML.R.rmap)(H := _).
+Lemma derives_eq : @derives _ Nveric = predicates_hered.derives(A := compcert_rmaps.RML.R.rmap)(AG := _)(EO := _).
 Proof.
   do 2 extensionality; apply prop_ext; split.
   - inversion 1; auto.
@@ -168,7 +168,7 @@ end.
 Lemma derives_eq':
   @derives (functors.MixVariantFunctor._functor
               functors.MixVariantFunctorGenerator.fidentity mpred) Nveric =
-  predicates_hered.derives(A := compcert_rmaps.RML.R.rmap)(H := _).
+  predicates_hered.derives(A := compcert_rmaps.RML.R.rmap)(AG := _)(EO := _).
 Proof.
   do 2 extensionality; apply prop_ext; split.
   - inversion 1; auto.

--- a/veric/age_to_resource_at.v
+++ b/veric/age_to_resource_at.v
@@ -8,9 +8,9 @@ Require Import VST.veric.compcert_rmaps.
 
 Set Bullet Behavior "Strict Subproofs".
 
-Lemma pred_hered {A} {_ : ageable A} (P : pred A) : hereditary age (app_pred P).
+Lemma pred_hered {A} {_ : ageable A} {EO : Ext_ord A} (P : pred A) : hereditary age (app_pred P).
 Proof.
-  destruct P; auto.
+  destruct P as (? & ? & ?); auto.
 Qed.
 
 Lemma hereditary_necR {phi phi' : rmap} {P} :

--- a/veric/assert_lemmas.v
+++ b/veric/assert_lemmas.v
@@ -242,13 +242,19 @@ left. destruct H; eauto.
 right. destruct H0; eauto.
 Qed.
 
+Lemma corable_unfash:
+  forall (A : Type) (JA : Join A) (PA : Perm_alg A) (SA : Sep_alg A) (agA : ageable A) 
+    (AgeA : Age_alg A) (P : pred nat), corable (! P).
+Proof.
+  unfold corable; simpl; intros.
+  destruct H0 as [[? J] | [? J]]; apply join_level in J as []; congruence.
+Qed.
+
 Lemma corable_funspec_sub_si f g: corable (funspec_sub_si f g).
 Proof.
- intros. intro w. destruct f; destruct g. apply prop_ext; split; intro Hx; inv Hx; split; trivial.
-+ rewrite later_unfash in H0|-*.
-    intros n ?. rewrite level_core in H1. apply (H0 _ H1).
-+ rewrite later_unfash in H0|-*.
-    intros n ?. rewrite <- level_core in H1. apply (H0 _ H1).
+ unfold funspec_sub_si; intros.
+ destruct f, g. apply corable_andp; [apply corable_prop|].
+ apply corable_later, corable_unfash.
 Qed.
 (*
 Lemma corable_funspec_sub_early f g: corable (funspec_sub_early f g).
@@ -260,13 +266,9 @@ Qed.
 *)
 Lemma corable_pureat: forall pp k loc, corable (pureat pp k loc).
 Proof.
- intros. intro w.
- unfold pureat.
-  simpl. rewrite <- core_resource_at.
-  destruct (w @ loc).
-  rewrite core_NO; apply prop_ext; split; intro Hx; inv Hx.
-  rewrite core_YES; apply prop_ext; split; intro Hx; inv Hx.
-  rewrite core_PURE; rewrite level_core; auto.
+ unfold corable, pureat; simpl; intros.
+ destruct H0 as [[? J] | [? J]]; destruct (join_level _ _ _ J) as [Hl _];
+   apply resource_at_join with (loc := loc) in J; rewrite H in J; inv J; rewrite Hl; auto.
 Qed.
 
 Lemma corable_func_at: forall f l, corable (func_at f l).

--- a/veric/assert_lemmas.v
+++ b/veric/assert_lemmas.v
@@ -15,7 +15,7 @@ Lemma mapsto_core_load: forall ch v sh loc m,
 Proof.
 unfold address_mapsto, core_load.
 intros until m; intros H.
-destruct H as [phi0 [phi1 [Hjoin [[bl [[[Hlen [Hdec Halign]] H] _]] ?]]]].
+destruct H as [phi0 [phi1 [Hjoin [[bl [[Hlen [Hdec Halign]] H]] ?]]]].
 unfold allp, jam in *.
 exists bl.
 repeat split; auto.
@@ -120,7 +120,7 @@ cut (0 <= Z_of_nat i < Z_of_nat (length bl)). intro H6.
 lia.
 Qed.
 
-Lemma extensible_core_load': forall ch loc v
+(*Lemma extensible_core_load': forall ch loc v
   w w', extendR w w' -> core_load ch loc v w -> core_load ch loc v w'.
 Proof.
 intros.
@@ -140,7 +140,7 @@ hnf in H2|-*.
 destruct H2 as [sh [rsh H2]].
 rewrite H2 in H.
 inv H; subst; eauto.
-Qed.
+Qed.*)
 
 (*
 Lenb: should be moved to tycontext or some other Clight-dependent file- but is in fact dead
@@ -148,7 +148,7 @@ Definition Dbool {CS: compspecs} (Delta: tycontext) (e: Clight.expr) : assert :=
   fun rho =>  EX b: bool, !! (bool_of_valf (eval_expr e rho) = Some b).
 *)
                              
-Lemma assert_truth:  forall {A} `{ageable A} (P:  Prop), P -> forall (Q: pred A), Q |-- (!! P) && Q.
+Lemma assert_truth:  forall {A} `{ageable A} {EO: Ext_ord A} (P:  Prop), P -> forall (Q: pred A), Q |-- (!! P) && Q.
 Proof.
 intros.
 intros st ?.
@@ -227,7 +227,7 @@ Qed.
 Lemma prop_imp_i {A}{agA: ageable A}:
   forall (P: Prop) Q w, (P -> app_pred Q w) -> (!!P --> Q) w.
 Proof.
- intros. intros w' ? ?. apply H in H1. eapply pred_nec_hereditary; eauto.
+ intros. intros w' ? ? ? H1. apply H in H1. eapply pred_upclosed, pred_nec_hereditary; eauto.
 Qed.
 
 Lemma or_pred_ext {A} `{agA : ageable A}: forall P Q P' Q',
@@ -235,7 +235,7 @@ Lemma or_pred_ext {A} `{agA : ageable A}: forall P Q P' Q',
 Proof.
 intros.
 intros w [? ?].
-split; intros w' ? [?|?].
+split; intros w' ??? [?|?].
 left. destruct H; eauto.
 right. destruct H0; eauto.
 left. destruct H; eauto.
@@ -247,14 +247,15 @@ Lemma corable_unfash:
     (AgeA : Age_alg A) (P : pred nat), corable (! P).
 Proof.
   unfold corable; simpl; intros.
-  destruct H0 as [[? J] | [? J]]; apply join_level in J as []; congruence.
+  destruct H0 as [[? J] | [[? J] | E]]; try (apply join_level in J as []; congruence).
+  apply ext_level in E; congruence.
 Qed.
 
 Lemma corable_funspec_sub_si f g: corable (funspec_sub_si f g).
 Proof.
  unfold funspec_sub_si; intros.
  destruct f, g. apply corable_andp; [apply corable_prop|].
- apply corable_later, corable_unfash.
+ eapply corable_later, corable_unfash; typeclasses eauto.
 Qed.
 (*
 Lemma corable_funspec_sub_early f g: corable (funspec_sub_early f g).
@@ -264,11 +265,39 @@ Proof.
 + intros ts. specialize (H0 ts). rewrite level_core in H0; auto.
 Qed.
 *)
+
+Lemma ext_join_sub : forall (a b : rmap), ext_order a b -> join_sub a b.
+Proof.
+  intros.
+  rewrite rmap_order in H.
+  destruct H as (? & ? & g & ?).
+  destruct (make_rmap (resource_at (core a)) (own.ghost_approx a g) (level a)) as (c & Hl & Hr & Hg).
+  { extensionality l; unfold compose.
+    rewrite <- level_core.
+    apply resource_at_approx. }
+  { rewrite ghost_fmap_fmap, approx_oo_approx; auto. }
+  exists c; apply resource_at_join2; auto.
+  - congruence.
+  - intros; rewrite Hr, <- core_resource_at, H0.
+    apply join_comm, core_unit.
+  - rewrite Hg, <- (ghost_of_approx a), <- (ghost_of_approx b), <- H.
+    apply ghost_fmap_join; auto.
+Qed.
+
+Lemma corable_cases : forall (P : mpred), (forall w, P w -> forall w', join_sub w w' \/ join_sub w' w -> P w') ->
+  corable P.
+Proof.
+  repeat intro.
+  destruct H1 as [? | [? | ?]]; eauto.
+  apply ext_join_sub in H1; eauto.
+Qed.
+
 Lemma corable_pureat: forall pp k loc, corable (pureat pp k loc).
 Proof.
- unfold corable, pureat; simpl; intros.
- destruct H0 as [[? J] | [? J]]; destruct (join_level _ _ _ J) as [Hl _];
-   apply resource_at_join with (loc := loc) in J; rewrite H in J; inv J; rewrite Hl; auto.
+  intros; apply corable_cases.
+  unfold pureat; simpl; intros.
+  destruct H0 as [[? J] | [? J]]; destruct (join_level _ _ _ J) as [Hl _];
+    apply resource_at_join with (loc := loc) in J; rewrite H in J; inv J; rewrite Hl; auto.
 Qed.
 
 Lemma corable_func_at: forall f l, corable (func_at f l).

--- a/veric/assert_lemmas.v
+++ b/veric/assert_lemmas.v
@@ -224,13 +224,13 @@ apply H3.
 split; auto||lia.
 Qed.
 
-Lemma prop_imp_i {A}{agA: ageable A}:
+Lemma prop_imp_i {A}{agA: ageable A}{EO: Ext_ord A}:
   forall (P: Prop) Q w, (P -> app_pred Q w) -> (!!P --> Q) w.
 Proof.
  intros. intros w' ? ? ? H1. apply H in H1. eapply pred_upclosed, pred_nec_hereditary; eauto.
 Qed.
 
-Lemma or_pred_ext {A} `{agA : ageable A}: forall P Q P' Q',
+Lemma or_pred_ext {A} `{agA : ageable A}{EO: Ext_ord A}: forall P Q P' Q',
        (P <--> P') && (Q <--> Q') |--  (P || Q) <--> (P' || Q').
 Proof.
 intros.
@@ -244,7 +244,7 @@ Qed.
 
 Lemma corable_unfash:
   forall (A : Type) (JA : Join A) (PA : Perm_alg A) (SA : Sep_alg A) (agA : ageable A) 
-    (AgeA : Age_alg A) (P : pred nat), corable (! P).
+    (AgeA : Age_alg A) (EO : Ext_ord A) (EA : Ext_alg A) (P : pred nat), corable (! P).
 Proof.
   unfold corable; simpl; intros.
   destruct H0 as [[? J] | [[? J] | E]]; try (apply join_level in J as []; congruence).
@@ -411,7 +411,7 @@ Qed.
 
 #[export] Hint Resolve corable_fun_assert : normalize.
 *)
-Lemma prop_derives {A}{H: ageable A}:
+Lemma prop_derives {A}{H: ageable A}{EO: Ext_ord A}:
  forall (P Q: Prop), (P -> Q) -> prop P |-- prop Q.
 Proof.
 intros. intros w ?; apply H0; auto.

--- a/veric/bi.v
+++ b/veric/bi.v
@@ -106,52 +106,6 @@ Proof.
   intros; rewrite wand_nonexpansive_l wand_nonexpansive_r; reflexivity.
 Qed.
 
-(*Program Definition persistently (P : mpred) : mpred := fun w => P (ghost_core2 w).
-Next Obligation.
-Proof.
-  repeat intro.
-  eapply pred_hereditary; eauto.
-  apply age_ghost_core; auto.
-Qed.
-
-Lemma approx_persistently: forall P n, approx n (persistently P) = persistently (approx n P).
-Proof.
-  intros; apply predicates_hered.pred_ext; intros ??; simpl in *; intros.
-  - rewrite level_ghost_core; auto.
-  - rewrite -> level_ghost_core in *.
-    destruct H as ([] & ?); repeat (split; auto).
-Qed.
-
-Lemma persistently_derives: forall P Q, P |-- Q -> persistently P |-- persistently Q.
-Proof.
-  intros.
-  change (predicates_hered.derives (persistently P) (persistently Q)).
-  change (predicates_hered.derives P Q) in H.
-  repeat intro.
-  apply H, H0; auto.
-Qed.
-
-Lemma persistently_persists : forall P, persistently P |-- persistently (persistently P).
-Proof.
-  intros.
-  change (predicates_hered.derives (persistently P) (persistently (persistently P))).
-  repeat intro; simpl in *.
-  rewrite -> ghost_core_idem in *.
-  apply H; eapply join_sub_trans; eauto.
-Qed.
-
-Lemma ghost_core_identity : forall w, identity w -> identity (ghost_core2 w).
-Proof.
-  intros.
-  apply resource_at_empty2.
-  - intros; rewrite resource_at_ghost_core.
-    apply resource_at_core_identity.
-  - rewrite ghost_of_ghost_core.
-    apply ghost_of_identity in H.
-    rewrite (identity_core H) R.ghost_core; simpl.
-    rewrite <- (R.ghost_core nil); apply core_identity.
-Qed.*)
-
 Program Definition persistently (P : mpred) : mpred := fun w => P (core w).
 Next Obligation.
 Proof.
@@ -167,17 +121,17 @@ Proof.
   - rewrite -> level_core in H; auto.
 Qed.
 
-Lemma persistently_derives: forall P Q, (P |-- Q) -> persistently P |-- persistently Q.
+Lemma persistently_derives: forall P Q, P |-- Q -> persistently P |-- persistently Q.
 Proof.
   intros.
-  unseal_derives; intros ??; simpl in *.
+  unseal_derives; unfold persistently; intros ??.
   apply H; auto.
 Qed.
 
 Lemma persistently_persists : forall P, persistently P |-- persistently (persistently P).
 Proof.
   intros.
-  unseal_derives; intros ??; simpl in *.
+  unseal_derives; unfold persistently; intros ??; simpl.
   rewrite core_idem; auto.
 Qed.
 
@@ -247,7 +201,7 @@ Proof.
   - intros; apply persistently_persists.
   - unfold persistently.
     unseal_derives; intros ??; simpl.
-    apply core_identity.
+    rewrite <- identity_core; auto.
   - unfold persistently; intros.
     unseal_derives; intros ??; auto.
   - intros.

--- a/veric/bi.v
+++ b/veric/bi.v
@@ -504,5 +504,5 @@ Canonical Structure env_mpredSI : sbi :=
 Ltac iVST := iStopProof; match goal with |-bi_entails ?P ?Q => change (P |-- Q) end;
   repeat match goal with |-context[bi_sep ?P ?Q] => change (bi_sep P Q) with (P * Q) end.
 
-Open Scope Z.
-Open Scope logic.
+Global Open Scope Z.
+Global Open Scope logic.

--- a/veric/compcert_rmaps.v
+++ b/veric/compcert_rmaps.v
@@ -591,7 +591,7 @@ Program Definition writable (l: address): pred rmap :=
     | _ => False
   end.
  Next Obligation.
-  intro; intros.
+  split; intro; intros.
   generalize (age1_res_option a a' l H); intro.
   destruct (a @ l); try contradiction.
   simpl in H1.
@@ -606,17 +606,21 @@ Program Definition writable (l: address): pred rmap :=
   clear H0.
   rewrite H3.
   apply Share.glb_lower2.
+
+  rewrite rmap_order in H; destruct H as (? & <- & ?); auto.
 Qed.
 
 Program Definition readable (loc: address) : pred rmap :=
    fun phi => match phi @ loc with YES _ _ k _ => isVAL k | _ => False end.
  Next Obligation.
-  intro; intros.
+  split; intro; intros.
   generalize (age1_res_option a a' loc H); intro.
   destruct (a @ loc); try contradiction.
   simpl in H1.
   destruct (a' @ loc); inv H1; auto.
-  Qed.
+
+  rewrite rmap_order in H; destruct H as (? & <- & ?); auto.
+ Qed.
 
 Lemma readable_join:
   forall phi1 phi2 phi3 loc, join phi1 phi2 phi3 ->

--- a/veric/expr.v
+++ b/veric/expr.v
@@ -1125,7 +1125,7 @@ Next Obligation.
 split; intros; congruence.
 Qed.
 Next Obligation.
-hnf; simpl; intros. hnf; simpl; intros. 
+split; simpl; repeat intro.
 destruct (a@(b,Ptrofs.unsigned ofs + d)) eqn:?; try contradiction.
 rewrite (necR_NO a a') in Heqr.
 rewrite Heqr; auto.
@@ -1134,6 +1134,8 @@ subst.
 apply (necR_YES a a') in Heqr; [ | constructor; auto].
 rewrite Heqr.
 auto.
+
+apply rmap_order in H as (_ & <- & _); auto.
 Qed.
 Next Obligation.
 split3; intros; congruence.

--- a/veric/expr_lemmas.v
+++ b/veric/expr_lemmas.v
@@ -1028,11 +1028,11 @@ Proof.
 Qed.
 
 Lemma denote_tc_nosignedover_eval_expr_cenv_sub {CS CS'} (CSUB : cenv_sub (@cenv_cs CS) (@cenv_cs CS')) rho e1 e2 w (z:Z -> Z -> Z) (s: signedness)
-      (E: @app_pred rmap ag_rmap
+      (E: @app_pred rmap ag_rmap Ext_rmap
         (@liftx (Tarrow val (Tarrow val (LiftEnviron mpred)))
            (denote_tc_nosignedover z s) (@eval_expr CS e1) 
            (@eval_expr CS e2) rho) w):
-  @app_pred rmap ag_rmap
+  @app_pred rmap ag_rmap Ext_rmap
         (@liftx (Tarrow val (Tarrow val (LiftEnviron mpred)))
            (denote_tc_nosignedover z s) (@eval_expr CS' e1) 
            (@eval_expr CS' e2) rho) w.

--- a/veric/expr_lemmas4.v
+++ b/veric/expr_lemmas4.v
@@ -497,14 +497,14 @@ Proof.
   + destruct (classify_add (typeof e1) (typeof e2));
     rewrite ?denote_tc_assert_andp in H;
     repeat match goal with
-    | H: app_pred (_ && _) _ |- _ => destruct H
+    | H: app_pred (_ && _)%pred _ |- _ => destruct H
     end;
     try solve [eapply tc_bool_e; eauto].
     auto.
   + destruct (classify_sub (typeof e1) (typeof e2));
     rewrite ?denote_tc_assert_andp in H;
     repeat match goal with
-    | H: app_pred (_ && _) _ |- _ => destruct H
+    | H: app_pred (_ && _)%pred _ |- _ => destruct H
     end;
     try solve [eapply tc_bool_e; eauto].
     auto.

--- a/veric/extend_tc.v
+++ b/veric/extend_tc.v
@@ -58,7 +58,6 @@ Proof.
 intros.
 rewrite denote_tc_assert_andp.
 apply boxy_andp; auto.
-apply extendM_refl.
 Qed.
 
 Lemma extend_tc_bool:
@@ -326,7 +325,6 @@ Proof.
 intros.
 rewrite denote_tc_assert_orp.
 apply boxy_orp; auto.
-apply extendM_refl.
 Qed.
 
 
@@ -358,7 +356,6 @@ Lemma extend_tc_andp':
 Proof.
 intros.
 apply boxy_andp; auto.
-apply extendM_refl.
 Qed.
 
 Ltac extend_tc_prover := 
@@ -609,7 +606,7 @@ Section CENV_SUB.
   rewrite <- ?(eval_expr_cenv_sub_eq CSUB _ _ n).
   rewrite <- ?(eval_expr_cenv_sub_eq CSUB _ _ n0).
   auto.
-  Qed.  
+  Qed.
 
 Ltac tc_expr_cenv_sub_tac := 
 repeat

--- a/veric/ghosts.v
+++ b/veric/ghosts.v
@@ -254,24 +254,23 @@ Global Program Instance snap_PCM : Ghost :=
         else ord (snd a) (snd b) /\ snd c = snd b else snd c = snd a /\
           if eq_dec (fst b) Share.bot then ord (snd b) (snd a) else snd c = snd b }.
 Next Obligation.
-  exists (fun '(sh, a) => (Share.bot, core a)); repeat intro.
+  exists (fun '(sh, a) => (Share.bot, a)); repeat intro.
   + destruct t; constructor; auto; simpl.
     rewrite eq_dec_refl.
-    if_tac; [apply core_unit | split; auto].
-    rewrite join_ord_eq; eexists; apply core_unit.
-  + destruct a, c, H as [? Hj]; eexists (_, _). split; simpl.
+    if_tac; [apply join_refl | split; auto].
+    reflexivity.
+  + destruct a, c, H as [? Hj].
+    assert (join_sub g g0) as [].
+    { if_tac in Hj. if_tac in Hj.
+      eexists; eauto.
+      destruct Hj; simpl in *; subst.
+      apply join_ord_eq; auto.
+      destruct Hj; simpl in *; subst.
+      apply join_sub_refl. }
+    eexists (_, _). split; simpl.
     * apply join_bot_eq.
-    * if_tac; [|contradiction].
-      simpl in H0.
-      assert (join_sub g g0) as [].
-      { if_tac in Hj. if_tac in Hj.
-        eexists; eauto.
-        destruct Hj; simpl in *; subst.
-        apply join_ord_eq; auto.
-        destruct Hj; simpl in *; subst.
-        apply join_sub_refl. }
-      eapply core_sub_join, join_core_sub; eassumption.
-  + destruct a. rewrite core_idem; reflexivity.
+    * rewrite !eq_dec_refl; eauto.
+  + destruct a; reflexivity.
 Defined.
 Next Obligation.
   constructor.
@@ -392,7 +391,7 @@ Corollary snaps_master_join : forall lv sh v2 p, sh <> Share.bot ->
   !!(Forall (fun v1 => ord v1 v2) lv) && ghost_master sh v2 p)%pred.
 Proof.
   induction lv; simpl; intros.
-  - rewrite res_predicates.emp_sepcon, prop_true_andp; auto.
+  - rewrite emp_sepcon, prop_true_andp; auto.
   - rewrite sepcon_comm, <-sepcon_assoc, (sepcon_comm (ghost_master _ _ _)), snap_master_join; auto.
     apply pred_ext.
     + rewrite sepcon_andp_prop1; apply prop_andp_left; intro.

--- a/veric/initial_world.v
+++ b/veric/initial_world.v
@@ -158,10 +158,9 @@ pose (f loc :=
    then YES sh (writable_readable_share wsh) (VAL (contents_at m' loc)) NoneP
    else core (w @ loc)).
 pose (H0 := True).
-destruct (remake_rmap f (core (ghost_of w)) (level w)) as [m2 [? ?]].
+destruct (remake_rmap f nil (level w)) as [m2 [? ?]]; auto.
 intros; unfold f, no_preds; simpl; intros; repeat if_tac; auto.
-left. exists (core w). rewrite core_resource_at. rewrite level_core.  auto.
-{ rewrite <- ghost_of_core, <- level_core; apply ghost_of_approx. }
+left. change fcore with (@core _ _ (fsep_sep Sep_resource)). exists (core w). rewrite core_resource_at. rewrite level_core.  auto.
 unfold f in *; clear f.
 exists m2.
 destruct H2 as [H2 Hg2].
@@ -222,19 +221,19 @@ specialize (IOK (b',z')). simpl in IOK.
 destruct IOK as [IOK1 IOK2].
 rewrite <- H.
 revert IOK2; case_eq (w @ (b',z')); intros.
-rewrite core_NO.
+change fcore with (@core _ _ (fsep_sep Sep_resource)). rewrite core_NO.
 destruct (access_at m (b', z')); try destruct p; try constructor; auto.
-rewrite core_YES.
+change fcore with (@core _ _ (fsep_sep Sep_resource)). rewrite core_YES.
 destruct (access_at m (b', z')); try destruct p0; try constructor; auto.
 destruct IOK2 as [? [? ?]].
-rewrite H2. rewrite core_PURE; constructor.
+rewrite H2. change fcore with (@core _ _ (fsep_sep Sep_resource)). rewrite core_PURE; constructor.
 +
 destruct H3 as [_ Hg].
 apply ghost_of_join in H4.
 unfold initial_mem in *; simpl in *; unfold inflate_initial_mem in *; simpl in *.
 rewrite ghost_of_make_rmap in *.
 rewrite (Hg _ _ (join_comm H4)).
-rewrite Hg2; apply join_comm, core_unit.
+rewrite Hg2; constructor.
 * (**** case 2 of 3 ****)
 destruct H3 as [H3 Hg].
 split.
@@ -251,7 +250,7 @@ apply H6.
 do 3 red. rewrite H2.
 rewrite if_false; auto.
 apply core_identity.
-simpl; rewrite Hg2; apply core_identity.
+apply ghost_identity; auto.
 Qed.
 
 (*Lemma mem_alloc_juicy:
@@ -532,7 +531,7 @@ Lemma writable_blocks_app:
   forall bl bl' rho, writable_blocks (bl++bl') rho = writable_blocks bl rho * writable_blocks bl' rho.
 Proof.
 induction bl; intros.
-simpl; rewrite emp_sepcon; auto.
+simpl; rewrite res_predicates.emp_sepcon; auto.
 simpl.
 destruct a as [b n]; simpl.
 rewrite sepcon_assoc.
@@ -599,7 +598,7 @@ intros.
               unfold Genv.find_symbol in H2. rewrite H2.
               split; intros. congruence. subst. exfalso. apply n1; trivial.
 
-        replace ((n + Z.to_pos (Z.succ (Zlength (p ::dl))))%positive) with
+        replace ((n + Z.to_pos (Z.succ (Zlength (p :: dl))))%positive) with
           ((Pos.succ n) + Z.to_pos (Zlength (p ::dl)))%positive.
         2: { clear - n dl. rewrite Z2Pos.inj_succ.
                    rewrite Pplus_one_succ_r. rewrite Pplus_one_succ_l.

--- a/veric/initial_world.v
+++ b/veric/initial_world.v
@@ -39,7 +39,7 @@ Lemma VALspec_range_e:
                 {x | m @ loc = YES sh (snd x) (VAL (fst x)) NoneP}.
 Proof.
 intros.
-destruct H as [H _]; specialize (H loc).
+specialize (H loc).
 rewrite jam_true in H; auto.
 simpl in H.
 destruct (m @ loc); try destruct k;
@@ -158,9 +158,13 @@ pose (f loc :=
    then YES sh (writable_readable_share wsh) (VAL (contents_at m' loc)) NoneP
    else core (w @ loc)).
 pose (H0 := True).
-destruct (remake_rmap f nil (level w)) as [m2 [? ?]]; auto.
+destruct (remake_rmap f (ghost_of m1) (level w)) as [m2 [? ?]]; auto.
 intros; unfold f, no_preds; simpl; intros; repeat if_tac; auto.
 left. change fcore with (@core _ _ (fsep_sep Sep_resource)). exists (core w). rewrite core_resource_at. rewrite level_core.  auto.
+{ apply join_level in H4 as [_ Hl].
+  simpl in Hl.
+  unfold inflate_initial_mem in Hl; rewrite level_make_rmap in Hl.
+  rewrite <- Hl; apply ghost_of_approx. }
 unfold f in *; clear f.
 exists m2.
 destruct H2 as [H2 Hg2].
@@ -177,7 +181,7 @@ simpl; repeat rewrite inflate_initial_mem_level; auto.
 rewrite H1; simpl; rewrite inflate_initial_mem_level; auto.
 destruct H as [H [H5 H7]].
 intros [b' z']; apply (resource_at_join _ _ _ (b',z')) in H4; specialize (H b' z').
-destruct H3 as [H3 Hg]. specialize (H3 (b',z')). unfold jam in H3.
+specialize (H3 (b',z')). unfold jam in H3.
 hnf in H3. if_tac in H3.
 2: rename H6 into H8.
 clear H. destruct H6 as [H H8].
@@ -206,7 +210,7 @@ destruct (w @ (b,z')); inv H4.
 inv H4.
 + (* case 1.2 *)
 apply join_unit2_e in H4; auto.
-clear m1 H3 Hg.
+clear m1 H3 Hg2.
 destruct H. contradiction.
 rewrite H2; clear H2.
 rewrite if_false; auto.
@@ -228,15 +232,11 @@ destruct (access_at m (b', z')); try destruct p0; try constructor; auto.
 destruct IOK2 as [? [? ?]].
 rewrite H2. change fcore with (@core _ _ (fsep_sep Sep_resource)). rewrite core_PURE; constructor.
 +
-destruct H3 as [_ Hg].
 apply ghost_of_join in H4.
 unfold initial_mem in *; simpl in *; unfold inflate_initial_mem in *; simpl in *.
 rewrite ghost_of_make_rmap in *.
-rewrite (Hg _ _ (join_comm H4)).
-rewrite Hg2; constructor.
+rewrite Hg2; auto.
 * (**** case 2 of 3 ****)
-destruct H3 as [H3 Hg].
-split.
 intro loc.
 specialize (H3 loc).
 hnf in H3|-*.
@@ -250,7 +250,6 @@ apply H6.
 do 3 red. rewrite H2.
 rewrite if_false; auto.
 apply core_identity.
-apply ghost_identity; auto.
 Qed.
 
 (*Lemma mem_alloc_juicy:
@@ -531,7 +530,7 @@ Lemma writable_blocks_app:
   forall bl bl' rho, writable_blocks (bl++bl') rho = writable_blocks bl rho * writable_blocks bl' rho.
 Proof.
 induction bl; intros.
-simpl; rewrite res_predicates.emp_sepcon; auto.
+simpl; rewrite emp_sepcon; auto.
 simpl.
 destruct a as [b n]; simpl.
 rewrite sepcon_assoc.

--- a/veric/initialize.v
+++ b/veric/initialize.v
@@ -40,7 +40,7 @@ Proof. intros.
   repeat rewrite level_make_rmap. auto.
   repeat rewrite level_make_rmap. auto.
  intro;   repeat rewrite resource_at_make_rmap. unfold compose.
- destruct (S_dec (fst loc)); simpl.
+ destruct (S_dec (fst loc)).
   try rewrite if_false by tauto. apply join_comm; apply core_unit.
   rewrite if_true by tauto; apply core_unit.
   rewrite !ghost_of_make_rmap.
@@ -1108,7 +1108,8 @@ assert (forall loc, fst loc <> b -> identity (phi @ loc)).
   unfold phi in *; clear phi.
   eapply init_data_lem; try eassumption.
   apply ghost_of_join in H7.
-  simpl; eapply split_identity; eauto.
+  apply ghost_identity in Hgw; rewrite Hgw in H7.
+  apply ghost_identity; inv H7; auto.
   clear - AL. apply andb_true_iff in AL. destruct AL; auto.
   pose proof (init_data_list_size_pos dl'); lia.
   pose proof (init_data_list_size_pos dl); lia.
@@ -1159,7 +1160,8 @@ assert (forall loc, fst loc <> b -> identity (phi @ loc)).
  contradict H12. destruct H12; split; auto.
   pose proof (init_data_size_pos a); lia.
   apply ghost_of_join, join_comm in H7.
-  simpl; eapply split_identity; eauto.
+  apply ghost_identity in Hgw; rewrite Hgw in H7.
+  apply ghost_identity; inv H7; auto.
  clear.
   induction dl'; simpl; intros; try lia.
 Qed.
@@ -2036,7 +2038,7 @@ Proof.
       destruct HACK as [HACK _]. rewrite <- HACK. apply NO_identity.
     destruct HACK as (? & <- & _).
     unfold inflate_initial_mem, initial_core; rewrite !ghost_of_make_rmap.
-    rewrite <- (ghost_core nil); apply core_identity.
+    apply ghost_identity; auto.
   + simpl in H0.
     revert H0; case_eq (alloc_globals_rev gev empty vl); intros; try congruence.
     spec IHvl. clear - AL. simpl in AL. destruct a. destruct g; auto. simpl in AL.
@@ -2138,7 +2140,7 @@ rewrite Pos_to_nat_eq_S.
   assert (identity (ghost_of phi)) as Hg.
   { destruct HACK as (? & <- & _).
     unfold inflate_initial_mem, initial_core; rewrite !ghost_of_make_rmap.
-    rewrite <- (ghost_core nil); apply core_identity. }
+    apply ghost_identity; auto. }
   pose proof (join_comm (join_upto_beyond_block (nextblock m0) phi Hg)).
   do 2 econstructor; split3; [ eassumption | |].
   unfold globvar2pred.
@@ -2190,7 +2192,7 @@ rewrite Pos_to_nat_eq_S.
 pose proof (init_data_list_lem {| genv_genv := gev; genv_cenv := cenv |} m0 v m1 b m2 m3 m (initial_core gev (G0 ++ G) n)
      H3 H5 H8 H9) .
  spec H7.
- { unfold initial_core; simpl; rewrite ghost_of_make_rmap, <- (ghost_core nil); apply core_identity. }
+ { unfold initial_core; simpl; rewrite ghost_of_make_rmap; apply ghost_identity; auto. }
  spec H7.
  clear - AL. simpl in AL. apply andb_true_iff in AL; destruct AL; auto.
  apply andb_true_iff in H. destruct H. apply Zlt_is_lt_bool; auto.

--- a/veric/invariants.v
+++ b/veric/invariants.v
@@ -19,7 +19,7 @@ Defined.
 
 Definition pred_of (P : mpred) := SomeP rmaps.Mpred (fun _ => P).
 
-Definition agree g (P : mpred) := own(RA := unit_PCM) g tt (pred_of P).
+Definition agree g (P : mpred) : mpred := own(RA := unit_PCM) g tt (pred_of P).
 
 Lemma agree_dup : forall g P, (agree g P = agree g P * agree g P)%pred.
 Proof.

--- a/veric/invariants.v
+++ b/veric/invariants.v
@@ -1152,10 +1152,12 @@ Lemma ghost_is_pred_nonexpansive : forall g H, nonexpansive (fun P => ghost_is (
         pred_of P))).
 Proof.
   unfold nonexpansive.
-  intros ??????; split; intros ???; simpl in *; etransitivity; eauto; simpl;
+  intros ??????; split; intros ?????; simpl in *;
+    match goal with H : join_sub ?a ?b |- join_sub ?c ?b =>
+      assert (a = c) as <-; auto end; simpl;
     rewrite !ghost_fmap_singleton; do 2 f_equal; simpl; f_equal;
     extensionality; apply pred_ext; intros ? []; split; auto;
-    eapply H0; try apply necR_refl; auto; apply necR_level in H2; lia.
+    eapply H0; try apply necR_refl; auto; apply necR_level in H2; apply ext_level in H3; lia.
 Qed.
 
 Lemma agree_nonexpansive : forall g, nonexpansive (agree g).
@@ -1184,11 +1186,12 @@ Lemma ghost_is_pred_nonexpansive2 : forall g H f,
         pred_of (f P)))).
 Proof.
   unfold nonexpansive.
-  intros ??????; split; intros ???; specialize (H0 _ _ _ H1);
-  simpl in *; etransitivity; eauto; simpl;
+  intros ??????; split; intros ?????; specialize (H0 _ _ _ H1);
+  simpl in *; match goal with H : join_sub ?a ?b |- join_sub ?c ?b =>
+      assert (a = c) as <-; auto end; simpl;
     rewrite !ghost_fmap_singleton; do 2 f_equal; simpl; f_equal;
     extensionality; apply pred_ext; intros ? []; split; auto;
-    eapply H0; try apply necR_refl; auto; apply necR_level in H3; lia.
+    eapply H0; try apply necR_refl; auto; apply necR_level in H3; apply ext_level in H4; lia.
 Qed.
 
 Lemma agree_nonexpansive2 : forall g f,

--- a/veric/juicy_extspec.v
+++ b/veric/juicy_extspec.v
@@ -19,8 +19,11 @@ Local Open Scope pred.
 Record juicy_ext_spec (Z: Type) := {
   JE_spec:> external_specification juicy_mem external_function Z;
   JE_pre_hered: forall e t ge_s typs args z, hereditary age (ext_spec_pre JE_spec e t ge_s typs args z);
+  JE_pre_ext: forall e t ge_s typs args z, hereditary ext_order (ext_spec_pre JE_spec e t ge_s typs args z);
   JE_post_hered: forall e t ge_s tret rv z, hereditary age (ext_spec_post JE_spec e t ge_s tret rv z);
-  JE_exit_hered: forall rv z, hereditary age (ext_spec_exit JE_spec rv z)
+  JE_post_ext: forall e t ge_s tret rv z, hereditary ext_order (ext_spec_post JE_spec e t ge_s tret rv z);
+  JE_exit_hered: forall rv z, hereditary age (ext_spec_exit JE_spec rv z);
+  JE_exit_ext: forall rv z, hereditary ext_order (ext_spec_exit JE_spec rv z)
 }.
 
 Class OracleKind := {
@@ -38,10 +41,13 @@ Definition void_spec T : external_specification juicy_mem external_function T :=
       (fun rv m z => False).
 
 Definition ok_void_spec (T : Type) : OracleKind.
- refine (Build_OracleKind T (Build_juicy_ext_spec _ (void_spec T) _ _ _)).
+ refine (Build_OracleKind T (Build_juicy_ext_spec _ (void_spec T) _ _ _ _ _ _)).
 Proof.
   simpl; intros; contradiction.
   simpl; intros; contradiction.
+  simpl; intros; contradiction.
+  simpl; intros; contradiction.
+  simpl; intros; intros ? ? ? ?; contradiction.
   simpl; intros; intros ? ? ? ?; contradiction.
 Defined.
 
@@ -127,7 +133,7 @@ Section upd_exit.
   Program Definition upd_exit {ef : external_function} (x : ext_spec_type spec ef) ge :=
     Build_juicy_ext_spec _ (upd_exit'' _ x ge) _ _ _.
   Next Obligation. intros. eapply JE_pre_hered; eauto. Qed.
-  Next Obligation. intros. eapply JE_post_hered; eauto. Qed.
+  Next Obligation. intros. eapply JE_pre_ext; eauto. Qed.
   Next Obligation. intros. eapply JE_post_hered; eauto. Qed.
 End upd_exit.
 
@@ -143,7 +149,7 @@ Program Definition juicy_mem_op (P : pred rmap) : pred juicy_mem :=
   destruct H.
   eapply pred_hereditary; eauto.
 
-  eapply pred_upclosed; eauto.
+  destruct H; eapply pred_upclosed; eauto.
  Qed.
 
 Lemma age_resource_decay:
@@ -299,7 +305,71 @@ Proof.
   replace (level x) with (level m); reflexivity.
 Qed.
 
-(* Just like we reserve ghost name 0 for the external ghost, we reserve 1-3 for invariants/world satisfaction.
+Lemma ext_join_approx : forall {Z} (z : Z) n g,
+  joins g (Some (ghost_PCM.ext_ref z, NoneP) :: nil) ->
+  joins (ghost_fmap (approx n) (approx n) g) (Some (ghost_PCM.ext_ref z, NoneP) :: nil).
+Proof.
+  intros.
+  destruct H.
+  change (Some (ghost_PCM.ext_ref z, NoneP) :: nil) with
+    (ghost_fmap (approx n) (approx n) (Some (ghost_PCM.ext_ref z, NoneP) :: nil)).
+  eexists; apply ghost_fmap_join; eauto.
+Qed.
+
+Lemma ext_join_sub_approx : forall {Z} (z : Z) n g,
+  join_sub (Some (ghost_PCM.ext_ref z, NoneP) :: nil) g ->
+  join_sub (Some (ghost_PCM.ext_ref z, NoneP) :: nil) (ghost_fmap (approx n) (approx n) g).
+Proof.
+  intros.
+  destruct H.
+  change (Some (ghost_PCM.ext_ref z, NoneP) :: nil) with
+    (ghost_fmap (approx n) (approx n) (Some (ghost_PCM.ext_ref z, NoneP) :: nil)).
+  eexists; apply ghost_fmap_join; eauto.
+Qed.
+
+Lemma ext_join_unapprox : forall {Z} (z : Z) n g,
+  joins (ghost_fmap (approx n) (approx n) g) (Some (ghost_PCM.ext_ref z, NoneP) :: nil) ->
+  joins g (Some (ghost_PCM.ext_ref z, NoneP) :: nil).
+Proof.
+  intros.
+  destruct H as (g' & J).
+  destruct g; [eexists; constructor|].
+  inv J.
+  exists (a3 :: g); repeat constructor.
+  destruct o; inv H4; constructor.
+  destruct p; inv H1; constructor; simpl in *; auto.
+  destruct p; simpl in *.
+  inv H0.
+  inv H1.
+  inj_pair_tac.
+  constructor; auto.
+  unfold NoneP; f_equal; auto.
+Qed.
+
+Lemma jm_bupd_ext : forall {Z} (ora : Z) (P : juicy_mem -> Prop) m m', jm_bupd ora P m ->
+  ext_order m m' -> (forall a b, level a = level m -> ext_order a b -> P a -> P b) ->
+  jm_bupd ora P m'.
+Proof.
+  intros ????? H [? Hext] Hclosed ? Hora H1.
+  apply rmap_order in Hext as (Hl & Hr & [? J]).
+  destruct H1 as [d J'].
+  destruct (join_assoc J J') as (c' & ? & Jc').
+  eapply ghost_fmap_join in Jc'; rewrite ghost_of_approx in Jc'.
+  destruct (H c') as (m'' & Jm'' & (? & Hl'' & ?) & ?).
+  { eapply ext_join_sub_approx in Hora.
+    eapply join_sub_trans; eauto.
+    eexists; eauto. }
+  { rewrite level_juice_level_phi; eauto. }
+  assert (level m'' = level m') as Hl'.
+  { rewrite <- !level_juice_level_phi in *; congruence. }
+  exists m''; repeat split; auto; try congruence.
+  eapply join_sub_joins'; eauto.
+  { apply join_sub_refl. }
+  eapply ghost_fmap_join in H1; rewrite ghost_fmap_fmap, 2approx_oo_approx in H1.
+  rewrite <- Hl'', Hl'; eexists; eauto.
+Qed.
+
+(*(* Just like we reserve ghost name 0 for the external ghost, we reserve 1-3 for invariants/world satisfaction.
   Presumably we'll have to prove that this isn't vacuous somewhere in the soundness proof.
   We could delay the instantiation and be generic in inv_names, but since we know we'll always need it and we get to allocate it
   before the program starts, I don't see any reason to hold off. *)
@@ -344,7 +414,7 @@ Proof.
   apply join_level in J2 as [Hl2 ?].
   rewrite <- !level_juice_level_phi in Hl2.
   lia.
-Qed.
+Qed.*)
 
 Section juicy_safety.
   Context {G C Z:Type}.
@@ -541,6 +611,70 @@ Proof.
     eapply JE_exit_hered; eauto.
 Qed.
 
+Lemma resource_decay_resource : forall b x x' y, resource_decay b x x' ->
+  level x = level y -> resource_at x = resource_at y ->
+  exists y', resource_decay b y y' /\ level y' = level x' /\
+    resource_at x' = resource_at y' /\ ghost_of y' = own.ghost_approx y' (ghost_of y).
+Proof.
+  intros.
+  destruct (make_rmap (resource_at x') (own.ghost_approx (level x') (ghost_of y)) (level x')) as (y' & Hl & Hr & Hg).
+  { extensionality; apply resource_at_approx. }
+  { rewrite ghost_fmap_fmap, !approx_oo_approx; reflexivity. }
+  rewrite <- Hl in Hg.
+  exists y'; split; [|repeat split; auto].
+  unfold resource_decay in *.
+  destruct H.
+  rewrite Hr, <- H1, Hl, <- H0; auto.
+Qed.
+
+Lemma ext_safe:
+  forall jm jm0, ext_order jm0 jm ->
+  forall ora c,
+   jsafeN_ (level jm0) ora c jm0 ->
+   jsafeN_ (level jm) ora c jm.
+Proof.
+  intros.
+  remember (level jm0) as N.
+  revert dependent c; revert dependent jm0; revert jm; induction N; intros.
+  { destruct H as [_ H].
+    destruct (proj1 (rmap_order _ _) H) as (Hl & _ & _).
+    rewrite level_juice_level_phi, <- Hl, <- level_juice_level_phi, <- HeqN; constructor. }
+  destruct H as [Hdry H].
+  destruct (proj1 (rmap_order _ _) H) as (Hl & Hr & Hg).
+  inv H0.
+  - destruct H2 as (? & ? & ? & Hg').
+    rewrite Hdry in *.
+    eapply resource_decay_resource in H1 as (? & Hdecay & ? & Hr' & Hg''); eauto.
+    rewrite level_juice_level_phi, <- Hl, <- level_juice_level_phi, H2.
+    symmetry in Hr'; destruct (juicy_mem_resource _ _ Hr') as (m'' & ? & Hdry'); subst.
+    eapply jsafeN_step.
+    + split; [rewrite Hdry'; eauto|].
+      split; auto; split; auto.
+      rewrite !level_juice_level_phi in *; congruence.
+    + rewrite H2 in HeqN; inv HeqN.
+      eapply jm_bupd_ext; eauto.
+      * simpl; rewrite rmap_order; repeat split; auto.
+        rewrite Hg', Hg'', level_juice_level_phi, H1.
+        destruct Hg; eexists; apply ghost_fmap_join; eauto.
+      * intros ?? Hl1 Hext ?. rewrite <- Hl1, (ext_level _ _ Hext). eauto.
+  - rewrite level_juice_level_phi, <- Hl, <- level_juice_level_phi, <- HeqN.
+    eapply jsafeN_external.
+    + unfold j_at_external in *.
+      rewrite <- Hdry; eauto.
+    + eapply JE_pre_ext; [|eauto].
+      split; auto.
+    + intros.
+      apply H4; auto.
+      unfold Hrel in *.
+      destruct H1 as (? & ? & ?); split; auto.
+      split; [rewrite !level_juice_level_phi in *; lia|].
+      unfold pures_eq, pures_sub in *.
+      rewrite Hr; auto.
+  - eapply jsafeN_halted; eauto.
+    eapply JE_exit_ext; [|eauto].
+    split; auto.
+Qed.
+
 Lemma jsafe_corestep_backward:
     forall c m c' m' n z,
     jstep Hcore c m c' m' ->
@@ -646,7 +780,7 @@ Proof.
   intros; eapply necR_safe; eauto.
 Qed.*)
 
-Polymorphic Lemma jm_fupd_age' : forall {Z} (ora : Z) E1 E2 z q m m', jm_fupd ora E1 E2 (fun jm => jsafeN_ (min (level m) (level jm)) z q jm) m ->
+(*Polymorphic Lemma jm_fupd_age' : forall {Z} (ora : Z) E1 E2 z q m m', jm_fupd ora E1 E2 (fun jm => jsafeN_ (min (level m) (level jm)) z q jm) m ->
   age m m' -> jm_fupd ora E1 E2 (fun jm => jsafeN_ (min (level m') (level jm)) z q jm) m'.
 Proof.
   intros.
@@ -655,7 +789,7 @@ Proof.
   apply age_level in H0.
   rewrite !level_juice_level_phi in H0.
   rewrite min_r in * by lia; auto.
-Qed.
+Qed.*)
 
 End juicy_safety.
 

--- a/veric/juicy_extspec.v
+++ b/veric/juicy_extspec.v
@@ -133,13 +133,17 @@ End upd_exit.
 
 Obligation Tactic := Tactics.program_simpl.
 
+Search ageable juicy_mem.
+
 Program Definition juicy_mem_op (P : pred rmap) : pred juicy_mem :=
   fun jm => P (m_phi jm).
  Next Obligation.
-  intro; intros.
+  split; repeat intro.
   apply age1_juicy_mem_unpack in H.
   destruct H.
   eapply pred_hereditary; eauto.
+
+  eapply pred_upclosed; eauto.
  Qed.
 
 Lemma age_resource_decay:

--- a/veric/juicy_mem.v
+++ b/veric/juicy_mem.v
@@ -601,36 +601,53 @@ destruct k; try inv H.
 eauto.
 Qed.
 
+Lemma ext_ord_juicy_mem : forall m b, ext_order (m_phi m) b ->
+  exists m', m_dry m' = m_dry m /\ m_phi m' = b.
+Proof.
+  intros.
+  destruct (juicy_mem_resource m b) as (? & ? & ?); eauto.
+  apply rmap_order in H as (Hl & Hr & Hg); auto.
+Qed.
+
+Lemma ext_ord_juicy_mem' : forall m b, ext_order b (m_phi m) ->
+  exists m', m_dry m' = m_dry m /\ m_phi m' = b.
+Proof.
+  intros.
+  destruct (juicy_mem_resource m b) as (? & ? & ?); eauto.
+  apply rmap_order in H as (Hl & Hr & Hg); auto.
+Qed.
+
 Program Instance juicy_mem_ord: Ext_ord juicy_mem :=
-  { ext_order a b := ext_order (m_phi a) (m_phi b) }.
+  { ext_order a b := m_dry a = m_dry b /\ ext_order (m_phi a) (m_phi b) }.
 Next Obligation.
 Proof.
   constructor; auto.
-  repeat intro; etransitivity; eauto.
+  intros ??? [] []; split; etransitivity; eauto.
 Qed.
 Next Obligation.
 Proof.
-  intros ?? ?%age1_juicy_mem_Some ??.
-  eapply age_ext_commut in H as [? ? Hage]; eauto.
-  destruct (age1_juicy_mem z) eqn: Hz.
-  unfold age in Hage.
-  erewrite age1_juicy_mem_Some in Hage by eauto.
-  inv Hage; eauto.
+  intros ?? Hage ? [? Hext].
+  apply age1_juicy_mem_unpack in Hage as [? ?].
+  eapply age_ext_commut in Hext as [? ? Hage]; eauto.
+  destruct (age1_juicy_mem z) as [j|] eqn: Hz.
+  destruct (age1_juicy_mem_unpack _ _ Hz) as (Hage' & ?).
+  unfold age in *; rewrite Hage' in Hage; inv Hage.
+  exists j; eauto; split; auto; congruence.
   { apply age1_juicy_mem_None1 in Hz. congruence. }
 Qed.
 Next Obligation.
 Proof.
-  apply age1_juicy_mem_Some in H0.
-  eapply ext_age_compat in H as (? & Hage & ?); eauto.
-  destruct (age1_juicy_mem b) eqn: Hb.
-  unfold age in Hage.
-  erewrite age1_juicy_mem_Some in Hage by eauto.
-  inv Hage; eauto.
+  apply age1_juicy_mem_unpack in H0 as [? ?].
+  eapply ext_age_compat in H1 as (? & Hage & ?); eauto.
+  destruct (age1_juicy_mem b) as [j|] eqn: Hb.
+  destruct (age1_juicy_mem_unpack _ _ Hb) as (Hage' & ?).
+  unfold age in *; rewrite Hage' in Hage; inv Hage.
+  exists j; split; auto; split; auto; congruence.
   { apply age1_juicy_mem_None1 in Hb. congruence. }
 Qed.
 Next Obligation.
 Proof.
-  apply ext_level in H; auto.
+  apply ext_level in H0; auto.
 Qed.
 
 (* resource coherence *)

--- a/veric/juicy_mem.v
+++ b/veric/juicy_mem.v
@@ -601,6 +601,38 @@ destruct k; try inv H.
 eauto.
 Qed.
 
+Program Instance juicy_mem_ord: Ext_ord juicy_mem :=
+  { ext_order a b := ext_order (m_phi a) (m_phi b) }.
+Next Obligation.
+Proof.
+  constructor; auto.
+  repeat intro; etransitivity; eauto.
+Qed.
+Next Obligation.
+Proof.
+  intros ?? ?%age1_juicy_mem_Some ??.
+  eapply age_ext_commut in H as [? ? Hage]; eauto.
+  destruct (age1_juicy_mem z) eqn: Hz.
+  unfold age in Hage.
+  erewrite age1_juicy_mem_Some in Hage by eauto.
+  inv Hage; eauto.
+  { apply age1_juicy_mem_None1 in Hz. congruence. }
+Qed.
+Next Obligation.
+Proof.
+  apply age1_juicy_mem_Some in H0.
+  eapply ext_age_compat in H as (? & Hage & ?); eauto.
+  destruct (age1_juicy_mem b) eqn: Hb.
+  unfold age in Hage.
+  erewrite age1_juicy_mem_Some in Hage by eauto.
+  inv Hage; eauto.
+  { apply age1_juicy_mem_None1 in Hb. congruence. }
+Qed.
+Next Obligation.
+Proof.
+  apply ext_level in H; auto.
+Qed.
+
 (* resource coherence *)
 
 (* FIXME: put somewhere else. *)

--- a/veric/juicy_mem.v
+++ b/veric/juicy_mem.v
@@ -309,7 +309,7 @@ simpl in H.
 destruct (phi@loc); eauto 50.
 Qed.
 
-Lemma age1_joinx {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A} : forall phi1 phi2 phi3 phi1' phi2' phi3',
+Lemma age1_joinx {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A} : forall phi1 phi2 phi3 phi1' phi2' phi3',
              age phi1 phi1' -> age phi2 phi2' -> age phi3 phi3' ->
              join phi1 phi2 phi3 -> join phi1' phi2' phi3'.
 Proof.
@@ -319,7 +319,7 @@ unfold age in *.
 congruence.
 Qed.
 
-Lemma constructive_age1_join  {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A} : forall x y z x' : A,
+Lemma constructive_age1_join  {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A} : forall x y z x' : A,
        join x y z ->
        age x x' ->
        { yz' : A*A | join x' (fst yz') (snd yz') /\ age y (fst yz') /\ age z (snd yz')}.
@@ -342,7 +342,7 @@ unfold age in *.
 congruence.
 Qed.
 
-Lemma age1_constructive_joins_eq : forall {A}  {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A}  {phi1 phi2},
+Lemma age1_constructive_joins_eq : forall {A}  {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A}  {phi1 phi2},
   constructive_joins phi1 phi2
   -> forall {phi1'}, age1 phi1 = Some phi1'
   -> forall {phi2'}, age1 phi2 = Some phi2'

--- a/veric/juicy_mem_lemmas.v
+++ b/veric/juicy_mem_lemmas.v
@@ -910,14 +910,14 @@ Variables (jm :juicy_mem) (m': mem)
           (PERM: forall ofs, lo <= ofs < hi ->
                       perm_of_res (m_phi jm @ (b,ofs)) = Some Freeable)
           (phi1 phi2 : rmap) (Hphi1: VALspec_range (hi-lo) Share.top (b,lo) phi1)
-          (Hg1: identity (ghost_of phi1))
           (Hjoin : join phi1 phi2 (m_phi jm)).
 
-Lemma phi2_eq : m_phi (free_juicy_mem _ _ _ _ _ FREE) = phi2.
+Lemma phi2_eq : ext_order phi2 (m_phi (free_juicy_mem _ _ _ _ _ FREE)).
 Proof.
-  apply rmap_ext; simpl; unfold inflate_free; rewrite ?level_make_rmap, ?resource_at_make_rmap.
+  apply rmap_order; simpl; unfold inflate_free; rewrite ?level_make_rmap, ?resource_at_make_rmap.
+  split; [|split].
   - apply join_level in Hjoin; destruct Hjoin; auto.
-  - intro.
+  - extensionality l.
     specialize (Hphi1 l); simpl in Hphi1.
     apply (resource_at_join _ _ _ l) in Hjoin.
     if_tac.
@@ -928,7 +928,7 @@ Proof.
         subst; contradiction bot_unreadable.
     + apply Hphi1 in Hjoin; auto.
   - rewrite ghost_of_make_rmap.
-    apply ghost_of_join, Hg1 in Hjoin; auto.
+    apply ghost_of_join in Hjoin; eexists; eauto.
 Qed.
 
 End free.
@@ -938,9 +938,8 @@ Lemma juicy_free_lemma':
     (H: Mem.free (m_dry j) b lo hi = Some m')
     (VR: app_pred (VALspec_range (hi-lo) Share.top (b,lo) * F)%pred (m_phi j)),
     VALspec_range (hi-lo) Share.top (b,lo) m1 ->
-    identity (ghost_of m1) ->
     join m1 m2 (m_phi j) ->
-    m_phi (free_juicy_mem _ _ _ _ _ H) = m2.
+    ext_order m2 (m_phi (free_juicy_mem _ _ _ _ _ H)).
 Proof.
   intros.
   eapply phi2_eq; eauto.

--- a/veric/own.v
+++ b/veric/own.v
@@ -13,12 +13,18 @@ Notation ghost_approx m := (ghost_fmap (approx (level m)) (approx (level m))).
 
 (* Ownership construction based on "Iris from the ground up", Jung et al. *)
 Program Definition ghost_is g: pred rmap :=
-  fun m => ghost_of m = ghost_approx m g.
+  fun m => join_sub (ghost_approx m g) (ghost_of m).
 Next Obligation.
-  intros ???? Hg.
-  rewrite (age1_ghost_of _ _ H), Hg.
-  pose proof (age_level _ _ H).
-  rewrite ghost_fmap_fmap, approx_oo_approx', approx'_oo_approx by lia; eauto.
+  split; intros ??? J.
+  - rewrite (age1_ghost_of _ _ H).
+    destruct J as [? J].
+    eapply ghost_fmap_join in J.
+    assert (level a >= level a')%nat as Hl by (apply age_level in H; lia).
+    erewrite ghost_fmap_fmap, approx_oo_approx', approx'_oo_approx in J by apply Hl.
+    eexists; eauto.
+  - apply rmap_order in H as (? & _ & J').
+    eapply join_sub_trans; eauto.
+    rewrite <- H; auto.
 Qed.
 
 Definition Own g: pred rmap := allp noat && ghost_is g.
@@ -26,12 +32,16 @@ Definition Own g: pred rmap := allp noat && ghost_is g.
 Lemma Own_op: forall a b c, join a b c -> Own c = Own a * Own b.
 Proof.
   intros; apply pred_ext.
-  - intros w (Hno & Hg).
+  - intros w (Hno & [? J]).
+    eapply ghost_fmap_join in H.
+    destruct (join_assoc H J) as (b' & J1 & J2).
+    eapply ghost_fmap_join in J1; rewrite ghost_fmap_fmap, 2approx_oo_approx in J1.
+    eapply ghost_fmap_join in J2; rewrite ghost_fmap_fmap, 2approx_oo_approx, ghost_of_approx in J2.
     destruct (make_rmap (resource_at w) (ghost_approx w a) (level w))
       as (wa & Hla & Hra & Hga).
     { extensionality; apply resource_at_approx. }
     { rewrite ghost_fmap_fmap, approx_oo_approx; auto. }
-    destruct (make_rmap (resource_at w) (ghost_approx w b) (level w))
+    destruct (make_rmap (resource_at w) (ghost_approx w b') (level w))
       as (wb & Hlb & Hrb & Hgb).
     { extensionality; apply resource_at_approx. }
     { rewrite ghost_fmap_fmap, approx_oo_approx; auto. }
@@ -39,18 +49,24 @@ Proof.
     + apply resource_at_join2; auto.
       * intro; rewrite Hra, Hrb.
         apply identity_unit', Hno.
-      * rewrite Hg, Hga, Hgb.
-        apply ghost_fmap_join; auto.
-    + simpl; rewrite Hla, Hlb, Hra, Hrb, Hga, Hgb; simpl; eauto 6.
+      * rewrite Hga, Hgb; auto.
+    + simpl; rewrite Hla, Hlb, Hra, Hrb, Hga, Hgb; simpl.
+      repeat split; auto.
+      * apply join_sub_refl.
+      * eexists; eauto.
   - intros w (w1 & w2 & J & (Hnoa & Hga) & (Hnob & Hgb)).
     split.
     + intro l; apply (resource_at_join _ _ _ l) in J.
       simpl in *; rewrite <- (Hnoa _ _ _ J); auto.
     + destruct (join_level _ _ _ J) as [Hl1 Hl2].
       apply ghost_of_join in J.
-      rewrite Hga, Hgb in J.
-      eapply join_eq; eauto.
-      rewrite Hl1, Hl2; apply ghost_fmap_join; auto.
+      destruct Hga as [? Ja], Hgb as [? Jb].
+      destruct (join_assoc (join_comm Ja) J) as (? & Ja' & J').
+      destruct (join_assoc (join_comm Jb) (join_comm Ja')) as (? & Jc & J'').
+      rewrite Hl1, Hl2 in Jc.
+      eapply ghost_fmap_join, join_eq in H; [|apply join_comm, Jc]; subst.
+      destruct (join_assoc (join_comm J'') (join_comm J')) as (? & ? & ?).
+      eexists; eauto.
 Qed.
 
 Fixpoint make_join (a c : ghost) : ghost :=
@@ -143,7 +159,7 @@ Program Definition bupd (P: pred rmap): pred rmap :=
     exists m', level m' = level m /\ resource_at m' = resource_at m /\ ghost_of m' = b /\ P m'.
 Next Obligation.
 Proof.
-  repeat intro.
+  split; repeat intro.
   rewrite (age1_ghost_of _ _ H) in H1.
   rewrite <- ghost_of_approx in H0.
   destruct (ghost_joins_approx _ _ _ H1) as (J0 & Hc0).
@@ -161,7 +177,17 @@ Proof.
     congruence.
   + rewrite (age1_ghost_of _ _ Hage').
     rewrite Hg', <- Hl''; auto.
-  + eapply (proj2_sig P); eauto.
+  + eapply pred_hereditary; eauto.
+  + apply rmap_order in H as (Hl & Hr & [? J]).
+    destruct H1 as [d J'].
+    destruct (join_assoc J J') as (c' & ? & Jc').
+    eapply ghost_fmap_join in Jc'; rewrite ghost_of_approx in Jc'.
+    destruct (H0 c') as (? & Jm' & m' & ? & ? & ? & ?); eauto; subst.
+    do 2 eexists; [|exists m'; repeat split; eauto; congruence].
+    eapply join_sub_joins'; eauto.
+    { apply join_sub_refl. }
+    eapply ghost_fmap_join in H; rewrite ghost_fmap_fmap, 2approx_oo_approx in H.
+    rewrite Hl; eexists; eauto.
 Qed.
 
 Lemma bupd_intro: forall P, P |-- bupd P.
@@ -252,10 +278,10 @@ Lemma subp_bupd: forall (G : pred nat) (P P' : pred rmap), (G |-- P >=> P') ->
     G |-- (bupd P >=> bupd P')%pred.
 Proof.
   repeat intro.
-  specialize (H3 _ H4) as (? & ? & ? & ? & ? & ? & HP).
+  specialize (H4 _ H5) as (? & ? & ? & ? & ? & ? & HP).
   do 2 eexists; eauto; do 2 eexists; eauto; repeat (split; auto).
-  pose proof (necR_level _ _ H2).
-  apply (H _ H0 x0 ltac:(lia) _ (necR_refl _)); auto.
+  eapply H; try apply ext_refl; try apply necR_refl; eauto.
+  apply necR_level in H2; apply ext_level in H3; lia.
 Qed.
 
 Lemma eqp_bupd: forall (G : pred nat) (P P' : pred rmap), (G |-- P <=> P') ->
@@ -274,12 +300,10 @@ Definition ghost_fp_update_ND a B :=
 Lemma Own_update_ND: forall a B, ghost_fp_update_ND a B ->
   Own a |-- bupd (EX b : _, !!(B b) && Own b).
 Proof.
-  repeat intro.
-  destruct H0 as (Hno & Hg).
-  rewrite Hg in H1.
-  destruct H1 as [? J].
-  destruct (H (level a0) (ghost_approx a0 c)) as (g' & ? & J').
-  { eexists; eauto. }
+  unfold ghost_fp_update_ND; repeat intro.
+  destruct H0 as (Hno & J).
+  eapply join_sub_joins_trans in H1; eauto; [|apply J].
+  apply H in H1 as (g' & ? & J').
   exists (ghost_fmap (approx (level a0)) (approx (level a0)) g'); split; auto.
   destruct (make_rmap (resource_at a0)
     (ghost_fmap (approx (level a0)) (approx (level a0)) g') (level a0))
@@ -290,6 +314,7 @@ Proof.
   exists g'; repeat split; auto.
   - simpl in *; intro; rewrite Hr; auto.
   - simpl; rewrite Hg', Hl; simpl; eauto.
+    apply join_sub_refl.
 Qed.
 
 Definition ghost_fp_update (a b : ghost) :=
@@ -330,22 +355,22 @@ Qed.
 
 Lemma Own_unit: emp |-- EX a : _, !!(identity a) && Own a.
 Proof.
-  intros w ?; simpl in *.
-  exists (ghost_of w); split; [|split].
+  intros w Hemp.
+  assert (forall l, identity (w @ l)).
+  { rewrite emp_no in Hemp; auto. }
+  destruct Hemp as (e & ? & Hext).
+  exists (ghost_of e); split; [|split; auto].
   - apply ghost_of_identity; auto.
-  - intro; apply resource_at_identity; auto.
-  - rewrite ghost_of_approx; auto.
+  - apply rmap_order in Hext as (? & ? & []).
+    eexists.
+    rewrite <- (ghost_of_approx w).
+    apply ghost_fmap_join; eauto.
 Qed.
 
-Lemma Own_dealloc: forall a, Own a |-- bupd emp.
+Lemma Own_dealloc: forall a, Own a |-- emp.
 Proof.
-  intros ? w [] ??.
-  exists nil; split; [eexists; constructor|].
-  destruct (ghostless_rmap w) as (w' & ? & Hr & ?); exists w'.
-  repeat split; auto.
-  apply all_resource_at_identity.
-  - rewrite Hr; auto.
-  - apply ghost_identity; auto.
+  rewrite emp_no.
+  intros; apply andp_left1; auto.
 Qed.
 
 Definition singleton {A} k (x : A) : list (option A) := repeat None k ++ Some x :: nil.
@@ -492,11 +517,13 @@ Lemma ghost_valid_2: forall {RA: Ghost} g a1 a2 pp,
   own g a1 pp * own g a2 pp |-- !!ghost.valid_2 a1 a2.
 Proof.
   intros.
-  intros w (? & ? & J%ghost_of_join & (? & ? & Hg1) & (? & ? & Hg2)).
-  rewrite Hg1, Hg2, !ghost_fmap_singleton in J.
-  apply singleton_join_inv in J as ([] & J & ?).
-  inv J; simpl in *.
-  inv H2; repeat inj_pair_tac.
+  intros w (? & ? & J%ghost_of_join & (? & ? & [? J1]) & (? & ? & [? J2])).
+  destruct (join_assoc (join_comm J1) J) as (? & J1' & ?).
+  destruct (join_assoc (join_comm J2) (join_comm J1')) as (? & J' & ?).
+  rewrite !ghost_fmap_singleton in J'.
+  apply singleton_join_inv in J' as ([] & J' & ?).
+  inv J'; simpl in *.
+  inv H4; repeat inj_pair_tac.
   eexists; eauto.
 Qed.
 
@@ -506,6 +533,8 @@ Proof.
   intros; apply pred_ext.
   - apply exp_left; intro.
     erewrite Own_op; [apply sepcon_derives; eapply exp_right; eauto|].
+    instantiate (1 := join_valid _ _ _ (join_comm H) x).
+    instantiate (1 := join_valid _ _ _ H x).
     apply singleton_join; constructor; constructor; auto.
   - eapply derives_trans; [apply andp_right, derives_refl; apply ghost_valid_2|].
     apply prop_andp_left; intros (? & J & ?).
@@ -513,11 +542,8 @@ Proof.
     unfold own; rewrite exp_sepcon1; apply exp_left; intro.
     rewrite exp_sepcon2; apply exp_left; intro.
     erewrite <- Own_op; [eapply exp_right; eauto|].
+    instantiate (1 := H0).
     apply singleton_join; constructor; constructor; auto.
-  Unshelve.
-  eapply join_valid; eauto.
-  eapply join_valid; eauto.
-  auto.
 Qed.
 
 Lemma ghost_valid: forall {RA: Ghost} g a pp,
@@ -580,12 +606,11 @@ Proof.
       eexists; apply singleton_join_gen.
       instantiate (1 := (_, _)).
       rewrite <- H1; constructor; constructor; [constructor|]; eauto.
+      Unshelve. auto.
   - apply bupd_mono, exp_left; intro.
     apply prop_andp_left; intros (b & ? & ? & ?); subst.
     apply exp_right with b, prop_andp_right; auto.
     eapply exp_right; auto.
-  Unshelve.
-  auto.
 Qed.
 
 Lemma ghost_update: forall {RA: Ghost} g (a b: G) pp,
@@ -600,7 +625,7 @@ Proof.
 Qed.
 
 Lemma ghost_dealloc: forall {RA: Ghost} g a pp,
-  own g a pp |-- bupd emp.
+  own g a pp |-- emp.
 Proof.
   intros; unfold own.
   apply exp_left; intro; apply Own_dealloc.
@@ -613,148 +638,78 @@ Proof.
   f_equal; eauto.
 Qed.
 
-(*
-(* The addition of ghost state means that there are rmaps that have only
-   cores for ghost state, but are not cores themselves (since they have ghost
-   state at all). An rmap of this sort is not emp, but is its own unit. *)
-
-Definition cored: pred rmap := ALL P : pred rmap, ALL Q : pred rmap,
-  P && Q --> P * Q.
-
-Lemma cored_unit: forall w, cored w = join w w w.
+Lemma map_firstn : forall {A B} (f : A -> B) (l : list A) n,
+  map f (firstn n l) = firstn n (map f l).
 Proof.
-  intro; apply prop_ext; split; unfold cored; intro.
-  - edestruct (H (exactly w) (exactly w)) as (? & ? & J & Hw1 & Hw2).
-    { apply necR_refl. }
-    { split; apply necR_refl. }
-    simpl in *.
-    destruct (join_level _ _ _ J).
-    eapply necR_linear' in Hw1; try apply necR_refl; auto.
-    eapply necR_linear' in Hw2; try apply necR_refl; auto.
-    subst; auto.
-  - intros P Q ?? [HP HQ].
-    exists a', a'; repeat split; auto.
-    eapply nec_join in H as (? & ? & ? & Hw1 & Hw2); eauto.
-    destruct (join_level _ _ _ H).
-    eapply necR_linear' in Hw1; try apply H0; [|lia].
-    eapply necR_linear' in Hw2; try apply H0; [|lia].
-    subst; auto.
+  induction l; destruct n; auto; simpl.
+  rewrite IHl; auto.
 Qed.
 
-Lemma cored_dup: forall P, P && cored |-- (P && cored) * (P && cored).
+Lemma map_skipn : forall {A B} (f : A -> B) (l : list A) n,
+  map f (skipn n l) = skipn n (map f l).
 Proof.
-  intros.
-  rewrite <- (andp_dup cored) at 1.
-  rewrite <- andp_assoc.
-  intros; unfold cored at 2.
-  eapply modus_ponens.
-  + apply andp_left1, derives_refl.
-  + eapply andp_left2, allp_left, allp_left.
-    rewrite andp_dup; apply derives_refl.
+  induction l; destruct n; auto; simpl.
+  rewrite IHl; auto.
 Qed.
 
-Lemma cored_core: forall w, cored (core w).
+Lemma list_set_set : forall {A} n l (a b : A), (n <= length l)%nat ->
+  list_set (list_set l n a) n b = list_set l n b.
 Proof.
-  intro; rewrite cored_unit.
-  apply identity_unit', core_identity.
+  intros; unfold list_set.
+  rewrite (proj2 (Nat.sub_0_le _ _) H).
+  rewrite !app_length, !skipn_app, firstn_app, firstn_length, min_l, minus_diag, app_nil_r, repeat_length by auto.
+  rewrite firstn_firstn, min_l by auto; f_equal.
+  unfold length; setoid_rewrite skipn_length; f_equal.
+  - f_equal. lia.
+  - rewrite skipn_all2, skipn_nil, Nat.sub_0_r; [|rewrite firstn_length; lia].
+    rewrite (Nat.add_sub 1); auto.
 Qed.
 
-Lemma cored_duplicable: cored = cored * cored.
+Lemma nth_list_set : forall {A} n l (a : A) d, nth n (list_set l n a) d = Some a.
 Proof.
-  apply pred_ext.
-  - rewrite <- andp_dup at 1.
-    eapply derives_trans; [apply cored_dup|].
-    apply sepcon_derives; apply andp_left1; auto.
-  - intros ? (? & ? & J & J1 & J2).
-    rewrite cored_unit in *.
-    destruct (join_assoc J1 J) as (? & J' & J1').
-    eapply join_eq in J'; [|apply J]; subst.
-    destruct (join_assoc J2 (join_comm J)) as (? & J' & J2').
-    eapply join_eq in J'; [|apply join_comm, J]; subst.
-    destruct (join_assoc (join_comm J1') (join_comm J2')) as (? & J' & ?).
-    eapply join_eq in J'; [|apply J]; subst; auto.
+  intros; unfold list_set.
+  rewrite 2app_nth2; rewrite ?repeat_length, ?firstn_length; try lia.
+  match goal with |- nth ?n _ _ = _ => replace n with O by lia end; auto.
 Qed.
 
-Lemma cored_emp: cored |-- bupd emp.
+Lemma own_core : forall {RA: Ghost} g (a : G) pp,
+  a = core a -> forall w, own g a pp w -> own g a pp (core w).
 Proof.
-  intro; rewrite cored_unit; intros J ??.
-  exists nil; split; [eexists; constructor|].
-  destruct (make_rmap (resource_at a) nil (level a)) as (m' & ? & Hr & Hg); auto.
-  { intros; extensionality; apply resource_at_approx. }
-  exists m'; repeat split; auto.
-  apply all_resource_at_identity.
-  - intro; rewrite Hr.
-    apply (resource_at_join _ _ _ l) in J.
+  unfold own, Own, ghost_is; intros; simpl in *.
+  destruct H0 as (Hv & _ & ? & J).
+  exists Hv; split; auto.
+  - intros ?; apply resource_at_core_identity.
+  - rewrite ghost_of_core.
+    rewrite ghost_fmap_singleton in J.
+    apply singleton_join_inv_gen in J as (J & ((?, (?, ?)), ?) & Hg & Hw).
+    rewrite Hg in J.
+    rewrite Hw, ghost_core_eq.
+    unfold list_set; rewrite !map_app, map_firstn, map_repeat.
+    unfold map at 2; setoid_rewrite map_skipn.
+    rewrite ghost_fmap_singleton; simpl Datatypes.option_map.
+    erewrite <- map_length.
+    rewrite level_core.
     inv J.
-    + apply join_self, identity_share_bot in RJ; subst.
-      apply NO_identity.
-    + apply join_self, identity_share_bot in RJ; subst.
-      contradiction shares.bot_unreadable.
-    + apply PURE_identity.
-  - rewrite Hg, <- (ghost_core nil); apply core_identity.
+    + inj_pair_tac.
+      eexists; apply singleton_join_gen.
+      setoid_rewrite (map_nth _ _ None). rewrite <- H2.
+      match goal with |- join ?a _ ?c => assert (a = c) as ->; [|constructor] end.
+      do 3 f_equal. apply exist_ext; auto.
+    + destruct a2, H3 as [J ?].
+      inv J.
+      repeat inj_pair_tac.
+      apply join_core_sub in H5 as [].
+      setoid_rewrite <- list_set_set.
+      eexists; apply singleton_join_gen.
+      rewrite nth_list_set.
+      instantiate (1 := (_, _)).
+      constructor. split; simpl in *; [|split; auto].
+      constructor. rewrite H; eauto.
+      Unshelve.
+      * inv H0; auto.
+      * rewrite map_length.
+        destruct (le_dec (length x) g); [|lia].
+        rewrite nth_overflow in H1 by auto; discriminate.
+      * apply join_comm, join_valid in H2; auto.
+        apply core_valid; auto.
 Qed.
-
-Lemma emp_cored : emp |-- cored.
-Proof.
-  repeat intro; simpl in *.
-  destruct H1.
-  eapply nec_identity, identity_unit' in H; eauto.
-Qed.
-
-Lemma cored_later : |> cored = cored || |> FF.
-Proof.
-  apply pred_ext.
-  - repeat intro.
-    destruct (age1 a) eqn: Ha.
-    + left; rewrite cored_unit.
-      specialize (H r); spec H.
-      { constructor; auto. }
-      rewrite cored_unit in H.
-      apply resource_at_join2; auto.
-      * intros.
-        apply (resource_at_join _ _ _ loc) in H.
-        erewrite age_resource_at in H by eauto.
-        destruct (a @ loc); inv H; constructor; auto.
-      * apply ghost_of_join in H.
-        erewrite age1_ghost_of in H by eauto.
-        induction (ghost_of a); constructor; inv H; [|apply IHg; auto].
-        destruct a0 as [[]|]; [inv H3 | constructor].
-        inv H2; repeat constructor; auto.
-    + right; repeat intro.
-      apply laterR_power_age in H0 as (? & ? & ? & ?).
-      unfold age in *; congruence.
-  - apply orp_left.
-    + apply now_later.
-    + apply later_derives, FF_derives.
-Qed.*)
-
-(*Lemma join_singleton_inv: forall k a b RA c v pp,
-  join a b (singleton k (existT _ RA (exist _ (core c) v), pp)) ->
-  a = singleton k (existT _ RA (exist _ (core c) v), pp) \/ b = singleton k (existT _ RA (exist _ (core c) v), pp).
-Proof.
-  induction k; unfold singleton; intros; simpl in *.
-  - inv H; auto.
-    assert (m1 = nil /\ m2 = nil) as [] by (inv H5; auto); subst.
-    inv H4; auto.
-    destruct a0, a3; inv H2; simpl in *.
-    inv H0; inv H.
-    inj_pair_tac.
-    pose proof (core_unit a0) as J.
-    erewrite join_core, core_idem in J by eauto.
-    unfold unit_for in J.
-    eapply join_positivity in J; eauto; subst.
-    left; repeat f_equal; apply proof_irr.
-  - inv H; auto.
-    edestruct IHk as [|]; eauto; [left | right]; f_equal; auto; inv H4; auto.
-Qed.*)
-
-(*Lemma own_cored: forall {RA: Ghost} g a pp, join a a a -> own g a pp |-- cored.
-Proof.
-  intros; intros ? (? & ? & Hg).
-  rewrite cored_unit; simpl in *.
-  apply resource_at_join2; auto.
-  - intro; apply identity_unit'.
-    eapply necR_resource_at_identity; eauto.
-  - rewrite Hg, ghost_fmap_singleton.
-    apply singleton_join; repeat constructor; auto.
-Qed.*)

--- a/veric/res_predicates.v
+++ b/veric/res_predicates.v
@@ -431,13 +431,13 @@ Proof.
    rewrite <- H0 in H1; auto.
 Qed.
 
-(*Definition extensible_jam: forall A (S': A -> Prop) S (P Q: A -> pred rmap),
+Definition extensible_jam: forall A (S': A -> Prop) S (P Q: A -> pred rmap),
       (forall (x: A), boxy extendM (P x)) ->
       (forall x, boxy extendM (Q x)) ->
       forall x, boxy extendM  (@jam _ _ _ _ _ _ _ _ _ S' S P Q x).
 Proof.
   apply boxy_jam; auto.
-Qed.*)
+Qed.
 
 Definition jam_vacuous:
   forall A JA PA SA agA AgeA EO EA B S S' P Q, (forall x:B, ~ S x) -> @jam A JA PA SA agA AgeA EO EA B S S' P Q = Q.

--- a/veric/rmaps_lemmas.v
+++ b/veric/rmaps_lemmas.v
@@ -1254,6 +1254,7 @@ Definition empty_rmap (n:nat) : rmap := R.squash (n, empty_rmap').
 Lemma emp_empty_rmap: forall n, emp (empty_rmap n).
 Proof.
 intros.
+do 2 eexists; [|reflexivity].
 intro; intros.
 apply rmap_ext.
 apply join_level in H as []; auto.
@@ -1967,7 +1968,7 @@ Proof.
   intros; unfold id_core; rewrite core_idem; reflexivity.
 Qed.
 
-(* rmaps still induce a flat sepalg, but only with this weaker core. *)
+(*(* rmaps still induce a flat sepalg, but only with this weaker core. *)
 Instance FSep_rmap : FSep_alg rmap.
 Proof.
   exists id_core.
@@ -2005,7 +2006,7 @@ Lemma sepcon_convert : sepcon(SA := fsep_sep FSep_rmap) = sepcon(SA := Sep_rmap)
 Proof.
   intros; extensionality P; extensionality Q.
   apply pred_ext; intros ? (? & ? & ? & ? & ?); do 3 eexists; eauto.
-Qed.
+Qed.*)
 
 Lemma core_YES: forall sh rsh k pp, core (YES sh rsh k pp) = NO Share.bot bot_unreadable.
 Proof.

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -804,17 +804,6 @@ Proof.
     auto.
 Qed.
 
-Lemma corable_unfash:
-  forall (A : Type) (JA : Join A) (PA : Perm_alg A) (SA : Sep_alg A) (agA : ageable A) 
-    (AgeA : Age_alg A) (P : pred nat), corable (! P).
-Proof.
-  intros.
-  unfold unfash; simpl.
-  hnf; simpl; intros.
-  rewrite level_core.
-  auto.
-Qed.
-
 Section believe_monotonicity.
 Context {CS: compspecs} {Espec: OracleKind}.
 

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -35,55 +35,22 @@ Definition jsafeN {Z} (Hspec : juicy_ext_spec Z) (ge: genv) :=
   @jsafeN_ genv _ _ genv_symb_injective (*(genv_symb := fun ge: genv => Genv.genv_symb ge)*)
                (cl_core_sem ge) Hspec ge.
 
-Lemma ext_join_approx : forall {Z} (z : Z) n g,
-  joins g (Some (ghost_PCM.ext_ref z, NoneP) :: nil) ->
-  joins (ghost_fmap (approx n) (approx n) g) (Some (ghost_PCM.ext_ref z, NoneP) :: nil).
-Proof.
-  intros.
-  destruct H.
-  change (Some (ghost_PCM.ext_ref z, NoneP) :: nil) with
-    (ghost_fmap (approx n) (approx n) (Some (ghost_PCM.ext_ref z, NoneP) :: nil)).
-  eexists; apply ghost_fmap_join; eauto.
-Qed.
-
-Lemma ext_join_sub_approx : forall {Z} (z : Z) n g,
-  join_sub (Some (ghost_PCM.ext_ref z, NoneP) :: nil) g ->
-  join_sub (Some (ghost_PCM.ext_ref z, NoneP) :: nil) (ghost_fmap (approx n) (approx n) g).
-Proof.
-  intros.
-  destruct H.
-  change (Some (ghost_PCM.ext_ref z, NoneP) :: nil) with
-    (ghost_fmap (approx n) (approx n) (Some (ghost_PCM.ext_ref z, NoneP) :: nil)).
-  eexists; apply ghost_fmap_join; eauto.
-Qed.
-
-Lemma ext_join_unapprox : forall {Z} (z : Z) n g,
-  joins (ghost_fmap (approx n) (approx n) g) (Some (ghost_PCM.ext_ref z, NoneP) :: nil) ->
-  joins g (Some (ghost_PCM.ext_ref z, NoneP) :: nil).
-Proof.
-  intros.
-  destruct H as (g' & J).
-  destruct g; [eexists; constructor|].
-  inv J.
-  exists (a3 :: g); repeat constructor.
-  destruct o; inv H4; constructor.
-  destruct p; inv H1; constructor; simpl in *; auto.
-  destruct p; simpl in *.
-  inv H0.
-  inv H1.
-  inj_pair_tac.
-  constructor; auto.
-  unfold NoneP; f_equal; auto.
-Qed.
-
-Program Definition ext_compat {Z} (ora : Z) : mpred :=
+(*Program Definition ext_compat {Z} (ora : Z) : mpred :=
   fun w => joins (ghost_of w) (Some (ghost_PCM.ext_ref ora, NoneP) :: nil).
 Next Obligation.
 Proof.
-  repeat intro.
+  split; repeat intro.
   erewrite age1_ghost_of by eauto.
   apply ext_join_approx; auto.
-Qed.
+
+  apply rmap_order in H as (_ & _ & ? & Hg).
+  destruct H0.
+  inv H.
+  - rewrite <- H1 in Hg; inv Hg.
+Qed.*)
+
+Definition ext_compat {Z} (ora : Z) (w : rmap) :=
+  joins (ghost_of w) (Some (ghost_PCM.ext_ref ora, NoneP) :: nil).
 
 Inductive contx :=
 | Stuck
@@ -126,13 +93,13 @@ Program Definition assert_safe
      (ctl: contx) : assert :=
   fun rho => bupd (assert_safe'_ (Espec : OracleKind) ge f ve te ctl rho).
 Next Obligation.
-  intro; intros.
-   hnf; intros.
+  split; repeat intro.
    subst.
    destruct (oracle_unage _ _ H) as [jm0 [? ?]].
    specialize (H0 ora jm0).
-   spec H0. 
-   {simpl in H1|-*. erewrite age1_ghost_of in H1 by eauto.
+   spec H0.
+   { unfold ext_compat in *.
+simpl in H1|-*. erewrite age1_ghost_of in H1 by eauto.
       eapply ext_join_unapprox; eauto. }
    specialize (H0 (eq_refl _) H3).
    spec H0. apply age_level in H. lia.
@@ -150,6 +117,33 @@ Next Obligation.
   eapply age_safe; eauto.
   apply (H0 e v'); auto;  rewrite (age_jm_dry H2); auto.
   eapply age_safe; eauto.
+
+  subst. destruct (ext_ord_juicy_mem' _ _ H) as (? & Hd & Ha).
+  destruct (proj1 (rmap_order _ _) H) as (Hl & Hr & Hg).
+  destruct (juicy_mem_resource jm a) as (jm0 & Hjm & Hdry).
+  { congruence. }
+  specialize (H0 ora jm0).
+   spec H0.
+   { unfold ext_compat in *.
+     eapply join_sub_joins_trans; eauto. }
+   specialize (H0 (eq_refl _) Hjm).
+   spec H0. rewrite Hl; auto.
+  subst.
+  rewrite <- Hjm in *.
+  change (level (m_phi jm)) with (level jm).
+  change (level (m_phi jm0)) with (level jm0) in *.
+  assert (ext_order jm0 jm) by (split; auto; congruence).
+  destruct ctl; auto. destruct c; try contradiction.
+  eapply ext_safe; eauto.
+  eapply ext_safe; eauto.
+  eapply ext_safe; eauto.
+  eapply ext_safe; eauto.
+  destruct o; intros; auto;
+  eapply ext_safe; eauto.
+  destruct o; intros; auto.
+  eapply ext_safe; eauto.
+  apply (H0 e v'); auto; rewrite Hdry; auto.
+  eapply ext_safe; eauto.
 Qed.
 
 Definition list2opt {T: Type} (vl: list T) : option T :=
@@ -221,19 +215,19 @@ Record semaxArg :Type := SemaxArg {
 Definition ext_spec_pre' (Espec: OracleKind) (ef: external_function)
    (x': ext_spec_type OK_spec ef) (ge_s: injective_PTree block)
    (ts: list typ) (args: list val) (z: OK_ty) : pred juicy_mem :=
-  exist (hereditary age)
+  exist (fun p => hereditary age p /\ hereditary ext_order p)
      (ext_spec_pre OK_spec ef x' ge_s ts args z)
-     (JE_pre_hered _ _ _ _ _ _ _ _).
+     (conj (JE_pre_hered _ _ _ _ _ _ _ _) (JE_pre_ext _ _ _ _ _ _ _ _) ).
 
 Program Definition ext_spec_post' (Espec: OracleKind)
    (ef: external_function) (x': ext_spec_type OK_spec ef) (ge_s: injective_PTree block)
    (tret: rettype) (ret: option val) (z: OK_ty) : pred juicy_mem :=
-  exist (hereditary age)
+  exist (fun p => hereditary age p /\ hereditary ext_order p)
    (ext_spec_post OK_spec ef x' ge_s tret ret z)
-     (JE_post_hered _ _ _ _ _ _ _ _).
+     (conj (JE_post_hered _ _ _ _ _ _ _ _) (JE_post_ext _ _ _ _ _ _ _ _) ).
 
-Definition juicy_mem_pred (P : pred rmap) (jm: juicy_mem): pred nat :=
-     # diamond fashionM (exactly (m_phi jm) && P).
+(*Definition juicy_mem_pred (P : pred rmap) (jm: juicy_mem): pred nat :=
+     # diamond fashionM (exactly (m_phi jm) && P).*)
 
 Definition make_ext_rval  (gx: genviron) (tret: rettype) (v: option val):=
   match tret with AST.Tvoid => mkEnviron gx (Map.empty _) (Map.empty _) 
@@ -243,6 +237,19 @@ Definition make_ext_rval  (gx: genviron) (tret: rettype) (v: option val):=
                               (Map.set 1%positive v' (Map.empty _))
   | None => mkEnviron gx (Map.empty _) (Map.empty _)
   end end.
+
+Program Definition if_ext_compat {Z} (z : Z) (P : pred juicy_mem) : pred juicy_mem :=
+  fun jm => ext_compat z (m_phi jm) -> P jm.
+Next Obligation.
+Proof.
+  unfold ext_compat; split; repeat intro.
+  - eapply pred_hereditary, H0; auto.
+    erewrite age1_ghost_of in H1 by (apply age1_juicy_mem_Some; eauto).
+    apply ext_join_unapprox in H1; auto.
+  - eapply pred_upclosed, H0; auto.
+    rewrite rmap_order in H; destruct H as (_ & _ & _ & ?).
+    eapply join_sub_joins_trans; eauto.
+Qed.
 
 Definition semax_external
   (Hspec: OracleKind) ef
@@ -257,8 +264,8 @@ Definition semax_external
    !!Val.has_type_list args (sig_args (ef_sig ef)) &&
    juicy_mem_op (P Ts x (filter_genv gx, args) * F) >=>
    EX x': ext_spec_type OK_spec ef,
-    (ALL z:_, juicy_mem_op (ext_compat z) -->
-     ext_spec_pre' Hspec ef x' (genv_symb_injective gx) ts args z) &&
+    (ALL z:_, if_ext_compat z
+       (ext_spec_pre' Hspec ef x' (genv_symb_injective gx) ts args z)) &&
      ! ALL tret: rettype, ALL ret: option val, ALL z': OK_ty,
       ext_spec_post' Hspec ef x' (genv_symb_injective gx) tret ret z' >=>
           juicy_mem_op (Q Ts x (make_ext_rval (filter_genv gx) tret ret) * F).
@@ -287,70 +294,37 @@ apply allp_derives; intros g.
 apply allp_right; intros ts.
 apply allp_right; intros x.
 destruct Hsub as [_ H]; simpl in H.
-intros n N m NM F typs vals y MY z YZ [HT [z1 [z2 [JZ [Z1 Z2]]]]].
-specialize (H ts x (filter_genv g, vals) z1).
-(*rewrite TTL2 in HSIG.*) Opaque bupd.
-simpl in H. Transparent bupd. simpl in N. rewrite HSIG in HT; simpl in HT.
-assert (HP: argsHaveTyps vals argtypes /\ P ts x (filter_genv g, vals) z1). {
-  split; trivial. clear -HT. 
+intros n N m NM F typs vals y MY ? z YZ EZ [HT HP].
+simpl in HP.
+rewrite HSIG in HT; simpl in HT.
+eapply sepcon_derives, bupd_frame_r in HP; [| intros ??; eapply H; split; eauto | apply derives_refl].
+2: { clear -HT. 
   apply has_type_list_Forall2 in HT.
-  eapply Forall2_implication; [ | apply HT]; auto. } specialize (H HP). clear HP.
-simpl in H. specialize (H (ghost_of z2)).
-destruct H as [g' [HJ2 [z1' [HL [HR [HG [ts1 [x1
-            [FRM [[z11 [z12 [JZ1 [H_FRM H_P1]]]] HQ]]]]]]]]]].
-{ rewrite <- (ghost_of_approx z1). exists (ghost_approx z1 (ghost_of (m_phi z))).
-  apply ghost_fmap_join. now apply ghost_of_join. } subst g'.
-rewrite <- (ghost_of_approx z1') in HJ2.
-replace (ghost_approx z1' (ghost_of z1')) with
-    (ghost_approx z1 (ghost_of z1')) in HJ2 by now rewrite HL.
-destruct HJ2 as [gz' HJ2]. pose proof (ghost_same_level_gen _ _ _ _ HJ2) as HGA.
-rewrite <- !age_to_resource_at.age_to_ghost_of in HJ2.
-destruct (join_level _ _ _ JZ) as [HLz1z HLz2z].
-rewrite !age_to.age_to_eq in HJ2; auto. 2: now rewrite <- HLz2z in HLz1z.
-assert (HRA: resource_fmap (approx (level z1)) (approx (level z1)) oo
-                           (resource_at (m_phi z)) = resource_at (m_phi z)). {
-  replace (level z1) with (level (m_phi z)).
-  apply resources_same_level. intros. exists (core (m_phi z @ l)).
-  apply join_comm. apply core_unit. }
-destruct (make_rmap _ _ _ HRA HGA) as [pz' [HL2 [HR2 HG]]]. clear HGA HRA.
-assert (JZ2: join z1' z2 pz'). {
-  apply resource_at_join2.
-  - now rewrite <- HL2 in HL.
-  - rewrite <- HLz1z in HLz2z. now rewrite <- HL2 in HLz2z.
-  - intros. rewrite HR, HR2. now apply resource_at_join.
-  - now rewrite HG. }
-destruct (juicy_mem_resource _ _ HR2) as [z' [HP _]]. subst pz'.
-assert (MY': m >= level z'). {
-  unfold ge in MY |-* . transitivity (level y); auto. apply necR_level in YZ.
-  unfold ge in YZ. cut (level z' = level z).
-  - intros. now rewrite H.
-  - rewrite !level_juice_level_phi. now transitivity (level z1). }
+  eapply Forall2_implication; [ | apply HT]; auto.
+}
+clear H.
+edestruct HP as (? & ? & z0 & ? & ? & ? & H); subst.
+{ eexists. rewrite ghost_fmap_core. apply join_comm, core_unit. }
+destruct H as [z1 [z2 [JZ [[ts1 [x1 [FRM [[z11 [z12 [JZ1 [H_FRM H_P1]]]] HQ]]]] Z2]]]].
 specialize (N ts1 x1). apply join_comm in JZ1.
-destruct (join_assoc JZ1 JZ2) as [zz [JJ JJzz]]. apply join_comm in JJ.
-simpl.
-destruct (N _ NM (sepcon F FRM) typs vals _ MY' _ (necR_refl z')) as
-    [est [EST1 EST2]]; clear N.
+destruct (join_assoc JZ1 JZ) as [zz [JJ JJzz]]. apply join_comm in JJ.
+destruct (juicy_mem_resource _ _ H2) as (jm0 & ? & ?); subst.
+edestruct (N _ NM (sepcon F FRM) typs vals jm0) as [est [EST1 EST2]]; clear N; eauto.
+{ apply necR_level in YZ. destruct EZ as [_ EZ%ext_level]. rewrite !level_juice_level_phi in *. lia. }
 { rewrite HSIG; simpl. split; trivial.
   exists z12, zz; split3. trivial. trivial.
   exists z2, z11; split3; trivial. }
-exists est; split.
-- simpl. intros. apply EST1; auto. apply necR_trans with z; auto.
+(*exists est; split.
+{ simpl. intros. apply EST1; auto. apply necR_trans with z; auto.
   rewrite age_to.necR_age_to_iff. admit.
-- simpl; intros. assert (level (m_phi z') >= level (m_phi y0)). {
-    cut (level (m_phi z') = level (m_phi z)).
-    - intros. now rewrite H2.
-    - now transitivity (level z1). }
-  destruct (EST2 b b0 b1 _ H2 _ H0 H1) as [u1 [u2 [JU [U1 U2]]]]; clear EST2.
-  destruct U2 as [w1 [w2 [JW [W1 W2]]]]. apply join_comm in JU.
-  destruct (join_assoc JW JU) as [v [JV V]]. apply join_comm in V.
-  exists v, w1; split3; trivial.
-  specialize (HQ (make_ext_rval (filter_genv g) b b0) v).
-  assert ((!! (ve_of (make_ext_rval (filter_genv g) b b0) = Map.empty (block * type))
-           && (FRM * Q1 ts1 x1 (make_ext_rval (filter_genv g) b b0))) v). {
-    simpl. split.
-    - simpl. destruct b,b0; reflexivity.
-    - exists w2, u1; split3; trivial. }
-  specialize (HQ H3). simpl in HQ.
+simpl; intros.
+destruct (EST2 b b0 b1 _ H _ H0 H1) as [u1 [u2 [JU [U1 U2]]]]; clear EST2.
+destruct U2 as [w1 [w2 [JW [W1 W2]]]]. apply join_comm in JU.
+destruct (join_assoc JW JU) as [v [JV V]]. apply join_comm in V.
+exists v, w1; split3; trivial.
+apply HQ; clear HQ; split.
++ simpl. destruct b,b0; reflexivity.
++ exists w2, u1; split3; trivial.*)
 Admitted.
 
 Definition tc_option_val (sig: type) (ret: option val) :=
@@ -566,10 +540,9 @@ Proof.
   apply allp_derives; intros gx.
   apply allp_derives; intros Delta'.
   apply allp_derives; intros CS''.
-  intros w W m WM [TC [M1 M2]] u MU U. specialize (W m WM).
-  assert (X: (!! (tycontext_sub Delta Delta' /\ cenv_sub (@cenv_cs CS) (@cenv_cs CS'') /\ cenv_sub (@cenv_cs CS'') gx)) m).
-  { clear W U. split. apply TC. split; trivial. intros i. eapply sub_option_trans. apply CSUB. apply M1. }
-  apply (W X); trivial.
+  apply imp_derives; auto.
+  intros ? [TC [M1 M2]].
+  split. apply TC. split; trivial. intros i. eapply sub_option_trans. apply CSUB. apply M1.
 Qed.
 Lemma semax'_cssub {CS CS'} (CSUB: cspecs_sub  CS CS') Espec Delta P c R:
       @semax' CS Espec Delta P c R |-- @semax' CS' Espec Delta P c R.
@@ -636,14 +609,14 @@ Qed.
 
 (* Copied from semax_switch. *)
 
-Lemma fash_TT: forall {A} {agA: ageable A}, @unfash A agA TT = TT.
+Lemma fash_TT: forall {A} {agA: ageable A} {EO: Ext_ord A}, @unfash A agA EO TT = TT.
 Proof.
 intros.
 apply pred_ext; intros ? ?; apply I.
 Qed.
 
 Lemma allp_andp: 
-  forall {A} {NA: ageable A} {B: Type} (b0: B) (P: B -> pred A) (Q: pred A),
+  forall {A} {NA: ageable A} {EO: Ext_ord A} {B: Type} (b0: B) (P: B -> pred A) (Q: pred A),
    (allp P && Q = allp (fun x => P x && Q))%pred.
 Proof.
 intros.
@@ -656,42 +629,36 @@ apply (H b0).
 Qed.
 
 Lemma unfash_prop_imp:
-  forall {A} {agA: ageable A} (P: Prop) (Q: pred nat),
-  (@unfash _ agA (prop P --> Q) = prop P --> @unfash _ agA Q)%pred.
+  forall {A} {agA: ageable A} {EO: Ext_ord A} (P: Prop) (Q: pred nat),
+  (@unfash _ agA _ (prop P --> Q) = prop P --> @unfash _ agA _ Q)%pred.
 Proof.
 intros.
 apply pred_ext; repeat intro.
-apply H; auto. apply necR_level'; auto.
-hnf in H.
-specialize (H a (necR_refl _) H1).
-eapply pred_nec_hereditary; try apply H0.
-apply H.
+simpl in H; eapply H in H2; eauto.
+eapply pred_upclosed, pred_nec_hereditary; eauto.
+simpl in H.
+specialize (H a _ (necR_refl _)  (ext_refl _) H2).
+eapply pred_upclosed, pred_nec_hereditary; eauto.
 Qed.
 
 Import age_to.
 
 Lemma unfash_imp:
-  forall {A} {NA: ageable A} (P Q: pred nat),
-  (@unfash A _ (P --> Q) = (@unfash A _ P) --> @unfash A _ Q)%pred.
+  forall {A} {NA: ageable A} {EO: Ext_ord A} (P Q: pred nat),
+  (@unfash A _ _ (P --> Q) = (@unfash A _ _ P) --> @unfash A _ _ Q)%pred.
 Proof.
 intros.
 apply pred_ext; repeat intro.
-apply H; auto. apply necR_level'; auto.
-specialize (H (age_to a' a)).
-spec H.
-apply age_to_necR.
-spec H.
-do 3 red. 
-rewrite level_age_to; auto.
-apply necR_level in H0. apply H0.
-do 3 red in H.
-rewrite level_age_to in H; auto.
+apply ext_level in H1.
+simpl in H; eapply H in H2; [| eapply necR_level', H0 | ..]; auto.
+simpl in *; subst a''.
+specialize (H (age_to a' a) _ (age_to_necR _ _) (ext_refl _)).
 apply necR_level in H0.
-apply H0.
+rewrite level_age_to in H; auto.
 Qed.
 
-Lemma unfash_andp:  forall {A} {agA: ageable A} (P Q: pred nat),
-  (@unfash A agA (andp P Q) = andp (@unfash A agA P) (@unfash A agA Q)).
+Lemma unfash_andp:  forall {A} {agA: ageable A} {EO: Ext_ord A} (P Q: pred nat),
+  (@unfash A agA _ (andp P Q) = andp (@unfash A agA _ P) (@unfash A agA _ Q)).
 Proof.
 intros.
 apply pred_ext.
@@ -703,7 +670,7 @@ split; auto.
 Qed.
 
 Lemma andp_imp_e':
-  forall (A : Type) (agA : ageable A) (P Q : pred A),
+  forall (A : Type) (agA : ageable A) (EO: Ext_ord A) (P Q : pred A),
    P && (P --> Q) |-- P && Q.
 Proof.
 intros.
@@ -716,7 +683,7 @@ Qed.
 (* End copied from semax_switch. *)
 
 Lemma unfash_fash:
-  forall (A : Type) (agA : ageable A) (P : pred A),
+  forall (A : Type) (agA : ageable A) (EO : Ext_ord A) (P : pred A),
    unfash (fash P) |-- P.
 Proof.
   intros.
@@ -728,7 +695,7 @@ Proof.
 Qed.
 
 Lemma imp_imp:
-  forall (A : Type) (agA : ageable A) (P Q R: pred A),
+  forall (A : Type) (agA : ageable A) (EO : Ext_ord A) (P Q R: pred A),
     P --> (Q --> R) = P && Q --> R.
 Proof.
   intros.
@@ -746,7 +713,7 @@ Proof.
 Qed.
 
 Lemma imp_allp:
-  forall B (A : Type) (agA : ageable A) (P: pred A) (Q: B -> pred A),
+  forall B (A : Type) (agA : ageable A) (EO : Ext_ord A) (P: pred A) (Q: B -> pred A),
     P --> allp Q  = ALL x: B, P --> Q x.
 Proof.
   intros.
@@ -817,8 +784,8 @@ Lemma guard_mono gx Delta Gamma f (P Q:assert) ctl
                      (funassert Delta (construct_rho (filter_genv gx) e te))):
   @guard Espec gx Delta f P ctl |--
   @guard Espec gx Gamma f Q ctl.
-Proof. intros n G te e r R a' A' [[[X1 X2] X3] X4].
-  apply (G te e r R a' A').
+Proof. intros n G te e r R ? a' A' ? [[[X1 X2] X3] X4].
+  eapply G; eauto.
   split; [split; [split;[auto | rewrite GD2; trivial] | apply GD3; trivial] | apply GD4; trivial].
 Qed.
 
@@ -833,7 +800,7 @@ Lemma believe_antimonoR gx Delta Gamma Gamma'
   (DG1: forall id spec, (glob_specs Gamma') ! id = Some spec ->
                         (glob_specs Gamma) ! id = Some spec):
   @believe CS Espec Delta gx Gamma |-- @believe CS Espec Delta gx Gamma'.
-Proof. intros n B v sig cc A P Q k nec CL. apply B; trivial. eapply claims_antimono; eauto. Qed.
+Proof. intros n B v sig cc A P Q ? k nec ? CL. eapply B; eauto. eapply claims_antimono; eauto. Qed.
 
 Lemma cenv_sub_complete_legal_cosu_type cenv1 cenv2 (CSUB: cenv_sub cenv1 cenv2): forall t,
     @composite_compute.complete_legal_cosu_type cenv1 t = true ->
@@ -868,9 +835,9 @@ Proof. destruct BI as [b [f [Hv X]]].
     + clear - CSUB H0 H4. forget (fn_vars f) as vars. induction vars.
       constructor. inv H4. inv H0.  specialize (IHvars H5 H3).
       constructor; [ rewrite (cenv_sub_sizeof CSUB); trivial | apply IHvars].
-  - intros PSI CS'' w W HSUB u WU HU ts x. apply (X PSI CS'' w W); trivial.
+  - intros PSI CS'' ? w W ? HSUB ? u WU ? HU ts x. eapply X; eauto.
     + simpl; intros. eapply tycontext_sub_trans. 2: apply HSUB. eauto.
-    + clear - CSUB HU; simpl. apply (cenv_sub_trans CSUB HU). 
+    + clear - CSUB HU; simpl. apply (cenv_sub_trans CSUB HU).
 Qed.
 Lemma believe_internal_mono {CS'} gx Delta Delta' v sig cc A P Q
   (SUB: forall f, tycontext_sub (func_tycontext' f Delta)
@@ -889,11 +856,10 @@ Lemma believe_cenv_sub_L {CS'} gx Delta Delta' Gamma
   (CSUB: cenv_sub (@cenv_cs CS) (@cenv_cs CS')):
   @believe CS Espec Delta gx Gamma |-- @believe CS' Espec Delta' gx Gamma.
 Proof.
- intros n B v sig cc A P Q k nec CL.
- destruct (B v sig cc A P Q k nec).
-+ eapply claims_antimono; eauto.
+ intros n B; repeat intro.
+ edestruct B; eauto.
 + left; trivial.
-+ right. clear -SUB CSUB H.
++ right. clear -SUB CSUB H H2.
   apply (@believe_internal_cenv_sub CS' gx Delta); eauto.
 Qed.
 Lemma believe_monoL {CS'} gx Delta Delta' Gamma
@@ -920,7 +886,7 @@ Lemma believe_internal__mono sem gx Delta Delta' v sig cc A P Q
 (believe_internal_ CS sem gx Delta' v sig cc A P Q) k.
 Proof. destruct BI as [b [f [Hv X]]].
   exists b, f; split; [trivial | clear Hv].
-  intros PSI CS' w W HSUB u WU HU ts x. apply (X PSI CS' w W); trivial.
+  intros PSI CS' ? w W ? HSUB u WU HU ts x. eapply X; eauto.
   simpl; intros. eapply tycontext_sub_trans. 2: apply HSUB. eauto.
 Qed.
 End believe_monotonicity.
@@ -929,28 +895,30 @@ Lemma semax__mono {CS} Espec Delta Delta'
   (SUB: tycontext_sub Delta Delta') sem P c R:
   derives (@semax_ Espec sem {| sa_cs := CS; sa_Delta := Delta; sa_P := P; sa_c := c; sa_R := R |})
       (@semax_ Espec sem {| sa_cs:=CS; sa_Delta := Delta'; sa_P := P; sa_c := c; sa_R := R |}).
-Proof. unfold semax_; intros w W.
-intros gx Gamma CS' n N [HSUB HCS] m M B k F a A CL.
-assert (X: tycontext_sub Delta Gamma) by (eapply tycontext_sub_trans; eauto).
-apply (W gx Gamma CS' n N (conj X HCS) m M B k F a A CL).
+Proof. unfold semax_.
+  repeat (apply allp_derives; intros).
+  eapply imp_derives; auto.
+  intros ? [HSUB HCS]; split; auto.
+  eapply tycontext_sub_trans; eauto.
 Qed.
 
 Lemma semax_mono {CS} Espec Delta Delta' P Q
-  (SUB: tycontext_sub Delta Delta') c w
-  (Hyp: @semax' CS Espec Delta P c Q w):
-   @semax' CS Espec Delta' P c Q w.
+  (SUB: tycontext_sub Delta Delta') c:
+  @semax' CS Espec Delta P c Q |--
+   @semax' CS Espec Delta' P c Q.
 Proof.
 rewrite semax_fold_unfold in *.
-intros gx Gamma CS' m M [HH HCS].
-assert (SUB': tycontext_sub Delta Gamma) by (eapply tycontext_sub_trans; eassumption).
-apply (Hyp gx Gamma CS' m M (conj SUB' HCS)).
+  repeat (apply allp_derives; intros).
+  eapply imp_derives; auto.
+  intros ? [HSUB HCS]; split; auto.
+  eapply tycontext_sub_trans; eauto.
 Qed.
 
 Lemma semax_mono_box {CS} Espec Delta Delta' P Q
   (SUB: tycontext_sub Delta Delta') c w
-  (BI: @box nat ag_nat (@laterM nat ag_nat)
+  (BI: @box nat ag_nat _ (@laterM nat ag_nat _)
           (@semax' CS Espec Delta P c Q) w):
-  @box nat ag_nat (@laterM nat ag_nat)
+  @box nat ag_nat _ (@laterM nat ag_nat _)
           (@semax' CS Espec Delta' P c Q) w.
 Proof. eapply box_positive; [ clear BI | apply BI].
 intros a Hyp.
@@ -961,9 +929,9 @@ Qed.
 Lemma semax_mono' {CS} Espec Delta Delta' P Q
   (SUB: forall f, tycontext_sub (func_tycontext' f Delta)
                                 (func_tycontext' f Delta')) c w f
-  (BI: @box nat ag_nat (@laterM nat ag_nat)
+  (BI: @box nat ag_nat _ (@laterM nat ag_nat _)
           (@semax' CS Espec (func_tycontext' f Delta) P c Q) w):
-  @box nat ag_nat (@laterM nat ag_nat)
+  @box nat ag_nat _ (@laterM nat ag_nat _)
           (@semax' CS Espec (func_tycontext' f Delta') P c Q) w.
 Proof. eapply semax_mono_box. eauto. eassumption. Qed.
 

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -154,6 +154,7 @@ intros x y x' H0 H1.
 revert y H0; induction H1; intros.
 destruct (age_twin' _ _ _ H0 H) as [y' [? ?]].
 exists y'; split; auto.
+apply t_step; auto.
 specialize (IHclos_trans1 _ H0).
 destruct IHclos_trans1 as [y2 [? ?]].
 specialize (IHclos_trans2 _ H).
@@ -205,7 +206,7 @@ Proof.
       apply necR_level in H2; simpl in *.
       lia.
     }
-    split; intros m'' ? ?.
+    split; intros ? m'' ? ? ?.
     - apply f_equal with (f:= fun x => app_pred x m'') in H.
       apply prop_unext in H.
       apply approx_p with (level w).
@@ -213,6 +214,7 @@ Proof.
       apply H.
       rewrite <- NEP'.
       apply approx_lt; auto.
+      apply necR_level in H3; apply ext_level in H4; apply laterR_level in H1; lia.
     - apply f_equal with (f:= fun x => app_pred x m'') in H.
       apply prop_unext in H.
       apply approx_p with (level w).
@@ -220,6 +222,7 @@ Proof.
       apply H.
       rewrite <- NEP.
       apply approx_lt; auto.
+      apply necR_level in H3; apply ext_level in H4; apply laterR_level in H1; lia.
   + apply equal_f_dep with ts in H.
     apply equal_f with x in H.
     apply equal_f_dep with false in H.
@@ -234,21 +237,23 @@ Proof.
       apply necR_level in H2; simpl in *.
       lia.
     }
-    split; intros m'' ? ?.
+    split; intros ? m'' ? ??.
     - apply f_equal with (f:= fun x => app_pred x m'') in H.
       apply prop_unext in H.
       apply approx_p with (level w).
       rewrite NEQ.
       apply H.
       rewrite <- NEQ'.
-     apply approx_lt; auto.
+      apply approx_lt; auto.
+      apply necR_level in H3; apply ext_level in H4; apply laterR_level in H1; lia.
     - apply f_equal with (f:= fun x => app_pred x m'') in H.
       apply prop_unext in H.
       apply approx_p with (level w).
       rewrite NEQ'.
       apply H.
       rewrite <- NEQ.
-     apply approx_lt; auto.
+      apply approx_lt; auto.
+      apply necR_level in H3; apply ext_level in H4; apply laterR_level in H1; lia.
 Qed.
 
 Import JuicyMemOps.
@@ -358,9 +363,9 @@ unfold resource_decay, funassert; intros until w'; intro CORE; intros.
 destruct H.
 destruct H0.
 split; [clear H2 | clear H0].
-+ intros id fs w2 Hw2 H3.
++ intros id fs ? w2 Hw2 Hext H3.
   specialize (H0 id fs). cbv beta in H0.
-  specialize (H0 _ (necR_refl _) H3).
+  specialize (H0 _ _ (necR_refl _) (ext_refl _) H3).
   destruct H0 as [loc [? ?]].
   exists loc; split; auto.
   destruct fs as [f cc A a a0].
@@ -369,6 +374,7 @@ split; [clear H2 | clear H0].
          (PURE (FUN f cc) (SomeP (SpecArgsTT A) (packPQ a a0))) CORE).
   pose proof (necR_resource_at _ _ (loc,0)
          (PURE (FUN f cc) (SomeP (SpecArgsTT A) (packPQ a a0))) Hw2).
+  apply rmap_order in Hext as (<- & <- & _).
   apply H5.
   clear - H4 H2.
   repeat rewrite <- core_resource_at in *.
@@ -378,12 +384,13 @@ split; [clear H2 | clear H0].
   rewrite core_YES in H4; inv H4.
   rewrite core_PURE in H4; inv H4. rewrite level_core; reflexivity.
 +
-intros loc sig cc w2 Hw2 H6.
-specialize (H2 loc sig cc _ (necR_refl _)).
+intros loc sig cc ? w2 Hw2 Hext H6.
+specialize (H2 loc sig cc _ _ (necR_refl _) (ext_refl _)).
 spec H2.
-{ clear - Hw2 CORE H6. simpl in *.
+{ clear - Hw2 Hext CORE H6. simpl in *.
   destruct H6 as [pp H6].
   rewrite <- resource_at_approx.
+  apply rmap_order in Hext as (Hl & Hr & _); rewrite <- Hr, <- Hl in H6.
   case_eq (w @ (loc,0)); intros.
   + assert (core w @ (loc,0) = resource_fmap (approx (level (core w))) (approx (level (core w))) (NO _ bot_unreadable)).
      - rewrite <- core_resource_at.
@@ -587,12 +594,12 @@ Lemma semax_call_typecheck_environ:
      (ve' : env) (jm' : juicy_mem) (te' : temp_env)
      (H15 : alloc_variables psi empty_env (m_dry jm) (fn_vars f) ve' (m_dry jm'))
      (TC5: typecheck_glob_environ (filter_genv psi) (glob_types Delta))
-   (H : forall (b : ident) (b0 : funspec) (a' : rmap),
-    necR (m_phi jm') a' ->
+   (H : forall (b : ident) (b0 : funspec) (a' a'' : rmap),
+    necR (m_phi jm') a' -> ext_order a' a'' ->
     (glob_specs Delta) ! b = Some b0 ->
     exists b1 : block,
         filter_genv psi b = Some b1 /\
-        func_at b0 (b1,0) a')
+        func_at b0 (b1,0) a'')
    (TC8 : tc_vals (snd (split (fn_params f))) args)
    (H21 : bind_parameter_temps (fn_params f) args
               (create_undef_temps (fn_temps f)) = Some te'),
@@ -795,8 +802,9 @@ intros jm bl; revert jm; induction bl; intros.
  destruct H0 as [phi1 [phi2 [? [? H6]]]].
 
  assert (H10:= @juicy_free_lemma' jm b lo hi m2 phi1 _ _ H1 H0' H3 H0).
- match type of H10 with m_phi ?A = _ => set (jm2:=A) in H10 end; subst.
+ match type of H10 with context[m_phi ?A] => set (jm2:=A) in H10 end; subst.
 
+ eapply pred_upclosed in H6; eauto.
  specialize (IHbl  jm2 m' F H2 H6).
  destruct IHbl as [jm' [? [? ?]]].
  exists jm'; split3; auto.
@@ -832,9 +840,9 @@ Proof.
  destruct H2 as [phi1 [phi2 [? [? ?]]]].
  apply IHfree_list_juicy_mem.
  pose proof  (@juicy_free_lemma' jm b lo hi _ phi1 _ _ H H2' H3 H2).
- match type of H5 with m_phi ?A = _ => set (jm3 := A) in H5 end.
+ match type of H5 with context[m_phi ?A] => set (jm3 := A) in H5 end.
  replace jm2 with jm3 by (subst jm3; rewrite <- H0; apply free_juicy_mem_ext; auto).
- subst; auto.
+ eapply pred_upclosed; eauto.
 Qed.
 
 (*
@@ -890,7 +898,7 @@ Proof.
  unfold blocks_of_env.
 match goal with |- ?A |-- _ =>
  replace A
-  with (fold_right (@sepcon _ _ _ _ _ _) emp
+  with (fold_right (@sepcon _ _ _ _ _ _ _) emp
             (map (fun idt : ident * type => var_block Share.top idt rho)
             (fn_vars f)))
 end.
@@ -1016,7 +1024,7 @@ destruct H0 as [phi2 H0].
 hnf; intros.
 pose proof (juicy_mem_access jm (b,ofs)).
 hnf. unfold access_at in H2. simpl in H2.
-destruct H as [H _]; specialize (H (b,ofs)).
+specialize (H (b,ofs)).
 hnf in H.
 rewrite if_true in H by (split; auto; lia).
 destruct H as [v ?].
@@ -1163,11 +1171,12 @@ Proof.
   pose (jm3 := free_juicy_mem _ _ _ _ _ H8 ).
   destruct H as [phix H].
   destruct (join_assoc H1 H) as [phi3 []].
-  assert (phi3 = m_phi jm3).
-  { subst jm3; symmetry; eapply juicy_free_lemma'; eauto.
+  assert (ext_order phi3 (m_phi jm3)) as Hext.
+  { eapply juicy_free_lemma'; eauto.
     rewrite Z.sub_0_r; auto.
   }
-  subst phi3.  assert (join_sub phi2 (m_phi jm3)) as Hphi2 by (eexists; eauto).
+  assert (join_sub phi2 (m_phi jm3)) as Hphi2.
+  { eapply join_sub_trans; [eexists; eauto | apply ext_join_sub; auto]. }
   destruct (IHel phi2 jm3 Hphi2) as [m4 ?]; auto; clear IHel.
   + intros.
     specialize (H2 id0 b0 t0).
@@ -1253,7 +1262,7 @@ Definition tc_fn_return (Delta: tycontext) (ret: option ident) (t: type) :=
  | Some i => match (temp_types Delta) ! i with Some t' => t=t' | _ => False end
  end.
 
-Lemma derives_refl' {A: Type}  `{ageable A}:
+Lemma derives_refl' {A: Type} `{ageable A} {EO: Ext_ord A} :
     forall P Q: pred A, P=Q -> P |-- Q.
 Proof.  intros; subst; apply derives_refl. Qed.
 
@@ -1293,7 +1302,7 @@ assert (forall Delta Delta' rho rho',
   unfold funassert.
   intros w [? ?]; split.
   - clear H2; intro id. rewrite <- (H id), <- H0; auto.
-  - intros loc sig cc w' Hw' H4; destruct (H2 loc sig cc w' Hw' H4)  as [id H3].
+  - intros loc sig cc ? w' Hw' Hext H4; destruct (H2 loc sig cc _ _ Hw' Hext H4)  as [id H3].
     exists id; rewrite <- (H id), <- H0; auto.
 + intros.
   apply pred_ext; apply H; intros; auto.
@@ -1447,7 +1456,7 @@ specialize (H15
           F (construct_rho (filter_genv psi) vx tx))
    (typlist_of_typelist tys) args jm).
 spec H15; [ clear; lia | ].
-specialize (H15 _ (necR_refl _)).
+specialize (H15 _ _ (necR_refl _) (ext_refl _)).
 spec H15.
 { clear - Eef Hargs H14 TC8.
   assert (AP: app_pred ((P ts x (filter_genv psi, args) *
@@ -1518,7 +1527,7 @@ apply (pred_nec_hereditary _ _ (level m')) in H15.
 apply (pred_nec_hereditary _ _ (level m')) in H15;
  [ | apply nec_nat; lia].
 rewrite Eef in *.
-specialize (H15 m' (le_refl _) _ (necR_refl _) H8).
+specialize (H15 m' (le_refl _) _ _ (necR_refl _) (ext_refl _) H8).
 assert (LAT: laterM (level (m_phi jm)) (level jm')). { simpl; apply laterR_level'. constructor. apply age_jm_phi. apply Hage. }
 apply (pred_nec_hereditary _ _ _ (laterR_necR LAT)) in H1.
 
@@ -1538,12 +1547,12 @@ assert (H1' : forall a' : rmap,
   assert (own.bupd (RA_normal R (construct_rho (filter_genv psi) vx tx') * F0 (construct_rho (filter_genv psi) vx tx')) a') as Ha'.
   { apply own.bupd_frame_r.
     destruct HB as [a1 [a2 [J [A1 A2]]]]; exists a1, a2; split; auto; split; auto.
-    apply (HR (construct_rho (filter_genv psi) vx tx') _ LATER a1); auto.
+    eapply (HR (construct_rho (filter_genv psi) vx tx') _ LATER a1); auto.
     destruct (join_level _ _ _ J) as [-> ?]; auto. }
   apply own.bupd_trans; intros ? J.
   destruct (Ha' _ J) as (? & ? & a'' & Hl & ? & ? & Hret); subst.
   eexists; split; eauto; exists a''; repeat (split; auto).
-  eapply H1; try apply necR_refl.
+  eapply H1; try apply necR_refl; try apply ext_refl.
   { rewrite Hl; auto. }
   split; [split|]; auto.
   - rewrite proj_frame_ret_assert; unfold proj_ret_assert.
@@ -1567,8 +1576,9 @@ assert (Htc: tc_option_val retty ret0).
     destruct H6 as [? [? ?]].  lia.
     apply age_level in Hage. lia.
   }
-  specialize (Hretty phi1).
+  specialize (Hretty phi1 phi1).
   spec Hretty. apply rt_refl.
+  spec Hretty. reflexivity.
   spec Hretty. split. apply Hb. apply Hretty0.
   simpl in Hretty. auto.
 }
@@ -1607,7 +1617,7 @@ spec H1.
         lia.
       }
       split.
-      + apply Hretty; auto. split; auto.
+      + eapply Hretty; auto. split; auto.
       + auto. }
     clear H15.
     revert Htc.
@@ -1727,15 +1737,16 @@ spec H1.
     destruct H6 as (?&?&?).
     destruct H4.
     split.
-    + intros id fs ???.
-      specialize (H2 id fs (m_phi jm) (necR_refl _)).    spec H2; auto.
+    + intros id fs ??? Hext ?.
+      specialize (H2 id fs (m_phi jm) _ (necR_refl _) (ext_refl _)).
+      spec H2; auto.
       destruct H2 as [b [? ?]].
       destruct H1 as [H1 H1'].
       specialize (H1 (b,0)).
       unfold func_at in H6. destruct fs; simpl in *.
       rewrite H6 in H1.
       apply (necR_PURE (m_phi m') a') in H1; eauto.
-      exists b. split; auto. rewrite H1. simpl.
+      exists b. split; auto. apply rmap_order in Hext as (<- & <- & _). rewrite H1. simpl.
       f_equal. f_equal.
       assert (Hlev1: (level (m_phi m') >= level a')%nat).
       { apply necR_level in H4; auto. }
@@ -1750,13 +1761,14 @@ spec H1.
       rewrite approx'_oo_approx by lia.
       rewrite approx'_oo_approx by lia.
       auto.
-    + intros b sig cc ???.
+    + intros b sig cc ??? Hext ?.
       specialize (H3 b sig cc (m_phi jm)).
-      specialize (H3 (necR_refl _)); spec H3; auto.
+      specialize (H3 _ (necR_refl _) (ext_refl _)); spec H3; auto.
       destruct H1 as [H1 H1'].
       specialize (H1' (b,0)).
       simpl in *.
       destruct H5 as [b0 ?].
+      apply rmap_order in Hext as (Hl & Hr & _); rewrite <- Hl, <- Hr in H5.
       destruct (m_phi m' @ (b,0)) eqn:?.
       eapply necR_NOx in Heqr; try apply H4. inversion2 H5 Heqr.
       eapply necR_YES in Heqr; try apply H4. inversion2 H5 Heqr.
@@ -2099,7 +2111,6 @@ rewrite Ptrofs.unsigned_zero.
 rewrite memory_block'_eq; try lia.
 unfold memory_block'_alt.
 rewrite if_true by apply readable_share_top.
-split.
 intro loc. hnf.
 rewrite Z2Nat.id by lia.
 if_tac.
@@ -2116,7 +2127,6 @@ rewrite H3.
 rewrite Z.sub_0_r.
 rewrite if_false by auto.
 apply core_identity.
-apply ghost_identity; auto.
 Qed.
 
 Lemma juicy_mem_alloc_block:
@@ -2262,11 +2272,11 @@ destruct ek; try solve [intros; simpl proj_ret_assert; normalize];
                RA_normal, RA_return.
 destruct (type_eq (fn_return f) Tvoid).
 2:{
-intros ? ? ? ? [[_ [? [? [? [[? [? [? [_ [? ?]]]]] _]]]]] _].
+intros ? ? ? ? ? ? [[_ [? [? [? [[? [? [? [_ [? ?]]]]] _]]]]] _].
 destruct (fn_return f); contradiction.
 }
 destruct vl. normalize.
-intros ? ? ? ? [[_ [? _]] _]; discriminate.
+intros ? ? ? ? ? ? [[_ [? _]] _]; discriminate.
 eapply subp_trans'; [ | eapply subp_trans'; [apply H0 | ]]; clear H0.
 rewrite e.
 apply derives_subp.
@@ -2304,7 +2314,7 @@ Lemma semax_call_aux2
   (f : function)
   (*(NEP : args_super_non_expansive P)*)
   (NEQ : super_non_expansive Q)
-  (Hora : app_pred (juicy_mem_op (ext_compat ora)) jm)
+  (Hora : ext_compat ora (m_phi jm))
   (TCret : tc_fn_return Delta ret (snd fsig))
   (TC5 : snd fsig = Tvoid -> ret = None)
   (H : closed_wrt_modvars (Scall ret a bl) F0)
@@ -2367,10 +2377,11 @@ apply guard_fallthrough_return; auto.
  rewrite <- (sepcon_comm (F0 rho * F rho)).
  change (stackframe_of' cenv_cs f rho') with (stackframe_of f rho').
 
- intros wx ? w' ? ?.
+ intros wx ? ? w' ? Hext ?.
  assert (level jmx >= level w')%nat.
- apply necR_level in H9.
- apply le_trans with (level wx); auto.
+ { apply necR_level in H9.
+   apply le_trans with (level wx); auto.
+   apply ext_level in Hext as <-; auto. }
  clear wx H8 H9.
  apply own.bupd_intro; simpl.
  intros ora' jm' Hora' VR ?.
@@ -2407,6 +2418,7 @@ apply guard_fallthrough_return; auto.
  apply laterR_necR. apply age_laterR. apply age_jm_phi; auto.
  subst m2.
  pose (rval := force_val vl).
+ clear dependent a'.
  assert (jsafeN OK_spec psi (level jm2) ora'
              (Returnstate rval (call_cont ctl)) jm2). {
    assert (LATER2': (level jmx > level (m_phi jm2))%nat). {
@@ -2431,12 +2443,12 @@ apply guard_fallthrough_return; auto.
     { apply own.bupd_frame_r.
       destruct HB as [a1 [a2 [J [A1 A2]]]]; simpl; exists a1, a2; split; auto; split; auto.
       assert (JMX: laterM (m_phi jm) (m_phi jmx)). { constructor. apply age_jm_phi. apply H13. }
-      apply (HR _ _ JMX a1); auto.
+      eapply (HR _ _ JMX a1); auto.
       destruct (join_level _ _ _ J) as [-> ?]; auto. apply necR_level in H8; rewrite <- level_juice_level_phi in *; lia. }
     apply own.bupd_trans; intros ? J.
     destruct (Ha' _ J) as (? & ? & a'' & Hl & ? & ? & Hret); subst.
     eexists; split; eauto; exists a''; repeat (split; auto).
-    eapply H1; try apply necR_refl.
+    eapply H1; try apply necR_refl; try apply ext_refl.
     { rewrite Hl; apply necR_level in H8; rewrite <- level_juice_level_phi in *; lia. }
     split; [split|]; auto.
     - rewrite proj_frame_ret_assert; unfold proj_ret_assert.
@@ -2652,7 +2664,7 @@ intros.
 destruct fspec as [[params retty] cc A P Q NEP NEQ].
 simpl.
 specialize (Believe (Vptr b Ptrofs.zero)
-                  (params,retty) cc A P Q _ (necR_refl _)).
+                  (params,retty) cc A P Q _ _ (necR_refl _) (ext_refl _)).
 spec Believe.  { exists id_fun, NEP, NEQ. split; auto. exists b; split; auto. }
 simpl (semantics.initial_core _). unfold j_initial_core.
 simpl (semantics.initial_core _). unfold cl_initial_core.
@@ -2710,7 +2722,7 @@ Lemma semax_call_aux {CS Espec}
   A deltaP deltaQ NEP' NEQ' retty clientparams
   (F0 : assert) (ret : option ident) (curf: function) args (a : expr)
   (bl : list expr) (R : ret_assert) (vx:env) (tx:Clight.temp_env) (k : cont) (rho : environ)
-  (Hora : juicy_mem_op (ext_compat ora) jm)
+  (Hora : ext_compat ora (m_phi jm))
 
   (Bel: believe Espec Delta psi Delta (level (m_phi jm)))
   (Spec: (glob_specs Delta)!id = Some (mk_funspec (clientparams, retty) cc A deltaP deltaQ NEP' NEQ'))
@@ -2775,8 +2787,8 @@ Proof.
   specialize (RGUARD _ (laterR_level' (age_laterR (age_jm_phi H13)))).
   apply (pred_nec_hereditary _ _ _
                              (laterR_necR (age_laterR (age_jm_phi H13)))) in Funassert.
-  apply (pred_nec_hereditary _ _ _
-                             (laterR_necR (age_laterR (age_jm_phi H13)))) in Hora.
+  eapply ext_join_approx in Hora.
+  erewrite <- age1_ghost_of in Hora by (eapply age_jm_phi; eauto).
   assert (LATER: laterR (level (m_phi jm)) n) by
       (constructor 1; rewrite <- level_juice_level_phi, H2; reflexivity).
 
@@ -2828,20 +2840,20 @@ Proof.
     exists m'; repeat (split; auto).
     destruct HR as (ts & x & F & [H14' HR]); exists ts, x, F; split; auto.
     intros rho'; specialize (HR rho').
-    intros ? ? ? ? ? ? [old ?].
-    apply (HR a' H y H0 a'0 H1); clear HR.
+    intros ? ? ? ? ? ? ? Hext [old ?].
+    apply (HR a' H y H0 _ _ H1 Hext); clear HR.
     exists old.
-    revert a'0 H1 H2.
+    revert a'0 a'' H1 Hext H2.
     eapply sepcon_subp'; try apply H0.
     - apply derives_subp; apply derives_refl.
     - intros ? ?. pose proof (laterR_level' H) as H'; rewrite Hl' in H'.
       unfold maybe_retval; destruct ret.
-      + intros ? ?. simpl. intros. destruct H3. split; auto. clear H3.
-        revert a'0 H2 H4. apply (H11 _ _ _ (level a')); auto; apply (laterR_level' H').
+      + intros ? ? ? Hext. simpl. intros. destruct H3. split; auto. clear H3.
+        revert a'0 a'' H2 Hext H4. apply (H11 _ _ _ (level a')); auto; apply (laterR_level' H').
       + destruct retty;
           [apply (H11 _ _ _ (level a')); auto; apply (laterR_level' H') |
-           intros ? ?  [v ?]; simpl in H3; destruct H3; exists v; simpl;
-            split; auto; clear H3; revert a'0 H2 H4;
+           intros ? ? ? Hext [v ?]; simpl in H3; destruct H3; exists v; simpl;
+            split; auto; clear H3; revert a'0 a'' H2 Hext H4;
             apply (H11 _ _ _ (level a')); auto; apply (laterR_level' H') ..]. }
 
   rewrite closed_wrt_modvars_Scall in CLosed.
@@ -2854,7 +2866,7 @@ Proof.
 
   assert (Prog_OK' := Bel).
   specialize (Prog_OK' (Vptr b Ptrofs.zero)
-                       (clientparams,retty) cc A deltaP Q _ (necR_refl _)).
+                       (clientparams,retty) cc A deltaP Q _ _ (necR_refl _) (ext_refl _)).
 
   spec Prog_OK'.
   { hnf. exists id, NEP', NEQ; split; auto.
@@ -2896,10 +2908,10 @@ Proof.
     destruct Hupd as (Hm' & Hl' & Hr'); rewrite <- level_juice_level_phi, <- Hl' in *.
     eapply (funassert_resource _ _ _ (m_phi jm')) in Funassert; eauto.
     change (level (m_phi jm')) with (level jm') in *.
-    specialize (H19 Delta CS _ (necR_refl _)).
+    specialize (H19 Delta CS _ _ (necR_refl _) (ext_refl _)).
     spec H19. {
       intro; apply tycontext_sub_refl. }
-    specialize (H19 _ (necR_refl _) (cenv_sub_refl) ts x).
+    specialize (H19 _ _ (necR_refl _) (ext_refl _) (cenv_sub_refl) ts x).
     red in H19.
 
     clear H2. destruct (level jm') eqn:H2; [constructor |].
@@ -2907,20 +2919,19 @@ Proof.
     rewrite <- H2 in *. clear H2. pose proof I.
     specialize (H19 _ (laterR_level' (age_laterR H13))).
     rewrite semax_fold_unfold in H19.
-    specialize (H19 _ _ _ _ (necR_refl _)
+    specialize (H19 _ _ _ _ _ (necR_refl _) (ext_refl _)
                     (conj (tycontext_sub_refl _) (conj cenv_sub_refl CSUB))
-                    _ (necR_refl _)
+                    _ _ (necR_refl _) (ext_refl _)
                     (pred_nec_hereditary
                        _ _ _
                        (necR_level' (laterR_necR (age_laterR H13))) Bel)
-                    ctl (fun _: environ => F0 rho * F rho) f _ (necR_refl _)).
+                    ctl (fun _: environ => F0 rho * F rho) f _ _ (necR_refl _) (ext_refl _)).
     clear Bel.
 
     spec H19. {
       eapply semax_call_aux2 with (bl:=nil)(a:=Econst_int Int.zero tint)
-                                  (Q:=Q)(fsig:=(clientparams,retty)); eauto.
-      + red. red. red. eauto.
-        apply @ext_join_sub_approx with (n := level jm') in Hext.
+                                  (Q:=Q)(fsig:=(clientparams,retty)); try apply HR; eauto.
+      + apply @ext_join_sub_approx with (n := level jm') in Hext.
         eapply joins_comm, join_sub_joins_trans; eauto.
         apply joins_comm; auto.
       + rewrite closed_wrt_modvars_Scall; auto.
@@ -2966,7 +2977,7 @@ Proof.
         destruct H20;  apply resource_decay_trans with
                            (nextblock (m_dry jm'')) (m_phi jm''); auto.
         apply age1_resource_decay; auto. }
-      specialize (H19 te' ve' _ H22 _ (necR_refl _)).
+      specialize (H19 te' ve' _ H22 _ _ (necR_refl _) (ext_refl _)).
       spec H19; [clear H19|]. {
         split; [split |]; auto.
         3:{ unfold rho3 in H23. unfold construct_rho. rewrite Hrho in H23.
@@ -3047,7 +3058,7 @@ Lemma semax_call_aux' {CS Espec}
   (F : environ -> pred rmap)
   (F0 : assert) (ret : option ident) (curf: function) args (a : expr)
   (bl : list expr) (R : ret_assert) (vx:env) (tx:Clight.temp_env) (k : cont) (rho : environ)
-  (Hora : juicy_mem_op (ext_compat ora) jm)
+  (Hora : ext_compat ora (m_phi jm))
 
   (Bel: believe Espec Delta psi Delta (level (m_phi jm)))
   (Spec: (glob_specs Delta)!id = Some (mk_funspec (clientparams, retty) cc A deltaP deltaQ NEP' NEQ'))
@@ -3115,14 +3126,14 @@ rename argsig into clientparams. rename retsig into retty.
 intros.
 rename H into Closed; rename H0 into RGUARD.
 intros tx vx.
-intros ? ? ? NecR_ya' [[TC3 ?] funassertDelta'].
+intros ? ? ? ? NecR_ya' Hext [[TC3 ?] funassertDelta'].
 
 assert (NecR_wa': necR w (level a')).
 { apply nec_nat. apply necR_level in NecR_ya'. apply le_trans with (level y); auto. }
 eapply pred_nec_hereditary in RGUARD; [ | apply NecR_wa'].
 eapply pred_nec_hereditary in Prog_OK; [ | apply NecR_wa'].
 clear w NecR_wa' NecR_ya' y H.
-rename a' into w.
+rename a'' into w.
 
 assert (TC7': tc_fn_return Delta' ret retty).
 {
@@ -3145,7 +3156,6 @@ destruct preB as [z1 [z2 [JZ [HF0 pre]]]].
 destruct (level w) eqn: Hl.
 { apply own.bupd_intro; repeat intro.
   rewrite Hl; constructor. }
-rewrite <- Hl in *.
 destruct (levelS_age w n) as (w' & Hage & Hw'); auto.
 
 hnf in funcatb.
@@ -3168,7 +3178,7 @@ assert (MYPROP: exists id fs,
                                /\ exists fs, (glob_specs Delta')!id = Some fs).
 
   { destruct funassertDelta' as [_ FD].
-    apply (FD b (clientparams, retty) cc _ (necR_refl _)); clear FD.
+    apply (FD b (clientparams, retty) cc _ _ (necR_refl _) (ext_refl _)); clear FD.
     simpl. destruct nspec. hnf in funcatb. simpl in SubClient.
     destruct SubClient as [[? ?] _]; subst.
     (*specialize (typesigs_match_typesigs_eq H); intros TS. rewrite <- TS.*)
@@ -3177,7 +3187,7 @@ assert (MYPROP: exists id fs,
 
   assert (exists v, Map.get (ge_of rho) id = Some v /\ func_at fs (v, 0) w).
   { destruct funassertDelta' as [funassertDeltaA _].
-    destruct (funassertDeltaA id fs _ (necR_refl _) specID) as [v [Hv funcatv]]; simpl in Hv.
+    destruct (funassertDeltaA id fs _ _ (necR_refl _) (ext_refl _) specID) as [v [Hv funcatv]]; simpl in Hv.
     exists v; split; trivial. }
   destruct H as [v [Hv funcatv]].
   assert (VB: b=v); [inversion2 Hb Hv; trivial | subst; clear Hb].
@@ -3290,7 +3300,8 @@ specialize (ClientAdaptation w2'). spec ClientAdaptation.
       apply tc_val_has_type in H. apply IHargs in H0.
       constructor; eauto.
   + apply age_laterR in Age2. apply (W2 _ Age2). }
-
+    apply rmap_order in Hext as (Hl' & _ & _).
+    rewrite Hl' in *; clear dependent a'.
 assert (ARGS: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho *
      (F rho * G) * deltaP ts1 x1 (ge_of rho, args) && !! (forall rho' : environ,
                             !! (ve_of rho' = Map.empty (block * type)) &&
@@ -3315,7 +3326,7 @@ assert (ARGS: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho *
       assert (LatWU2: laterM (level w) (level u2)).
       { rewrite LevU2, <- LevW2, Hlb. apply laterR_level'; trivial. }
       specialize (Hpre ts1 x1 (ge_of rho, args)).
-      apply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | trivial].
+      eapply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | apply ext_refl | trivial].
       rewrite HARGS. subst rho. rewrite <- Hpsi. apply U2.
     - apply (pred_nec_hereditary _ _ a') in ClientAdaptation.
       intros ? J2; destruct (ClientAdaptation _ J2) as
@@ -3329,7 +3340,7 @@ assert (ARGS: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho *
       assert (LatWU2: laterM (level w) (level u2)).
       { rewrite LevU2, <- LevW2, Hlb. apply laterR_level'; trivial. }
       specialize (Hpre ts1 x1 (ge_of rho, args)).
-      apply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | trivial].
+      eapply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | apply ext_refl | trivial].
       + rewrite HARGS. subst rho. rewrite <- Hpsi. apply U2.
       + apply laterR_necR; trivial. }
   rewrite <- HARGS. clear - XX. eapply later_derives, XX.
@@ -3362,7 +3373,7 @@ apply exp_right with (fun rho => F rho * G).
 apply andp_derives; auto.
 intros ? HG2.
 clear - TRIV TC7' HG2.
-intros rho' u U m NEC [v V].
+intros rho' u U ? m NEC Hext [v V].
 hnf in TC7'.
 rewrite <- exp_sepcon1.
 apply own.bupd_frame_l.
@@ -3442,14 +3453,14 @@ rename argsig into clientparams. rename retsig into retty.
 intros.
 rename H into Closed; rename H0 into RGUARD.
 intros tx vx.
-intros ? ? ? NecR_ya' [[TC3 ?] funassertDelta'].
+intros ? ? ? ? NecR_ya' Hext [[TC3 ?] funassertDelta'].
 
 assert (NecR_wa': necR w (level a')).
 { apply nec_nat. apply necR_level in NecR_ya'. apply le_trans with (level y); auto. }
 eapply pred_nec_hereditary in RGUARD; [ | apply NecR_wa'].
 eapply pred_nec_hereditary in Prog_OK; [ | apply NecR_wa'].
 clear w NecR_wa' NecR_ya' y H.
-rename a' into w.
+rename a'' into w.
 
 assert (TC7': tc_fn_return Delta' ret retty).
 {
@@ -3472,7 +3483,6 @@ destruct preB as [z1 [z2 [JZ [HF0 pre]]]].
 destruct (level w) eqn: Hl.
 { apply own.bupd_intro; repeat intro.
   rewrite Hl; constructor. }
-rewrite <- Hl in *.
 destruct (levelS_age w n) as (w' & Hage & Hw'); auto.
 
 hnf in funcatb.
@@ -3495,7 +3505,7 @@ assert (MYPROP: exists id fs,
                                /\ exists fs, (glob_specs Delta')!id = Some fs).
 
   { destruct funassertDelta' as [_ FD].
-    apply (FD b (clientparams, retty) cc _ (necR_refl _)); clear FD.
+    apply (FD b (clientparams, retty) cc _ _ (necR_refl _) (ext_refl _)); clear FD.
     simpl. destruct nspec. destruct SubClient as [[FSM Hcc] _]. subst t c.
     (*specialize (typesigs_match_typesigs_eq FSM); intros TS; subst.*)
     eexists; trivial. apply funcatb. }
@@ -3503,7 +3513,7 @@ assert (MYPROP: exists id fs,
 
   assert (exists v, Map.get (ge_of rho) id = Some v /\ func_at fs (v, 0) w).
   { destruct funassertDelta' as [funassertDeltaA _].
-    destruct (funassertDeltaA id fs _ (necR_refl _) specID) as [v [ Hv funcatv]]; simpl in Hv.
+    destruct (funassertDeltaA id fs _ _ (necR_refl _) (ext_refl _) specID) as [v [ Hv funcatv]]; simpl in Hv.
     exists v; split; trivial. }
   destruct H as [v [Hv funcatv]].
   assert (VB: b=v); [inversion2 Hb Hv; trivial | subst; clear Hb].
@@ -3577,7 +3587,7 @@ specialize (W2 _ LA2).
 
 specialize (ClientAdaptation x (ge_of rho, args)). hnf in ClientAdaptation.
 assert (LW2': (level w' >= level w2')%nat). { apply age_level in Age2. destruct (join_level _ _ _ J); lia. }
-specialize (ClientAdaptation _ LW2' _ (necR_refl _)). spec ClientAdaptation.
+specialize (ClientAdaptation _ LW2' _ _ (necR_refl _) (ext_refl _)). spec ClientAdaptation.
 { split; trivial. simpl.
   clear - TC3 LENargs TC2 Hage. destruct TC3. 
   apply age_laterR in Hage. specialize (TC2 w' Hage).
@@ -3592,7 +3602,8 @@ specialize (ClientAdaptation _ LW2' _ (necR_refl _)). spec ClientAdaptation.
   - destruct clientparams; simpl in *. contradiction. destruct H.
     apply tc_val_has_type in H. apply IHargs in H0.
     constructor; eauto. }
-
+apply rmap_order in Hext as (Hl' & _ & _).
+rewrite Hl' in *; clear dependent a'.
 assert (ArgsW: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho * (F rho * G) *
                deltaP ts1 x1 (ge_of rho, args) && (ALL rho' : environ,
          ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> own.bupd (Q ts x rho'))))) w).
@@ -3610,7 +3621,7 @@ assert (ArgsW: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho * (F rho * G) *
     exists u1, u2; split; trivial. split; trivial.
     assert (LatWU2: laterM (level w) (level u2)). { rewrite LevU2, <- LevW2, Hlb. apply laterR_level'; trivial. }
     specialize (Hpre ts1 x1 (ge_of rho, args)).
-    apply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | rewrite HARGS; trivial]. }
+    eapply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | apply ext_refl | rewrite HARGS; trivial]. }
   rewrite <- HARGS. clear - XX. eapply later_derives, XX.
   eapply derives_trans; [apply own.bupd_frame_l | apply own.bupd_mono].
   apply derives_refl'.
@@ -3640,7 +3651,7 @@ apply exp_left; intros ts1; apply exp_left; intros x1; apply exp_left; intros G;
 apply exp_right with (fun rho => F rho * G).
 apply andp_derives; auto.
 intros ? HG2.
-intros rho' l L y Y z YZ [v Z].
+intros rho' l L y Y ? z YZ EZ [v Z].
 rewrite <- exp_sepcon1; apply own.bupd_frame_l.
 assert (TRIV: (forall rho, typecheck_temp_environ rho (PTree.empty type)) /\
               (typecheck_var_environ (Map.empty (block * type)) (PTree.empty type)) /\
@@ -3653,7 +3664,7 @@ assert (TRIV: (forall rho, typecheck_temp_environ rho (PTree.empty type)) /\
 assert (LEV2': (level a0 >= level a0)%nat) by lia.
 assert (LEVz: (level a0 >= level z)%nat).
 { apply necR_level in YZ.
-  apply laterR_level in L; lia. }
+  apply laterR_level in L; apply ext_level in EZ; lia. }
 destruct ret; simpl.
 - destruct Z as [z1 [z2 [JZ [Z1 Z2]]]]; destruct (join_level _ _ _ JZ) as
       [Levz1 Levz2]. simpl in Z1, Z2.
@@ -3663,7 +3674,7 @@ destruct ret; simpl.
       [_ Levy11].
   assert (LL: (level a0 >= level y11)%nat) by lia.
   exists z1_1, y11; split; trivial. split; [exists v; trivial|].
-  specialize (HG2 (get_result1 i rho') _ LL _ (necR_refl _)). destruct Z2 as [Z21 Z22].
+  specialize (HG2 (get_result1 i rho') _ LL _ _ (necR_refl _) (ext_refl _)). destruct Z2 as [Z21 Z22].
   spec HG2. {
     simpl. split; trivial. exists z1_2, z2; auto. }
   intros. specialize (HG2 c H). destruct HG2 as [b0 [HJ [m' [HL [HR [HG HQ]]]]]].
@@ -3677,7 +3688,7 @@ destruct ret; simpl.
   exists z1_1, y11; split; trivial. split; [exists v; trivial|].
   destruct (type_eq retty Tvoid).
   + subst retty.
-    apply (HG2 (globals_only rho') _ LL _ (necR_refl _)).
+    apply (HG2 (globals_only rho') _ LL _ _ (necR_refl _) (ext_refl _)).
     simpl; split. hnf; simpl; intuition.
     exists z1_2, z2; auto.
   + assert (Z22: ((fun rho : environ =>
@@ -3685,7 +3696,7 @@ destruct ret; simpl.
                                     (env_set (globals_only rho) ret_temp v)) rho') z2).
     { destruct retty; trivial. congruence. }
     clear Z2; destruct Z22 as [vv [Z21 Z2]]. simpl in Z21.
-    specialize (HG2 (env_set (globals_only rho') ret_temp vv) _ LL _ (necR_refl _)).
+    specialize (HG2 (env_set (globals_only rho') ret_temp vv) _ LL _ _ (necR_refl _) (ext_refl _)).
     spec HG2. {
       simpl; split. hnf; simpl; intuition. exists z1_2, z2; auto. }
     eapply own.bupd_mono, HG2.
@@ -3733,8 +3744,8 @@ assert (HGpsi: cenv_sub (@cenv_cs CS)  psi).
 { destruct HGG as [CSUB HGG]. apply (cenv_sub_trans CSUB HGG). }
 specialize (H2 psi Delta' CS' w TS HGG Prog_OK k F f H3 H4).
 intros tx vx; specialize (H2 tx vx).
-intros ? ? ? ? ?.
-specialize (H2 y H5 a'0 H6 H7).
+intros ? ? ? ? ? Hext ?.
+specialize (H2 y H5 _ _ H6 Hext H7).
 destruct H7 as[[? ?] _].
 hnf in H7.
 pose proof I.
@@ -3752,7 +3763,7 @@ simpl; intros ? ?. unfold cl_after_external. destruct ret0; auto.
 reflexivity.
 intros.
 destruct H8 as [w1 [w2 [H8' [_ ?]]]]. subst m'.
-assert (H8'': extendM w2 a'0) by (eexists; eauto). clear H8'.
+assert (H8'': extendM w2 a'') by (eexists; eauto). clear H8'.
 remember (construct_rho (filter_genv psi) vx tx) as rho.
 assert (H7': typecheck_environ Delta rho).
 destruct H7; eapply typecheck_environ_sub; eauto.
@@ -3881,22 +3892,23 @@ Proof.
   apply derives_imp.
   clear n.
   intros w ? k F f.
-  intros w' ? ?.
+  intros ? w' ? Hext H1.
   clear H.
   clear w H0.
   rename w' into w.
   destruct H1.
   do 3 red in H.
   intros te ve.
-  intros n ? w' ? ?.
-  assert (necR w (level w')).
+  intros n ? ? w' ? Hext' ?.
+  assert (necR w (level w')) as H4.
   {
     apply nec_nat.
     apply necR_level in H2.
     apply le_trans with (level n); auto.
+    apply ext_level in Hext' as <-; auto.
   }
   apply (pred_nec_hereditary _ _ _ H4) in H0.
-  clear w n H2 H1 H4.
+  clear w n Hext H2 H1 H4.
   destruct H3 as [[H3 ?] ?].
   pose proof I.
   remember ((construct_rho (filter_genv psi) ve te)) as rho.
@@ -3921,7 +3933,7 @@ Proof.
   }
   clear H1; rename H1' into H1.
   specialize (H0 EK_return (cast_expropt ret (ret_type Delta') rho) te ve).
-  specialize (H0 _ (le_refl _) _ (necR_refl _)).
+  specialize (H0 _ (le_refl _) _ _ (necR_refl _) (ext_refl _)).
   spec H0.
   {
     rewrite <- Heqrho.

--- a/veric/semax_conseq.v
+++ b/veric/semax_conseq.v
@@ -108,7 +108,7 @@ Proof.
   apply pred_ext.
   + hnf; intros.
     hnf; intros.
-    hnf; intros.
+    intros ?? H1 Hext H2.
     destruct H2 as [[? ?] ?].
     apply bupd_trans.
     hnf.
@@ -117,10 +117,8 @@ Proof.
     destruct H3 as [b [? [m' [? [? [? ?]]]]]].
     exists b; split; auto.
     exists m'; split; [| split; [| split]]; auto.
-    change (assert_safe Espec gx f vx tx k rho m').
-    specialize (H m' ltac: (apply necR_level in H1; lia)).
-    specialize (H m' ltac: (apply necR_refl)).
-    apply H.
+    eapply H; try reflexivity; try apply necR_refl.
+    { apply necR_level in H1; apply ext_level in Hext; lia. }
     split; [split |]; auto.
     subst PP2.
     pose proof funassert_resource Delta rho _ _ (eq_sym H6) (eq_sym H7).
@@ -128,9 +126,8 @@ Proof.
   + hnf; intros.
     hnf; intros.
     specialize (H y H0).
-    hnf; intros.
-    specialize (H a' H1).
-    apply H.
+    intros ?? H1 Hext H2.
+    eapply H; eauto.
     destruct H2 as [[? ?] ?].
     split; [split |]; auto.
     apply bupd_intro; auto.
@@ -180,7 +177,7 @@ Proof.
   apply pred_ext.
   + hnf; intros.
     hnf; intros.
-    hnf; intros.
+    intros ?? H1 Hext H2.
     destruct H2 as [[? ?] ?].
     apply bupd_trans.
     hnf.
@@ -190,10 +187,8 @@ Proof.
     destruct H3 as [b [? [m' [? [? [? ?]]]]]].
     exists b; split; auto.
     exists m'; split; [| split; [| split]]; auto.
-    change (assert_safe Espec gx f vx tx k rho m').
-    specialize (H m' ltac: (apply necR_level in H1; lia)).
-    specialize (H m' ltac: (apply necR_refl)).
-    apply H.
+    eapply H; try reflexivity; try apply necR_refl.
+    { apply necR_level in H1; apply ext_level in Hext; lia. }
     split; [split |]; auto.
     subst PP2.
     pose proof funassert_resource Delta rho _ _ (eq_sym H6) (eq_sym H7).
@@ -201,9 +196,8 @@ Proof.
   + hnf; intros.
     hnf; intros.
     specialize (H y H0).
-    hnf; intros.
-    specialize (H a' H1).
-    apply H.
+    intros ?? H1 Hext H2.
+    eapply H; eauto.
     destruct H2 as [[? ?] ?].
     split; [split |]; auto.
     revert H3.
@@ -273,10 +267,10 @@ Proof.
   + hnf; intros.
     hnf; intros.
     specialize (H y H0).
-    hnf; intros.
-    specialize (H a' H1).
+    intros ?? H1 Hext H2.
+    specialize (H _ _ H1 Hext).
     clear - H H2.
-    destruct (level a') eqn:?H in |- *.
+    destruct (level a'') eqn:?H in |- *.
     - hnf.
       intros.
       eexists; split; [exact H1 |].
@@ -291,16 +285,15 @@ Proof.
       destruct H2; auto.
       hnf in H2.
       unfold laterM in H2; simpl in H2.
-      pose proof levelS_age a' n (eq_sym H0) as [? [? ?]].
+      pose proof levelS_age a'' n (eq_sym H0) as [? [? ?]].
       exfalso; apply (H2 x).
       apply age_laterR.
       auto.
   + hnf; intros.
     hnf; intros.
     specialize (H y H0).
-    hnf; intros.
-    specialize (H a' H1).
-    apply H.
+    intros ?? H1 Hext H2.
+    eapply H; eauto.
     destruct H2 as [[? ?] ?].
     split; [split |]; auto.
     right; auto.
@@ -358,10 +351,10 @@ Proof.
   + hnf; intros.
     hnf; intros.
     specialize (H y H0).
-    hnf; intros.
-    specialize (H a' H1).
+    intros ?? H1 Hext H2.
+    specialize (H _ _ H1 Hext).
     clear - H H2.
-    destruct (level a') eqn:?H in |- *.
+    destruct (level a'') eqn:?H in |- *.
     - hnf.
       intros.
       eexists; split; [exact H1 |].
@@ -388,9 +381,8 @@ Proof.
   + hnf; intros.
     hnf; intros.
     specialize (H y H0).
-    hnf; intros.
-    specialize (H a' H1).
-    apply H.
+    intros ?? H1 Hext H2.
+    eapply H; eauto.
     destruct H2 as [[? ?] ?].
     split; [split |]; auto.
     destruct H3 as [? [? [? [? ?]]]].
@@ -437,7 +429,7 @@ Proof.
   apply allp_derives; intro vx;
   forget (construct_rho (filter_genv ge) vx tx) as rho;
   cbv beta iota zeta;
-  (destruct vl; simpl; [intros ? ? ? ? ? ? [[_ [? [? [? [_ [? _]]]]]] _]; discriminate | ]);
+  (destruct vl; simpl; [intros ? ? ? ? ? ? ? ? [[_ [? [? [? [_ [? _]]]]]] _]; discriminate | ]);
   rewrite !(prop_true_andp (None=None)) by auto;
   rewrite assert_safe_except_0; auto.
 Qed.
@@ -591,7 +583,7 @@ all:    specialize (Hx rho); inv Hx; simpl in *;
         (allp_fun_id Delta rho && ek R' rho))); subst ek;
      [  intros ? [? [? [? ?]]];  split3; auto; split; auto | ];
     apply prop_andp_left; intro Hvl;
-    rewrite (prop_true_andp _ _ _ Hvl); auto.
+    rewrite (prop_true_andp _ _ Hvl); auto.
   + erewrite (guard_allp_fun_id _ _ _ _ _ P) by eauto.
     erewrite (guard_tc_environ _ _ _ _ _ (fun rho => allp_fun_id Delta rho && P rho)) by eauto.
     rewrite (guard_except_0 _ _ _ _ P').
@@ -628,10 +620,10 @@ apply allp_derives; intro vl.
 apply allp_derives; intro te.
 apply allp_derives; intro ve.
 intros ? ?.
-intros ? ? ? ? ?.
+intros ? ? ? ? ? Hext ?.
 destruct H3 as [[? HFP] ?].
 assert (bupd (proj_ret_assert (frame_ret_assert R F) ek vl
-  (construct_rho (filter_genv psi) ve te)) a') as HFP'.
+  (construct_rho (filter_genv psi) ve te)) a'') as HFP'.
 { specialize (H ek vl (construct_rho (filter_genv psi) ve te)).
   rewrite prop_true_andp in H.
   destruct ek; [ | simpl in * |- .. ].
@@ -660,15 +652,16 @@ assert (bupd (proj_ret_assert (frame_ret_assert R F) ek vl
     destruct R; auto.
   * destruct H3; eapply typecheck_environ_sub; eauto. }
 assert ((bupd (assert_safe Espec psi f ve te (exit_cont ek vl k)
-  (construct_rho (filter_genv psi) ve te))) a') as Hsafe.
+  (construct_rho (filter_genv psi) ve te))) a'') as Hsafe.
 { intros ? J.
   destruct (HFP' _ J) as (b & ? & m' & ? & ? & ? & ?).
   exists b; split; auto; exists m'; repeat split; auto.
   pose proof (necR_level _ _ H2).
+  apply rmap_order in Hext as (? & Hr & ?).
   lapply (H0 m'); [|lia].
-  intro X; apply X; auto.
+  intro X; eapply X; auto.
   split; [split|]; auto.
-  apply funassert_resource with (a := a'); auto. }
+  apply funassert_resource with (a := a''); auto. }
 eapply bupd_trans; eauto.
 Qed.
 
@@ -704,7 +697,7 @@ unfold guard.
 apply allp_derives; intro te.
 apply allp_derives; intro ve.
 intros ? ?.
-intros ? ? ? ? ?.
+intros ? ? ? ? ? Hext ?.
 destruct H3 as [[? HFP] ?].
 eapply sepcon_derives in HFP; [| apply derives_refl | apply H].
 apply bupd_frame_l in HFP.
@@ -712,10 +705,11 @@ apply bupd_trans; intros ? J.
 destruct (HFP _ J) as (b & ? & m' & ? & ? & ? & HFP').
 exists b; split; auto; exists m'; repeat split; auto.
 pose proof (necR_level _ _ H2).
+apply rmap_order in Hext as (? & ? & ?).
 lapply (H0 m'); [|lia].
-intro X; apply X; auto.
+intro X; eapply X; auto.
 split; [split|]; auto.
-apply funassert_resource with (a := a'); auto.
+apply funassert_resource with (a := a''); auto.
 { destruct H3; eapply typecheck_environ_sub; eauto. }
 Qed.
 
@@ -791,7 +785,7 @@ apply semax'_post_bupd.
 intros; destruct ek; simpl;
 repeat (apply normalize.derives_extract_prop; intro); rewrite ?prop_true_andp by auto;
 specialize (H rho); specialize (H0 rho); specialize (H1 rho); specialize (H2 vl rho);
-rewrite prop_true_andp in * by auto; auto.
+rewrite ?prop_true_andp in H, H0, H1, H2 by auto; auto.
 Qed.
 
 Lemma semax_post' {CS: compspecs} {Espec: OracleKind}:
@@ -827,7 +821,7 @@ apply semax'_post.
 intros; destruct ek; simpl;
 repeat (apply normalize.derives_extract_prop; intro); rewrite ?prop_true_andp by auto;
 specialize (H rho); specialize (H0 rho); specialize (H1 rho); specialize (H2 vl rho);
-rewrite prop_true_andp in * by auto; auto.
+rewrite prop_true_andp in H, H0, H1, H2 by auto; auto.
 Qed.
 
 Lemma semax_pre_bupd {CS: compspecs} {Espec: OracleKind} :

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -74,7 +74,7 @@ Qed.
 
 Section SemaxContext.
 
-Lemma universal_imp_unfold {A} {agA: ageable A}:
+Lemma universal_imp_unfold {A} {agA: ageable A} {EO: Ext_ord A}:
    forall B (P Q: B -> pred A) w,
      (ALL psi : B, P psi --> Q psi) w = (forall psi : B, (P psi --> Q psi) w).
 Proof.
@@ -97,15 +97,15 @@ Proof.
  destruct k; auto.
 Qed.
 
-Lemma prop_imp_derives {A}{agA: ageable A}:
+Lemma prop_imp_derives {A}{agA: ageable A} {EO: Ext_ord A}:
   forall (P: Prop) (Q Q': pred A),  (P -> Q |-- Q') -> !!P --> Q |-- !!P --> Q'.
 Proof.
  intros.
  repeat intro.
- apply H; auto.
+ apply H; eauto.
 Qed.
 
-Lemma prop_imp {A}{agA: ageable A}:
+Lemma prop_imp {A}{agA: ageable A} {EO: Ext_ord A}:
   forall (P: Prop) (Q Q': pred A),  (P -> Q = Q') -> !!P --> Q = !!P --> Q'.
 Proof.
   intros.
@@ -114,7 +114,7 @@ Proof.
   + intros; rewrite H by auto; auto.
 Qed.
 
-Lemma age_laterR {A} `{ageable A}: forall {x y}, age x y -> laterR x y.
+Lemma age_laterR {A} `{ageable A} {EO: Ext_ord A}: forall {x y}, age x y -> laterR x y.
 Proof.
 intros. constructor 1; auto.
 Qed.
@@ -150,12 +150,13 @@ Lemma funassert_resource: forall Delta rho a a' (Hl: level a = level a')
 Proof.
   intros.
   destruct H as [H1 H2]; split; repeat intro. (*rename H into H1; repeat intro.*)
-  - destruct (H1 _ _ _ (rt_refl _ _ _) H0) as (b1 & ? & ?).
+  - destruct (H1 _ _ _ _ (rt_refl _ _ _) (ext_refl _) H3) as (b1 & ? & ?).
     exists b1; split; auto.
     destruct b0; simpl in *.
-    rewrite Hr in H4.
+    rewrite Hr in H5.
     pose proof (necR_level _ _ H).
     eapply necR_PURE in H; eauto.
+    apply rmap_order in H0 as (<- & <- & _).
     rewrite H; simpl; f_equal; f_equal.
     extensionality i a0 a1 a2.
     match goal with |-context[compcert_rmaps.R.approx ?a (approx ?b ?c)] =>
@@ -163,10 +164,12 @@ Proof.
     rewrite fmap_app, approx_oo_approx', approx'_oo_approx by lia; auto.
   - specialize (H2 b b0 b1). clear H1.
     destruct b0; simpl in *.
-    apply (H2 _  (rt_refl _ _ _)).
+    apply (H2 _  _ (rt_refl _ _ _) (ext_refl _)).
     rewrite Hr, Hl.
-    destruct H0 as [p Hp].
+    destruct H3 as [p Hp].
     pose proof (necR_level _ _ H).
+    apply rmap_order in H0 as (Hl' & Hr' & _).
+    rewrite <- Hl', <- Hr' in Hp.
     rewrite <- resource_at_approx.
     eapply necR_PURE' in H as [? ->]; simpl; eauto.
 Qed.
@@ -314,9 +317,9 @@ rewrite semax_fold_unfold.
 intros psi Delta' CS'.
 apply prop_imp_i; intros [? HGG].
 clear H0 Delta. rename Delta' into Delta.
-intros ?w _ _. clear n.
+intros _ ?w _ _ _. clear n.
 intros k F f.
-intros ?w _ ?.
+intros _ ?w _ _ ?.
 clear w. rename w0 into n.
 intros te ve w ?.
 destruct H0 as [H0' H0].
@@ -397,9 +400,9 @@ apply prop_ext; split; intros.
   - split; trivial.
 + intros psi Delta' CS'.
   apply prop_imp_i; intros [? HGG].
-  intros w' ? ? k F f w'' ? [? ?].
-  apply (H psi Delta' CS' w'' H0 HGG); trivial. 
-  eapply pred_nec_hereditary; eauto.
+  intros ? w' ? ? ? k F f ? w'' ? ? [? ?].
+  apply (H psi Delta' CS' w'' H0 HGG); trivial.
+  eapply pred_upclosed, pred_nec_hereditary; eauto.
 Qed.
 
 Fixpoint list_drop (A: Type) (n: nat) (l: list A) {struct n} : list A :=
@@ -426,7 +429,7 @@ Proof.
 rewrite semax_unfold in *.
 intros.
 intros.
-intros te ve ?w ? ?w ? ?.
+intros te ve ?w ? ? ?w ? Hext ?.
 destruct H4.
 destruct H4.
 destruct H6 as [w2 [w3 [? [? [HQ ?]]]]].
@@ -441,7 +444,7 @@ specialize (H x psi Delta' CS' w TS HGG Prog_OK k F f H0 H1).
 unfold guard, _guard in H.
 specialize (H te ve).
 cbv beta in H.
-specialize (H w0 H2 w1 H3).
+specialize (H w0 H2 _ w1 H3 Hext).
 apply H.
 split; auto. split; auto.
 exists w2, w3. split3; auto.
@@ -476,7 +479,7 @@ Proof.
 rewrite semax_unfold in *.
 intros.
 intros.
-intros te ve ?w ? ?w ? ?.
+intros te ve ?w ? ? ?w ? Hext ?.
 rewrite exp_sepcon2 in H4.
 destruct H4 as [[TC [x H5]] ?].
 specialize (H x).
@@ -507,7 +510,7 @@ Proof.
 intros Delta ge w ?.
 intro b.
 intros fsig cc A P Q.
-intros ?n ? ?.
+intros ? ?n ? Hext ?.
 destruct H1 as [id [? [b0 [? ?]]]].
 rewrite H in H1. rewrite PTree.gempty in H1.
 inv H1.
@@ -520,23 +523,7 @@ Definition all_assertions_computable  :=
   to the programming language
 *)
 
-Global Existing Instance FSep_rmap.
-
-Lemma ewand_TT_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{CA: Canc_alg A}:
-    ewand TT emp = emp.
-Proof.
-intros.
-apply pred_ext; intros w ?.
-destruct H as [w1 [w3 [? [? ?]]]].
-hnf; eapply split_identity.
-eapply join_comm; eauto.
-auto.
-exists w; exists w; split; auto.
-change (identity w) in H.
-apply identity_unit'; auto.
-Qed.
-
-Lemma subp_derives' {A}{agA: ageable A}:
+Lemma subp_derives' {A}{agA: ageable A}{EO: Ext_ord A}:
   forall P Q: pred A, (forall n, (P >=> Q) n) -> P |-- Q.
 Proof.
 intros.
@@ -578,47 +565,51 @@ Lemma semax_extensionality0 {CS: compspecs} {Espec: OracleKind}:
 Proof.
 apply loeb.
 intros w ? Delta Delta' P P' c R R'.
-intros w1 ? w2 ? [[[? ?] ?] ?].
+intros w1 ? ? w2 ? Hext [[[? ?] ?] ?].
 do 3 red in H2.
 rewrite semax_fold_unfold; rewrite semax_fold_unfold in H5.
 intros gx Delta'' CS'.
 apply prop_imp_i. intros [TS HGG].
-intros w3 ? ?.
-specialize (H5 gx Delta'' CS' _ (necR_refl _)
+intros ? w3 ? Hext3 ?.
+specialize (H5 gx Delta'' CS' _ _ (necR_refl _) (ext_refl _)
  (conj (tycontext_sub_trans _ _ _ H2 TS) HGG)
-                  _ H6 H7).
+                  _ _ H6 Hext3 H7).
 
-intros k F f w4 Hw4 [? ?].
-specialize (H5 k F f w4 Hw4).
+intros k F f ? w4 Hw4 Hext4 [? ?].
+specialize (H5 k F f _ w4 Hw4 Hext4).
 assert ((rguard Espec gx Delta'' f (frame_ret_assert R F) k) w4).
-do 9 intro.
-apply (H9 b b0 b1 b2 y H10 a' H11).
+do 9 intro. intros Hext' ?.
+apply (H9 b b0 b1 b2 y H10 _ _ H11 Hext').
 destruct H12; split; auto; clear H13.
 pose proof I.
 destruct H12; split; auto.
 rewrite proj_frame_ret_assert in H14|-*.
 clear H12 H13.
-revert a' H11 H14.
+revert a'2 a'' H11 Hext' H14.
 apply sepcon_subp' with (level w2).
 apply H3.
 auto.
 apply necR_level in H6.
 apply necR_level in Hw4.
+apply ext_level in Hext3, Hext4.
 eapply le_trans; try eassumption.
 eapply le_trans; try eassumption.
+rewrite Hext3; setoid_rewrite <- Hext4; auto.
 
 specialize (H5 (conj H8 H10)). clear H8 H9 H10.
-do 7 intro.
-apply (H5 b b0 y H8 _ H9).
+do 7 intro. intros Hext' ?.
+apply (H5 b b0 y H8 _ _ H9 Hext').
 destruct H10; split; auto.
 destruct H10; split; auto.
 clear H10 H11.
-revert a' H9 H12.
+revert a'2 a'' H9 Hext' H12.
 apply sepcon_subp' with (level w2); auto.
 apply necR_level in H6.
 apply necR_level in Hw4.
+apply ext_level in Hext3, Hext4.
 eapply le_trans; try eassumption.
 eapply le_trans; try eassumption.
+rewrite Hext3; setoid_rewrite <- Hext4; auto.
 Qed.
 
 Lemma semax_extensionality1 {CS: compspecs} {Espec: OracleKind}:
@@ -630,7 +621,7 @@ Lemma semax_extensionality1 {CS: compspecs} {Espec: OracleKind}:
 Proof.
 intros.
 intros n ?.
-apply (semax_extensionality0 n I Delta Delta' P P' c R R' _ (le_refl _) _ (necR_refl _)).
+apply (semax_extensionality0 n I Delta Delta' P P' c R R' _ (le_refl _) _ _ (necR_refl _) (ext_refl _)).
 destruct H0;
 split; auto.
 destruct H0;
@@ -666,12 +657,12 @@ red in H1.
 remember ((construct_rho (filter_genv psi) vx tx)) as rho.
 red.
 hnf; intros. specialize (H1 _ H).
-hnf; intros. apply H1; auto.
-destruct H2; split; auto. destruct H2; split; auto.
-rewrite proj_frame_ret_assert in H4|-*.
+hnf; intros. eapply H1; eauto.
+destruct H3; split; auto. destruct H3; split; auto.
+rewrite proj_frame_ret_assert in H5|-*.
 rewrite proj_frame_ret_assert.
 rewrite seplog.sepcon_assoc.
-eapply sepcon_derives; try apply H4; auto. simpl.
+eapply sepcon_derives; try apply H5; auto. simpl.
 rewrite sepcon_comm; auto.
 *
 unfold F0F.
@@ -692,12 +683,12 @@ intro; apply bupd_intro; repeat intro.
 apply age1_level0 in H. lia. 
 Qed.
 
-Lemma pred_sub_later' {A} `{H: ageable A}:
+(*Lemma pred_sub_later' {A} `{H: ageable A} {EO: Ext_ord A}:
   forall (P Q: pred A),
            (|> P >=> |> Q)  |--  (|> (P >=> Q)).
 Proof.
 intros.
-rewrite later_fash; auto.
+apply subp_later1.
 rewrite later_imp.
 auto.
 Qed.
@@ -712,7 +703,7 @@ apply (@pred_sub_later' _ _ P  (assert_safe Espec f ge ve te k rho)); auto.
 eapply subp_trans'; try apply H.
 apply derives_subp; clear.
 apply now_later.
-Qed.
+Qed.*)
 
 End SemaxContext.
 
@@ -850,13 +841,13 @@ Proof.
   induction l; simpl; intros; try congruence; auto.
 Qed.
 
-Lemma and_FF : forall {A} `{ageable A} (P:pred A),
+Lemma and_FF : forall {A} `{ageable A} {EO: Ext_ord A} (P:pred A),
   P && FF = FF.
 Proof.
   intros. rewrite andp_comm. apply FF_and.
 Qed.
 
-Lemma sepcon_FF : forall {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} (P:pred A),
+Lemma sepcon_FF : forall {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A}{EO: Ext_ord A}{EA: Ext_alg A} (P:pred A),
   (P * FF = FF)%pred.
 Proof.
   intros. rewrite sepcon_comm. apply FF_sepcon.
@@ -1160,7 +1151,7 @@ Proof.
   if_tac; rename H into H_READ.
   + destruct H0 as [H0|H0]; [left | right].
     destruct H0 as [H0' H0]; split; auto.
-    destruct H0 as [bl [[] ?]]; exists bl; split; [split|]; auto.
+    destruct H0 as [bl []]; exists bl; split; auto.
     clear - H0 H1.
      intro loc'; specialize (H0 loc').
      hnf in *.
@@ -1171,9 +1162,8 @@ Proof.
      apply (age1_YES w r); auto.
      unfold noat in *; simpl in *.
     apply <- (age1_resource_at_identity _ _ loc' H1); auto.
-    eapply age1_ghost_of_identity; eauto.
-    destruct H0 as [? [v2' [bl [[] ?]]]].
-    hnf in H. subst v2. split; hnf; auto. exists v2', bl; split; [split|]; auto.
+    destruct H0 as [? [v2' [bl []]]].
+    hnf in H. subst v2. split; hnf; auto. exists v2', bl; split; auto.
     clear - H2 H1; rename H2 into H0.
      intro loc'; specialize (H0 loc').
      hnf in *.
@@ -1184,10 +1174,8 @@ Proof.
      apply (age1_YES w r); auto.
      unfold noat in *; simpl in *.
     apply <- (age1_resource_at_identity _ _ loc' H1); auto.
-    eapply age1_ghost_of_identity; eauto.
   + split; [exact (proj1 H0) |].
-    destruct H0 as [_ [? Hg]].
-    split; [|eapply age1_ghost_of_identity; eauto].
+    destruct H0 as [_ ?].
     intro loc'; specialize (H loc').
     hnf in *.
     if_tac.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -432,7 +432,7 @@ destruct H4.
 destruct H6 as [w2 [w3 [? [? [HQ ?]]]]].
 destruct (age1 w2) as [w2' | ] eqn:?.
 *
-destruct (@age1_join _ _ _ _ _ _ _ _ H6 Heqo)
+destruct (@age1_join _ _ _ _ _ _ _ _ _ H6 Heqo)
   as [w3' [w1' [? [? ?]]]].
 hnf in H8.
 specialize (H8 _ (age_laterR H10)).
@@ -519,6 +519,8 @@ Definition all_assertions_computable  :=
 (* This is not generally true, but could be made true by adding an "assert" operator
   to the programming language
 *)
+
+Global Existing Instance FSep_rmap.
 
 Lemma ewand_TT_emp {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{CA: Canc_alg A}:
     ewand TT emp = emp.
@@ -854,7 +856,7 @@ Proof.
   intros. rewrite andp_comm. apply FF_and.
 Qed.
 
-Lemma sepcon_FF : forall {A}{JA: Join A}{PA: Perm_alg A}{AG: ageable A}{XA: Age_alg A} (P:pred A),
+Lemma sepcon_FF : forall {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{AG: ageable A}{XA: Age_alg A} (P:pred A),
   (P * FF = FF)%pred.
 Proof.
   intros. rewrite sepcon_comm. apply FF_sepcon.
@@ -1661,4 +1663,4 @@ Lemma jm_bupd_local_step
 Proof.
 intros.
 destruct (age1 m) as [m' | ] eqn:?H.
-Abort.  
+Abort.

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -51,7 +51,7 @@ Lemma semax_straight_simple:
 Proof.
 intros until Q; intros EB Hc.
 rewrite semax_unfold.
-intros psi Delta' CS' n TS [CSUB HGG'] _ k F f Hcl Hsafe te ve w Hx w0 H Hglob.
+intros psi Delta' CS' n TS [CSUB HGG'] _ k F f Hcl Hsafe te ve w Hx ? w0 H Hext Hglob.
 specialize (cenv_sub_trans CSUB HGG'); intros HGG.
 apply nec_nat in Hx.
 apply (pred_nec_hereditary _ _ _ Hx) in Hsafe.
@@ -70,6 +70,7 @@ specialize (Hc jm jm1 Delta' psi ve te _ k F f TS TC2 TC' Hcl (eq_refl _) Hage).
 specialize (Hc (conj Hglob Hglob') HGG); clear Hglob Hglob'.
 destruct Hc as [jm' [te' [rho' [H9 [H2 [TC'' [H3 H4]]]]]]].
 change (@level rmap _  (m_phi jm) = S (level (m_phi jm'))) in H2.
+apply rmap_order in Hext as (Hl & Hr & _); rewrite Hl in *.
 rewrite H2 in Hsafe.
 rewrite <- level_juice_level_phi, (age_level _ _ Hage).
 econstructor; [eassumption | ].
@@ -79,7 +80,7 @@ simpl exit_cont in Hsafe.
 specialize (Hsafe (m_phi jm')).
 spec Hsafe.
 change R.rmap with rmap; lia.
-specialize (Hsafe _ (necR_refl _)).
+specialize (Hsafe _ _ (necR_refl _) (ext_refl _)).
 destruct H4.
 spec Hsafe; [clear Hsafe| ].
 split; auto.
@@ -176,7 +177,7 @@ destruct m; simpl; lia.
 * (* ~ readable_share sh *)
 destruct (access_mode t) eqn:?; try contradiction.
 destruct (type_is_volatile t); [inversion H0 |].
-destruct H0 as [_ [? _]].
+destruct H0 as [_ ?].
 specialize (H0 (b, Ptrofs.unsigned o)).
 simpl in H0.
 rewrite if_true in H0
@@ -1377,15 +1378,15 @@ pose (f loc := if adr_range_dec (b,i) (size_chunk ch) loc
                                (readable_share_lub (writable0_readable writable0_Rsh))
                                (VAL (contents_at m' loc)) NoneP
                      else core (m_phi jm @ loc)).
-destruct (make_rmap f nil (level jm)) as [mf [? [? Hg]]]; auto.
-unfold f, compose; clear f; extensionality loc.
-symmetry. if_tac.
-unfold resource_fmap. rewrite preds_fmap_NoneP.
-reflexivity.
-generalize (resource_at_approx (m_phi jm) loc);
-destruct (m_phi jm @ loc); [rewrite core_NO | rewrite core_YES | rewrite core_PURE]; try reflexivity.
-auto.
-
+destruct (make_rmap f (ghost_of m1) (level jm)) as [mf [? [? Hg]]]; auto.
+{ unfold f, compose; clear f; extensionality loc.
+  symmetry. if_tac.
+  unfold resource_fmap. rewrite preds_fmap_NoneP.
+  reflexivity.
+  generalize (resource_at_approx (m_phi jm) loc);
+  destruct (m_phi jm @ loc); [rewrite core_NO | rewrite core_YES | rewrite core_PURE]; try reflexivity.
+  auto. }
+{ rewrite level_juice_level_phi. apply join_level in H as [<- _]. apply ghost_of_approx. }
 unfold f in H5; clear f.
 exists mf; exists m2; split3; auto.
 apply resource_at_join2.
@@ -1396,7 +1397,7 @@ rewrite H6; symmetry. apply (level_store_juicy_mem _ _ _ _ _ _ STORE).
 intro; rewrite H5. clear mf H4 H5 Hg.
 simpl m_phi.
 apply (resource_at_join _ _ _ loc) in H.
-destruct H1 as [vl [[? ?] Hg]]. specialize (H4 loc). hnf in H4.
+destruct H1 as [vl [? ?]]. specialize (H4 loc). hnf in H4.
 if_tac.
 destruct H4. hnf in H4. rewrite H4 in H.
 rewrite (proof_irr x (writable0_readable wsh)) in *; clear x.
@@ -1427,8 +1428,7 @@ apply join_unit1; auto.
 rewrite core_PURE; constructor.
 rewrite Hg; simpl.
 unfold inflate_store; rewrite ghost_of_make_rmap.
-destruct H1 as [? [? Hid]].
-rewrite (Hid _ _ (ghost_of_join _ _ _ H)); constructor.
+apply ghost_of_join; auto.
 
 unfold address_mapsto in *.
 destruct (load_store_similar' _ _ _ _ _ _ STORE ch' (eq_sym (decode_encode_val_size _ _ OK)))
@@ -1436,8 +1436,8 @@ destruct (load_store_similar' _ _ _ _ _ _ STORE ch' (eq_sym (decode_encode_val_s
 exists v''.
 rewrite prop_true_andp by auto.
 exists (encode_val ch v').
-destruct H1 as [vl [[[? [? ?]] ?] Hg1]].
-split; [split|].
+destruct H1 as [vl [[? [? ?]] ?]].
+split.
 split3; auto.
 rewrite encode_val_length.
 clear - OK. apply decode_encode_val_size in OK.
@@ -1479,7 +1479,6 @@ do 3 red. rewrite H5.
 rewrite (decode_encode_val_size _ _ OK).
  rewrite if_false by auto.
 apply core_identity.
-simpl; apply ghost_identity; auto.
 Qed.
 
 
@@ -1494,7 +1493,7 @@ Proof.
 intros.
 pose proof (address_mapsto_can_store' _ _ ch _ _ wsh _ _ v' _ H (decode_encode_val_ok_same _)).
 destruct H1 as [m' [? ?]].
-destruct H as [? [? [_ [[? [[[ _ [_ ?]] _] _]] _]]]]; auto.
+destruct H as [? [? [_ [[? [[ _ [_ ?]] _]] _]]]]; auto.
 rewrite exp_sepcon1 in a.
 destruct a as [v'' ?].
 rewrite sepcon_andp_prop1 in H1.
@@ -1614,13 +1613,8 @@ assert (H11': (res_predicates.address_mapsto ch v3 sh
  by (exists w1; exists w3; split3; auto).
 assert (H11: (res_predicates.address_mapsto ch v3  sh
         (b0, Ptrofs.unsigned i) * exactly w3)%pred (m_phi jm1)).
-generalize (address_mapsto_precise ch v3 sh (b0,Ptrofs.unsigned i)); unfold precise; intro.
-destruct H11' as [m7 [m8 [? [? _]]]].
-specialize (H2 (m_phi jm1) _ _ H4 H9).
-spec H2; [ eauto with typeclass_instances| ].
-spec H2; [ eauto with typeclass_instances | ].
-subst m7.
-exists w1; exists w3; split3; auto. hnf. apply necR_refl.
+{ exists w1; exists w3; split3; auto.
+  hnf; eauto. }
 apply address_mapsto_can_store 
    with (v':=((force_val (Cop.sem_cast (eval_expr e2 rho) (typeof e2) (typeof e1) (m_dry jm1))))) in H11;
   auto.
@@ -1667,7 +1661,7 @@ apply juicy_store_nodecay.
 {intros.
  clear - H11' H2 WS.
  destruct H11' as [phi1 [phi2 [? [? ?]]]].
- destruct H0 as [bl [[_ ?] Hg]]. specialize  (H0 (b0,z)).
+ destruct H0 as [bl [_ ?]]. specialize  (H0 (b0,z)).
  hnf in H0. rewrite if_true in H0 by (split; auto; lia).
  destruct H0. hnf in H0.
  apply (resource_at_join _ _ _ (b0,z)) in H.
@@ -1716,8 +1710,9 @@ eapply tc_val_sem_cast; eauto.
 intros ? ?. apply H2.
 *
 intros ? ?.
-do 3 red in H2.
+destruct H2 as (? & H2 & ?).
 destruct (nec_join2 H6 H2) as [w2' [w' [? [? ?]]]].
+eapply pred_upclosed; eauto.
 exists w2'; exists w'; split3; auto; eapply pred_nec_hereditary; eauto.
 Qed.
 
@@ -1815,13 +1810,8 @@ assert (H11': (res_predicates.address_mapsto ch v3 sh
  by (exists w1; exists w3; split3; auto).
 assert (H11: (res_predicates.address_mapsto ch v3  sh
         (b0, Ptrofs.unsigned i) * exactly w3)%pred (m_phi jm1)).
-generalize (address_mapsto_precise ch v3 sh (b0,Ptrofs.unsigned i)); unfold precise; intro.
-destruct H11' as [m7 [m8 [? [? _]]]].
-specialize (H2 (m_phi jm1) _ _ H4 H9).
-spec H2; [ eauto with typeclass_instances| ].
-spec H2; [ eauto with typeclass_instances | ].
-subst m7.
-exists w1; exists w3; split3; auto. hnf. apply necR_refl.
+{ exists w1; exists w3; split3; auto.
+  hnf; eauto. }
 apply address_mapsto_can_store'
    with (ch':=ch') (v':=((force_val (Cop.sem_cast (eval_expr e2 rho) (typeof e2) (typeof e1) (m_dry jm1))))) in H11;
   auto.
@@ -1871,7 +1861,7 @@ apply juicy_store_nodecay.
 {intros.
  clear - H11' H2 WS.
  destruct H11' as [phi1 [phi2 [? [? ?]]]].
- destruct H0 as [bl [[_ ?] Hg]]. specialize  (H0 (b0,z)).
+ destruct H0 as [bl [_ ?]]. specialize  (H0 (b0,z)).
  hnf in H0. rewrite if_true in H0 by (split; auto; lia).
  destruct H0. hnf in H0.
  apply (resource_at_join _ _ _ (b0,z)) in H.
@@ -1949,7 +1939,9 @@ end.
 *
 intros ? ?.
 clear - H9 H6 H1 H5.
+destruct H9 as (? & H9 & ?).
 destruct (nec_join2 H6 H9) as [w2' [w' [? [? ?]]]].
+eapply pred_upclosed; eauto.
 exists w2'; exists w'; split3; auto; eapply pred_nec_hereditary; eauto.
 Qed.
 

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -1377,7 +1377,7 @@ pose (f loc := if adr_range_dec (b,i) (size_chunk ch) loc
                                (readable_share_lub (writable0_readable writable0_Rsh))
                                (VAL (contents_at m' loc)) NoneP
                      else core (m_phi jm @ loc)).
-destruct (make_rmap f (core (ghost_of (m_phi jm))) (level jm)) as [mf [? [? Hg]]].
+destruct (make_rmap f nil (level jm)) as [mf [? [? Hg]]]; auto.
 unfold f, compose; clear f; extensionality loc.
 symmetry. if_tac.
 unfold resource_fmap. rewrite preds_fmap_NoneP.
@@ -1385,7 +1385,6 @@ reflexivity.
 generalize (resource_at_approx (m_phi jm) loc);
 destruct (m_phi jm @ loc); [rewrite core_NO | rewrite core_YES | rewrite core_PURE]; try reflexivity.
 auto.
-rewrite ghost_core; auto.
 
 unfold f in H5; clear f.
 exists mf; exists m2; split3; auto.
@@ -1413,10 +1412,10 @@ rewrite H4; simpl.
 rewrite writable0_lub_retainer_Rsh; auto.
 apply join_unit1_e in H; auto.
 rewrite H.
-unfold inflate_store; simpl.
+unfold inflate_store.
 rewrite resource_at_make_rmap.
 rewrite resource_at_approx.
-case_eq (m_phi jm @ loc); simpl; intros.
+case_eq (m_phi jm @ loc); intros.
 rewrite core_NO. constructor. apply join_unit1; auto.
 destruct k; try solve [rewrite core_YES; constructor; apply join_unit1; auto].
 rewrite core_YES.
@@ -1429,8 +1428,7 @@ rewrite core_PURE; constructor.
 rewrite Hg; simpl.
 unfold inflate_store; rewrite ghost_of_make_rmap.
 destruct H1 as [? [? Hid]].
-rewrite (Hid _ _ (ghost_of_join _ _ _ H)).
-apply core_unit.
+rewrite (Hid _ _ (ghost_of_join _ _ _ H)); constructor.
 
 unfold address_mapsto in *.
 destruct (load_store_similar' _ _ _ _ _ _ STORE ch' (eq_sym (decode_encode_val_size _ _ OK)))
@@ -1481,7 +1479,7 @@ do 3 red. rewrite H5.
 rewrite (decode_encode_val_size _ _ OK).
  rewrite if_false by auto.
 apply core_identity.
-simpl; rewrite Hg; apply core_identity.
+simpl; apply ghost_identity; auto.
 Qed.
 
 
@@ -1681,11 +1679,7 @@ rewrite level_store_juicy_mem. split; [apply age_level; auto|].
 simpl. unfold inflate_store; rewrite ghost_of_make_rmap.
 apply age1_ghost_of, age_jm_phi; auto.
 split.
-2 : {
-      rewrite corable_funassert.
-      replace (core  (m_phi (store_juicy_mem _ _ _ _ _ _ H11))) with (core (m_phi jm1)).
-      rewrite <- corable_funassert.
-      eapply pred_hereditary; eauto. apply age_jm_phi; auto.
+2 : { eapply (corable_core _ (m_phi jm1)), pred_hereditary; eauto; [|apply age_jm_phi; auto].
       symmetry.
       forget (force_val (Cop.sem_cast (eval_expr e2 rho) (typeof e2) (typeof e1) (m_dry jm1))) as v.
       apply rmap_ext.
@@ -1693,11 +1687,11 @@ split.
       rewrite <- level_juice_level_phi; rewrite level_store_juicy_mem.
       reflexivity.
       intro loc.
-      unfold store_juicy_mem.
-      simpl. rewrite <- core_resource_at. unfold inflate_store. simpl.
+      unfold store_juicy_mem. simpl.
+      rewrite <- core_resource_at. unfold inflate_store.
       rewrite resource_at_make_rmap. rewrite <- core_resource_at.
       case_eq (m_phi jm1 @ loc); intros; auto.
-      destruct k0; simpl; repeat rewrite core_YES; auto.
+      destruct k0; simpl resource_fmap; repeat rewrite core_YES; auto.
       simpl.
       rewrite !ghost_of_core.
       unfold inflate_store; rewrite ghost_of_make_rmap; auto.
@@ -1890,10 +1884,7 @@ simpl. unfold inflate_store; rewrite ghost_of_make_rmap.
 apply age1_ghost_of, age_jm_phi; auto.
 split.
 2 : {
-      rewrite corable_funassert.
-      replace (core  (m_phi (store_juicy_mem _ _ _ _ _ _ H11))) with (core (m_phi jm1)).
-      rewrite <- corable_funassert.
-      eapply pred_hereditary; eauto. apply age_jm_phi; auto.
+      eapply (corable_core _ (m_phi jm1)), pred_hereditary; eauto; [|apply age_jm_phi; auto].
       symmetry.
       forget (force_val (Cop.sem_cast (eval_expr e2 rho) (typeof e2) (typeof e1) (m_dry jm1))) as v.
       apply rmap_ext.
@@ -1901,11 +1892,11 @@ split.
       rewrite <- level_juice_level_phi; rewrite level_store_juicy_mem.
       reflexivity.
       intro loc.
-      unfold store_juicy_mem.
-      simpl. rewrite <- core_resource_at. unfold inflate_store. simpl.
+      unfold store_juicy_mem. simpl.
+      rewrite <- core_resource_at. unfold inflate_store.
       rewrite resource_at_make_rmap. rewrite <- core_resource_at.
       case_eq (m_phi jm1 @ loc); intros; auto.
-      destruct k0; simpl; repeat rewrite core_YES; auto.
+      destruct k0; simpl resource_fmap; repeat rewrite core_YES; auto.
       simpl.
       rewrite !ghost_of_core.
       unfold inflate_store; rewrite ghost_of_make_rmap; auto.

--- a/veric/seplog.v
+++ b/veric/seplog.v
@@ -417,7 +417,7 @@ Lemma bupd_unfash: forall P, bupd (! P) |-- ! P.
 Proof.
   repeat intro; simpl in *.
   destruct (H (core (ghost_of a))) as (? & ? & ? & <- & ? & ? & ?); auto.
-  rewrite ghost_core; eexists; constructor.
+  rewrite <- ghost_of_approx at 1; eexists; apply ghost_fmap_join, join_comm, core_unit.
 Qed.
 
 Lemma bupd_andp_unfash: forall P Q, bupd (!P && Q) = !P && bupd Q.

--- a/veric/slice.v
+++ b/veric/slice.v
@@ -380,7 +380,7 @@ Lemma jam_noat_splittable_aux:
            (rsh1: readable_share sh1) (rsh2: readable_share sh2)
            l
            (H: join sh1 sh2 sh3)
-           w (H0: allp (@jam _ _ _ _ _ _ (S' l) (S l) (Q l sh3) noat) w)
+           w (H0: allp (@jam _ _ _ _ _ _ _ (S' l) (S l) (Q l sh3) noat) w)
            f (Hf: resource_at f = fun loc => slice_resource (if S l loc then sh1 else Share.bot) (w @ loc))
            g (Hg: resource_at g = fun loc => slice_resource (if S l loc then sh2 else Share.bot) (w @ loc))
            (H1: join f g w),
@@ -433,7 +433,7 @@ Proof.
    apply YES_not_identity in H. contradiction.
 Qed.
 
-Definition splittable {A} {JA: Join A}{PA: Perm_alg A}{agA: ageable A}{AgeA: Age_alg A} (Q: Share.t -> pred A) := 
+Definition splittable {A} {JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}{agA: ageable A}{AgeA: Age_alg A} (Q: Share.t -> pred A) := 
   forall (sh1 sh2 sh3: Share.t) (rsh1: readable_share sh1) (rsh2: readable_share sh2),
     join sh1 sh2 sh3 ->
     Q sh1 * Q sh2 = Q sh3.

--- a/veric/superprecise.v
+++ b/veric/superprecise.v
@@ -446,7 +446,7 @@ Qed.
 Abort.
 
 
-Lemma superprecise_ewand_lem1:
+(*Lemma superprecise_ewand_lem1:
   forall S P: pred rmap, superprecise P ->
           (S |-- P * TT) ->
           S = (P * (ewand P S))%pred.
@@ -464,7 +464,7 @@ apply join_core2 in H1; apply join_core2 in H3; unfold comparable; congruence.
 subst w3.
 pose proof (join_eq H1 H3); subst w4.
 auto.
-Qed.
+Qed.*)
 
 (*Lemma superprecise_address_mapsto:
   wishes_eq_horses -> 

--- a/veric/valid_pointer.v
+++ b/veric/valid_pointer.v
@@ -27,7 +27,6 @@ Proof.
   simpl in H2 |- *.
   rewrite Ptrofs.unsigned_repr by (unfold Ptrofs.max_unsigned; lia).
   rewrite Z.add_0_r.
-  destruct H2 as [H2 _].
   specialize (H2 (b, ofs + i)).
   if_tac in H2.
   + destruct H2.
@@ -50,7 +49,6 @@ Proof.
   simpl in H1 |- *.
   rewrite Ptrofs.unsigned_repr by (unfold Ptrofs.max_unsigned; lia).
   rewrite Z.add_0_r.
-  destruct H1 as [H1 _].
   specialize (H1 (b, ofs + i)).
   if_tac in H1.
   + destruct H1 as [? [? ?]].
@@ -150,7 +148,7 @@ Lemma VALspec_range_weak_valid_pointer: forall sh b ofs n i,
 Proof.
   intros. unfold VALspec_range, weak_valid_pointer. intros w ?. simpl in H2 |- *.
   rewrite Ptrofs.unsigned_repr by (unfold Ptrofs.max_unsigned; lia).
-  rewrite Z.add_0_r. destruct H2 as [H2 _].
+  rewrite Z.add_0_r.
   assert (0 <= i < n \/ i = n) by lia. destruct H3.
   - specialize (H2 (b, ofs + i)). if_tac in H2.
     + left. destruct H2 as [? [? ?]]. rewrite H2; auto.
@@ -169,7 +167,7 @@ Proof.
   intros. unfold nonlock_permission_bytes, weak_valid_pointer.
   intros w ?. simpl in H3 |- *.
   rewrite Ptrofs.unsigned_repr by (unfold Ptrofs.max_unsigned; lia).
-  rewrite Z.add_0_r. destruct H3 as [H3 _].
+  rewrite Z.add_0_r.
   assert (0 <= i < n \/ i = n) by lia. destruct H4.
   - left. specialize (H3 (b, ofs + i)). if_tac in H3.
     + destruct H3. destruct (w @ (b, ofs + i)); inv H3; auto.


### PR DESCRIPTION
This PR lets us treat nontrivial ghost state, including invariants, as persistent resources in IPM (e.g., we can use the `#` intro pattern with them). This saves us from having to manually duplicate and deallocate invariants, and also lets us use Iris's definition of atomic updates directly. As a side effect, ghost state in general can now be deallocated without a view shift.

This required two changes to the foundations of VST. First, the `join_core` axiom from `msl/sepalg.v` has been weakened: if two elements of an algebra are related then their cores are also related, but need not be equal. This allows for the existence of nontrivial cores, like the knowledge that a piece of state has reached at least some value. Second, all ghost state has been made affine: `emp` means that an rmap's non-ghost resources are identities, but it may still have nontrivial ghost state. This makes the persistent modality absorbing as required by Iris, and also means that our logic is now *semi-affine*: memory is malloc-free but ghost state is garbage-collected. Somewhat surprisingly, this requires almost no changes to the existing rules of Verifiable C. (Details: I removed some of the rules for `ewand`, but they could probably be restored by taking another look at its definition, and anyway I don't think we ever use it. Also, the relationship between later and imp is a bit weaker, but there were workarounds in every place it mattered.)