### PR TITLE
/bin/bash -> /usr/bin/env bash

### DIFF
--- a/aes/grab_mbedtls_aes.sh
+++ b/aes/grab_mbedtls_aes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run this script to copy the AES files of mbed TLS to ./mbedtls
 
 if [ -e "$1" ]; then

--- a/aes/invoke_clightgen.sh
+++ b/aes/invoke_clightgen.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ../../compcert/clightgen -I./mbedtls/include/ ./mbedtls/library/aes.c && mv ./mbedtls/library/aes.v .
 

--- a/aes/invoke_clightgen_preprocessor.sh
+++ b/aes/invoke_clightgen_preprocessor.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ../../compcert/clightgen -E -I./mbedtls/include/ ./mbedtls/library/aes.c > ./aes.preprocessed.c
 

--- a/archive-unused
+++ b/archive-unused
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script deletes, from each directory in Makefile/DIRS, all files
 # that don't appear in the VST Makefile.

--- a/pg
+++ b/pg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file adapts to the VST the 'pg' script distributed with CompCert. -Gordon
 # Purpose: start Proof General with the right -I options
 # Usage: ./pg [desired-proofgeneral-start-directory]

--- a/util/GRAB
+++ b/util/GRAB
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run this script to copy over all the files of a (new) CompCert
 # version into the vst repository.
 #

--- a/util/GRABNEW
+++ b/util/GRABNEW
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run this script to copy over all the files of a (new) CompCert
 # version into the vst repository.
 #

--- a/util/PACKAGE
+++ b/util/PACKAGE
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script builds a VST distribution as a tgz file.
 # To run it:
 # FIRST DO A "git push" if necessary.

--- a/util/calc_install_files
+++ b/util/calc_install_files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #  The $1 argument of this script should be $(PROGSDIR)
 make depend >& /dev/null
 make CLIGHTGEN="CLIGHTGEN" IGNORECOQVERSION=true -Bn vst $1 2>/dev/null | \

--- a/util/get-travis-logs
+++ b/util/get-travis-logs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SINCE=236
 BUILDS=`travis history --all --no-interactive | awk '$2=="passed:"{A=$1; sub(/#/,"",A); print A;}' `

--- a/util/list-solver
+++ b/util/list-solver
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 mkdir -p sublist
 cp floyd/sublist.v sublist/sublist.v

--- a/util/make_version
+++ b/util/make_version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 F=veric/version.v
 set -e
 printf >$F 'Require Import ZArith Coq.Strings.String. Open Scope string.\n'


### PR DESCRIPTION
Some systems install bash in a non-standard location (BSDs, NixOS, etc.). VST fails to install properly on some of  those systems. This patch updates shebangs to use `/usr/bin/env bash` instead of `/bin/bash`.