### PR TITLE
Use explicit $MAKE variable in calc_install_files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 # ##### Configure Compcert #####
 
 # Note:  You can make a CONFIGURE file with the below definitions or give them
-# on th emake command line
+# on the make command line
 #
 # # Choosing compcert #
 # COMPCERT=platform     (default, choose 32 or 64 bit platform supplied x86 variant, dependent on BITSIZE, ARCH can be left empty or must be x86)
@@ -139,7 +139,7 @@ endif
 
 ifeq ($(COMPCERT_BUILD_FROM_SRC),false)
   ifeq ($(wildcard $(COMPCERT_INST_DIR)/*/Clight.vo), )
-    $(error FIRST BUILD COMPCERT, by:  cd $(COMPCERT_INST_DIR); make clightgen)
+    $(error FIRST BUILD COMPCERT, by:  cd $(COMPCERT_INST_DIR); $(MAKE) clightgen)
   endif
 endif
 
@@ -637,7 +637,7 @@ endif
 
 PROGS64_FILES=$(V64_ORDINARY)
 
-INSTALL_FILES_SRC=$(shell COMPCERT=$(COMPCERT) COMPCERT_INST_DIR=$(COMPCERT_INST_DIR) BITSIZE=$(BITSIZE) ARCH=$(ARCH) util/calc_install_files $(PROGSDIR))
+INSTALL_FILES_SRC=$(shell COMPCERT=$(COMPCERT) COMPCERT_INST_DIR=$(COMPCERT_INST_DIR) BITSIZE=$(BITSIZE) ARCH=$(ARCH) MAKE=$(MAKE) util/calc_install_files $(PROGSDIR))
 INSTALL_FILES_VO=$(patsubst %.v,%.vo,$(INSTALL_FILES_SRC))
 INSTALL_FILES=$(sort $(INSTALL_FILES_SRC) $(INSTALL_FILES_VO))
 

--- a/util/calc_install_files
+++ b/util/calc_install_files
@@ -1,5 +1,8 @@
 #!/bin/bash
+
 #  The $1 argument of this script should be $(PROGSDIR)
-make depend >& /dev/null
-make CLIGHTGEN="CLIGHTGEN" IGNORECOQVERSION=true -Bn vst $1 2>/dev/null | \
+
+MAKE=${MAKE:-make}
+${MAKE} depend >& /dev/null
+${MAKE} CLIGHTGEN="CLIGHTGEN" -Bn veric floyd $1 2>/dev/null | \
  awk '/^echo COQC /{print $NF}/^CLIGHTGEN/{print $NF}'


### PR DESCRIPTION
Some systems (such as OpenBSD) use BSD make by default, and package
GNU make separately as `gmake`. The current VST Makefile invokes util/calc_install_files, which in turn calls `make` explicitly, which causes install errors on BSD systems. Passing in the `$MAKE` variable to the calc_install_files script solves this issue.

I managed to get a successful build and install of VST on OpenBSD using both this patch and the patch in https://github.com/PrincetonUniversity/VST/pull/551. Thank you!