### PR TITLE
Unfolding in forward

### DIFF
--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -3884,6 +3884,7 @@ Ltac forward :=
            try_forward_store_union_hack e1 s2 id1 t1
     | |- semax _ _ (Ssequence ?c _) _ =>
       check_precondition;
+      check_unfold_mpred_for_at;
       eapply semax_seq';
       [ forward1 c
       | fwd_result;

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -530,7 +530,7 @@ Ltac solve_msubst_efield_denote :=
              rewrite (Ptrofs.to_int64_of_int64 (eq_refl _));
              reflexivity
             | |- Vptrofs _ = Vptrofs _ => reflexivity
-            | |- ?A = _ => fail 99 "Your subscript expression evaluates to" A "which is not in the form (Vint _) or (Vptrofs _).  Perhaps rewrite one of your LOCAL(temp _) clauses."
+            | |- ?A = _ => fail 4 "Your subscript expression evaluates to" A "which is not in the form (Vint _) or (Vptrofs _).  Perhaps rewrite one of your LOCAL(temp _) clauses."
            end
         ]
       | solve_Ptrofs_eqm_unsigned
@@ -839,6 +839,10 @@ Ltac find_unfold_mpred_aux P A p :=
   handle_intros;
   has_at_already p.
 
+(* This tactic is needed for matches where `p` is
+  not the last argument, since we have the entire mpred
+  expression. Note the two places it is called.
+*)
 Ltac find_unfold_mpred_aux' P A p :=
   lazymatch A with
   | ?A' _ _ _ _ => find_unfold_mpred_aux' P A' p

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -858,7 +858,18 @@ Ltac find_unfold_mpred_aux' P A p :=
 
 Ltac find_unfold_mpred_aux2 R1 p :=
   lazymatch R1 with
-  | context [_ p] => find_unfold_mpred_aux' R1 R1 p
+  | ?A _ _ _ _ _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ _ _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ p => find_unfold_mpred_aux' R1 A p
+  | ?A _ p => find_unfold_mpred_aux' R1 A p
+  | ?A p => find_unfold_mpred_aux' R1 A p
+  | context [p] => find_unfold_mpred_aux' R1 R1 p
   end.
 
 Ltac find_unfold_mpred R p :=

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -923,15 +923,11 @@ Ltac check_unfold_mpred_for_at_aux Delta P Q R e :=
   lazymatch goal with
   | |- ?p1 = ?p1 /\ ?p2 = ?p2 /\ _ =>
     split3; [ reflexivity | reflexivity | ];
-    (tryif (
-      assert (exists t gfs p, p1 = field_address t gfs p) by eassumption
-    ) then fail else idtac);
-    first
-    [ constr_eq p1 p2
-    | tryif
-        assert (exists t gfs p, p2 = field_address t gfs p) by eassumption
-      then fail else idtac
-    ];
+    lazymatch goal with
+    | _ : p1 = field_address _ _ _ |- _ => fail
+    | _ : p2 = field_address _ _ _ |- _ => fail
+    | _ => idtac
+    end;
     lazymatch p1 with
     | offset_val _ ?p' =>
       first

--- a/floyd/sc_set_load_store.v
+++ b/floyd/sc_set_load_store.v
@@ -859,16 +859,16 @@ Ltac find_unfold_mpred_aux' P A p :=
 Ltac find_unfold_mpred_aux2 R1 p :=
   lazymatch R1 with
   | ?A _ _ _ _ _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ _ _ _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ _ _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ _ _ _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ _ _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ _ p => find_unfold_mpred_aux' R1 A p
-  | ?A _ p => find_unfold_mpred_aux' R1 A p
-  | ?A p => find_unfold_mpred_aux' R1 A p
+  | ?A _ _ _ _ _ _ _ _ _ p => find_unfold_mpred_aux R1 A p
+  | ?A _ _ _ _ _ _ _ _ p => find_unfold_mpred_aux R1 A p
+  | ?A _ _ _ _ _ _ _ p => find_unfold_mpred_aux R1 A p
+  | ?A _ _ _ _ _ _ p => find_unfold_mpred_aux R1 A p
+  | ?A _ _ _ _ _ p => find_unfold_mpred_aux R1 A p
+  | ?A _ _ _ _ p => find_unfold_mpred_aux R1 A p
+  | ?A _ _ _ p => find_unfold_mpred_aux R1 A p
+  | ?A _ _ p => find_unfold_mpred_aux R1 A p
+  | ?A _ p => find_unfold_mpred_aux R1 A p
+  | ?A p => find_unfold_mpred_aux R1 A p
   | context [p] => find_unfold_mpred_aux' R1 R1 p
   end.
 

--- a/progs/verif_bst.v
+++ b/progs/verif_bst.v
@@ -393,14 +393,13 @@ Proof.
     Exists b t. entailer.
     apply ramify_PPQQ.
   * (* Loop body *)
-    unfold insert_inv.
+    unfold insert_inv at 1.
     Intros b1 t1.
     forward. (* Sskip *)
-    unfold treebox_rep at 1. Intros p1.
     forward. (* p = *t; *)
     forward_if.
     + (* then clause *)
-      subst p1.
+      subst p.
       Time forward_call (sizeof t_struct_tree).
       Intros p'.
       rewrite memory_block_data_at_ by auto.
@@ -426,7 +425,7 @@ Proof.
       - (* Inner if, then clause: x<k *)
         forward. (* t=&p->left *)
         unfold insert_inv.
-        Exists (field_address t_struct_tree [StructField _left] p1) t1_1.
+        Exists (field_address t_struct_tree [StructField _left] p) t1_1.
         entailer!. simpl.
         simpl_compb.
         (* TODO: SIMPLY THIS LINE 
@@ -440,7 +439,7 @@ Proof.
       - (* Inner if, second branch:  k<x *)
         forward. (* t=&p->right *)
         unfold insert_inv.
-        Exists (field_address t_struct_tree [StructField _right] p1) t1_2.
+        Exists (field_address t_struct_tree [StructField _right] p) t1_2.
         entailer!. simpl.
         simpl_compb; simpl_compb.
         (* TODO: SIMPLY THIS LINE 
@@ -460,11 +459,11 @@ Proof.
         simpl_compb.
         simpl_compb.
         apply modus_ponens_wand'.
-        unfold treebox_rep. Exists p1.
+        unfold treebox_rep. Exists p.
         simpl tree_rep. Exists pa pb. entailer!.
   * (* After the loop *)
     forward.
-    unfold loop2_ret_assert. apply andp_left2. auto.
+    apply andp_left2. auto.
 Qed.
 
 Definition lookup_inv (b0 p0: val) (t0: tree val) (x: Z): environ -> mpred :=
@@ -476,7 +475,6 @@ Definition lookup_inv (b0 p0: val) (t0: tree val) (x: Z): environ -> mpred :=
 Lemma body_lookup: semax_body Vprog Gprog f_lookup lookup_spec.
 Proof.
   start_function.
-  unfold treebox_rep. Intros p.
   forward. (* p=*t; *)
   apply (semax_post_ret1 nil
           (data_at Tsh (tptr t_struct_tree) p b :: tree_rep t p :: nil)).
@@ -518,7 +516,6 @@ Proof.
       assert (x=k) by lia. subst x. clear H H3 H4.
       forward. (* v=p->value *)
       forward. (* return v; *) simpl.
-      unfold treebox_rep. unfold normal_ret_assert.
       entailer!.
       - rewrite <- H0. simpl.
         simpl_compb; simpl_compb; auto.


### PR DESCRIPTION
If a forward would fail in `sc_set_load_store.load_tac`'s `hint_msg`, we will now try to find an appropriate definition and unfold it.

### How it works:
Using a similar lemma to `hint_msg_lemma`, we get the pointer, `p` which we need in a `data_at _ _ _ p` or similar for.
We then check if one exists, if not, we check if any `mpred` has `p` as an argument, if so, unfold it, `Intros`/`Intros x` and check if it now contains a `data_at _ _ _ p` or similar.

### Limitations:
Currently, it is only looking at the base pointer, so if we get `offset_val 4 p`, we'll only look for `p`.
This means, we won't try to unfold to get a `field_at` if another one exists, even if it's the wrong member.

### Questions:
Currently, I removed `unfold`'s in `verif_bst.v` that are now done automatically, as a test.
Is this fine as a test?