### PR TITLE
Improve entailer; faster proofs in veric.extend_tc; Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,12 +79,15 @@ ifeq ($(COMPCERT),platform)
   # Platform supplied CompCert
   ifeq ($(BITSIZE),)
     COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
+    REL_COMPCERT_INST_DIR=$(COMPCERT_INST_DIR)
     COMPCERT_EXPLICIT_PATH = false
   else ifeq ($(BITSIZE),64)
     COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
+    REL_COMPCERT_INST_DIR=$(COMPCERT_INST_DIR)
     COMPCERT_EXPLICIT_PATH = false
   else ifeq ($(BITSIZE),32)
     COMPCERT_INST_DIR = $(COQLIB)/../coq-variant/compcert32/compcert
+    REL_COMPCERT_INST_DIR=$(COMPCERT_INST_DIR)
   else 
     $(error ILLEGAL BITSIZE $(BITSIZE))
   endif
@@ -93,11 +96,13 @@ else ifeq ($(COMPCERT),bundled)
   # Bundled CompCert
   COMPCERT_SRC_DIR = compcert
   COMPCERT_INST_DIR = compcert
+  REL_COMPCERT_INST_DIR=../../compcert
   COMPCERT_BUILD_FROM_SRC = true
 else ifeq ($(COMPCERT),bundled_new)
   # Bundled CompCert (new variant)
   COMPCERT_SRC_DIR = compcert_new
   COMPCERT_INST_DIR = compcert_new
+  REL_COMPCERT_INST_DIR=../../compcert_new
   COMPCERT_NEW = true
   COMPCERT_INFO_PATH_REF = compcert_new
   COMPCERT_BUILD_FROM_SRC = true
@@ -107,6 +112,8 @@ else ifeq ($(COMPCERT),src_dir)
     $(error COMPCERT_SRC_DIR must not be empty if COMPCERT=src_dir)
   endif
   COMPCERT_INST_DIR = $(COMPCERT_SRC_DIR)
+  # this next line is a bit dicey . . .
+  REL_COMPCERT_INST_DIR=../../$(COMPCERT_INST_DIR)
   COMPCERT_BUILD_FROM_SRC = true
 else ifeq ($(COMPCERT),inst_dir)
   # Find CompCert in install dir
@@ -876,7 +883,7 @@ progs64v: progs64c $(V64_ORDINARY:%.v=progs64/%.v) $(C64_ORDINARY:%.c=progs64/%.
 progs64: _CoqProject  $(PROGS64_FILES:%.v=progs64/%.vo)
 
 VSUpile: floyd/proofauto.vo floyd/library.vo floyd/VSU.vo
-	cd progs/VSUpile; $(MAKE) VST_LOC=../.. COMPCERT_LOC=$(COMPCERT_INST_DIR)
+	cd progs/VSUpile; $(MAKE) VST_LOC=../.. COMPCERT_LOC=$(REL_COMPCERT_INST_DIR)
 
 # $(CC_TARGET): compcert/make
 #	(cd compcert; ./make)

--- a/compcert/lib/Floats.v
+++ b/compcert/lib/Floats.v
@@ -18,7 +18,7 @@
 (** Formalization of floating-point numbers, using the Flocq library. *)
 
 Require Import Coqlib Zbits Integers.
-From Flocq Require Import Binary Bits Core.
+From Flocq3 Require Import Binary Bits Core.
 Require Import IEEE754_extra.
 Require Import Program.
 Require Archi.

--- a/compcert/lib/IEEE754_extra.v
+++ b/compcert/lib/IEEE754_extra.v
@@ -18,7 +18,7 @@
 (** Additional operations and proofs about IEEE-754 binary
     floating-point numbers, on top of the Flocq library. *)
 
-From Flocq Require Import Core Digits Operations Round Bracket Sterbenz
+From Flocq3 Require Import Core Digits Operations Round Bracket Sterbenz
                           Binary Round_odd.
 Require Import Psatz.
 Require Import Bool.

--- a/compcert/x86_32/Archi.v
+++ b/compcert/x86_32/Archi.v
@@ -17,7 +17,7 @@
 
 (** Architecture-dependent parameters for x86 in 32-bit mode *)
 
-From Flocq Require Import Binary Bits.
+From Flocq3 Require Import Binary Bits.
 Require Import ZArith List.
 
 Definition ptr64 := false.

--- a/compcert/x86_64/Archi.v
+++ b/compcert/x86_64/Archi.v
@@ -17,7 +17,7 @@
 
 (** Architecture-dependent parameters for x86 in 64-bit mode *)
 
-From Flocq Require Import Binary Bits.
+From Flocq3 Require Import Binary Bits.
 Require Import ZArith List.
 
 Definition ptr64 := true.

--- a/floyd/entailer.v
+++ b/floyd/entailer.v
@@ -423,8 +423,9 @@ Ltac prove_it_now :=
         | computable
         | apply Coq.Init.Logic.I
         | reflexivity
-        | rewrite ?intsigned_intrepr_bytesigned; rep_lia (* Omega0 *)
+        | rewrite ?intsigned_intrepr_bytesigned; rep_lia
         | prove_signed_range
+        | congruence
         | repeat match goal with
                       | H: ?A |- _ => has_evar A; clear H 
                       | H: @value_fits _ _ _ |- _ => clear H  (* delete these because they can cause slowness in the 'auto' *)
@@ -559,6 +560,7 @@ Ltac my_auto_reiter :=
         |eassumption].
 
 Ltac my_auto :=
+ repeat match goal with |- ?P -> _ => match type of P with Prop => intro end end;
  rewrite ?isptr_force_ptr by auto;
  let H := fresh in eapply my_auto_lem; [intro H; my_auto_iter H | ];
  try all_True;

--- a/hmacdrbg/spec_hmac_drbg.v
+++ b/hmacdrbg/spec_hmac_drbg.v
@@ -979,7 +979,7 @@ f_equal. unfold hmac_init_funspec. simpl.
         destruct args; [ | inv H]. 
         unfold env_set, eval_id in *.  simpl in *. subst. entailer!.
       * unfold argsassert2assert, local, lift1, liftx, lift; simpl. destruct x as [g args]. simpl.
-        normalize. entailer!. split; discriminate. 
+        normalize. entailer!.  discriminate. 
     - unfold convertPre. simpl. unfold PROPx, LAMBDAx, GLOBALSx, LOCALx, SEPx. change_compspecs CompSepcs.
       apply pred_ext; simpl; intros.
       * unfold argsassert2assert, local, lift1, liftx, lift; simpl. destruct x as [g args]. simpl.
@@ -987,7 +987,7 @@ f_equal. unfold hmac_init_funspec. simpl.
         destruct args; [ | inv H]. 
         unfold env_set, eval_id in *.  simpl in *. subst. entailer!.
       * unfold argsassert2assert, local, lift1, liftx, lift; simpl. destruct x as [g args]. simpl.
-        normalize. entailer!. split; discriminate. 
+        normalize. entailer!.
   + extensionality ts x.
     destruct x as [[[[[c sh] l] key] gv] | [[[[[[[c sh] l] key] b] i] shk] gv]].
     - auto.

--- a/progs/verif_strlib.v
+++ b/progs/verif_strlib.v
@@ -335,7 +335,7 @@ forward_loop (EX i : Z,
  *
    forward_if.
    forward.
-   Exists (Int.repr 1). entailer!. simpl. intro. subst. lia.
+   Exists (Int.repr 1). entailer!.
 
    assert (H17: Byte.signed (Znth i (ls1 ++ [Byte.zero])) =
      Byte.signed (Znth i (ls2 ++ [Byte.zero]))) by lia.

--- a/progs64/verif_strlib.v
+++ b/progs64/verif_strlib.v
@@ -336,7 +336,7 @@ forward_loop (EX i : Z,
  *
    forward_if.
    forward.
-   Exists (Int.repr 1). entailer!. simpl. intro. subst. lia.
+   Exists (Int.repr 1). entailer!.
 
    assert (H17: Byte.signed (Znth i (ls1 ++ [Byte.zero])) =
      Byte.signed (Znth i (ls2 ++ [Byte.zero]))) by lia.

--- a/sha/verif_hmac_crypto.v
+++ b/sha/verif_hmac_crypto.v
@@ -138,7 +138,6 @@ assert_PROP (s256a_len (absCtxt (hmacInit key)) = 512).
 rename H into absH_len512.
 
 forward_call (Tsh, shm, hmacInit key, buf, msg, dl, data, gv).
-  { rewrite absH_len512. auto. }
 
 (* Call to HMAC_Final*)
 assert_PROP (@field_compatible CompSpecs (Tstruct _hmac_ctx_st noattr) nil buf).

--- a/sha/verif_hmac_double.v
+++ b/sha/verif_hmac_double.v
@@ -78,7 +78,6 @@ assert_PROP (s256a_len (absCtxt (hmacInit key)) = 512) as H0_len512.
   { unfold hmacstate_. Intros r. apply prop_right. apply H. }
 remember (hmacInit key) as h0.
 forward_call (Tsh, sh, h0, c, d, dl, data, gv).
-  { rewrite H0_len512; auto. }
 apply isptrD in Pmd. destruct Pmd as [b [i Pmd]]. rewrite Pmd in *.
 assert (GTmod64: 64 < Ptrofs.modulus).
   rewrite <- initialize.max_unsigned_modulus, ptrofs_max_unsigned_eq. lia.
@@ -110,7 +109,6 @@ assert_PROP (s256a_len (absCtxt (hmacInit key)) = 512).
   { unfold hmacstate_. entailer!. }
 rename H into H3_len512.
 forward_call (Tsh, sh, hmacInit key, c, d, dl, data, gv).
-  { rewrite H3_len512. auto. }
 
 assert_PROP (field_compatible (Tstruct _hmac_ctx_st noattr) [] c)
   as FC_c by (unfold hmacstate_; Intros r;  entailer!).

--- a/sha/verif_hmac_simple.v
+++ b/sha/verif_hmac_simple.v
@@ -61,7 +61,6 @@ thaw FR2.
 thaw FR1.
 freeze FR3 := - (K_vector _) (data_block _ _ d) (hmacstate_ _ _ c).
 Time forward_call (Tsh, shm, hmacInit key, c, d, dl, data, gv). (*2.8*)
-  { rewrite H0_len512; assumption. }
 
 thaw FR3.
 freeze FR4 := - (K_vector _) (hmacstate_ _ _ c) (memory_block _ _ md).

--- a/veric/extend_tc.v
+++ b/veric/extend_tc.v
@@ -709,6 +709,141 @@ Proof.
     auto.
 Qed.
 
+
+Lemma denote_tc_assert_andp_i:
+  forall x y rho w, 
+   app_pred (denote_tc_assert x rho) w ->
+   app_pred (denote_tc_assert y rho) w ->
+   app_pred (denote_tc_assert (tc_andp x y) rho) w.
+Proof.
+intros.
+rewrite denote_tc_assert_andp. split; auto.
+Qed.
+
+Lemma denote_tc_assert_andp'_imp:
+ forall x x' y y' rho w,
+  (app_pred (@denote_tc_assert CS x rho) w -> app_pred (@denote_tc_assert CS' x' rho) w) ->
+  (app_pred (@denote_tc_assert CS y rho) w -> app_pred (@denote_tc_assert CS' y' rho) w) ->
+  app_pred (@denote_tc_assert CS (tc_andp' x y) rho) w ->
+  app_pred (@denote_tc_assert CS' (tc_andp' x' y') rho) w.
+Proof.
+intros.
+destruct H1.
+split; auto.
+Qed.
+
+Lemma denote_tc_assert_andp_imp:
+ forall x x' y y' rho w,
+  (app_pred (@denote_tc_assert CS x rho) w -> app_pred (@denote_tc_assert CS' x' rho) w) ->
+  (app_pred (@denote_tc_assert CS y rho) w -> app_pred (@denote_tc_assert CS' y' rho) w) ->
+  app_pred (@denote_tc_assert CS (tc_andp x y) rho) w ->
+  app_pred (@denote_tc_assert CS' (tc_andp x' y') rho) w.
+Proof.
+intros.
+rewrite @denote_tc_assert_andp in H1|-*.
+eapply denote_tc_assert_andp'_imp; eauto.
+Qed.
+
+Lemma denote_tc_assert_andp'_imp2:
+ forall x x' y y' rho w,
+  (app_pred (@denote_tc_assert CS y rho) w -> 
+   app_pred (@denote_tc_assert CS x rho) w -> 
+   app_pred (@denote_tc_assert CS' x' rho) w) ->
+  (app_pred (@denote_tc_assert CS x rho) w ->
+   app_pred (@denote_tc_assert CS y rho) w ->
+   app_pred (@denote_tc_assert CS' y' rho) w) ->
+  app_pred (@denote_tc_assert CS (tc_andp' x y) rho) w ->
+  app_pred (@denote_tc_assert CS' (tc_andp' x' y') rho) w.
+Proof.
+intros.
+destruct H1.
+split; auto.
+Qed.
+
+Lemma denote_tc_assert_andp_imp2:
+ forall x x' y y' rho w,
+  (app_pred (@denote_tc_assert CS y rho) w -> 
+   app_pred (@denote_tc_assert CS x rho) w -> 
+   app_pred (@denote_tc_assert CS' x' rho) w) ->
+  (app_pred (@denote_tc_assert CS x rho) w ->
+   app_pred (@denote_tc_assert CS y rho) w ->
+   app_pred (@denote_tc_assert CS' y' rho) w) ->
+  app_pred (@denote_tc_assert CS (tc_andp x y) rho) w ->
+  app_pred (@denote_tc_assert CS' (tc_andp x' y') rho) w.
+Proof.
+intros.
+rewrite @denote_tc_assert_andp in H1|-*.
+eapply denote_tc_assert_andp'_imp2; eauto.
+Qed.
+
+Lemma tc_bool_cenv_sub:
+ forall b e rho w,
+  app_pred (@denote_tc_assert CS (tc_bool b e) rho) w ->
+  app_pred (@denote_tc_assert CS' (tc_bool b e) rho) w.
+Proof.
+intros.
+apply tc_bool_e in H.
+apply tc_bool_i.
+auto.
+Qed.
+
+Lemma tc_complete_type_cenv_sub:
+ forall t e rho w,
+  app_pred (@denote_tc_assert CS (tc_bool (complete_type (@cenv_cs CS) t) e) rho) w ->
+  app_pred (@denote_tc_assert CS' (tc_bool (complete_type (@cenv_cs CS') t) e) rho) w.
+Proof.
+intros.
+apply tc_bool_e in H.
+apply tc_bool_i.
+rewrite (cenv_sub_complete_type _ _ CSUB); auto.
+Qed.
+
+Local Lemma tc_andp'_intro:
+  forall x y rho w Q P,
+   (app_pred (@denote_tc_assert CS x rho) w ->
+    app_pred (@denote_tc_assert CS y rho) w ->
+    Q -> P) ->
+   (app_pred (@denote_tc_assert CS (tc_andp' x y) rho) w -> Q -> P).
+Proof.
+intros.
+destruct H; auto.
+Qed.
+
+Local Lemma tc_andp_intro:
+  forall x y rho w Q P,
+   (app_pred (@denote_tc_assert CS x rho) w ->
+    app_pred (@denote_tc_assert CS y rho) w ->
+    Q -> P) ->
+   (app_pred (@denote_tc_assert CS (tc_andp x y) rho) w -> Q -> P).
+Proof.
+intros.
+rewrite @denote_tc_assert_andp in H.
+destruct H; auto.
+Qed.
+
+Local Lemma tc_bool_intro:
+  forall b e rho w Q P,
+   (b = true -> Q -> P) ->
+   (app_pred (@denote_tc_assert CS (tc_bool b e) rho) w -> Q -> P).
+Proof.
+intros.
+apply tc_bool_e in H. auto.
+Qed.
+
+Lemma tc_check_pp_int'_cenv_sub:
+ forall a1 a2 op t e rho w,
+ app_pred (@denote_tc_assert CS (check_pp_int' a1 a2 op t e) rho) w ->
+ app_pred (@denote_tc_assert CS' (check_pp_int' a1 a2 op t e) rho) w.
+Proof.
+unfold check_pp_int'.
+intros.
+destruct op; try contradiction H; revert H;
+ (apply denote_tc_assert_andp'_imp; 
+  [ | apply tc_bool_cenv_sub]).
+all: try simple apply tc_test_eq'_cenv_sub.
+all: try simple apply tc_test_order'_cenv_sub.
+Qed.
+
 Lemma tc_expr_cenv_sub_binop:
  forall 
  (b : binary_operation)
@@ -723,18 +858,50 @@ Lemma tc_expr_cenv_sub_binop:
  (@tc_expr CS' Delta (Ebinop b a1 a2 t) rho) w.
 Proof.
   intros.
-  unfold tc_expr in *; simpl in T|-*.
-  tc_expr_cenv_sub_tac.
-  rewrite den_isBinOpR;
-  rewrite den_isBinOpR in H;
-   destruct b; simpl in H|-*;
-  unfold binarithType' in *; tc_expr_cenv_sub_tac;
-   repeat match goal with |- app_pred (denote_tc_assert match ?A with _ => _ end _) _ =>
-      destruct A; tc_expr_cenv_sub_tac
+  rename T into H.
+  revert H.
+  unfold tc_expr, typecheck_expr;
+  fold (@typecheck_expr CS);
+  fold (@typecheck_expr CS').
+  repeat apply denote_tc_assert_andp_imp; auto.
+ clear - CSUB.
+  rewrite !den_isBinOpR.
+  cbv zeta.
+   repeat match goal with |- _ -> app_pred (denote_tc_assert match ?A with _ => _ end _) _ =>
+      destruct A; auto
    end;
-   tc_expr_cenv_sub_tac;
-  try solve [simple apply tc_nobinover_cenv_sub; auto].
-Time Qed.  (* This Qed takes a really long time *)
+  unfold tc_int_or_ptr_type.
+Local Ltac andp_simpl := 
+ repeat first [simple apply tc_andp'_intro
+                  |simple apply tc_andp_intro
+                  |simple apply tc_bool_intro; intro
+                  |match goal with |- _ -> _ -> _ => intros _ end
+                  ].
+
+all:
+ repeat
+ first [simple apply denote_tc_assert_andp'_imp2; andp_simpl
+        |simple apply denote_tc_assert_andp_imp2; andp_simpl
+        |simple apply tc_bool_cenv_sub
+        |apply isptr_eval_expr_cenv_sub; auto
+        |simple apply tc_complete_type_cenv_sub
+        |simple apply tc_nobinover_cenv_sub
+        |simple apply tc_nodivover'_cenv_sub
+        |simple apply tc_samebase_cenv_sub
+        |simple apply tc_nonzero'_cenv_sub
+        |simple apply tc_ilt'_cenv_sub
+        |simple apply tc_llt'_cenv_sub
+        |simple apply tc_test_eq'_cenv_sub
+        |simple apply tc_test_eq_cenv_sub
+        |simple apply tc_test_order'_cenv_sub
+        |simple apply tc_check_pp_int'_cenv_sub
+        |unfold sizeof; rewrite (cenv_sub_sizeof CSUB) by assumption
+        | match goal with |- _ -> app_pred (denote_tc_assert (binarithType' _ _ _ _ _) _) _ =>
+               unfold binarithType'; destruct (classify_binarith' _ _)
+          end
+        | solve [intro H; contradiction H]
+     ].
+Qed.
 
 Lemma tc_expr_cenv_sub_cast:
  forall
@@ -867,11 +1034,17 @@ Lemma tc_expr_cenv_sub a rho Delta w (T: @tc_expr CS Delta a rho w):
   induction a;
   try solve [apply  (denote_tc_assert_cenv_sub CSUB); auto].
  + (* Ederef *)
-   simpl in T|-*;
-   tc_expr_cenv_sub_tac.
+   rename T into H; revert H.
+  unfold typecheck_lvalue;
+   fold (@typecheck_lvalue CS); fold (@typecheck_lvalue CS');
+   fold (@typecheck_expr CS); fold (@typecheck_expr CS').
+   repeat simple apply denote_tc_assert_andp_imp.
+   apply tc_expr_cenv_sub.
+   apply tc_bool_cenv_sub.
+   apply isptr_eval_expr_cenv_sub; auto.
  + (* Efield *) 
    apply (tc_lvalue_cenv_sub_field _ _ _ _ _ _ T IHa).
-Time Qed.
+ Qed.
 
   Lemma tc_exprlist_cenv_sub Delta rho w:
     forall types bl, (@tc_exprlist CS Delta types bl rho) w ->
@@ -879,17 +1052,15 @@ Time Qed.
   Proof.
     induction types; simpl; intros.
     + destruct bl; simpl in *; trivial.
-    + destruct bl; simpl in *; trivial.
-        specialize (IHtypes bl).
-      unfold tc_exprlist in H|-*. rename a into t.
-   unfold typecheck_exprlist; fold typecheck_exprlist.
-      change 
-        (app_pred (@denote_tc_assert CS
-            (tc_andp (@typecheck_expr CS Delta (Ecast e t))
-             (@typecheck_exprlist CS Delta types bl))  rho) w) in H.
-    rewrite denote_tc_assert_andp in H.
-    rewrite denote_tc_assert_andp.
-    destruct H. split; auto.
-    eapply tc_expr_cenv_sub; try eassumption.
-  Qed.
+    + destruct bl. trivial.
+       revert H.
+    unfold tc_exprlist.
+   unfold typecheck_exprlist; 
+        fold (@typecheck_exprlist CS);
+        fold (@typecheck_exprlist CS').
+        simple apply denote_tc_assert_andp_imp.
+        intros; eapply tc_expr_cenv_sub_cast; eauto.
+        apply tc_expr_cenv_sub.
+        apply IHtypes.
+   Qed.
 End CENV_SUB.


### PR DESCRIPTION
1. entailer! now does automatic intro of Props, and uses congruence.
This closes #565

2. veric/extend_tc.v builds much faster now, because two or three
 Qeds that previously took a total of 120 seconds now take total of 0.5 seconds.
 Because extend_tc.v was previously a bottleneck in "make -j", this
 improves overall build time for VST.

3. "make VSUpile" or (equivalently) "make test5" now works properly
 when using bundled compcert.