### PR TITLE
Fancy updates in the model

### DIFF
--- a/atomics/SC_atomics.v
+++ b/atomics/SC_atomics.v
@@ -8,8 +8,6 @@ Require Export VST.atomics.general_atomics.
 Require Import VST.floyd.library.
 Require Import VST.zlist.sublist.
 
-Set Bullet Behavior "Strict Subproofs".
-
 (* Warning: it is UNSOUND to use both this file and acq_rel_atomics.v in the same proof! There is
    not yet an operational model that can validate the use of both SC and RA atomics. *)
 

--- a/atomics/SC_atomics.v
+++ b/atomics/SC_atomics.v
@@ -74,12 +74,12 @@ Definition free_atomic_int_spec :=
     LOCAL ()
     SEP ().
 
-Definition AL_type := ProdType (ProdType (ProdType (ProdType (ConstType val)
+Definition AL_type := ProdType (ProdType (ProdType (ConstType val)
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType val) Mpred)) (ConstType invG).
+  (ArrowType (ConstType val) Mpred).
 
 Program Definition atomic_load_spec := TYPE AL_type
-  WITH p : val, Eo : coPset, Ei : coPset, Q : val -> mpred, inv_names : invG
+  WITH p : val, Eo : coPset, Ei : coPset, Q : val -> mpred
   PRE [ tptr atomic_int ]
    PROP (subseteq Ei Eo)
    PARAMS (p)
@@ -109,11 +109,11 @@ Proof.
     rewrite -> !sepcon_emp, ?approx_sepcon, ?approx_idem; auto.
 Qed.
 
-Definition AS_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * val))
-  (ConstType coPset)) (ConstType coPset)) Mpred) (ConstType invG).
+Definition AS_type := ProdType (ProdType (ProdType (ConstType (val * val))
+  (ConstType coPset)) (ConstType coPset)) Mpred.
 
 Program Definition atomic_store_spec := TYPE AS_type
-  WITH p : val, v : val, Eo : coPset, Ei : coPset, Q : mpred, inv_names : invG
+  WITH p : val, v : val, Eo : coPset, Ei : coPset, Q : mpred
   PRE [ tptr atomic_int, tint ]
    PROP (subseteq Ei Eo)
    PARAMS (p; v)
@@ -140,12 +140,12 @@ Proof.
     rewrite -> !sepcon_emp, ?approx_sepcon, ?approx_idem; auto.
 Qed.
 
-Definition ACAS_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * share * val * val * val))
+Definition ACAS_type := ProdType (ProdType (ProdType (ConstType (val * share * val * val * val))
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType val) Mpred)) (ConstType invG).
+  (ArrowType (ConstType val) Mpred).
 
 Program Definition atomic_CAS_spec := TYPE ACAS_type
-  WITH p : val, shc : share, pc : val, c : val, v : val, Eo : coPset, Ei : coPset, Q : val -> mpred, inv_names : invG
+  WITH p : val, shc : share, pc : val, c : val, v : val, Eo : coPset, Ei : coPset, Q : val -> mpred
   PRE [ tptr atomic_int, tptr tint, tint ]
    PROP (readable_share shc; subseteq Ei Eo)
    PARAMS (p; pc; v)
@@ -177,12 +177,12 @@ Proof.
     rewrite -> !sepcon_emp, ?approx_sepcon, ?approx_idem; auto.
 Qed.
 
-Definition AEX_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * val))
+Definition AEX_type := ProdType (ProdType (ProdType (ConstType (val * val))
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType val) Mpred)) (ConstType invG).
+  (ArrowType (ConstType val) Mpred).
 
 Program Definition atomic_exchange_spec := TYPE AEX_type
-  WITH p : val, v : val, Eo : coPset, Ei : coPset, Q : val -> mpred, inv_names : invG
+  WITH p : val, v : val, Eo : coPset, Ei : coPset, Q : val -> mpred
   PRE [ tptr tint, tint ]
    PROP (subseteq Ei Eo)
    PARAMS (p; v)
@@ -215,12 +215,12 @@ Proof.
 Qed.
 
 (* subspecs for integer operations *)
-Definition ALI_type := ProdType (ProdType (ProdType (ProdType (ConstType val)
+Definition ALI_type := ProdType (ProdType (ProdType (ConstType val)
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType Z) Mpred)) (ConstType invG).
+  (ArrowType (ConstType Z) Mpred).
 
 Program Definition atomic_load_int_spec := TYPE ALI_type
-  WITH p : val, Eo : coPset, Ei : coPset, Q : Z -> mpred, inv_names : invG
+  WITH p : val, Eo : coPset, Ei : coPset, Q : Z -> mpred
   PRE [ tptr atomic_int ]
    PROP (subseteq Ei Eo)
    PARAMS (p)
@@ -252,11 +252,11 @@ Qed.
 
 Lemma atomic_load_int : funspec_sub atomic_load_spec atomic_load_int_spec.
 Proof.
+  apply prove_funspec_sub.
   split; auto; intros; simpl in *.
-  destruct x2 as ((((p, Eo), Ei), Q), inv_names).
-  intros; match goal with |- ?P |-- |==> ?Q => change (P |-- (|==> Q)%I) end.
+  destruct x2 as (((p, Eo), Ei), Q).
   intros; iIntros "[_ H] !>".
-  iExists nil, (p, Eo, Ei, fun v => match v with Vint i => Q (Int.signed i) | _ => FF end, inv_names), emp.
+  iExists nil, (p, Eo, Ei, fun v => match v with Vint i => Q (Int.signed i) | _ => FF end), emp.
   rewrite emp_sepcon; iSplit.
   - unfold PROPx, PARAMSx, GLOBALSx, LOCALx, SEPx, argsassert2assert; simpl.
     iDestruct "H" as "($ & $ & $ & H & $)".
@@ -266,8 +266,7 @@ Proof.
     iExists sh, (vint v); iFrame.
     rewrite Int.signed_repr; auto.
   - iPureIntro.
-    intros; match goal with |- ?P |-- |==> ?Q => change (P |-- (|==> Q)%I) end.
-    iIntros "(_ & _ & H) !>".
+    iIntros (?) "(_ & _ & H)".
     unfold PROPx, LOCALx, SEPx; simpl.
     iDestruct "H" as (r) "(_ & % & Q & _)".
     destruct H, r; try done.
@@ -279,11 +278,11 @@ Proof.
     rewrite sepcon_emp; auto.
 Qed.
 
-Definition ASI_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * Z))
-  (ConstType coPset)) (ConstType coPset)) Mpred) (ConstType invG).
+Definition ASI_type := ProdType (ProdType (ProdType (ConstType (val * Z))
+  (ConstType coPset)) (ConstType coPset)) Mpred.
 
 Program Definition atomic_store_int_spec := TYPE ASI_type
-  WITH p : val, v : Z, Eo : coPset, Ei : coPset, Q : mpred, inv_names : invG
+  WITH p : val, v : Z, Eo : coPset, Ei : coPset, Q : mpred
   PRE [ tptr atomic_int, tint ]
    PROP (repable_signed v; subseteq Ei Eo)
    PARAMS (p; vint v)
@@ -312,26 +311,25 @@ Qed.
 
 Lemma atomic_store_int : funspec_sub atomic_store_spec atomic_store_int_spec.
 Proof.
+  apply prove_funspec_sub.
   split; auto; intros; simpl in *.
-  destruct x2 as (((((p, v), Eo), Ei), Q), inv_names).
-  intros; match goal with |- ?P |-- |==> ?Q => change (P |-- (|==> Q)%I) end.
+  destruct x2 as ((((p, v), Eo), Ei), Q).
   intros; iIntros "[_ H] !>".
-  iExists nil, (p, vint v, Eo, Ei, Q, inv_names), emp.
+  iExists nil, (p, vint v, Eo, Ei, Q), emp.
   rewrite emp_sepcon; iSplit.
   - unfold PROPx, PARAMSx, GLOBALSx, LOCALx, SEPx; simpl.
     iDestruct "H" as "(% & $ & $ & H & $)".
     destruct H; auto.
   - iPureIntro.
-    intros; match goal with |- ?P |-- |==> ?Q => change (P |-- (|==> Q)%I) end.
-    by iIntros "(_ & _ & $)".
+    by iIntros (?) "(_ & _ & $)".
 Qed.
 
-Definition ACASI_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * share * val * Z * Z))
+Definition ACASI_type := ProdType (ProdType (ProdType (ConstType (val * share * val * Z * Z))
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType Z) Mpred)) (ConstType invG).
+  (ArrowType (ConstType Z) Mpred).
 
 Program Definition atomic_CAS_int_spec := TYPE ACASI_type
-  WITH p : val, shc : share, pc : val, c : Z, v : Z, Eo : coPset, Ei : coPset, Q : Z -> mpred, inv_names : invG
+  WITH p : val, shc : share, pc : val, c : Z, v : Z, Eo : coPset, Ei : coPset, Q : Z -> mpred
   PRE [ tptr atomic_int, tptr tint, tint ]
    PROP (repable_signed c; repable_signed v; readable_share shc; subseteq Ei Eo)
    PARAMS (p; pc; vint v)
@@ -365,11 +363,11 @@ Qed.
 
 Lemma atomic_CAS_int : funspec_sub atomic_CAS_spec atomic_CAS_int_spec.
 Proof.
+  apply prove_funspec_sub.
   split; auto; intros; simpl in *.
-  destruct x2 as ((((((((p, shc), pc), c), v), Eo), Ei), Q), inv_names).
-  intros; match goal with |- ?P |-- |==> ?Q => change (P |-- (|==> Q)%I) end.
+  destruct x2 as (((((((p, shc), pc), c), v), Eo), Ei), Q).
   intros; iIntros "[_ H] !>".
-  iExists nil, (p, shc, pc, vint c, vint v, Eo, Ei, fun v => match v with Vint i => Q (Int.signed i) | _ => FF end, inv_names), emp.
+  iExists nil, (p, shc, pc, vint c, vint v, Eo, Ei, fun v => match v with Vint i => Q (Int.signed i) | _ => FF end), emp.
   rewrite emp_sepcon; iSplit.
   - unfold PROPx, PARAMSx, GLOBALSx, LOCALx, SEPx; simpl.
     iDestruct "H" as "(% & $ & $ & $ & H & $)".
@@ -388,8 +386,7 @@ Proof.
     iDestruct "H" as "[% _]".
     destruct H as [Hc _].
     iPureIntro.
-    intros; match goal with |- ?P |-- |==> ?Q => change (P |-- (|==> Q)%I) end.
-    iIntros "(_ & _ & H) !>".
+    iIntros (?) "(_ & _ & H)".
     iDestruct "H" as (r) "(_ & % & ? & Q & _)".
     destruct H, r; try done.
     iExists (Int.signed i); iSplit; auto.
@@ -403,12 +400,12 @@ Proof.
     rewrite Int.repr_signed sepcon_emp; iFrame.
 Qed.
 
-Definition AEXI_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * Z))
+Definition AEXI_type := ProdType (ProdType (ProdType (ConstType (val * Z))
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType Z) Mpred)) (ConstType invG).
+  (ArrowType (ConstType Z) Mpred).
 
 Program Definition atomic_exchange_int_spec := TYPE AEXI_type
-  WITH p : val, v : Z, Eo : coPset, Ei : coPset, Q : Z -> mpred, inv_names : invG
+  WITH p : val, v : Z, Eo : coPset, Ei : coPset, Q : Z -> mpred
   PRE [ tptr tint, tint ]
    PROP (repable_signed v; subseteq Ei Eo)
    PARAMS (p; vint v)
@@ -441,11 +438,11 @@ Qed.
 
 Lemma atomic_exchange_int : funspec_sub atomic_exchange_spec atomic_exchange_int_spec.
 Proof.
+  apply prove_funspec_sub.
   split; auto; intros; simpl in *.
-  destruct x2 as (((((p, v), Eo), Ei), Q), inv_names).
-  intros; match goal with |- ?P |-- |==> ?Q => change (P |-- (|==> Q)%I) end.
+  destruct x2 as ((((p, v), Eo), Ei), Q).
   intros; iIntros "[_ H] !>".
-  iExists nil, (p, vint v, Eo, Ei, fun v => match v with Vint i => Q (Int.signed i) | _ => FF end, inv_names), emp.
+  iExists nil, (p, vint v, Eo, Ei, fun v => match v with Vint i => Q (Int.signed i) | _ => FF end), emp.
   rewrite emp_sepcon; iSplit.
   - unfold PROPx, PARAMSx, GLOBALSx, LOCALx, SEPx; simpl.
     iDestruct "H" as "(% & $ & $ & H & $)".
@@ -457,8 +454,7 @@ Proof.
     rewrite -> Int.signed_repr; auto.
   - unfold PROPx, LOCALx, SEPx; simpl.
     iPureIntro.
-    intros; match goal with |- ?P |-- |==> ?Q => change (P |-- (|==> Q)%I) end.
-    iIntros "(_ & _ & H) !>".
+    iIntros (?) "(_ & _ & H)".
     iDestruct "H" as (r) "(_ & % & Q & _)".
     destruct H, r; try done.
     iExists (Int.signed i); iSplit; auto.
@@ -471,12 +467,12 @@ Qed.
 
 (* specs for pointer operations *)
 
-Definition ALI_ptr_type := ProdType (ProdType (ProdType (ProdType (ConstType val)
+Definition ALI_ptr_type := ProdType (ProdType (ProdType (ConstType val)
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType val) Mpred)) (ConstType invG).
+  (ArrowType (ConstType val) Mpred).
 
 Program Definition atomic_load_ptr_spec := TYPE ALI_ptr_type
-  WITH p : val, Eo : coPset, Ei : coPset, Q : val -> mpred, inv_names : invG
+  WITH p : val, Eo : coPset, Ei : coPset, Q : val -> mpred
   PRE [ tptr atomic_ptr ]
    PROP (subseteq Ei Eo)
    PARAMS (p)
@@ -507,11 +503,11 @@ Proof.
 Qed.
 
 
-Definition ASI_ptr_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * val))
-  (ConstType coPset)) (ConstType coPset)) Mpred) (ConstType invG).
+Definition ASI_ptr_type := ProdType (ProdType (ProdType (ConstType (val * val))
+  (ConstType coPset)) (ConstType coPset)) Mpred.
 
 Program Definition atomic_store_ptr_spec := TYPE ASI_ptr_type
-  WITH p : val, v : val, Eo : coPset, Ei : coPset, Q : mpred, inv_names : invG
+  WITH p : val, v : val, Eo : coPset, Ei : coPset, Q : mpred
   PRE [ tptr atomic_ptr, tptr Tvoid ]
    PROP (subseteq Ei Eo)
    PARAMS (p; v)
@@ -539,12 +535,12 @@ Proof.
 Qed.
 
 
-Definition ACASI_ptr_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * share * val * val * val))
+Definition ACASI_ptr_type := ProdType (ProdType (ProdType (ConstType (val * share * val * val * val))
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType val) Mpred)) (ConstType invG).
+  (ArrowType (ConstType val) Mpred).
 
 Program Definition atomic_CAS_ptr_spec := TYPE ACASI_ptr_type
-  WITH p : val, shc : share, pc : val, c : val, v : val, Eo : coPset, Ei : coPset, Q : val -> mpred, inv_names : invG
+  WITH p : val, shc : share, pc : val, c : val, v : val, Eo : coPset, Ei : coPset, Q : val -> mpred
   PRE [ tptr atomic_ptr, tptr (tptr Tvoid), tptr Tvoid ]
    PROP (readable_share shc; subseteq Ei Eo)
    PARAMS (p; pc; v)
@@ -577,12 +573,12 @@ Proof.
 Qed.
 
 
-Definition AEXI_ptr_type := ProdType (ProdType (ProdType (ProdType (ConstType (val * val))
+Definition AEXI_ptr_type := ProdType (ProdType (ProdType (ConstType (val * val))
   (ConstType coPset)) (ConstType coPset))
-  (ArrowType (ConstType val) Mpred)) (ConstType invG).
+  (ArrowType (ConstType val) Mpred).
 
 Program Definition atomic_exchange_ptr_spec := TYPE AEXI_ptr_type
-  WITH p : val, v : val, Eo : coPset, Ei : coPset, Q : val -> mpred, inv_names : invG
+  WITH p : val, v : val, Eo : coPset, Ei : coPset, Q : val -> mpred
   PRE [ tptr atomic_ptr, tptr Tvoid ]
    PROP (subseteq Ei Eo)
    PARAMS (p; v)

--- a/atomics/general_atomics.v
+++ b/atomics/general_atomics.v
@@ -20,8 +20,8 @@ Definition atomic_shift {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : 
   @atomic_update mpredI _ [tele _ : A] [tele _ : B] Eo Ei (λ.. x, a (tele_unwrap x)) (λ.. x y, b (tele_unwrap x) (tele_unwrap y)) (λ.. x y, Q (tele_unwrap y)).
 
 Lemma atomic_commit_fupd : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
-  (forall x, R * a x |-- (|==> (EX y, b x y * R' y))%I) ->
-  (atomic_shift a Ei Eo b Q * R |-- |={Eo}=> (EX y, Q y * R' y))%I.
+  (forall x, R * a x |-- |==> (EX y, b x y * R' y)) ->
+  atomic_shift a Ei Eo b Q * R |-- |={Eo}=> (EX y, Q y * R' y).
 Proof.
   intros.
   iIntros "[AS R]".
@@ -31,30 +31,9 @@ Proof.
   iExists y; iMod ("commit" with "b") as "$"; auto.
 Qed.
 
-Corollary atomic_commit_elim : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
-  (forall x, R * a x |-- (|==> (EX y, b x y * R' y))%I) ->
-  (wsat * ghost_set g_en (coPset_to_Ensemble Eo) * atomic_shift a Ei Eo b Q * R |-- |==> ◇ (wsat * ghost_set g_en (coPset_to_Ensemble Eo) * (EX y, Q y * R' y)))%I.
-Proof.
-  intros.
-  iIntros "[[[wsat en] AS] R]".
-  iApply wsat_fupd_elim'; iFrame.
-  iApply atomic_commit_fupd; eauto; iFrame.
-Qed.
-
-(*(* This is unsound: what we really need is fupd in WP.
-   But that might not be necessary if we use atomic specs for all concurrent operations. *)
-Lemma atomic_commit : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
-  (forall x, R * a x |-- (|==> (EX y, b x y * R' y))%I) ->
-  (atomic_shift a Ei Eo b Q * R |-- |==> (EX y, Q y * R' y))%I.
-Proof.
-  intros.
-  eapply atomic_commit_elim in H.
-  admit.
-Admitted.*)
-
 Lemma atomic_rollback_fupd : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
-  (forall x, R * a x |-- (|==> a x * R')%I) ->
-  (atomic_shift a Ei Eo b Q * R |-- |={Eo}=> atomic_shift a Ei Eo b Q * R')%I.
+  (forall x, R * a x |-- |==> a x * R') ->
+  atomic_shift a Ei Eo b Q * R |-- |={Eo}=> atomic_shift a Ei Eo b Q * R'.
 Proof.
   intros.
   iIntros "[AS R]".
@@ -64,25 +43,6 @@ Proof.
   iMod ("rollback" with "a") as "$"; auto.
 Qed.
 
-Corollary atomic_rollback_elim : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
-  (forall x, R * a x |-- (|==> a x * R')%I) ->
-  (wsat * ghost_set g_en (coPset_to_Ensemble Eo) * atomic_shift a Ei Eo b Q * R |-- |==> ◇ (wsat * ghost_set g_en (coPset_to_Ensemble Eo) * (atomic_shift a Ei Eo b Q * R')))%I.
-Proof.
-  intros.
-  iIntros "[[[wsat en] AS] R]".
-  iApply wsat_fupd_elim'; iFrame "wsat en".
-  iApply atomic_rollback_fupd; eauto; iFrame.
-Qed.
-
-(*Lemma atomic_rollback : forall {A B} (a : A -> mpred) Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R',
-  (forall x, R * a x |-- (|==> a x * R')%I) ->
-  (atomic_shift a Ei Eo b Q * R |-- atomic_shift a Ei Eo b Q * R')%I.
-Proof.
-  intros.
-  eapply atomic_rollback_elim in H.
-  admit.
-Admitted.*)
-
 Lemma atomic_shift_mask_weaken {A B} Eo1 Eo2 Ei a (b : A -> B -> mpred) Q :
   Eo1 ⊆ Eo2 ->
   atomic_shift a Ei Eo1 b Q |-- atomic_shift a Ei Eo2 b Q.
@@ -91,26 +51,26 @@ Proof.
   apply atomic_update_mask_weaken; auto.
 Qed.
 
-(* might be able to get rid of this if we do iInv instances *)
+(* use iInv instead of applying this lemma *)
 Lemma inv_atomic_shift : forall {A B} a Ei Eo (b : A -> B -> mpred) Q i R P
-  (Hi : inv i ⊆ Eo) (Hio : Ei ⊆ Eo ∖ inv i)
-  (Ha1 : (invariant i R * |>R |-- |={Eo ∖ inv i}=> EX x, a x * ((a x -* |={Ei}=> |>R) &&
-    (ALL y, |> P * b x y -* |={Ei}=> |>R * Q y)))%I),
-  invariant i R * |> P |-- atomic_shift a Ei Eo b Q.
+  (Hi : to_coPset i ⊆ Eo) (Hio : Ei ⊆ Eo ∖ to_coPset i)
+  (Ha1 : (inv i R * |>R |-- |={Eo ∖ to_coPset i}=> EX x, a x * ((a x -* |={Ei}=> |>R) &&
+    (ALL y, |> P * b x y -* |={Ei}=> |>R * Q y)))),
+  inv i R * |> P |-- atomic_shift a Ei Eo b Q.
 Proof.
   intros; unfold atomic_shift.
   iIntros "[#I P]". iAuIntro.
   rewrite /atomic_acc /=.
-  iMod (inv_open with "I") as "[R Hclose]"; first done.
+  iInv "I" as "R" "Hclose".
   iMod (Ha1 with "[$I $R]") as (x) "(a & shift)".
-  iExists x; iFrame "a".
-  iMod fupd_mask_subseteq as "mask"; first done.
-  iIntros "!>"; iSplit.
+  iExists x; iFrame.
+  iApply fupd_mask_intro; first done.
+  iIntros "Hclose'"; iSplit.
   - iIntros "a"; iMod ("shift" with "a") as "R".
-    iMod "mask"; iMod ("Hclose" with "R"); auto.
+    iMod "Hclose'"; iMod ("Hclose" with "R"); auto.
   - iIntros (y) "b".
     iMod ("shift" with "[$P $b]") as "[R Q]".
-    iMod "mask"; iMod ("Hclose" with "R"); auto.
+    iMod "Hclose'"; iMod ("Hclose" with "R"); auto.
 Qed.
 
 Lemma atomic_shift_nonexpansive : forall {A B} n a Ei Eo (b : A -> B -> mpred) Q,
@@ -141,7 +101,7 @@ Qed.
 Lemma atomic_shift_derives_frame : forall {A A' B B'} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
   (b : A -> B -> mpred) (b' : A' -> B' -> mpred) (Q : B -> mpred) (Q' : B' -> mpred) R
   (Ha : (forall x, a x * |>R |-- |={Ei}=> EX x' : A', a' x' *
-    ((a' x' -* |={Ei}=> a x * |>R) && ALL y' : _, b' x' y' -* |={Ei}=> EX y : _, b x y * (Q y -* |={Eo}=> Q' y')))%I),
+    ((a' x' -* |={Ei}=> a x * |>R) && ALL y' : _, b' x' y' -* (|={Ei}=> EX y : _, b x y * (Q y -* |={Eo}=> Q' y'))))),
   atomic_shift a Ei Eo b Q * |>R |-- atomic_shift a' Ei Eo b' Q'.
 Proof.
   intros; unfold atomic_shift.
@@ -162,7 +122,7 @@ Qed.
 Lemma atomic_shift_derives : forall {A A' B B'} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
   (b : A -> B -> mpred) (b' : A' -> B' -> mpred) (Q : B -> mpred) (Q' : B' -> mpred)
   (Ha : (forall x, a x  |-- |={Ei}=> EX x' : A', a' x' *
-    ((a' x' -* |={Ei}=> a x) && ALL y' : _, b' x' y' -* |={Ei}=> EX y : _, b x y * (Q y -* |={Eo}=> Q' y')))%I),
+    ((a' x' -* |={Ei}=> a x) && ALL y' : _, b' x' y' -* (|={Ei}=> EX y : _, b x y * (Q y -* |={Eo}=> Q' y'))))),
   atomic_shift a Ei Eo b Q |-- atomic_shift a' Ei Eo b' Q'.
 Proof.
   intros; unfold atomic_shift.
@@ -179,7 +139,7 @@ Qed.
 Lemma atomic_shift_derives' : forall {A A' B} (a : A -> mpred) (a' : A' -> mpred) Ei Eo
   (b : A -> B -> mpred) (b' : A' -> B -> mpred) (Q : B -> mpred)
   (Ha : (forall x, a x |-- |={Ei}=> EX x' : A', a' x' *
-    ((a' x' -* |={Ei}=> a x) && ALL y : _, b' x' y -* |={Ei}=> b x y))%I),
+    ((a' x' -* |={Ei}=> a x) && ALL y : _, b' x' y -* |={Ei}=> b x y))),
   atomic_shift a Ei Eo b Q |-- atomic_shift a' Ei Eo b' Q.
 Proof.
   intros; apply atomic_shift_derives.
@@ -194,9 +154,9 @@ Proof.
 Qed.
 
 Lemma atomic_shift_derives_simple : forall {A B} (a a' : A -> mpred) Ei Eo (b b' : A -> B -> mpred) (Q : B -> mpred)
-  (Ha1 : (forall x, a x |-- |={Ei}=> a' x)%I)
-  (Ha2 : (forall x, a' x |-- |={Ei}=> a x)%I)
-  (Hb : (forall x y, b' x y |-- |={Ei}=> b x y)%I),
+  (Ha1 : forall x, a x |-- |={Ei}=> a' x)
+  (Ha2 : forall x, a' x |-- |={Ei}=> a x)
+  (Hb : forall x y, b' x y |-- |={Ei}=> b x y),
   atomic_shift a Ei Eo b Q |-- atomic_shift a' Ei Eo b' Q.
 Proof.
   intros; apply atomic_shift_derives'; intros.
@@ -229,7 +189,7 @@ End atomicity.
 
 Global Hint Resolve empty_subseteq : core.
 
-Definition atomic_spec_type W T := ProdType W (ArrowType (ConstType T) Mpred)).
+Definition atomic_spec_type W T := ProdType W (ArrowType (ConstType T) Mpred).
 
 Definition super_non_expansive_a {A W} (a : forall ts : list Type, functors.MixVariantFunctor._functor
   (dependent_type_functor_rec ts W) (predicates_hered.pred rmap) -> A ts -> predicates_hered.pred rmap) :=
@@ -249,17 +209,17 @@ Import List.
 
 (* A is the type of the abstract data. T is the type quantified over in the postcondition.
    W is the TypeTree of the witness for the rest of the function. *)
-(*Notation atomic_spec1 T W args tz la P a t lb b Ei Eo :=
+(*Notation atomic_spec1 T W args tz la P a t lb b E :=
   (mk_funspec (pair args tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) '(w, Q) =>
      PROP ()
      (LOCALx (map (fun l => l ts w) la)
-     (SEP (atomic_shift (a ts w) Ei Eo (b ts w) Q; P ts w))))
+     (SEP (atomic_shift (a ts w) (⊤ ∖ E) ∅ (b ts w) Q; P ts w))))
    (fun (ts: list Type) '(w, Q) => EX v : T,
      PROP () (LOCALx (map (fun l => l ts w v) lb)
      (SEP (Q v)))) _ _).*)
 
-Lemma atomic_spec_nonexpansive_pre' : forall {A T} {t : Inhabitant T} W P L G R S2 Ei Eo SQ
+Lemma atomic_spec_nonexpansive_pre' : forall {A T} {t : Inhabitant T} W P L G R S2 E SQ
   (HP : @super_non_expansive_list W (fun ts a _ => map prop (P ts a)))
   (HL: forall n ts x, L ts x = L ts (functors.MixVariantFunctor.fmap _ (compcert_rmaps.RML.R.approx n) (compcert_rmaps.RML.R.approx n) x))
   (HG: @super_non_expansive_list W (fun ts a rho => map (fun Q0 => prop (locald_denote (gvars Q0) rho)) (G ts a)))
@@ -270,28 +230,28 @@ Lemma atomic_spec_nonexpansive_pre' : forall {A T} {t : Inhabitant T} W P L G R 
   (fun ts (_a : functors.MixVariantFunctor._functor (dependent_type_functor_rec ts W) mpred * (T -> mpred)) =>
     let '(w, Q) := _a in
     PROPx (P ts w) (PARAMSx (L ts w) (GLOBALSx (G ts w)
-     (SEPx (atomic_shift(A := A ts) (S2 ts w) Ei Eo (SQ ts w) Q :: R ts w))))).
+     (SEPx (atomic_shift(A := A ts) (S2 ts w) (⊤ ∖ E) ∅ (SQ ts w) Q :: R ts w))))).
 Proof.
   intros.
   hnf; intros.
   etransitivity; [|etransitivity; [
-    apply (PROP_PARAMS_GLOBALS_SEP_args_super_non_expansive' (atomic_spec_type W T) (fun ts x => P ts (fst (fst x))) (fun ts x => L ts (fst (fst x))) (fun ts x => G ts (fst (fst x))) (fun ts '(w, Q) => atomic_shift(A := A ts) (S2 ts w) Ei Eo (SQ ts w) Q :: R ts w))|]].
-  - instantiate (9 := x). destruct x as ((?, ?), ?). reflexivity.
-  - intros ? ? ((?, ?), ?) ?; apply HP; auto.
-  - intros ? ? ((?, ?), ?); apply HL; auto.
-  - intros ? ? ((?, ?), ?); apply HG; auto.
-  - intros ? ? ((?, ?), ?) ?; constructor; [|apply HR; auto].
+    apply (PROP_PARAMS_GLOBALS_SEP_args_super_non_expansive' (atomic_spec_type W T) (fun ts x => P ts (fst x)) (fun ts x => L ts (fst x)) (fun ts x => G ts (fst x)) (fun ts '(w, Q) => atomic_shift(A := A ts) (S2 ts w) (⊤ ∖ E) ∅ (SQ ts w) Q :: R ts w))|]].
+  - instantiate (9 := x). destruct x. reflexivity.
+  - intros ? ? (?, ?) ?; apply HP; auto.
+  - intros ? ? (?, ?); apply HL; auto.
+  - intros ? ? (?, ?); apply HG; auto.
+  - intros ? ? (?, ?) ?; constructor; [|apply HR; auto].
     rewrite -> atomic_shift_nonexpansive by auto; setoid_rewrite atomic_shift_nonexpansive at 2; auto.
     f_equal; f_equal; repeat extensionality; simpl.
     + apply H.
     + apply H0.
     + rewrite approx_idem; auto.
-  - destruct x as ((?, ?), ?); reflexivity.
+  - destruct x as (?, ?); reflexivity.
 Qed.
 
 Definition atomic_spec_type0 W := ProdType W Mpred.
 
-Lemma atomic_spec_nonexpansive_pre0 : forall {A} W P L G R S2 Ei Eo SQ
+Lemma atomic_spec_nonexpansive_pre0 : forall {A} W P L G R S2 E SQ
   (HP : super_non_expansive_list (fun ts w _ => map prop (P ts w)))
   (HL: forall n ts x, L ts x = L ts (functors.MixVariantFunctor.fmap _ (compcert_rmaps.RML.R.approx n) (compcert_rmaps.RML.R.approx n) x))
   (HG: @super_non_expansive_list W (fun ts a rho => map (fun Q0 => prop (locald_denote (gvars Q0) rho)) (G ts a)))
@@ -302,30 +262,30 @@ Lemma atomic_spec_nonexpansive_pre0 : forall {A} W P L G R S2 Ei Eo SQ
   (fun ts (_a : functors.MixVariantFunctor._functor (dependent_type_functor_rec ts W) mpred * mpred) =>
     let '(w, Q) := _a in
     PROPx (P ts w) (PARAMSx (L ts w) (GLOBALSx (G ts w)
-     (SEPx (atomic_shift(A := A ts)(B := unit) (S2 ts w) Ei Eo (SQ ts w) (fun _ => Q) :: R ts w))))).
+     (SEPx (atomic_shift(A := A ts)(B := unit) (S2 ts w) (⊤ ∖ E) ∅ (SQ ts w) (fun _ => Q) :: R ts w))))).
 Proof.
   intros.
   hnf; intros.
   etransitivity; [|etransitivity; [
-    apply (PROP_PARAMS_GLOBALS_SEP_args_super_non_expansive' (atomic_spec_type0 W) (fun ts x => P ts (fst (fst x))) (fun ts x => L ts (fst (fst x))) (fun ts x => G ts (fst (fst x))) (fun ts '(w, Q) => atomic_shift(A := A ts) (S2 ts w) Ei Eo (SQ ts w) (fun _ => Q) :: R ts w))|]].
-  - instantiate (9 := x). destruct x as ((?, ?), ?). reflexivity.
-  - intros ? ? ((?, ?), ?) ?; apply HP; auto.
-  - intros ? ? ((?, ?), ?); apply HL; auto.
-  - intros ? ? ((?, ?), ?); apply HG; auto.
-  - intros ? ? ((?, ?), ?) ?; constructor; [|apply HR; auto].
+    apply (PROP_PARAMS_GLOBALS_SEP_args_super_non_expansive' (atomic_spec_type0 W) (fun ts x => P ts (fst x)) (fun ts x => L ts (fst x)) (fun ts x => G ts (fst x)) (fun ts '(w, Q) => atomic_shift(A := A ts) (S2 ts w) (⊤ ∖ E) ∅ (SQ ts w) (fun _ => Q) :: R ts w))|]].
+  - instantiate (9 := x). destruct x. reflexivity.
+  - intros ? ? (?, ?) ?; apply HP; auto.
+  - intros ? ? (?, ?); apply HL; auto.
+  - intros ? ? (?, ?); apply HG; auto.
+  - intros ? ? (?, ?) ?; constructor; [|apply HR; auto].
     rewrite -> atomic_shift_nonexpansive by auto; setoid_rewrite atomic_shift_nonexpansive at 2; auto.
     f_equal; f_equal; repeat extensionality; simpl.
     + apply H.
     + apply H0.
     + rewrite approx_idem; auto.
-  - destruct x as ((?, ?), ?); reflexivity.
+  - destruct x as (?, ?); reflexivity.
 Qed.
 
-Lemma atomic_spec_nonexpansive_pre : forall {A T} {t : Inhabitant T} W P L G R S2 Ei Eo SQ Pre
+Lemma atomic_spec_nonexpansive_pre : forall {A T} {t : Inhabitant T} W P L G R S2 E SQ Pre
   (Heq : (forall ts (_a : functors.MixVariantFunctor._functor (dependent_type_functor_rec ts W) mpred * (T -> mpred)),
    Pre ts _a = let '(w, Q) := _a in
     PROPx (P ts w) (PARAMSx (L ts w) (GLOBALSx (G ts w)
-     (SEPx (atomic_shift(A := A ts) (S2 ts w) Ei Eo (SQ ts w) Q :: R ts w))))))
+     (SEPx (atomic_shift(A := A ts) (S2 ts w) (⊤ ∖ E) ∅ (SQ ts w) Q :: R ts w))))))
   (HP : super_non_expansive_list (fun ts w _ => map prop (P ts w)))
   (HL: forall n ts x, L ts x = L ts (functors.MixVariantFunctor.fmap _ (compcert_rmaps.RML.R.approx n) (compcert_rmaps.RML.R.approx n) x))
   (HG: @super_non_expansive_list W (fun ts a rho => map (fun Q0 => prop (locald_denote (gvars Q0) rho)) (G ts a)))
@@ -354,11 +314,11 @@ Proof.
   destruct x as (w, Q).
   rewrite !approx_exp; f_equal; extensionality v.
   etransitivity; [|etransitivity; [
-    apply (PROP_LOCAL_SEP_super_non_expansive' (atomic_spec_type W T) (fun ts '(w, _, _) => []) (fun ts '(w, _, _) => L ts w v) (fun ts '(w, Q) => Q v :: R ts w v))|]].
+    apply (PROP_LOCAL_SEP_super_non_expansive' (atomic_spec_type W T) (fun ts '(w, _) => []) (fun ts '(w, _) => L ts w v) (fun ts '(w, Q) => Q v :: R ts w v))|]].
   - instantiate (1 := rho); instantiate (1 := ts); instantiate (1 := (w, Q)); reflexivity.
-  - intros ? ? ((?, ?), ?) ?; constructor.
-  - intros ? ? ((?, ?), ?) ?; apply HL; auto.
-  - intros ? ? ((?, ?), ?) ?; constructor; [|apply HR; auto].
+  - intros ? ? (?, ?) ?; constructor.
+  - intros ? ? (?, ?) ?; apply HL; auto.
+  - intros ? ? (?, ?) ?; constructor; [|apply HR; auto].
     simpl; rewrite approx_idem; auto.
   - reflexivity.
 Qed.
@@ -374,11 +334,11 @@ Proof.
   intros.
   hnf; intros.
   etransitivity; [|etransitivity; [
-    apply (PROP_LOCAL_SEP_super_non_expansive' (atomic_spec_type0 W) (fun ts '(w, _, _) => []) (fun ts '(w, _, _) => L ts w) (fun ts '(w, Q) => Q :: R ts w))|]].
-  - instantiate (1 := rho); instantiate (1 := ts); instantiate (1 := x); destruct x as ((?, ?), ?); reflexivity.
-  - intros ? ? ((?, ?), ?) ?; constructor.
-  - intros ? ? ((?, ?), ?) ?; apply HL; auto.
-  - intros ? ? ((?, ?), ?) ?; constructor; [|apply HR; auto].
+    apply (PROP_LOCAL_SEP_super_non_expansive' (atomic_spec_type0 W) (fun ts '(w, _) => []) (fun ts '(w, _) => L ts w) (fun ts '(w, Q) => Q :: R ts w))|]].
+  - instantiate (1 := rho); instantiate (1 := ts); instantiate (1 := x); destruct x as (?, ?); reflexivity.
+  - intros ? ? (?, ?) ?; constructor.
+  - intros ? ? (?, ?) ?; apply HL; auto.
+  - intros ? ? (?, ?) ?; constructor; [|apply HR; auto].
     simpl; rewrite approx_idem; auto.
   - reflexivity.
 Qed.
@@ -401,7 +361,7 @@ Qed.
 (* A is the type of the abstract data. T is the type quantified over in the postcondition.
    W is the TypeTree of the witness for the rest of the function. *)
 Program Definition atomic_spec {A T} {t : Inhabitant T} W args tz la P G Qp a lb
-        b Ei Eo
+        b E
    (HP : super_non_expansive' P) (HQp : forall v:T, super_non_expansive' (Qp v))
   (Ha : super_non_expansive_a(A := A) a) (Hla: forall n ts x, la ts x = la ts (functors.MixVariantFunctor.fmap _ (compcert_rmaps.RML.R.approx n) (compcert_rmaps.RML.R.approx n) x))
   (HG: @super_non_expansive_list W (fun ts a rho => map (fun Q0 => prop (locald_denote (gvars Q0) rho)) (G ts a)))
@@ -410,14 +370,14 @@ Program Definition atomic_spec {A T} {t : Inhabitant T} W args tz la P G Qp a lb
   (fun (ts: list Type) '(w, Q) =>
     PROP ()
     (PARAMSx (la ts w) (GLOBALSx (G ts w) (
-    (SEP (atomic_shift (a ts w) Ei Eo (b ts w) Q; P ts w))%assert5))))
+    (SEP (atomic_shift (a ts w) (⊤ ∖ E) ∅ (b ts w) Q; P ts w))%assert5))))
   (fun (ts: list Type) '(w, Q) => EX v : T,
     PROP () (LOCALx (lb ts w v)
     (SEP (Q v; Qp v ts w))%assert5)) _ _.
 Next Obligation.
 Proof.
   intros; eapply atomic_spec_nonexpansive_pre; try eassumption.
-  { intros ? ((?, ?), ?). reflexivity. }
+  { intros ? (?, ?). reflexivity. }
   all: auto.
   - constructor.
   - repeat constructor; repeat intro; auto.
@@ -425,17 +385,17 @@ Qed.
 Next Obligation.
 Proof.
   intros; eapply atomic_spec_nonexpansive_post.
-  { intros ? ((?, ?), ?); reflexivity. }
+  { intros ? (?, ?); reflexivity. }
   - auto.
   - repeat constructor.
     unfold super_non_expansive, super_non_expansive' in *.
     intros; apply HQp.
 Qed.
 
-Definition stable_spec_type W := ProdType (ProdType W
+(*Definition stable_spec_type W := ProdType (ProdType W
   (ArrowType (DependentType 0) (ArrowType (DependentType 1) Mpred))) (ArrowType (DependentType 1) Mpred).
 
-(*Lemma stabilize : forall T W args tz P1 P2 Q1 Q2 neP1 neP2 neQ1 neQ2
+Lemma stabilize : forall T W args tz P1 P2 Q1 Q2 neP1 neP2 neQ1 neQ2
   PP la P a lb b Ei Eo Q'
   (Hpre1 : forall ts w Q, P1 ts (w, Q) =
      PROP (PP ts w)
@@ -595,12 +555,12 @@ Definition tcurry_rev (A : tlist) : tuple_type_rev A -> tuple_type A
 Definition rev_curry {A B} (f : tuple_type A -> B) : tuple_type_rev A -> B
   := fun v => f (tcurry_rev _ v).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x : A 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x : A 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) (⊤ ∖ E) ∅ (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCALx (cons LQx .. (cons LQy nil) ..) ((SEPx (Q r :: cons SPx .. (cons SPy nil) ..))))))))) ..)))
@@ -609,21 +569,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x : A 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons LQx%assert3 .. (cons LQy%assert3 nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert3 .. (cons SPy%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) (⊤ ∖ E) ∅ (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCALx (cons LQx .. (cons LQy nil) ..) ((SEPx (Q r :: cons SPx .. (cons SPy nil) ..))))))))) ..)))
@@ -632,21 +591,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons LQx%assert3 .. (cons LQy%assert3 nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert3 .. (cons SPy%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) E (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCAL () (SEPx (Q r :: cons SPx .. (cons SPy nil) ..)))))))) ..)))
@@ -655,21 +613,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -677,21 +634,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons LQx%logic .. (cons LQy%logic nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -699,21 +655,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair nil tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) (⊤ ∖ E) ∅ (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCALx (cons LQx .. (cons LQy nil) ..) ((SEPx (Q r :: cons SPx .. (cons SPy nil) ..))))))))) ..)))
@@ -722,21 +677,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons LQx%assert3 .. (cons LQy%assert3 nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert3 .. (cons SPy%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair nil tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) (⊤ ∖ E) ∅ (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCAL () (SEPx (Q r :: cons SPx .. (cons SPy nil) ..)))))))) ..)))
@@ -745,21 +699,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair nil tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -767,21 +720,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons LQx%logic .. (cons LQy%logic nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair nil tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -789,21 +741,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx nil (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) (⊤ ∖ E) ∅ (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCALx (cons LQx .. (cons LQy nil) ..) ((SEPx (Q r :: cons SPx .. (cons SPy nil) ..))))))))) ..)))
@@ -812,21 +763,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons LQx%assert3 .. (cons LQy%assert3 nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert3 .. (cons SPy%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx nil (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) (⊤ ∖ E) ∅ (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCAL () (SEPx (Q r :: cons SPx .. (cons SPy nil) ..)))))))) ..)))
@@ -835,21 +785,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx nil (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -857,21 +806,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons LQx%logic .. (cons LQy%logic nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx nil (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -879,21 +827,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair nil tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx nil (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) (⊤ ∖ E) ∅ (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCALx (cons LQx .. (cons LQy nil) ..) ((SEPx (Q r :: cons SPx .. (cons SPy nil) ..))))))))) ..)))
@@ -902,21 +849,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons LQx%assert3 .. (cons LQy%assert3 nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert3 .. (cons SPy%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'EX' r : T , 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair nil tz) cc_default (atomic_spec_type W T)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx nil (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift (fun x => S2) Ei Eo (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift (fun x => S2) (⊤ ∖ E) ∅ (fun x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) Q) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : (T -> mpred) => tcurry (fun (_ : tuple_type tnil) =>
     @exp (environ -> mpred) _ T (fun r =>
      PROP () (LOCAL () (SEPx (Q r :: cons SPx .. (cons SPy nil) ..)))))))) ..)))
@@ -925,21 +871,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x r => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post' W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) r => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0, r at level 0, T at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0, r at level 0, T at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' ( LQx ; .. ; LQy ) 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair nil tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx nil (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -947,21 +892,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons LQx%logic .. (cons LQy%logic nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ ] 'PROP' ( Px ; .. ; Py ) 'PARAMS' () 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair nil tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx (cons Px%type .. (cons Py%type nil) ..)
      (PARAMSx nil (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -969,21 +913,20 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ ] 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' () 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' () 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx nil
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun _ : unit => S2) Ei Eo (fun _ _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun _ : unit => S2) (⊤ ∖ E) ∅ (fun _ _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -991,21 +934,20 @@ Notation "'ATOMIC' 'TYPE' W 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) (_:unit) => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) (_:unit) => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) _ _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, E at level 0, S2 at level 0).
 
-Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' () 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
+Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' E 'WITH' x1 , .. , xn 'PRE'  [ u , .. , v ] 'PROP' () 'PARAMS' ( Lx ; .. ; Ly ) 'GLOBALS' ( Gx ; .. ; Gy ) 'SEP' ( S1x ; .. ; S1y ) '|' S2 'POST' [ tz ] 'PROP' () 'LOCAL' () 'SEP' ( SPx ; .. ; SPy ) '|' ( SQx ; .. ; SQy )" :=
   (mk_funspec (pair (cons u%type .. (cons v%type nil) ..) tz) cc_default (atomic_spec_type0 W)
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROPx nil
      (PARAMSx (cons Lx%type .. (cons Ly%type nil) ..) (GLOBALSx (cons Gx .. (cons Gy nil) ..)
-     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) Ei Eo (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
+     (SEPx (cons (atomic_shift(B := unit) (fun x => S2) (⊤ ∖ E) ∅ (fun x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..)) (fun _ => Q)) (cons S1x%logic .. (cons S1y%logic nil) ..))))))))) ..)))
    (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn => tcurry (fun Q : mpred => tcurry (fun (_ : tuple_type tnil) =>
      PROP () LOCAL () (SEPx (Q :: cons SPx .. (cons SPy nil) ..)))))) ..)))
    (@atomic_spec_nonexpansive_pre0 _ W
@@ -1013,14 +955,13 @@ Notation "'ATOMIC' 'TYPE' W 'OBJ' x 'INVS' Ei Eo 'WITH' x1 , .. , xn 'PRE'  [ u 
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Lx%type .. (cons Ly%type nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons Gx .. (cons Gy nil) ..))) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons S1x%logic .. (cons S1y%logic nil) ..))) ..)))
-      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..)))
-      Ei Eo
+      (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x => S2)) ..))) E
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) x _ => fold_right_sepcon (cons SQx%logic .. (cons SQy%logic nil) ..))) ..)))
      _ _ _ _ _ _)
   (atomic_spec_nonexpansive_post0 W
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => nil)) ..)))
       (fun (ts: list Type) => rev_curry (tcurry (fun x1 => .. (tcurry (fun xn (_ : tuple_type tnil) => (cons SPx%assert5%assert3 .. (cons SPy%assert5%assert3 nil) ..))) ..))) _ _))
-  (at level 200, x1 closed binder, xn closed binder, x at level 0, Ei at level 0, Eo at level 0, S2 at level 0).
+  (at level 200, x1 closed binder, xn closed binder, x at level 0, E at level 0, S2 at level 0).
 
 Ltac atomic_nonexpansive_tac := try (let x := fresh "x" in intros ?? x;
   try match type of x with list Type => (let ts := fresh "ts" in rename x into ts; intros x) end;

--- a/atomics/general_locks.v
+++ b/atomics/general_locks.v
@@ -71,8 +71,8 @@ Proof.
   contradiction H; apply share_self_join_bot; auto.
 Qed.
 
-Lemma sync_commit_simple : forall Ei Eo (Q : mpred) g (x0 x' : G),
-  (atomic_shift(B := unit) (fun x => public_half g x) Ei Eo (fun x _ => !!(x = x0) && public_half g x') (fun _ => Q) * my_half g Tsh x0 |-- |={Eo}=> Q * my_half g Tsh x')%I.
+Lemma sync_commit_simple : forall Eo Ei (Q : mpred) g (x0 x' : G),
+  (atomic_shift(B := unit) (fun x => public_half g x) Eo Ei (fun x _ => !!(x = x0) && public_half g x') (fun _ => Q) * my_half g Tsh x0 |-- |={Eo}=> Q * my_half g Tsh x')%I.
 Proof.
   intros; eapply derives_trans; [apply atomic_commit_fupd with (R' := fun _ => my_half g Tsh x')|].
   - intros.
@@ -83,9 +83,9 @@ Proof.
   - iIntros ">Q !>"; iDestruct "Q" as (_) "$".
 Qed.
 
-Lemma sync_rollback : forall {A B} a Ei Eo (b : A -> B -> mpred) (Q : B -> mpred) R R' g sh (x0 : G)
+Lemma sync_rollback : forall {A B} a Eo Ei (b : A -> B -> mpred) (Q : B -> mpred) R R' g sh (x0 : G)
   (Ha : forall x, R * a x |-- (|==> EX x1, public_half g x1 * (!!(if eq_dec sh Tsh then x0 = x1 else exists x, sepalg.join x0 x x1) --> (public_half g x1 -* |==> R' * a x)))%I),
-  (atomic_shift a Ei Eo b Q * my_half g sh x0 * R |-- |={Eo}=> atomic_shift a Ei Eo b Q * my_half g sh x0 * R')%I.
+  (atomic_shift a Eo Ei b Q * my_half g sh x0 * R |-- |={Eo}=> atomic_shift a Eo Ei b Q * my_half g sh x0 * R')%I.
 Proof.
   intros; rewrite !sepcon_assoc; apply atomic_rollback_fupd.
   intros; iIntros "((my & R) & a)".
@@ -94,10 +94,10 @@ Proof.
   rewrite bi.sep_comm; iApply ("a'" with "[%]"); auto.
 Qed.
 
-Lemma sync_commit_gen : forall {A B} a Ei Eo (b : A -> B -> mpred) Q R R' g sh (x0 : G)
+Lemma sync_commit_gen : forall {A B} a Eo Ei (b : A -> B -> mpred) Q R R' g sh (x0 : G)
   (Ha : forall x, R * a x |-- (|==> EX x1, public_half g x1 * (!!(if eq_dec sh Tsh then x0 = x1 else exists x, sepalg.join x0 x x1) -->
     |==> (EX x0' x1' : G, !!(forall b, sepalg.join x0 b x1 -> sepalg.join x0' b x1' /\ (x0 = x1 -> x0' = x1')) && (my_half g sh x0' * public_half g x1' -* |==> (EX y, b x y * R' y))))%I)%I),
-  (atomic_shift a Ei Eo b Q * my_half g sh x0 * R |-- |={Eo}=> EX y, Q y * R' y)%I.
+  (atomic_shift a Eo Ei b Q * my_half g sh x0 * R |-- |={Eo}=> EX y, Q y * R' y)%I.
 Proof.
   intros; rewrite sepcon_assoc.
   apply @atomic_commit_fupd with (R' := fun y => R' y).
@@ -109,10 +109,10 @@ Proof.
   iApply ("H" with "[$my $public]").
 Qed.
 
-Lemma sync_commit_same : forall {A B} a Ei Eo (b : A -> B -> mpred) Q R R' g sh (x0 : G)
+Lemma sync_commit_same : forall {A B} a Eo Ei (b : A -> B -> mpred) Q R R' g sh (x0 : G)
   (Ha : forall x, R * a x |-- (|==> EX x1, public_half g x1 * (!!(if eq_dec sh Tsh then x0 = x1 else exists x, sepalg.join x0 x x1) -->
     |==> (my_half g sh x0 * public_half g x1 -* |==> (EX y, b x y * R' y)))%I)%I),
-  (atomic_shift a Ei Eo b Q * my_half g sh x0 * R |-- |={Eo}=> EX y, Q y * R' y)%I.
+  (atomic_shift a Eo Ei b Q * my_half g sh x0 * R |-- |={Eo}=> EX y, Q y * R' y)%I.
 Proof.
   intros; rewrite sepcon_assoc.
   apply @atomic_commit_fupd with (R' := fun y => R' y).
@@ -123,10 +123,10 @@ Proof.
   iApply "H"; iFrame.
 Qed.
 
-Lemma sync_commit_gen1 : forall {A B} a Ei Eo (b : A -> B -> mpred) Q R R' g sh (x0 : G)
+Lemma sync_commit_gen1 : forall {A B} a Eo Ei (b : A -> B -> mpred) Q R R' g sh (x0 : G)
   (Ha : forall x, R * a x |-- (|==> EX x1, public_half g x1 * (!!(if eq_dec sh Tsh then x0 = x1 else exists x, sepalg.join x0 x x1) -->
     |==> (EX x0' x1' : G, !!(forall b, sepalg.join x0 b x1 -> sepalg.join x0' b x1' /\ (x0 = x1 -> x0' = x1')) && (my_half g sh x0' * public_half g x1' -* |==> (EX y, b x y) * R')))%I)%I),
-  (atomic_shift a Ei Eo b (fun _ => Q) * my_half g sh x0 * R |-- |={Eo}=> Q * R')%I.
+  (atomic_shift a Eo Ei b (fun _ => Q) * my_half g sh x0 * R |-- |={Eo}=> Q * R')%I.
 Proof.
   intros; rewrite sepcon_assoc; eapply derives_trans; [apply @atomic_commit_fupd with
       (R' := fun _ => R')|].
@@ -139,10 +139,10 @@ Proof.
   - iIntros ">Q !>"; iDestruct "Q" as (?) "[$ $]".
 Qed.
 
-Lemma sync_commit_same1 : forall {A B} a Ei Eo (b : A -> B -> mpred) Q R R' g sh (x0 : G)
+Lemma sync_commit_same1 : forall {A B} a Eo Ei (b : A -> B -> mpred) Q R R' g sh (x0 : G)
   (Ha : forall x, R * a x |-- (|==> EX x1, public_half g x1 * (!!(if eq_dec sh Tsh then x0 = x1 else exists x, sepalg.join x0 x x1) -->
     |==> (my_half g sh x0 * public_half g x1 -* |==> (EX y, b x y * R')))%I)%I),
-  (atomic_shift a Ei Eo b (fun _ => Q) * my_half g sh x0 * R |-- |={Eo}=> Q * R')%I.
+  (atomic_shift a Eo Ei b (fun _ => Q) * my_half g sh x0 * R |-- |={Eo}=> Q * R')%I.
 Proof.
   intros; rewrite sepcon_assoc; eapply derives_trans; [apply @atomic_commit_fupd with
       (R' := fun _ => R')|].
@@ -155,9 +155,9 @@ Proof.
 Qed.
 
 (* These are useful when the shared resource matches the lock invariant exactly. *)
-Lemma sync_commit1 : forall Ei Eo (b : G -> unit -> mpred) Q g (x0 x' : G)
+Lemma sync_commit1 : forall Eo Ei (b : G -> unit -> mpred) Q g (x0 x' : G)
   (Hb : public_half g x' |-- (|==> b x0 tt)%I),
-  (atomic_shift (fun x => public_half g x) Ei Eo b (fun _ => Q) * my_half g Tsh x0 |-- |={Eo}=> Q * my_half g Tsh x')%I.
+  (atomic_shift (fun x => public_half g x) Eo Ei b (fun _ => Q) * my_half g Tsh x0 |-- |={Eo}=> Q * my_half g Tsh x')%I.
 Proof.
   intros; eapply derives_trans, sync_commit_simple.
   apply sepcon_derives, derives_refl.
@@ -166,9 +166,9 @@ Proof.
   iIntros "[% H]"; subst; iMod (Hb with "H"); auto.
 Qed.
 
-Lemma sync_commit2 : forall Ei Eo (b : G -> G -> mpred) Q g (x0 x' : G)
+Lemma sync_commit2 : forall Eo Ei (b : G -> G -> mpred) Q g (x0 x' : G)
   (Hb : public_half g x' |-- (|==> b x0 x0)%I),
-  (atomic_shift (fun x => public_half g x) Ei Eo b Q * my_half g Tsh x0 |-- |={Eo}=> Q x0 * my_half g Tsh x')%I.
+  (atomic_shift (fun x => public_half g x) Eo Ei b Q * my_half g Tsh x0 |-- |={Eo}=> Q x0 * my_half g Tsh x')%I.
 Proof.
   intros; eapply derives_trans, sync_commit_simple.
   apply sepcon_derives, derives_refl.
@@ -184,12 +184,12 @@ Proof.
 Qed.
 
 (* sync_commit for holding two locks simultaneously *)
-Lemma two_sync_commit : forall {A B} a Ei Eo (b : A -> B -> mpred) Q R R' g1 g2 sh1 sh2 (x1 x2 : G)
+Lemma two_sync_commit : forall {A B} a Eo Ei (b : A -> B -> mpred) Q R R' g1 g2 sh1 sh2 (x1 x2 : G)
   (Ha : forall x, R * a x |-- (|==> EX y1 y2, public_half g1 y1 * public_half g2 y2 *
     (!!((if eq_dec sh1 Tsh then x1 = y1 else exists z, sepalg.join x1 z y1) /\ (if eq_dec sh2 Tsh then x2 = y2 else exists z, sepalg.join x2 z y2)) -->
     |==> (EX x1' x2' y1' y2' : G, !!((forall z, sepalg.join x1 z y1 -> sepalg.join x1' z y1' /\ (x1 = y1 -> x1' = y1')) /\ (forall z, sepalg.join x2 z y2 -> sepalg.join x2' z y2' /\ (x2 = y2 -> x2' = y2'))) &&
       (my_half g1 sh1 x1' * public_half g1 y1' * my_half g2 sh2 x2' * public_half g2 y2' -* |==> (EX y, b x y * R' y))))%I)%I),
-  (atomic_shift a Ei Eo b Q * my_half g1 sh1 x1 * my_half g2 sh2 x2 * R |-- |={Eo}=> EX y, Q y * R' y)%I.
+  (atomic_shift a Eo Ei b Q * my_half g1 sh1 x1 * my_half g2 sh2 x2 * R |-- |={Eo}=> EX y, Q y * R' y)%I.
 Proof.
   intros; rewrite -> 2sepcon_assoc.
   apply @atomic_commit_fupd with (R' := fun y => R' y).
@@ -204,12 +204,12 @@ Proof.
   iApply "H"; iFrame.
 Qed.
 
-Lemma two_sync_commit1 : forall {A B} a Ei Eo (b : A -> B -> mpred) Q R R' g1 g2 sh1 sh2 (x1 x2 : G)
+Lemma two_sync_commit1 : forall {A B} a Eo Ei (b : A -> B -> mpred) Q R R' g1 g2 sh1 sh2 (x1 x2 : G)
   (Ha : forall x, R * a x |-- (|==> EX y1 y2, public_half g1 y1 * public_half g2 y2 *
     (!!((if eq_dec sh1 Tsh then x1 = y1 else exists z, sepalg.join x1 z y1) /\ (if eq_dec sh2 Tsh then x2 = y2 else exists z, sepalg.join x2 z y2)) -->
     |==> (EX x1' x2' y1' y2' : G, !!((forall z, sepalg.join x1 z y1 -> sepalg.join x1' z y1' /\ (x1 = y1 -> x1' = y1')) /\ (forall z, sepalg.join x2 z y2 -> sepalg.join x2' z y2' /\ (x2 = y2 -> x2' = y2'))) &&
       (my_half g1 sh1 x1' * public_half g1 y1' * my_half g2 sh2 x2' * public_half g2 y2' -* |==> ((EX y, b x y) * R'))))%I)%I),
-  (atomic_shift a Ei Eo b (fun _ => Q) * my_half g1 sh1 x1 * my_half g2 sh2 x2 * R |-- |={Eo}=> Q * R')%I.
+  (atomic_shift a Eo Ei b (fun _ => Q) * my_half g1 sh1 x1 * my_half g2 sh2 x2 * R |-- |={Eo}=> Q * R')%I.
 Proof.
   intros; rewrite -> 2sepcon_assoc.
   eapply derives_trans; [apply @atomic_commit_fupd with (R' := fun _ => R')|].

--- a/atomics/general_locks.v
+++ b/atomics/general_locks.v
@@ -1,11 +1,8 @@
 (* Specifications for locks for use with general invariants, in the style of TaDA *)
-Require Import VST.veric.rmaps.
-Require Import VST.veric.compcert_rmaps.
-Require Import VST.concurrency.ghosts.
-Require Import VST.concurrency.conclib.
-Require Export VST.concurrency.invariants.
-Require Export VST.concurrency.fupd.
-Require Export VST.atomics.general_atomics.
+From VST.veric Require Import rmaps compcert_rmaps.
+From VST.concurrency Require Import ghosts conclib.
+From VST.concurrency Require Export invariants fupd.
+From VST.atomics Require Export general_atomics.
 
 Section locks.
 

--- a/atomics/verif_hashtable_atomic.v
+++ b/atomics/verif_hashtable_atomic.v
@@ -10,8 +10,6 @@ Require Import VST.atomics.hashtable.
 Require Import VST.msl.iter_sepcon.
 Import List.
 
-Set Bullet Behavior "Strict Subproofs".
-
 #[(*export, after Coq 8.13*)global] Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 

--- a/atomics/verif_lock.v
+++ b/atomics/verif_lock.v
@@ -8,26 +8,6 @@ Require Import VST.atomics.lock.
 
 Section PROOFS.
 
-Context {inv_names0 : invG}.
-
-Definition funspec_sub (f1 f2 : funspec): Prop :=
-match f1 with
-| mk_funspec tpsig1 cc1 A1 P1 Q1 _ _ =>
-    match f2 with
-    | mk_funspec tpsig2 cc2 A2 P2 Q2 _ _ =>
-        (tpsig1=tpsig2 /\ cc1=cc2) /\
-        forall ts2 x2 (gargs:argsEnviron),
-        ((!! (argsHaveTyps(snd gargs)(fst tpsig1)) && P2 ts2 x2 gargs)
-         |-- (|={⊤}=> (EX ts1:_,  EX x1:_, EX F:_,
-                           (F * (P1 ts1 x1 gargs)) &&
-                               (!! (forall rho',
-                                           ((!!(ve_of rho' = Map.empty (Values.block * type))) &&
-                                                 (F * (Q1 ts1 x1 rho')))
-                                         |-- |={⊤}=> (Q2 ts2 x2 rho'))))))%I
-    end
-end.
-
-
 #[local] Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 
@@ -75,7 +55,7 @@ Definition t_lock := Tstruct _atom_int noattr.
 
   Program Definition release_spec :=
     DECLARE _release
-    ATOMIC TYPE (rmaps.ConstType _) INVS empty top
+    ATOMIC TYPE (rmaps.ConstType _) INVS empty
     WITH p, gv
     PRE [ tptr t_lock ]
        PROP ()
@@ -88,7 +68,7 @@ Definition t_lock := Tstruct _atom_int noattr.
 
   Program Definition acquire_spec :=
     DECLARE _acquire
-    ATOMIC TYPE (rmaps.ConstType _) OBJ l INVS empty top
+    ATOMIC TYPE (rmaps.ConstType _) OBJ l INVS empty
     WITH p, gv
     PRE [ tptr t_lock ]
        PROP ()
@@ -128,7 +108,7 @@ Definition t_lock := Tstruct _atom_int noattr.
   Lemma body_release: semax_body Vprog Gprog f_release release_spec.
   Proof.
     start_function.
-    forward_call (p, (vint 0), top: coPset, empty: coPset, Q, inv_names).
+    forward_call (p, (vint 0), top: coPset, empty: coPset, Q).
     - assert (Frame = [mem_mgr gv]); subst Frame; [ reflexivity | clear H].
       simpl fold_right_sepcon. cancel.
       iIntros ">AS".
@@ -147,30 +127,18 @@ Definition t_lock := Tstruct _atom_int noattr.
   Proof.
     start_function.
     forward.
+    set (AS := atomic_shift _ _ _ _ _).
     forward_loop (PROP ( )
                        LOCAL (temp _b (vint 0); lvar _expected tint v_expected;
                               gvars gv; temp _lock p)
-                       SEP (data_at_ Tsh tint v_expected;
-                            atomic_shift
-                              (λ l : bool,
-                                  !! (l = true) && atomic_int_at Ews (vint 0) p
-                                  || !! (l = false) && atomic_int_at Ews (vint 1) p) ∅ ⊤
-                              (λ (l : bool) (_ : ()),
-                                fold_right_sepcon [!! (l = true) && atomic_int_at Ews (vint 1) p])
-                              (λ _ : (), Q); mem_mgr gv)).
+                       SEP (data_at_ Tsh tint v_expected; AS; mem_mgr gv)).
     - entailer !.
     - forward.
       forward_call
         (p , Tsh, v_expected, (vint 0), (vint 1), top : coPset,
             empty : coPset,
               fun v':val =>
-                if (eq_dec v' (vint 0)) then Q else
-                  (atomic_shift
-                     (λ l : bool,
-                         !! (l = true) && atomic_int_at Ews (vint 0) p
-                         || !! (l = false) && atomic_int_at Ews (vint 1) p) ∅ ⊤
-                     (λ (l : bool) (_ : ()),
-                       fold_right_sepcon [!! (l = true) && atomic_int_at Ews (vint 1) p]) (λ _ : (), Q)), inv_names).
+                if (eq_dec v' (vint 0)) then Q else AS).
       + assert (Frame = [mem_mgr gv]); subst Frame; [ reflexivity | clear H].
         simpl fold_right_sepcon. cancel.
         iIntros ">AS". iExists Ews.
@@ -182,9 +150,9 @@ Definition t_lock := Tstruct _atom_int noattr.
              destruct (eq_dec (vint 0) (vint 0)). 2: exfalso; now apply n.
              iSplit; [iSplit|]; auto.
         * iExists (vint 1). iModIntro. destruct (eq_dec (vint 1) (vint 0)).
-          1: inversion e. do 2 rewrite sepcon_andp_prop'. iSplit.
+          1: inversion e. rewrite sepcon_andp_prop'. iSplit.
           -- iPureIntro. apply writable_Ews.
-          -- iDestruct "a" as (Hx) "a". iSplitL "a". 1: auto. iIntros "AS".
+          -- iDestruct "a" as (Hx) "a". iSplitL "a"; first auto. iIntros "AS".
              iMod ("H" with "[AS]").
              { iRight; iFrame; auto. }
              iFrame; auto.
@@ -194,15 +162,14 @@ Definition t_lock := Tstruct _atom_int noattr.
   Qed.
 
   Definition lock_inv (l: val) (R: mpred): mpred :=
-    EX i, invariant i (atomic_int_at Ews (vint 0) l * R || atomic_int_at Ews (vint 1) l).
+    EX i, inv i (atomic_int_at Ews (vint 0) l * R || atomic_int_at Ews (vint 1) l).
 
   Lemma nonexpansive_lock_inv : forall p, nonexpansive (lock_inv p).
   Proof.
     intros.
     unfold lock_inv.
-    apply @exists_nonexpansive.
-    intros i.
-    apply invariant_nonexpansive2.
+    apply @exists_nonexpansive; intros i.
+    apply inv_nonexpansive2.
     apply @disj_nonexpansive.
     - apply @sepcon_nonexpansive.
       + apply _.
@@ -257,6 +224,7 @@ Definition t_lock := Tstruct _atom_int noattr.
 
   Lemma makelock_funspec_sub: funspec_sub (snd makelock_spec) makelock_spec2.
   Proof.
+    apply prove_funspec_sub.
     split; auto. intros. simpl in *. destruct x2 as [gv R]. Intros.
     iIntros "H !>". iExists nil, gv, emp. rewrite emp_sepcon. iSplit; auto.
     iPureIntro. intros. Intros. rewrite emp_sepcon. Intros x.
@@ -333,14 +301,14 @@ Definition t_lock := Tstruct _atom_int noattr.
   Proof.
     split; auto. intros. simpl in *. destruct x2 as [[v gv] R]. Intros.
     unfold rev_curry, tcurry. iIntros "H !>". iExists nil.
-    iExists (((v, gv), lock_inv v R * |> R), inv_names0), emp. simpl in *.
+    iExists (((v, gv), lock_inv v R * |> R)0), emp. simpl in *.
     rewrite emp_sepcon. iSplit.
     - unfold PROPx, PARAMSx, GLOBALSx, LOCALx, SEPx; simpl. normalize.
       iDestruct "H" as "(% & H1 & H2 & H3)". iSplit.
       + iPureIntro. auto.
       + iSplit; auto. unfold argsassert2assert. iSplitL "H3"; auto. unfold lock_inv.
         iDestruct "H3" as (i) "# H". unfold atomic_shift. iAuIntro. unfold atomic_acc; simpl.
-        iMod (inv_open with "H") as "[inv Hclose]". set_solver.
+        iInv "H" as "inv" "Hclose"; first set_solver.
         rewrite later_orp. rewrite later_sepcon.
         iDestruct "inv" as "[[> H1 R]|> H1]".
         * iApply fupd_mask_intro; try set_solver. iIntros "H2". iExists true.
@@ -431,14 +399,14 @@ Definition t_lock := Tstruct _atom_int noattr.
   Proof.
     split; auto. intros. simpl in *. destruct x2 as [[v gv] R]. Intros.
     unfold rev_curry, tcurry. iIntros "H !>". iExists nil.
-    iExists (((v, gv), lock_inv v R), inv_names0), emp. simpl in *.
+    iExists (((v, gv), lock_inv v R)0), emp. simpl in *.
     rewrite emp_sepcon. iSplit.
     - unfold PROPx, PARAMSx, GLOBALSx, LOCALx, SEPx; simpl. normalize.
       iDestruct "H" as "(% & H1 & H2 & H3 & H4 & H5)". iSplit.
       + iPureIntro. auto.
       + iSplit; auto. unfold argsassert2assert. iSplitR "H2"; auto. unfold lock_inv.
         iDestruct "H4" as (i) "#H". unfold atomic_shift. iAuIntro. unfold atomic_acc; simpl.
-        iMod (inv_open with "H") as "[inv Hclose]". set_solver.
+        iInv "H" as "inv" "Hclose"; first set_solver.
         rewrite later_orp. rewrite later_sepcon.
         iDestruct "inv" as "[[> H2 R]|> H2]".
         * iAssert (|>FF) with "[H3 H5 R]" as ">[]".

--- a/concurrency/ghosts.v
+++ b/concurrency/ghosts.v
@@ -1669,20 +1669,6 @@ End GHist.
 (*#[export] Hint Resolve ghost_var_precise ghost_var_precise'.*)
 #[export] Hint Resolve (*ghost_var_init*) master_init (*ghost_map_init*) ghost_hist_init : init.
 
-Ltac ghost_alloc G :=
-  match goal with |-semax _ (PROPx ?P (LOCALx ?Q (SEPx ?R))) _ _ =>
-    apply (semax_pre_fupd (PROPx P (LOCALx Q (SEPx ((EX g : _, G g) :: R)))));
-  [go_lower; eapply derives_trans, bupd_fupd; erewrite !prop_true_andp by (repeat (split; auto));
-   rewrite <- emp_sepcon at 1; eapply derives_trans, ghost_seplog.bupd_frame_r;
-   apply sepcon_derives, derives_refl; apply own_alloc; auto; simpl; auto with init share ghost|] end.
-
-Ltac ghosts_alloc G n :=
-  match goal with |-semax _ (PROPx ?P (LOCALx ?Q (SEPx ?R))) _ _ =>
-    apply (semax_pre_fupd (PROPx P (LOCALx Q (SEPx ((EX lg : _, !!(Zlength lg = n) && iter_sepcon G lg) :: R)))));
-  [go_lower; eapply derives_trans, bupd_fupd; erewrite !prop_true_andp by (repeat (split; auto));
-   rewrite <- emp_sepcon at 1; eapply derives_trans, bupd_frame_r;
-   apply sepcon_derives, derives_refl; apply own_list_alloc'; auto; simpl; auto with init share ghost|] end.
-
 Lemma wand_nonexpansive_l: forall P Q n,
   approx n (P -* Q)%logic = approx n (approx n P  -* Q)%logic.
 Proof.

--- a/concurrency/ghosts.v
+++ b/concurrency/ghosts.v
@@ -1671,72 +1671,34 @@ End GHist.
 
 Ltac ghost_alloc G :=
   match goal with |-semax _ (PROPx ?P (LOCALx ?Q (SEPx ?R))) _ _ =>
-    apply (semax_pre_bupd (PROPx P (LOCALx Q (SEPx ((EX g : _, G g) :: R)))));
-  [go_lower; erewrite !prop_true_andp by (repeat (split; auto));
+    apply (semax_pre_fupd (PROPx P (LOCALx Q (SEPx ((EX g : _, G g) :: R)))));
+  [go_lower; eapply derives_trans, bupd_fupd; erewrite !prop_true_andp by (repeat (split; auto));
    rewrite <- emp_sepcon at 1; eapply derives_trans, ghost_seplog.bupd_frame_r;
    apply sepcon_derives, derives_refl; apply own_alloc; auto; simpl; auto with init share ghost|] end.
 
 Ltac ghosts_alloc G n :=
   match goal with |-semax _ (PROPx ?P (LOCALx ?Q (SEPx ?R))) _ _ =>
-    apply (semax_pre_bupd (PROPx P (LOCALx Q (SEPx ((EX lg : _, !!(Zlength lg = n) && iter_sepcon G lg) :: R)))));
-  [go_lower; erewrite !prop_true_andp by (repeat (split; auto));
+    apply (semax_pre_fupd (PROPx P (LOCALx Q (SEPx ((EX lg : _, !!(Zlength lg = n) && iter_sepcon G lg) :: R)))));
+  [go_lower; eapply derives_trans, bupd_fupd; erewrite !prop_true_andp by (repeat (split; auto));
    rewrite <- emp_sepcon at 1; eapply derives_trans, bupd_frame_r;
    apply sepcon_derives, derives_refl; apply own_list_alloc'; auto; simpl; auto with init share ghost|] end.
 
 Lemma wand_nonexpansive_l: forall P Q n,
   approx n (P -* Q)%logic = approx n (approx n P  -* Q)%logic.
 Proof.
-  repeat intro.
-  apply (nonexpansive_super_non_expansive (fun P => predicates_sl.wand P Q)).
-  split; intros ???? Hshift ??????.
-  - eapply Hshift; eauto.
-    apply necR_level in H1; apply ext_level in H2; apply necR_level in H3.
-    apply join_level in H4 as [].
-    eapply (H y0); auto; lia.
-  - eapply Hshift; eauto.
-    apply necR_level in H1; apply ext_level in H2; apply necR_level in H3.
-    apply join_level in H4 as [].
-    eapply (H y0); auto; lia.
+  apply wand_nonexpansive_l.
 Qed.
 
 Lemma wand_nonexpansive_r: forall P Q n,
   approx n (P -* Q)%logic = approx n (P  -* approx n Q)%logic.
 Proof.
-  repeat intro.
-  apply (nonexpansive_super_non_expansive (fun Q => predicates_sl.wand P Q)).
-  split; intros ???? Hshift ??????.
-  - eapply Hshift in H5; eauto.
-    apply necR_level in H1; apply ext_level in H2; apply necR_level in H3.
-    apply join_level in H4 as [].
-    eapply (H z); auto; lia.
-  - eapply Hshift in H5; eauto.
-    apply necR_level in H1; apply ext_level in H2; apply necR_level in H3.
-    apply join_level in H4 as [].
-    eapply (H z); auto; lia.
-Qed.
-
-Lemma approx_bupd: forall P n, (approx n (own.bupd P) = (own.bupd (approx n P)))%logic.
-Proof.
-  intros; apply predicates_hered.pred_ext.
-  - intros ? [? HP].
-    change ((own.bupd (approx n P)) a).
-    intros ? J.
-    destruct (HP _ J) as (? & ? & m' & ? & ? & ? & ?);
-      eexists; split; eauto; eexists; split; eauto; repeat split; auto; lia.
-  - intros ? HP.
-    destruct (HP nil) as (? & ? & m' & ? & ? & ? & []).
-    { eexists; constructor. }
-    split; [lia|].
-    change ((own.bupd P) a).
-    intros ? J.
-    destruct (HP _ J) as (? & ? & m'' & ? & ? & ? & []);
-      eexists; split; eauto; eexists; split; eauto; repeat split; auto.
+  apply wand_nonexpansive_r.
 Qed.
 
 Lemma wand_nonexpansive: forall P Q n,
   approx n (P -* Q)%logic = approx n (approx n P  -* approx n Q)%logic.
 Proof.
-  intros; rewrite wand_nonexpansive_l, wand_nonexpansive_r; reflexivity.
+  apply wand_nonexpansive.
 Qed.
 
 Corollary view_shift_nonexpansive : forall P Q n,

--- a/concurrency/ghostsI.v
+++ b/concurrency/ghostsI.v
@@ -7,6 +7,15 @@ Import List.
 
 (* Lemmas about ghost state, proved with Iris bupd *)
 
+Instance unfash_persistent P : Persistent (alg_seplog.unfash P).
+Proof.
+  change unfash with (@subtypes.unfash rmap _ _).
+  constructor; intros ??; hnf.
+  unfold bi_persistently; simpl.
+  unfold unfash in *; simpl in *.
+  rewrite level_core; auto.
+Qed.
+
 Section ghost.
 
 Context {RA: Ghost}.

--- a/concurrency/invariants.v
+++ b/concurrency/invariants.v
@@ -15,7 +15,7 @@ Proof.
   rewrite IHl; auto.
 Qed.
 
-Lemma nth_replace_nth : forall {A} n l a (d : A), (n < length l)%nat ->
+(*Lemma nth_replace_nth : forall {A} n l a (d : A), (n < length l)%nat ->
   nth n (replace_nth n l a) d = a.
 Proof.
   induction n; destruct l; auto; simpl; intros; try lia.
@@ -27,11 +27,9 @@ Lemma nth_replace_nth' : forall {A} n m l a (d : A), m <> n ->
 Proof.
   induction n; destruct l; auto; destruct m; auto; simpl; intros; try lia.
   apply IHn; lia.
-Qed.
+Qed.*)
 
 Section Invariants.
-
-Context {inv_names : invG}.
 
 Global Instance agree_persistent g P : Persistent (agree g P : mpred).
 Proof.

--- a/concurrency/invariants.v
+++ b/concurrency/invariants.v
@@ -326,3 +326,20 @@ Proof.
 Qed.
 
 Global Instance into_inv_inv N P : IntoInv (inv N P) N := {}.
+
+Lemma inv_nonexpansive : forall N, nonexpansive (inv N).
+Proof.
+  intros; unfold inv.
+  apply @exists_nonexpansive; intros i.
+  apply @conj_nonexpansive, invariant_nonexpansive.
+  apply const_nonexpansive.
+Qed.
+
+Lemma inv_nonexpansive2 : forall N f, nonexpansive f ->
+  nonexpansive (fun a => inv N (f a)).
+Proof.
+  intros; unfold inv.
+  apply @exists_nonexpansive; intros i.
+  apply @conj_nonexpansive, invariant_nonexpansive2, H.
+  apply const_nonexpansive.
+Qed.

--- a/concurrency/invariants.v
+++ b/concurrency/invariants.v
@@ -1,3 +1,4 @@
+Require Import stdpp.namespaces.
 Require Export VST.veric.invariants.
 Require Import VST.msl.ghost_seplog.
 Require Import VST.msl.sepalg_generators.
@@ -31,27 +32,29 @@ Qed.*)
 
 Section Invariants.
 
+Definition inv (N : namespace) P := EX i : iname, !!(N = nroot .@ (Pos.of_nat (S i))) && invariant i P.
+
 Global Instance agree_persistent g P : Persistent (agree g P : mpred).
 Proof.
   apply core_persistent; auto.
 Qed.
 
-Global Instance inv_persistent i P : Persistent (invariant i P).
+Global Instance inv_persistent N P : Persistent (inv N P).
 Proof.
   apply _.
 Qed.
 
-Global Instance inv_affine i P : Affine (invariant i P).
+Global Instance inv_affine N P : Affine (inv N P).
 Proof.
   apply _.
 Qed.
 
-Lemma invariant_dup : forall i P, invariant i P = invariant i P * invariant i P.
+Lemma invariant_dup : forall N P, inv N P = (inv N P * inv N P)%logic.
 Proof.
-  intros; apply pred_ext; rewrite <- (bi.persistent_sep_dup (invariant i P)); auto.
+  intros; apply pred_ext; rewrite <- (bi.persistent_sep_dup (inv N P)); auto.
 Qed.
 
-Lemma wsat_alloc : forall P, wsat * |> P |-- (|==> wsat * EX i : _, invariant i P)%I.
+Lemma wsat_alloc : forall P, wsat * |> P |-- (|==> wsat * EX N : _, inv N P)%I.
 Proof.
   intros; iIntros "[wsat P]".
   unfold wsat.
@@ -142,7 +145,8 @@ Proof.
         rewrite <- Zlength_correct, <- app_assoc, app_Znth2 by lia.
         erewrite app_Znth1, Znth_repeat'; auto; try lia.
         rewrite coqlib4.Zlength_repeat; lia.
-  - iExists (length l + i)%nat; unfold invariant.
+  - unfold inv. iExists (nroot .@ (Pos.of_nat (S (length l + i))))%nat; unfold invariant.
+    iExists (length l + i)%nat; iSplit; auto.
     iExists g; rewrite H; iFrame.
 Qed.
 
@@ -305,23 +309,7 @@ Proof.
   - unfold Ensembles.In; auto.
 Qed.
 
-(* Consider putting rules for invariants and fancy updates in msl (a la ghost_seplog), and proofs
-   in veric (a la own). *)
-
-(*
-
-need to do namespaces if we want to use iInv!
-
-Global Instance into_inv_inv N P : IntoInv (invariant N P) N := {}.
-
-Global Instance into_acc_inv N P E:
-  IntoAcc (X := unit) (inv N P)
-          (↑N ⊆ E) True (fupd E (E ∖ ↑N)) (fupd (E ∖ ↑N) E)
-          (λ _ : (), (▷ P)%I) (λ _ : (), (▷ P)%I) (λ _ : (), None).
-Proof.
-  rewrite inv_eq /IntoAcc /accessor bi.exist_unit.
-  iIntros (?) "#Hinv _". iApply "Hinv"; done.
-Qed.*)
+(* Consider putting rules for invariants in msl/ghost_seplog.v. *)
 
 End Invariants.
 
@@ -336,3 +324,5 @@ Proof.
   iExists {| g_inv := g_inv; g_dis := g_dis; g_en := g_en |}.
   iExists nil, nil, nil; simpl; iFrame "inv dis en"; auto.
 Qed.
+
+Global Instance into_inv_inv N P : IntoInv (inv N P) N := {}.

--- a/concurrency/juicy/resource_decay_join.v
+++ b/concurrency/juicy/resource_decay_join.v
@@ -10,17 +10,12 @@ Require Import VST.veric.Clight_new.
 Require Import VST.veric.semax.
 Require Import VST.veric.semax_ext.
 Require Import VST.veric.juicy_extspec.
-Require Import VST.veric.juicy_extspec.
 Require Import VST.veric.tycontext.
 Require Import VST.veric.res_predicates.
 Require Import VST.veric.coqlib4.
 Require Import VST.veric.age_to_resource_at.
 Require Import VST.concurrency.common.permjoin.
 Require Import VST.concurrency.juicy.sync_preds_defs.
-
-Set Bullet Behavior "Strict Subproofs".
-
-(* @andrew those lemmas already somewhere? *)
 
 Lemma NO_ext: forall sh1 sh2 p1 p2, sh1=sh2 -> NO sh1 p1 = NO sh2 p2.
 Proof.

--- a/floyd/SeparationLogicAsLogicSoundness.v
+++ b/floyd/SeparationLogicAsLogicSoundness.v
@@ -227,7 +227,7 @@ Theorem semax_prog_rule :
          { jm |
            m_dry jm = m /\ level jm = n /\
            nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
-           jsafeN (@OK_spec Espec) (globalenv prog) n z q jm /\
+           jsafeN (@OK_spec Espec) (globalenv prog) z q jm /\
            no_locks (m_phi jm) /\
            matchfunspecs (globalenv prog) G (m_phi jm) /\
            app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)

--- a/floyd/SeparationLogicAsLogicSoundness.v
+++ b/floyd/SeparationLogicAsLogicSoundness.v
@@ -227,6 +227,7 @@ Theorem semax_prog_rule :
          { jm |
            m_dry jm = m /\ level jm = n /\
            nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
+           (exists z, join (m_phi jm) (wsat_rmap (m_phi jm)) (m_phi z) /\ ext_order jm z) /\
            jsafeN (@OK_spec Espec) (globalenv prog) z q jm /\
            no_locks (m_phi jm) /\
            matchfunspecs (globalenv prog) G (m_phi jm) /\

--- a/floyd/SeparationLogicFacts.v
+++ b/floyd/SeparationLogicFacts.v
@@ -493,7 +493,7 @@ Axiom semax_conseq:
     (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_normal R') |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
     (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_break R') |-- (|={Ensembles.Full_set}=> RA_break R)) ->
     (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_continue R') |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
-    (forall vl, local (tc_environ Delta) && ((allp_fun_id Delta) && RA_return R' vl) |-- (|={Ensembles.Full_set}=> RA_return R vl)) ->
+    (forall vl, local (tc_environ Delta) && ((allp_fun_id Delta) && RA_return R' vl) |-- (RA_return R vl)) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
 
 End CLIGHT_SEPARATION_HOARE_LOGIC_COMPLETE_CONSEQUENCE.
@@ -508,11 +508,11 @@ Import CConseq.
 Lemma semax_pre_post_indexed_fupd:
   forall {CS: compspecs} {Espec: OracleKind} (Delta: tycontext),
  forall P' (R': ret_assert) P c (R: ret_assert) ,
-    (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> |> FF || P')) ->
-    (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> |> FF || RA_normal R)) ->
-    (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> |> FF || RA_break R)) ->
-    (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> |> FF || RA_continue R)) ->
-    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|={Ensembles.Full_set}=> |> FF || RA_return R vl)) ->
+    (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> P')) ->
+    (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
+    (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> RA_break R)) ->
+    (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
+    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (RA_return R vl)) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
 Proof.
   intros.
@@ -529,33 +529,33 @@ Lemma semax_pre_post_fupd:
     (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
     (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> RA_break R)) ->
     (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
-    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|={Ensembles.Full_set}=> RA_return R vl)) ->
+    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (RA_return R vl)) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
 Proof.
   intros.
   eapply semax_pre_post_indexed_fupd; [.. | exact H4]; try intros;
-  try apply derives_bupd_derives_bupd0; auto.
+  try apply derives_fupd_derives_fupd; auto.
 Qed.
 
 Lemma semax_pre_indexed_fupd:
  forall P' Espec {cs: compspecs} Delta P c R,
-     (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> |> FF || P')) ->
+     (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> P')) ->
      @semax cs Espec Delta P' c R  -> @semax cs Espec Delta P c R.
 Proof.
   intros; eapply semax_pre_post_indexed_fupd; eauto;
-  intros; reduce2derives; apply derives_refl.
+  intros; reduce2derives; (apply fupd_intro || apply derives_refl).
 Qed.
 
 Lemma semax_post_indexed_fupd:
  forall (R': ret_assert) Espec {cs: compspecs} Delta (R: ret_assert) P c,
-   (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> |> FF || RA_normal R)) ->
-   (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> |> FF || RA_break R)) ->
-   (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> |> FF || RA_continue R)) ->
-   (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|={Ensembles.Full_set}=> |> FF || RA_return R vl)) ->
+   (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
+   (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> RA_break R)) ->
+   (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
+   (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (RA_return R vl)) ->
    @semax cs Espec Delta P c R' ->  @semax cs Espec Delta P c R.
 Proof.
   intros; eapply semax_pre_post_indexed_fupd; try eassumption.
-  apply derives_bupd0_refl.
+  apply derives_fupd_refl.
 Qed.
 
 Lemma semax_post''_indexed_fupd: forall R' Espec {cs: compspecs} Delta R P c,
@@ -575,7 +575,7 @@ Lemma semax_pre_fupd:
      @semax cs Espec Delta P' c R  -> @semax cs Espec Delta P c R.
 Proof.
 intros; eapply semax_pre_post_fupd; eauto;
-intros; apply andp_left2, bupd_intro; auto.
+intros; apply andp_left2, fupd_intro; auto.
 Qed.
 
 Lemma semax_post_fupd:
@@ -583,11 +583,11 @@ Lemma semax_post_fupd:
    (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
    (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> RA_break R)) ->
    (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
-   (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|={Ensembles.Full_set}=> RA_return R vl)) ->
+   (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (RA_return R vl)) ->
    @semax cs Espec Delta P c R' ->  @semax cs Espec Delta P c R.
 Proof.
   intros; eapply semax_pre_post_fupd; try eassumption.
-  apply derives_bupd_refl.
+  apply derives_fupd_refl.
 Qed.
 
 Lemma semax_post'_fupd: forall R' Espec {cs: compspecs} Delta R P c,
@@ -670,7 +670,7 @@ Lemma semax_pre_post : forall {Espec: OracleKind}{CS: compspecs},
     (forall vl, local (tc_environ Delta) && RA_return R' vl |-- RA_return R vl) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
 Proof.
-  intros; eapply semax_pre_post_bupd; eauto; intros; eapply derives_trans, bupd_intro; auto.
+  intros; eapply semax_pre_post_fupd; eauto; intros; eapply derives_trans, fupd_intro; auto.
 Qed.
 
 End GenConseq.
@@ -852,19 +852,19 @@ Lemma semax_extract_later_prop:
 Proof.
   intros.
   apply semax_extract_prop in H.
-  eapply semax_pre_post_indexed_bupd; [.. | exact H].
+  eapply semax_pre_post_indexed_fupd; [.. | exact H].
   + apply andp_left2.
-    eapply derives_trans; [| apply bupd_intro].
+    eapply derives_trans; [| apply fupd_intro].
     rewrite orp_comm, distrib_andp_orp.
     apply andp_right.
     - apply andp_left1.
       apply later_prop.
     - apply orp_right1.
       solve_andp.
-  + apply derives_bupd0_refl.
-  + apply derives_bupd0_refl.
-  + apply derives_bupd0_refl.
-  + intros; apply derives_bupd0_refl.
+  + apply derives_fupd_refl.
+  + apply derives_fupd_refl.
+  + apply derives_fupd_refl.
+  + intros; apply derives_fupd_refl.
 Qed.
 
 End GenIExtrFacts.

--- a/floyd/SeparationLogicFacts.v
+++ b/floyd/SeparationLogicFacts.v
@@ -489,11 +489,11 @@ Import CSHL_Def.
 Axiom semax_conseq:
   forall {CS: compspecs} {Espec: OracleKind} (Delta: tycontext),
   forall P' (R': ret_assert) P c (R: ret_assert) ,
-    (local (tc_environ Delta) && ((allp_fun_id Delta) && P) |-- (|==> |> FF || P')) ->
-    (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_normal R') |-- (|==> |> FF || RA_normal R)) ->
-    (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_break R') |-- (|==> |> FF || RA_break R)) ->
-    (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_continue R') |-- (|==> |> FF || RA_continue R)) ->
-    (forall vl, local (tc_environ Delta) && ((allp_fun_id Delta) && RA_return R' vl) |-- (|==> |> FF || RA_return R vl)) ->
+    (local (tc_environ Delta) && ((allp_fun_id Delta) && P) |-- (|={Ensembles.Full_set}=> P')) ->
+    (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_normal R') |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
+    (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_break R') |-- (|={Ensembles.Full_set}=> RA_break R)) ->
+    (local (tc_environ Delta) && ((allp_fun_id Delta) && RA_continue R') |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
+    (forall vl, local (tc_environ Delta) && ((allp_fun_id Delta) && RA_return R' vl) |-- (|={Ensembles.Full_set}=> RA_return R vl)) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
 
 End CLIGHT_SEPARATION_HOARE_LOGIC_COMPLETE_CONSEQUENCE.
@@ -505,14 +505,14 @@ Module GenCConseqFacts
 Import Def.
 Import CConseq.
 
-Lemma semax_pre_post_indexed_bupd:
+Lemma semax_pre_post_indexed_fupd:
   forall {CS: compspecs} {Espec: OracleKind} (Delta: tycontext),
  forall P' (R': ret_assert) P c (R: ret_assert) ,
-    (local (tc_environ Delta) && P |-- (|==> |> FF || P')) ->
-    (local (tc_environ Delta) && RA_normal R' |-- (|==> |> FF || RA_normal R)) ->
-    (local (tc_environ Delta) && RA_break R' |-- (|==> |> FF || RA_break R)) ->
-    (local (tc_environ Delta) && RA_continue R' |-- (|==> |> FF || RA_continue R)) ->
-    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|==> |> FF || RA_return R vl)) ->
+    (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> |> FF || P')) ->
+    (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> |> FF || RA_normal R)) ->
+    (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> |> FF || RA_break R)) ->
+    (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> |> FF || RA_continue R)) ->
+    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|={Ensembles.Full_set}=> |> FF || RA_return R vl)) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
 Proof.
   intros.
@@ -522,114 +522,114 @@ Proof.
   end.
 Qed.
 
-Lemma semax_pre_post_bupd:
+Lemma semax_pre_post_fupd:
   forall {CS: compspecs} {Espec: OracleKind} (Delta: tycontext),
  forall P' (R': ret_assert) P c (R: ret_assert) ,
-    (local (tc_environ Delta) && P |-- (|==> P')) ->
-    (local (tc_environ Delta) && RA_normal R' |-- (|==> RA_normal R)) ->
-    (local (tc_environ Delta) && RA_break R' |-- (|==> RA_break R)) ->
-    (local (tc_environ Delta) && RA_continue R' |-- (|==> RA_continue R)) ->
-    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|==> RA_return R vl)) ->
+    (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> P')) ->
+    (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
+    (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> RA_break R)) ->
+    (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
+    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|={Ensembles.Full_set}=> RA_return R vl)) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
 Proof.
   intros.
-  eapply semax_pre_post_indexed_bupd; [.. | exact H4]; try intros;
+  eapply semax_pre_post_indexed_fupd; [.. | exact H4]; try intros;
   try apply derives_bupd_derives_bupd0; auto.
 Qed.
 
-Lemma semax_pre_indexed_bupd:
+Lemma semax_pre_indexed_fupd:
  forall P' Espec {cs: compspecs} Delta P c R,
-     (local (tc_environ Delta) && P |-- (|==> |> FF || P')) ->
+     (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> |> FF || P')) ->
      @semax cs Espec Delta P' c R  -> @semax cs Espec Delta P c R.
 Proof.
-  intros; eapply semax_pre_post_indexed_bupd; eauto;
+  intros; eapply semax_pre_post_indexed_fupd; eauto;
   intros; reduce2derives; apply derives_refl.
 Qed.
 
-Lemma semax_post_indexed_bupd:
+Lemma semax_post_indexed_fupd:
  forall (R': ret_assert) Espec {cs: compspecs} Delta (R: ret_assert) P c,
-   (local (tc_environ Delta) && RA_normal R' |-- (|==> |> FF || RA_normal R)) ->
-   (local (tc_environ Delta) && RA_break R' |-- (|==> |> FF || RA_break R)) ->
-   (local (tc_environ Delta) && RA_continue R' |-- (|==> |> FF || RA_continue R)) ->
-   (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|==> |> FF || RA_return R vl)) ->
+   (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> |> FF || RA_normal R)) ->
+   (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> |> FF || RA_break R)) ->
+   (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> |> FF || RA_continue R)) ->
+   (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|={Ensembles.Full_set}=> |> FF || RA_return R vl)) ->
    @semax cs Espec Delta P c R' ->  @semax cs Espec Delta P c R.
 Proof.
-  intros; eapply semax_pre_post_indexed_bupd; try eassumption.
+  intros; eapply semax_pre_post_indexed_fupd; try eassumption.
   apply derives_bupd0_refl.
 Qed.
 
-Lemma semax_post''_indexed_bupd: forall R' Espec {cs: compspecs} Delta R P c,
-           (local (tc_environ Delta) && R' |-- (|==> |> FF || RA_normal R)) ->
+Lemma semax_post''_indexed_fupd: forall R' Espec {cs: compspecs} Delta R P c,
+           (local (tc_environ Delta) && R' |-- (|={Ensembles.Full_set}=> |> RA_normal R)) ->
       @semax cs Espec Delta P c (normal_ret_assert R') ->
       @semax cs Espec Delta P c R.
-Proof. intros. eapply semax_post_indexed_bupd; eauto.
+Proof. intros. eapply semax_post_indexed_fupd; eauto.
  simpl RA_normal; auto.
  simpl RA_break; normalize.
  simpl RA_continue; normalize.
  intro vl; simpl RA_return; normalize.
 Qed.
 
-Lemma semax_pre_bupd:
+Lemma semax_pre_fupd:
  forall P' Espec {cs: compspecs} Delta P c R,
-     (local (tc_environ Delta) && P |-- (|==> P')) ->
+     (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> P')) ->
      @semax cs Espec Delta P' c R  -> @semax cs Espec Delta P c R.
 Proof.
-intros; eapply semax_pre_post_bupd; eauto;
+intros; eapply semax_pre_post_fupd; eauto;
 intros; apply andp_left2, bupd_intro; auto.
 Qed.
 
-Lemma semax_post_bupd:
+Lemma semax_post_fupd:
  forall (R': ret_assert) Espec {cs: compspecs} Delta (R: ret_assert) P c,
-   (local (tc_environ Delta) && RA_normal R' |-- (|==> RA_normal R)) ->
-   (local (tc_environ Delta) && RA_break R' |-- (|==> RA_break R)) ->
-   (local (tc_environ Delta) && RA_continue R' |-- (|==> RA_continue R)) ->
-   (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|==> RA_return R vl)) ->
+   (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
+   (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> RA_break R)) ->
+   (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
+   (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|={Ensembles.Full_set}=> RA_return R vl)) ->
    @semax cs Espec Delta P c R' ->  @semax cs Espec Delta P c R.
 Proof.
-  intros; eapply semax_pre_post_bupd; try eassumption.
+  intros; eapply semax_pre_post_fupd; try eassumption.
   apply derives_bupd_refl.
 Qed.
 
-Lemma semax_post'_bupd: forall R' Espec {cs: compspecs} Delta R P c,
-           (local (tc_environ Delta) && R' |-- (|==> R)) ->
+Lemma semax_post'_fupd: forall R' Espec {cs: compspecs} Delta R P c,
+           (local (tc_environ Delta) && R' |-- (|={Ensembles.Full_set}=> R)) ->
       @semax cs Espec Delta P c (normal_ret_assert R') ->
       @semax cs Espec Delta P c (normal_ret_assert R).
-Proof. intros. eapply semax_post_bupd; eauto.
+Proof. intros. eapply semax_post_fupd; eauto.
  simpl RA_normal; auto.
  simpl RA_break; normalize.
  simpl RA_continue; normalize.
  intro vl; simpl RA_return; normalize.
 Qed.
 
-Lemma semax_post''_bupd: forall R' Espec {cs: compspecs} Delta R P c,
-           (local (tc_environ Delta) && R' |-- (|==> RA_normal R)) ->
+Lemma semax_post''_fupd: forall R' Espec {cs: compspecs} Delta R P c,
+           (local (tc_environ Delta) && R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
       @semax cs Espec Delta P c (normal_ret_assert R') ->
       @semax cs Espec Delta P c R.
-Proof. intros. eapply semax_post_bupd; eauto.
+Proof. intros. eapply semax_post_fupd; eauto.
  simpl RA_normal; auto.
  simpl RA_break; normalize.
  simpl RA_continue; normalize.
  intro vl; simpl RA_return; normalize.
 Qed.
 
-Lemma semax_pre_post'_bupd: forall P' R' Espec {cs: compspecs} Delta R P c,
-      (local (tc_environ Delta) && P |-- (|==> P')) ->
-      (local (tc_environ Delta) && R' |-- (|==> R)) ->
+Lemma semax_pre_post'_fupd: forall P' R' Espec {cs: compspecs} Delta R P c,
+      (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> P')) ->
+      (local (tc_environ Delta) && R' |-- (|={Ensembles.Full_set}=> R)) ->
       @semax cs Espec Delta P' c (normal_ret_assert R') ->
       @semax cs Espec Delta P c (normal_ret_assert R).
 Proof. intros.
- eapply semax_pre_bupd; eauto.
- eapply semax_post'_bupd; eauto.
+ eapply semax_pre_fupd; eauto.
+ eapply semax_post'_fupd; eauto.
 Qed.
 
-Lemma semax_pre_post''_bupd: forall P' R' Espec {cs: compspecs} Delta R P c,
-      (local (tc_environ Delta) && P |-- (|==> P')) ->
-      (local (tc_environ Delta) && R' |-- (|==> RA_normal R)) ->
+Lemma semax_pre_post''_fupd: forall P' R' Espec {cs: compspecs} Delta R P c,
+      (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> P')) ->
+      (local (tc_environ Delta) && R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
       @semax cs Espec Delta P' c (normal_ret_assert R') ->
       @semax cs Espec Delta P c R.
 Proof. intros.
- eapply semax_pre_bupd; eauto.
- eapply semax_post''_bupd; eauto.
+ eapply semax_pre_fupd; eauto.
+ eapply semax_post''_fupd; eauto.
 Qed.
 
 End GenCConseqFacts.

--- a/floyd/SeparationLogicFacts.v
+++ b/floyd/SeparationLogicFacts.v
@@ -559,7 +559,7 @@ Proof.
 Qed.
 
 Lemma semax_post''_indexed_fupd: forall R' Espec {cs: compspecs} Delta R P c,
-           (local (tc_environ Delta) && R' |-- (|={Ensembles.Full_set}=> |> RA_normal R)) ->
+           (local (tc_environ Delta) && R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
       @semax cs Espec Delta P c (normal_ret_assert R') ->
       @semax cs Espec Delta P c R.
 Proof. intros. eapply semax_post_indexed_fupd; eauto.
@@ -575,7 +575,7 @@ Lemma semax_pre_fupd:
      @semax cs Espec Delta P' c R  -> @semax cs Espec Delta P c R.
 Proof.
 intros; eapply semax_pre_post_fupd; eauto;
-intros; apply andp_left2, fupd_intro; auto.
+intros; apply andp_left2; try apply fupd_intro; auto.
 Qed.
 
 Lemma semax_post_fupd:
@@ -854,17 +854,14 @@ Proof.
   apply semax_extract_prop in H.
   eapply semax_pre_post_indexed_fupd; [.. | exact H].
   + apply andp_left2.
-    eapply derives_trans; [| apply fupd_intro].
-    rewrite orp_comm, distrib_andp_orp.
-    apply andp_right.
-    - apply andp_left1.
-      apply later_prop.
-    - apply orp_right1.
-      solve_andp.
+    eapply derives_trans, except_0_fupd.
+    eapply derives_trans; [apply andp_derives, orp_right1, derives_refl; apply later_prop|].
+    rewrite <- distrib_andp_orp.
+    rewrite orp_comm; apply orp_derives, fupd_intro; auto.
   + apply derives_fupd_refl.
   + apply derives_fupd_refl.
   + apply derives_fupd_refl.
-  + intros; apply derives_fupd_refl.
+  + intros; apply andp_left2; auto.
 Qed.
 
 End GenIExtrFacts.

--- a/floyd/assert_lemmas.v
+++ b/floyd/assert_lemmas.v
@@ -988,6 +988,8 @@ Ltac derives_fupd_L2R H :=
 
 Ltac derives_full_L2R H :=
   match type of H with
+  | @derives (environ -> mpred) _ (local (tc_environ ?Delta) && (allp_fun_id ?Delta && _)) (|={_,_}=> _) =>
+      eapply derives_full_trans; [apply H |]
   | @derives (environ -> mpred) _ (local (tc_environ _) && _) (|={_,_}=> _) =>
       eapply derives_full_trans; [apply derives_fupd_derives_full, H |]
   | @derives (environ -> mpred) _ (local (tc_environ _) && _) _ =>
@@ -998,6 +1000,8 @@ Ltac derives_full_L2R H :=
 
 Tactic Notation "derives_rewrite" "->" constr(H) :=
   match goal with
+  | |- @derives (environ -> mpred) _ (local (tc_environ ?Delta) && (allp_fun_id ?Delta && _)) (|={_,_}=> _) =>
+         derives_full_L2R H
   | |- @derives (environ -> mpred) _ (local (tc_environ _) && _) (|={_,_}=> _) =>
          derives_fupd_L2R H
   | |- @derives (environ -> mpred) _ (local (tc_environ _) && _) _ =>
@@ -1027,18 +1031,10 @@ Ltac derives_fupd_R2L H :=
       eapply derives_fupd_trans; [| apply ENTAIL_derives_fupd, derives_ENTAIL, H]
   end.
 
-Ltac derives_bupd0_R2L H :=
-  match type of H with
-  | @derives (environ -> mpred) _ (local (tc_environ _) && _) (|={_,_}=> _) =>
-      eapply derives_fupd_trans; [| apply H]
-  | @derives (environ -> mpred) _ (local (tc_environ _) && _) _ =>
-      eapply derives_fupd_trans; [| apply ENTAIL_derives_fupd, H]
-  | _ =>
-      eapply derives_fupd_trans; [| apply ENTAIL_derives_fupd, derives_ENTAIL, H]
-  end.
-
 Ltac derives_full_R2L H :=
   match type of H with
+  | @derives (environ -> mpred) _ (local (tc_environ ?Delta) && (allp_fun_id ?Delta && _)) (|={_,_}=> _) =>
+      eapply derives_fupd_trans; [| apply H]
   | @derives (environ -> mpred) _ (local (tc_environ _) && _) (|={_,_}=> _) =>
       eapply derives_fupd_trans; [| apply derives_fupd_derives_full, H]
   | @derives (environ -> mpred) _ (local (tc_environ _) && _) _ =>
@@ -1049,6 +1045,8 @@ Ltac derives_full_R2L H :=
 
 Tactic Notation "derives_rewrite" "<-" constr(H) :=
   match goal with
+  | |- @derives (environ -> mpred) _ (local (tc_environ _) && _) (|={_,_}=> _) =>
+         derives_fupd_R2L H
   | |- @derives (environ -> mpred) _ (local (tc_environ _) && _) (|={_,_}=> _) =>
          derives_fupd_R2L H
   | |- @derives (environ -> mpred) _ (local (tc_environ _) && _) _ =>

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -854,18 +854,14 @@ Proof.
   apply extract_exists_pre in H.
   eapply semax_conseq; [.. | exact H].
   + reduceL.
-    eapply derives_trans; [| apply bupd_intro].
-    rewrite andp_comm.
-    apply imp_andp_adjoint.
-    eapply derives_trans; [apply later_exp'' |].
+    eapply derives_trans, except_0_fupd.
+    eapply derives_trans; [apply andp_derives, later_exp''; apply derives_refl|].
+    rewrite andp_comm, distrib_orp_andp.
     apply orp_left.
-    - apply imp_andp_adjoint.
-      rewrite andp_comm.
-      apply orp_right2.
-      rewrite exp_andp2.
-      apply derives_refl.
-    - apply imp_andp_adjoint.
-      apply andp_left1, orp_right1, derives_refl.
+    - apply orp_right2.
+      eapply derives_trans, fupd_intro.
+      rewrite <- exp_andp2, andp_comm; apply derives_refl.
+    - apply orp_right1, andp_left1, derives_refl.
   + reduce2derives; apply derives_refl.
   + reduce2derives; apply derives_refl.
   + reduce2derives; apply derives_refl.
@@ -875,19 +871,19 @@ Qed.
 Lemma semax_pre_post_fupd:
   forall {CS: compspecs} {Espec: OracleKind} (Delta: tycontext),
  forall P' (R': ret_assert) P c (R: ret_assert) ,
-    (local (tc_environ Delta) && P |-- (|==> P')) ->
-    (local (tc_environ Delta) && RA_normal R' |-- (|==> RA_normal R)) ->
-    (local (tc_environ Delta) && RA_break R' |-- (|==> RA_break R)) ->
-    (local (tc_environ Delta) && RA_continue R' |-- (|==> RA_continue R)) ->
-    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (|==> RA_return R vl)) ->
+    (local (tc_environ Delta) && P |-- (|={Ensembles.Full_set}=> P')) ->
+    (local (tc_environ Delta) && RA_normal R' |-- (|={Ensembles.Full_set}=> RA_normal R)) ->
+    (local (tc_environ Delta) && RA_break R' |-- (|={Ensembles.Full_set}=> RA_break R)) ->
+    (local (tc_environ Delta) && RA_continue R' |-- (|={Ensembles.Full_set}=> RA_continue R)) ->
+    (forall vl, local (tc_environ Delta) && RA_return R' vl |-- (RA_return R vl)) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
-Proof. exact @CConseqFacts.semax_pre_post_bupd. Qed.
+Proof. exact @CConseqFacts.semax_pre_post_fupd. Qed.
 
-Lemma semax_pre_bupd:
+Lemma semax_pre_fupd:
  forall P' Espec {cs: compspecs} Delta P c R,
-     ENTAIL Delta , P |-- (|==> P') ->
+     ENTAIL Delta , P |-- (|={Ensembles.Full_set}=> P') ->
      @semax cs Espec Delta P' c R  -> @semax cs Espec Delta P c R.
-Proof. exact @CConseqFacts.semax_pre_bupd. Qed.
+Proof. exact @CConseqFacts.semax_pre_fupd. Qed.
 
 Lemma semax_pre:
  forall P' Espec {cs: compspecs} Delta P c R,
@@ -921,7 +917,7 @@ Lemma semax_pre_post : forall {Espec: OracleKind}{CS: compspecs},
     (forall vl, local (tc_environ Delta) && RA_return R' vl |-- RA_return R vl) ->
    @semax CS Espec Delta P' c R' -> @semax CS Espec Delta P c R.
 Proof.
-  intros; eapply semax_pre_post_bupd; eauto; intros; eapply derives_trans, bupd_intro; auto.
+  intros; eapply semax_pre_post_fupd; eauto; intros; eapply derives_trans, fupd_intro; auto.
 Qed.
 
 Lemma semax_frame_PQR:
@@ -976,16 +972,16 @@ apply H1.
 apply semax_frame_PQR; auto.
 Qed.
 
-Lemma semax_post_bupd:
+Lemma semax_post_fupd:
  forall (R': ret_assert) Espec {cs: compspecs} Delta (R: ret_assert) P c,
-   ENTAIL Delta, RA_normal R' |-- (|==> RA_normal R) ->
-   ENTAIL Delta, RA_break R' |-- (|==> RA_break R) ->
-   ENTAIL Delta, RA_continue R' |-- (|==> RA_continue R) ->
-   (forall vl, ENTAIL Delta, RA_return R' vl |-- (|==> RA_return R vl)) ->
+   ENTAIL Delta, RA_normal R' |-- (|={Ensembles.Full_set}=> RA_normal R) ->
+   ENTAIL Delta, RA_break R' |-- (|={Ensembles.Full_set}=> RA_break R) ->
+   ENTAIL Delta, RA_continue R' |-- (|={Ensembles.Full_set}=> RA_continue R) ->
+   (forall vl, ENTAIL Delta, RA_return R' vl |-- (RA_return R vl)) ->
    @semax cs Espec Delta P c R' ->  @semax cs Espec Delta P c R.
 Proof.
-intros; eapply semax_pre_post_bupd; try eassumption.
-apply andp_left2, bupd_intro; auto.
+intros; eapply semax_pre_post_fupd; try eassumption.
+apply andp_left2, fupd_intro; auto.
 Qed.
 
 Lemma semax_post:
@@ -1209,7 +1205,7 @@ Fixpoint replace_nth {A} (n: nat) (al: list A) (x: A) {struct n}: list A :=
  | _, nil => nil
  end.
 
-Fixpoint my_nth{A} (n: nat) (al: list A) (default: A) {struct n} : A :=
+Fixpoint my_nth {A} (n: nat) (al: list A) (default: A) {struct n} : A :=
   (* just like nth; make a new copy, for better control of unfolding *)
 match n, al with
 | O, a::al' => a
@@ -1346,14 +1342,14 @@ Tactic Notation "replace_SEP" constr(n) constr(R) "by" tactic1(t):=
   unfold my_nth,replace_nth; simpl Z.to_nat;
    repeat simpl_nat_of_P; cbv beta iota; cbv beta iota; [ now t | ].
 
-Lemma replace_SEP'_bupd:
+Lemma replace_SEP'_fupd:
  forall n R' Espec {cs: compspecs} Delta P Q Rs c Post,
- ENTAIL Delta, PROPx P (LOCALx Q (SEPx (my_nth n Rs TT ::  nil))) |-- `(|==> R') ->
+ ENTAIL Delta, PROPx P (LOCALx Q (SEPx (my_nth n Rs TT ::  nil))) |-- `(|={Ensembles.Full_set}=> R') ->
  @semax cs Espec Delta (PROPx P (LOCALx Q (SEPx (replace_nth n Rs R')))) c Post ->
  @semax cs Espec Delta (PROPx P (LOCALx Q (SEPx Rs))) c Post.
 Proof.
 intros.
-eapply semax_pre_bupd; [ | apply H0].
+eapply semax_pre_fupd; [ | apply H0].
 clear - H.
 unfold PROPx, LOCALx, SEPx in *; intro rho; specialize (H rho).
 unfold local, lift1 in *.
@@ -1362,20 +1358,21 @@ normalize.
 rewrite !prop_true_andp in H by auto.
 rewrite sepcon_emp in H.
 rewrite prop_true_andp by auto.
-revert Rs H; induction n; destruct Rs; simpl ; intros; auto; try solve [apply bupd_intro; auto].
-- eapply derives_trans, bupd_frame_r; apply sepcon_derives; auto.
-- eapply derives_trans, bupd_frame_l; apply sepcon_derives; auto.
+change fupd with (ghost_seplog.fupd Ensembles.Full_set Ensembles.Full_set).
+revert Rs H; induction n; destruct Rs; intros; auto; try solve [apply fupd_intro; auto].
+- eapply derives_trans, fupd_frame_r; apply sepcon_derives; auto.
+- eapply derives_trans, fupd_frame_l; apply sepcon_derives; auto.
 Qed.
 
-Lemma replace_SEP''_bupd:
+Lemma replace_SEP''_fupd:
  forall n R' Delta P Q Rs Post,
- ENTAIL Delta, PROPx P (LOCALx Q (SEPx (my_nth n Rs TT ::  nil))) |-- `(|==> R') ->
- ENTAIL Delta, PROPx P (LOCALx Q (SEPx (replace_nth n Rs R'))) |-- (|==> Post) ->
- ENTAIL Delta, PROPx P (LOCALx Q (SEPx Rs)) |-- (|==> Post).
+ ENTAIL Delta, PROPx P (LOCALx Q (SEPx (my_nth n Rs TT ::  nil))) |-- `(|={Ensembles.Full_set}=> R') ->
+ ENTAIL Delta, PROPx P (LOCALx Q (SEPx (replace_nth n Rs R'))) |-- (|={Ensembles.Full_set}=> Post) ->
+ ENTAIL Delta, PROPx P (LOCALx Q (SEPx Rs)) |-- (|={Ensembles.Full_set}=> Post).
 Proof.
 intros.
-eapply derives_trans, bupd_trans.
-eapply derives_trans; [ | apply bupd_mono, H0].
+eapply derives_trans, fupd_trans.
+eapply derives_trans; [ | apply fupd_mono, H0].
 clear - H.
 unfold PROPx, LOCALx, SEPx in *; intro rho; specialize (H rho).
 unfold local, lift1 in *.
@@ -1384,18 +1381,19 @@ normalize.
 rewrite !prop_true_andp in H by auto.
 rewrite sepcon_emp in H.
 rewrite !prop_true_andp by auto.
-revert Rs H; induction n; destruct Rs; simpl ; intros; auto; try solve [apply bupd_intro; auto].
-- eapply derives_trans, bupd_frame_r; apply sepcon_derives; auto.
-- eapply derives_trans, bupd_frame_l; apply sepcon_derives; auto.
+change fupd with (ghost_seplog.fupd Ensembles.Full_set Ensembles.Full_set).
+revert Rs H; induction n; destruct Rs; intros; auto; try solve [apply fupd_intro; auto].
+- eapply derives_trans, fupd_frame_r; apply sepcon_derives; auto.
+- eapply derives_trans, fupd_frame_l; apply sepcon_derives; auto.
 Qed.
 
 Tactic Notation "viewshift_SEP" constr(n) constr(R) :=
-  first [apply (replace_SEP'_bupd (Z.to_nat n) R) | apply (replace_SEP''_bupd (Z.to_nat n) R)];
+  first [apply (replace_SEP'_fupd (Z.to_nat n) R) | apply (replace_SEP''_fupd (Z.to_nat n) R)];
   unfold my_nth,replace_nth; simpl Z.to_nat;
    repeat simpl_nat_of_P; cbv beta iota; cbv beta iota.
 
 Tactic Notation "viewshift_SEP" constr(n) constr(R) "by" tactic1(t):=
-  first [apply (replace_SEP'_bupd (Z.to_nat n) R) | apply (replace_SEP''_bupd (Z.to_nat n) R)];
+  first [apply (replace_SEP'_fupd (Z.to_nat n) R) | apply (replace_SEP''_fupd (Z.to_nat n) R)];
   unfold my_nth,replace_nth; simpl Z.to_nat;
    repeat simpl_nat_of_P; cbv beta iota; cbv beta iota; [ now t | ].
 

--- a/floyd/canon.v
+++ b/floyd/canon.v
@@ -872,7 +872,7 @@ Proof.
   + intros; reduce2derives; apply derives_refl.
 Qed.
 
-Lemma semax_pre_post_bupd:
+Lemma semax_pre_post_fupd:
   forall {CS: compspecs} {Espec: OracleKind} (Delta: tycontext),
  forall P' (R': ret_assert) P c (R: ret_assert) ,
     (local (tc_environ Delta) && P |-- (|==> P')) ->

--- a/floyd/client_lemmas.v
+++ b/floyd/client_lemmas.v
@@ -37,16 +37,16 @@ eapply derives_trans; [ apply H|].
 apply derives_refl.
 Qed.
 
-Lemma SEP_entail'_bupd:
+Lemma SEP_entail'_fupd:
  forall R' Delta P Q R, 
-   ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |-- ` (|==> fold_right_sepcon R') -> 
-   ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |-- |==> PROPx P (LOCALx Q (SEPx R')).
+   ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |-- ` (|={Ensembles.Full_set}=> fold_right_sepcon R') -> 
+   ENTAIL Delta, PROPx P (LOCALx Q (SEPx R)) |-- |={Ensembles.Full_set}=> PROPx P (LOCALx Q (SEPx R')).
 Proof.
 intros.
-eapply derives_trans, corable_andp_bupd, corable_prop.
+eapply derives_trans, corable_andp_fupd, corable_prop.
 apply andp_right.
 apply andp_left2; apply andp_left1; auto.
-eapply derives_trans, local_andp_bupd.
+eapply derives_trans, local_andp_fupd.
 apply andp_right.
 do 2 apply andp_left2; apply andp_left1; auto.
 eapply derives_trans; [ apply H|].

--- a/floyd/subsume_funspec.v
+++ b/floyd/subsume_funspec.v
@@ -68,14 +68,12 @@ simpl in H0.
 specialize (H0 ts1). destruct H0 as [H0 H0'].
 rewrite H0.
 eapply derives_trans; [apply H3 | clear H3 ].
-eapply derives_trans; [|apply bupd_intro].
+eapply derives_trans; [|apply fupd_intro].
 apply (exp_right (@nil Type)). simpl.
 apply exp_derives; intros x2.
 apply exp_derives; intros F.
 apply andp_derives; trivial. simpl. apply prop_derives. intros.
-rewrite H0'. eapply derives_trans.
-2: { eapply derives_trans. 2: apply bupd_intro. apply H1. }
-clear H1. apply andp_derives; trivial; try apply derives_refl.
+rewrite H0'. apply H1.
 Qed.
 
 (*

--- a/msl/ghost_seplog.v
+++ b/msl/ghost_seplog.v
@@ -2,12 +2,13 @@ Require Import VST.msl.Extensionality.
 Require Import VST.msl.seplog.
 Require Import VST.msl.sepalg.
 Require Import VST.msl.ghost.
-Require Import List.
+Require Import Ensembles List.
 
 Local Open Scope logic.
 
 Definition pred_infinite {N} (P : N -> Prop) := forall l, exists x, ~In x l /\ P x.
 
+(* c.f. https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/bi/updates.v *)
 Class BupdSepLog (A N D: Type) {ND: NatDed A}{SL: SepLog A} := mkBSL {
   bupd: A -> A;
   own: forall {RA: Ghost}, N -> G -> D -> A;
@@ -30,7 +31,11 @@ Class BupdSepLog (A N D: Type) {ND: NatDed A}{SL: SepLog A} := mkBSL {
 
 Notation "|==> P" := (bupd P) (at level 99, P at level 200): logic.
 
-Lemma bupd_orp_r: forall `{BupdSepLog} (P Q: A), ((|==> P) || Q) |-- |==> P || Q.
+Section bupd_derived.
+
+Context `{BUPD : BupdSepLog}.
+
+Lemma bupd_orp_r: forall (P Q: A), ((|==> P) || Q) |-- |==> P || Q.
 Proof.
   intros.
   apply orp_left.
@@ -40,12 +45,12 @@ Proof.
     apply orp_right2, derives_refl.
 Qed.
 
-Lemma bupd_orp_l: forall `{BupdSepLog} (P Q: A), (P || |==> Q) |-- |==> P || Q.
+Lemma bupd_orp_l: forall (P Q: A), (P || |==> Q) |-- |==> P || Q.
 Proof.
   intros; rewrite orp_comm, (orp_comm P Q); apply bupd_orp_r.
 Qed.
 
-Lemma bupd_orp: forall `{BupdSepLog} (P Q: A), ((|==> P) || |==> Q) |-- |==> P || Q.
+Lemma bupd_orp: forall (P Q: A), ((|==> P) || |==> Q) |-- |==> P || Q.
 Proof.
   intros.
   eapply derives_trans, bupd_trans.
@@ -53,12 +58,12 @@ Proof.
   apply bupd_mono, bupd_orp_r.
 Qed.
 
-Lemma bupd_frame_l: forall `{BupdSepLog} (P Q: A), (P * |==> Q) |-- |==> P * Q.
+Lemma bupd_frame_l: forall (P Q: A), (P * |==> Q) |-- |==> P * Q.
 Proof.
   intros; rewrite sepcon_comm, (sepcon_comm P Q); apply bupd_frame_r.
 Qed.
 
-Lemma bupd_sepcon: forall `{BupdSepLog} (P Q: A), ((|==> P) * |==> Q) |-- |==> P * Q.
+Lemma bupd_sepcon: forall (P Q: A), ((|==> P) * |==> Q) |-- |==> P * Q.
 Proof.
   intros.
   eapply derives_trans, bupd_trans.
@@ -66,10 +71,7 @@ Proof.
   apply bupd_mono, bupd_frame_r.
 Qed.
 
-Inductive Singleton {A} (x : A) : A -> Prop :=
-| Singleton_I : Singleton x x.
-
-Lemma own_alloc: forall `{BUPD: BupdSepLog} {RA: Ghost} (a: G) pp,
+Lemma own_alloc: forall {RA: Ghost} (a: G) pp,
   valid a -> emp |-- bupd (EX g: N, own g a pp).
 Proof.
   intros.
@@ -81,11 +83,11 @@ Proof.
   apply andp_left2, derives_refl.
 Qed.
 
-Lemma own_update: forall `{BUPD: BupdSepLog} {RA: Ghost} g (a: G) b pp, fp_update a b ->
+Lemma own_update: forall {RA: Ghost} g (a: G) b pp, fp_update a b ->
     own g a pp |-- |==> (own g b pp).
 Proof.
   intros.
-  eapply derives_trans; [apply own_update_ND with (B := Singleton b)|].
+  eapply derives_trans; [apply own_update_ND with (B := Singleton _ b)|].
   - intros ? J; destruct (H _ J).
     do 2 eexists; [constructor | eauto].
   - apply bupd_mono.
@@ -95,7 +97,7 @@ Proof.
     rewrite <- imp_andp_adjoint; apply andp_left2, derives_refl.
 Qed.
 
-Lemma own_valid: forall `{BupdSepLog} {RA: Ghost} g (a: G) pp,
+Lemma own_valid: forall {RA: Ghost} g (a: G) pp,
   own g a pp |-- !!valid a.
 Proof.
   intros.
@@ -106,26 +108,21 @@ Proof.
   eapply join_eq; eauto; apply core_unit.
 Qed.
 
-Lemma own_sub: forall `{BupdSepLog} {RA: Ghost} g (a b: G) pp,
+Lemma own_sub: forall {RA: Ghost} g (a b: G) pp,
   join_sub b a ->
   own g a pp |-- |==> own g b pp.
 Proof.
   intros; apply own_update, fp_update_sub; auto.
 Qed.
 
-Lemma own_core: forall `{BupdSepLog} {RA: Ghost} g (a: G) pp,
+Lemma own_core: forall {RA: Ghost} g (a: G) pp,
   own g a pp |-- |==> own g (core a) pp.
 Proof.
   intros; apply own_sub.
   eexists; apply core_unit.
 Qed.
 
-(*Lemma own_core2: forall `{BupdSepLog} {RA: Ghost} g (a: G) pp,
-  own g a pp |-- |==> own g (core2 a) pp.
-Proof.
-  intros; apply own_sub.
-  eexists; apply core2_unit.
-Qed.*)
+End bupd_derived.
 
 #[global] Instance LiftBupdSepLog (A B N D: Type) {NB: NatDed B}{SB: SepLog B}{BSLB: BupdSepLog B N D} :
   BupdSepLog (A -> B) N D.
@@ -141,4 +138,127 @@ Qed.*)
  apply own_valid_2.
  apply own_update_ND; auto.
  apply own_dealloc; auto.
+Defined.
+
+Class FupdSepLog (A N D I: Type) {ND: NatDed A}{IA: Indir A}{SL: SepLog A}{BSL: BupdSepLog A N D} := mkFSL {
+  fupd: Ensemble I -> Ensemble I -> A -> A;
+  fupd_mask_subseteq: forall E1 E2, Included _ E2 E1 ->
+    emp |-- fupd E1 E2 (fupd E2 E1 emp);
+  except_0_fupd: forall E1 E2 P, ((|> FF) || fupd E1 E2 P) |-- fupd E1 E2 P;
+  fupd_mono: forall E1 E2 P Q, (P |-- Q) -> fupd E1 E2 P |-- fupd E1 E2 Q;
+  fupd_trans: forall E1 E2 E3 P, fupd E1 E2 (fupd E2 E3 P) |-- fupd E1 E3 P;
+  fupd_mask_frame_r': forall E1 E2 Ef P, Disjoint _ E1 Ef ->
+    fupd E1 E2 (!! (Disjoint _ E2 Ef) --> P) |-- fupd (Union _ E1 Ef) (Union _ E2 Ef) P;
+  fupd_frame_r: forall E1 E2 P Q, (fupd E1 E2 P) * Q |-- fupd E1 E2 (P * Q);
+  bupd_fupd: forall E P, bupd P |-- fupd E E P
+  }.
+
+Notation "|={ E1 , E2 }=> P" := (fupd E1 E2 P) (at level 99, E1 at level 50, E2 at level 50, P at level 200): logic.
+Notation "|={ E }=> P" := (fupd E E P) (at level 99, E at level 50, P at level 200): logic.
+
+Section fupd_derived.
+
+Context `{FUPD : FupdSepLog}.
+
+Lemma fupd_mask_intro_subseteq {CA : ClassicalSep A} E1 E2 P : Included _ E2 E1 ->
+  P |-- |={E1,E2}=> |={E2,E1}=> P.
+Proof.
+  intros.
+  rewrite <- (sepcon_emp P), sepcon_comm.
+  eapply derives_trans; [apply sepcon_derives, derives_refl; apply fupd_mask_subseteq; eauto|].
+  eapply derives_trans; [apply fupd_frame_r | apply fupd_mono].
+  apply fupd_frame_r.
+Qed.
+
+Lemma fupd_intro {CA : ClassicalSep A} E P : P |-- |={E}=> P.
+Proof.
+  eapply derives_trans, fupd_trans.
+  apply fupd_mask_intro_subseteq.
+  hnf; eauto.
+Qed.
+
+Lemma fupd_except_0 {CA : ClassicalSep A} E1 E2 (P : A) : (|={E1,E2}=> ((|> FF) || P)) |-- |={E1,E2}=> P.
+Proof.
+  eapply derives_trans; [apply fupd_mono|].
+  { apply orp_left; [apply orp_right1, derives_refl | apply orp_right2, fupd_intro]. }
+  eapply derives_trans; [apply fupd_mono, except_0_fupd|].
+  apply fupd_trans.
+Qed.
+
+Lemma fupd_idem E P {CA : ClassicalSep A} : (|={E}=> |={E}=> P) = |={E}=> P.
+Proof.
+  apply pred_ext.
+  - apply fupd_trans.
+  - apply fupd_intro.
+Qed.
+
+Lemma fupd_frame_l E1 E2 P Q : (P * |={E1,E2}=> Q) |-- |={E1,E2}=> P * Q.
+Proof.
+  rewrite !(sepcon_comm P); apply fupd_frame_r.
+Qed.
+
+Lemma fupd_elim E1 E2 E3 P Q :
+    Q |-- (|={E2,E3}=> P) -> (|={E1,E2}=> Q) |-- (|={E1,E3}=> P).
+Proof.
+  intros.
+  eapply derives_trans; [apply fupd_mono, H|].
+  apply fupd_trans.
+Qed.
+
+Lemma fupd_mask_frame_r E1 E2 Ef P :
+  Disjoint _ E1 Ef -> (|={E1,E2}=> P) |-- |={Union _ E1 Ef, Union _ E2 Ef}=> P.
+Proof.
+  intros.
+  eapply derives_trans, fupd_mask_frame_r'; auto.
+  apply fupd_mono.
+  rewrite <- imp_andp_adjoint.
+  apply andp_left1, derives_refl.
+Qed.
+
+Lemma fupd_or E1 E2 P Q :
+    (|={E1,E2}=> P) || (|={E1,E2}=> Q) |-- (|={E1,E2}=> (P || Q)).
+Proof.
+  apply orp_left; apply fupd_mono; [apply orp_right1 | apply orp_right2]; apply derives_refl.
+Qed.
+
+Lemma fupd_and E1 E2 P Q :
+    (|={E1,E2}=> (P && Q)) |-- (|={E1,E2}=> P) && (|={E1,E2}=> Q).
+Proof.
+  apply andp_right; apply fupd_mono; [apply andp_left1 | apply andp_left2]; apply derives_refl.
+Qed.
+
+Lemma fupd_exists E1 E2 T (P : T -> A) : (EX x : T, |={E1, E2}=> P x) |-- |={E1, E2}=> EX x : T, P x.
+Proof.
+  apply exp_left; intros x.
+  apply fupd_mono.
+  apply exp_right with x, derives_refl.
+Qed.
+
+Lemma fupd_forall E1 E2 T (P : T -> A) : (|={E1, E2}=> ALL x : T, P x) |-- ALL x : T, |={E1, E2}=> P x.
+Proof.
+  apply allp_right; intros x.
+  apply fupd_mono.
+  apply allp_left with x, derives_refl.
+Qed.
+
+Lemma fupd_sep E P Q : (|={E}=> P) * (|={E}=> Q) |-- |={E}=> P * Q.
+Proof.
+  eapply derives_trans; [apply fupd_frame_r|].
+  eapply derives_trans, fupd_trans; apply fupd_mono.
+  apply fupd_frame_l.
+Qed.
+
+End fupd_derived.
+
+#[global] Instance LiftFupdSepLog (A B N D I: Type) {NB: NatDed B}{IB: Indir B}{SB: SepLog B}{BSLB: BupdSepLog B N D}{FSLB: FupdSepLog B N D I} :
+  FupdSepLog (A -> B) N D I.
+ apply (mkFSL _ _ _ _ _ _ _ _ (fun E1 E2 P rho => |={E1,E2}=> P rho));
+   repeat intro; simpl.
+ apply fupd_mask_subseteq; auto.
+ apply except_0_fupd.
+ apply fupd_mono; auto.
+ apply fupd_trans.
+ apply fupd_mask_frame_r'; auto.
+ apply fupd_frame_r.
+ apply bupd_fupd.
 Defined.

--- a/msl/log_normalize.v
+++ b/msl/log_normalize.v
@@ -1693,3 +1693,13 @@ Proof.
   rewrite (andp_comm _ Q), (andp_left_corable Q), sepcon_comm by auto.
   auto.
 Qed.
+
+Lemma fupd_andp2_corable: forall {A N D I: Type} {ND : NatDed A} {IA : Indir A} {SL : SepLog A} {CSL: ClassicalSep A} {BS : BupdSepLog A N D} {FS : FupdSepLog A N D I} {CoSL: CorableSepLog A},
+  forall E1 E2 P Q, corable Q -> (|={E1,E2}=> P) && Q |-- |={E1,E2}=> (P && Q).
+Proof.
+  intros.
+  rewrite (andp_comm P Q), (andp_left_corable Q), sepcon_comm by auto.
+  eapply derives_trans; [| apply fupd_frame_r].
+  rewrite (andp_comm _ Q), (andp_left_corable Q), sepcon_comm by auto.
+  auto.
+Qed.

--- a/msl/predicates_sl.v
+++ b/msl/predicates_sl.v
@@ -98,7 +98,7 @@ Qed.
 
 (*Definition compareM  : modality
   := exist _ compareR valid_rel_compare.*)
-Definition extendM {A}{JA: Join A}{PA: Perm_alg A}{SA : Sep_alg A}{AG: ageable A}{XA: Age_alg A} : modality
+Definition extendM : modality
   := exist _ extendR valid_rel_extend.
 
 (* Definitions of the BI connectives. *)

--- a/msl/subtypes.v
+++ b/msl/subtypes.v
@@ -491,6 +491,12 @@ Proof. intros.
  hnf. apply ext_level in H3 as <-. auto.
 Qed.
 
+Lemma subp_eq :
+  forall (P : pred nat) (Q R: pred A ), (!P && Q |-- R) <-> (P |-- Q >=> R).
+Proof. intros. split; [apply subp_i1|].
+  intros ?? []. eapply H; eauto. auto.
+Qed.
+
 Lemma eqp_nat: forall P Q: pred nat, (P <=> Q) = (P <--> Q).
 Proof.
 intros.

--- a/progs/verif_incr_atomic.v
+++ b/progs/verif_incr_atomic.v
@@ -18,7 +18,7 @@ Definition ctr_state ctr (g : gname) n := data_at Ews tuint (Vint (Int.repr (Z.o
 
 Program Definition incr_spec :=
  DECLARE _incr
-  ATOMIC TYPE (rmaps.ConstType _) OBJ n INVS empty top
+  ATOMIC TYPE (rmaps.ConstType _) OBJ n INVS ∅
   WITH sh, g, gv
   PRE [ ]
          PROP  (readable_share sh)
@@ -31,7 +31,7 @@ Program Definition incr_spec :=
 
 Program Definition read_spec :=
  DECLARE _read
-  ATOMIC TYPE (rmaps.ConstType (_ * _ * _)) OBJ n INVS empty top
+  ATOMIC TYPE (rmaps.ConstType (_ * _ * _)) OBJ n INVS ∅
   WITH sh, g, gv
   PRE [ ]
          PROP  (readable_share sh)
@@ -52,12 +52,12 @@ Definition thread_lock_inv sh g g1 gv lockt := selflock (thread_lock_R sh g g1 g
 
 Definition thread_func_spec :=
  DECLARE _thread_func
-  WITH y : val, x : iname * share * gname * gname * gname * globals * invG
+  WITH y : val, x : namespace * share * gname * gname * gname * globals
   PRE [ tptr tvoid ]
-         let '(i, sh, g, g1, g2, gv, inv_names) := x in
+         let '(i, sh, g, g1, g2, gv) := x in
          PROP  (readable_share sh)
          PARAMS (y) GLOBALS (gv)
-         SEP   (invariant i (cptr_inv g g1 g2); ghost_var gsh2 O g1;
+         SEP   (inv i (cptr_inv g g1 g2); ghost_var gsh2 O g1;
                     lock_inv sh (gv _ctr_lock) (sync_inv g Tsh (ctr_state (gv _ctr)));
                 lock_inv sh (gv _thread_lock) (thread_lock_inv sh g g1 gv (gv _thread_lock)))
   POST [ tptr tvoid ]
@@ -82,7 +82,7 @@ Proof.
   apply exclusive_sepcon1.
   apply ghost_var_exclusive; auto with share.
 Qed.
-Hint Resolve thread_inv_exclusive : exclusive.
+#[local] Hint Resolve thread_inv_exclusive : exclusive.
 
 Lemma body_incr: semax_body Vprog Gprog f_incr incr_spec.
 Proof.
@@ -128,21 +128,21 @@ Proof.
 Qed.
 
 (* prove a lemma about our specific use pattern of incr *)
-Lemma incr_inv_shift : forall {inv_names : invG} i g g1 g2 gv, (gv = g1 \/ gv = g2) ->
-  invariant i (cptr_inv g g1 g2) * ghost_var gsh2 0%nat gv |--
-  atomic_shift (λ n : nat, public_half g n) ∅ ⊤
+Lemma incr_inv_shift : forall i g g1 g2 gv, (gv = g1 \/ gv = g2) ->
+  inv i (cptr_inv g g1 g2) * ghost_var gsh2 0%nat gv |--
+  atomic_shift (λ n : nat, public_half g n) (to_coPset i) ∅
       (λ (n : nat) (_ : ()), fold_right_sepcon [public_half g (n + 1)%nat]) (λ _ : (), ghost_var gsh2 1%nat gv).
 Proof.
   intros; unfold cptr_inv.
   iIntros "[#inv g]".
   iAuIntro.
   rewrite /atomic_acc /=.
-  iMod (inv_open with "inv") as "[c Hclose]"; auto.
+  iInv "inv" as "c" "Hclose"; auto.
   iDestruct "c" as (x y) "[[>g1 >g2] >c]".
-  iMod fupd_mask_subseteq as "Hclose'"; [|iModIntro]; first set_solver.
+  rewrite difference_diag_L; iModIntro.
   iExists (x + y)%nat; iFrame "c"; iSplit.
   - iIntros "c". iFrame.
-    iMod "Hclose'" as "_"; iApply "Hclose".
+    iApply "Hclose".
     iExists x, y; iFrame; auto.
   - iIntros (_) "(c & _)".
     destruct H; subst.
@@ -151,7 +151,7 @@ Proof.
       { rewrite <- (ghost_var_share_join gsh1 gsh2 Tsh) by auto with share; iFrame. }
       rewrite <- (ghost_var_share_join gsh1 gsh2 Tsh) by auto with share.
       iDestruct "g1" as "[g1 $]".
-      iMod "Hclose'" as "_"; iApply "Hclose".
+      iApply "Hclose".
       iExists 1%nat, y; iFrame; auto.
       rewrite Nat.add_0_l Nat.add_comm; auto.
     + iPoseProof (ghost_var_inj(A := nat) with "[$g2 $g]") as "%"; auto with share; subst.
@@ -159,7 +159,7 @@ Proof.
       { rewrite <- (ghost_var_share_join gsh1 gsh2 Tsh) by auto with share; iFrame. }
       rewrite <- (ghost_var_share_join gsh1 gsh2 Tsh) by auto with share.
       iDestruct "g2" as "[g2 $]".
-      iMod "Hclose'" as "_"; iApply "Hclose".
+      iApply "Hclose".
       iExists x, 1%nat; iFrame; auto.
       rewrite Nat.add_0_r; auto.
 Qed.
@@ -169,9 +169,9 @@ Proof.
   start_function.
   Intros.
   forward.
-  forward_call (sh, g, gv, ghost_var gsh2 1%nat g1, inv_names).
+  forward_call (sh, g, gv, ghost_var gsh2 1%nat g1).
   { sep_apply incr_inv_shift; auto.
-    apply sepcon_derives; [apply derives_refl | cancel]. }
+    apply sepcon_derives; [apply atomic_update_mask_weaken; set_solver | cancel]. }
   forward_call ((gv _thread_lock), sh, thread_lock_R sh g g1 gv, thread_lock_inv sh g g1 gv (gv _thread_lock)).
   { lock_props.
     unfold thread_lock_inv, thread_lock_R.
@@ -198,14 +198,9 @@ Proof.
   { lock_props.
     unfold sync_inv, ctr_state.
     Exists O; cancel. }
-  rewrite <- (emp_sepcon (lock_inv _ _ _)); Intros.
-  viewshift_SEP 0 (EX inv_names : invG, wsat).
-  { go_lower; apply make_wsat. }
-  Intros inv_names.
   rewrite <- 2(ghost_var_share_join gsh1 gsh2 Tsh) by auto with share; Intros.
-  gather_SEP wsat (public_half _ _) (ghost_var gsh1 _ _) (ghost_var gsh1 _ _); viewshift_SEP 0 (EX i, |> (wsat * invariant i (cptr_inv g g1 g2))).
-  { go_lower.
-    rewrite !sepcon_assoc; apply make_inv'.
+  gather_SEP (public_half _ _) (ghost_var gsh1 _ _) (ghost_var gsh1 _ _); viewshift_SEP 0 (EX i, inv i (cptr_inv g g1 g2)).
+  { go_lower; apply make_inv.
     unfold cptr_inv.
     Exists O O; simpl; cancel. }
   Intros i.
@@ -213,30 +208,29 @@ Proof.
   destruct split_Ews as (sh1 & sh2 & ? & ? & Hsh).
   forward_call (lockt, Ews, thread_lock_inv sh1 g g1 gv lockt).
   rewrite invariant_dup; Intros.
-  forward_spawn _thread_func nullval (i, sh1, g, g1, g2, gv, inv_names).
+  forward_spawn _thread_func nullval (i, sh1, g, g1, g2, gv).
   { erewrite <- 2(lock_inv_share_join sh1 sh2 Ews) by (try apply Hsh; auto).
     subst ctr lock lockt; entailer!. }
   rewrite invariant_dup; Intros.
-  gather_SEP (invariant _ _) (ghost_var _ _ _).
-  forward_call (sh2, g, gv, ghost_var gsh2 1%nat g2, inv_names).
+  gather_SEP (inv _ _) (ghost_var _ _ _).
+  forward_call (sh2, g, gv, ghost_var gsh2 1%nat g2).
   { sep_apply incr_inv_shift; auto.
-    apply sepcon_derives; [apply derives_refl | cancel]. }
+    apply sepcon_derives; [apply atomic_update_mask_weaken; set_solver | cancel]. }
   forward_call (lockt, sh2, thread_lock_inv sh1 g g1 gv lockt).
   { subst ctr lock lockt; cancel. }
   unfold thread_lock_inv at 2; unfold thread_lock_R.
   rewrite selflock_eq.
   Intros.
-  gather_SEP (invariant _ _) (ghost_var _ _ g1) (ghost_var _ _ g2).
-  forward_call (sh2, g, gv, fun n => !!(n = 2)%nat && ghost_var gsh2 1%nat g1 * ghost_var gsh2 1%nat g2, inv_names).
-  { rewrite -> 4sepcon_assoc; apply sepcon_derives; cancel.
+  gather_SEP (inv _ _) (ghost_var _ _ g1) (ghost_var _ _ g2).
+  forward_call (sh2, g, gv, fun n => !!(n = 2)%nat && ghost_var gsh2 1%nat g1 * ghost_var gsh2 1%nat g2).
+  { rewrite -> 3sepcon_assoc; apply sepcon_derives; cancel.
     unfold atomic_shift.
     iIntros "[[#I g1] g2]"; iAuIntro.
     rewrite /atomic_acc /=.
-    iMod (inv_open with "I") as "[>c H]"; auto.
+    iInv "I" as ">c" "H"; first set_solver.
     iDestruct "c" as (x y) "[gs c]"; iExists (x + y)%nat; iFrame "c".
-    iMod (fupd_mask_subseteq) as "mask".
-    { apply empty_subseteq. }
-    iIntros "!>"; iSplit.
+    iApply fupd_mask_intro; first set_solver.
+    iIntros "mask"; iSplit.
     - iIntros "lock"; iMod "mask" as "_".
       iMod ("H" with "[-g1 g2]"); last by iFrame.
       unfold cptr_inv.

--- a/progs64/os_combine.v
+++ b/progs64/os_combine.v
@@ -99,6 +99,7 @@ Section ext_trace.
     OS_valid s' /\ exists z', consume_trace z z' t' /\
     ext_spec_post dryspec e w b (sig_res (ef_sig e)) ret z' (extr_mem e args m s').
 
+
   Lemma dry_safe_ext_trace_safe : forall n t z q m,
     step_lemmas.dry_safeN(genv_symb := semax.genv_symb_injective)
      (cl_core_sem (globalenv prog)) dryspec
@@ -127,11 +128,18 @@ Section ext_trace.
   Lemma safety_trace:
    forall {CS: compspecs} (initial_oracle: OK_ty)
      (EXIT: semax_prog.postcondition_allows_exit Espec tint)
+     (Jsub: forall ef se lv m t v m' (EFI : ef_inline ef = true) m1
+       (EFC : Events.external_call ef se lv m t v m'), mem_sub m m1 ->
+       exists m1' (EFC1 : Events.external_call ef se lv m1 t v m1'),
+         mem_sub m' m1' /\ proj1_sig (inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC1) =
+         proj1_sig (inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC))
+     (Jframe: extspec_frame OK_spec)
      (dessicate : forall (ef : external_function) jm,
                ext_spec_type OK_spec ef ->
                ext_spec_type dryspec ef)
      (JDE: juicy_dry_ext_spec _ (@JE_spec OK_ty OK_spec) dryspec dessicate)
      (DME: ext_spec_mem_evolve _ dryspec)
+     (Esub: forall v z m m', ext_spec_exit dryspec v z m -> mem_sub m m' -> ext_spec_exit dryspec v z m')
      V G m,
      @semax_prog Espec CS prog initial_oracle V G ->
      Genv.init_mem prog = Some m ->
@@ -167,11 +175,18 @@ Section ext_trace.
   Theorem OS_soundness:
    forall {CS: compspecs} (initial_oracle: OK_ty)
      (EXIT: semax_prog.postcondition_allows_exit Espec tint)
+     (Jsub: forall ef se lv m t v m' (EFI : ef_inline ef = true) m1
+       (EFC : Events.external_call ef se lv m t v m'), mem_sub m m1 ->
+       exists m1' (EFC1 : Events.external_call ef se lv m1 t v m1'),
+         mem_sub m' m1' /\ proj1_sig (inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC1) =
+         proj1_sig (inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC))
+     (Jframe: extspec_frame OK_spec)
      (dessicate : forall (ef : external_function) jm,
                ext_spec_type OK_spec ef ->
                ext_spec_type dryspec ef)
      (JDE: juicy_dry_ext_spec _ (@JE_spec OK_ty OK_spec) dryspec dessicate)
      (DME: ext_spec_mem_evolve _ dryspec)
+     (Esub: forall v z m m', ext_spec_exit dryspec v z m -> mem_sub m m' -> ext_spec_exit dryspec v z m')
      V G m,
      @semax_prog Espec CS prog initial_oracle V G ->
      Genv.init_mem prog = Some m ->

--- a/progs64/verif_io.v
+++ b/progs64/verif_io.v
@@ -398,6 +398,12 @@ Qed.
 
 Definition main_block := proj1_sig main_block_exists.
 
+Hypothesis (Jsub: forall ef se lv m t v m' (EFI : ef_inline ef = true) m1
+       (EFC : Events.external_call ef se lv m t v m'), juicy_mem.mem_sub m m1 ->
+       exists m1' (EFC1 : Events.external_call ef se lv m1 t v m1'),
+         juicy_mem.mem_sub m' m1' /\ proj1_sig (Clight_core.inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC1) =
+         proj1_sig (Clight_core.inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC)).
+
 Theorem prog_ext_correct : exists q,
   semantics.initial_core (Clight_core.cl_core_sem (globalenv prog)) 0 init_mem q init_mem (Vptr main_block Ptrofs.zero) [] /\
   forall n, @step_lemmas.dry_safeN _ _ _ _ semax.genv_symb_injective (Clight_core.cl_core_sem (globalenv prog))
@@ -407,8 +413,11 @@ Proof.
   edestruct whole_program_sequential_safety_ext with (V := Vprog) as (b & q & Hb & Hq & Hsafe).
   - repeat intro; hnf.
     apply I.
+  - apply Jsub.
+  - apply add_funspecs_frame.
   - apply juicy_dry_specs.
   - apply dry_spec_mem.
+  - intros; apply I.
   - apply CSHL_Sound.semax_prog_sound, prog_correct.
   - apply (proj2_sig init_mem_exists).
   - exists q.
@@ -427,11 +436,12 @@ Theorem prog_OS_correct : forall {H : io_os_specs.ThreadsConfigurationOps},
   semantics.initial_core (Clight_core.cl_core_sem (globalenv prog)) 0 init_mem q init_mem (Vptr main_block Ptrofs.zero) [] /\
      forall n s0, s0.(io_log) = [] -> s0.(console) = {| cons_buf := []; rpos := 0 |} ->
     exists traces, OS_safeN_trace prog n Traces.TEnd traces main_itree s0 q init_mem /\
-     forall t s, Ensembles.In traces (t, s) -> exists z', consume_trace main_itree z' t /\ t = trace_of_ostrace s.(io_log) /\
+     forall t s, traces (t, s) -> exists z', consume_trace main_itree z' t /\ t = trace_of_ostrace s.(io_log) /\
       valid_trace_user s.(io_log).
 Proof.
   intros.
   edestruct IO_OS_ext with (V := Vprog) as (b & q & Hb & Hq & Hsafe).
+  - apply Jsub.
   - apply prog_correct.
   - apply (proj2_sig init_mem_exists).
   - exists q.

--- a/progs64/verif_io_mem.v
+++ b/progs64/verif_io_mem.v
@@ -575,6 +575,12 @@ Qed.
 
 Definition main_block := proj1_sig main_block_exists.
 
+Hypothesis (Jsub: forall ef se lv m t v m' (EFI : ef_inline ef = true) m1
+       (EFC : Events.external_call ef se lv m t v m'), juicy_mem.mem_sub m m1 ->
+       exists m1' (EFC1 : Events.external_call ef se lv m1 t v m1'),
+         juicy_mem.mem_sub m' m1' /\ proj1_sig (Clight_core.inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC1) =
+         proj1_sig (Clight_core.inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC)).
+
 Theorem prog_toplevel : exists q,
   semantics.initial_core (Clight_core.cl_core_sem (globalenv prog)) 0 init_mem q init_mem (Vptr main_block Ptrofs.zero) [] /\
   forall n, @step_lemmas.dry_safeN _ _ _ _ semax.genv_symb_injective (Clight_core.cl_core_sem (globalenv prog))
@@ -583,8 +589,11 @@ Theorem prog_toplevel : exists q,
 Proof.
   edestruct whole_program_sequential_safety_ext with (V := Vprog) as (b & q & Hb & Hq & Hsafe).
   - repeat intro; simpl. apply I.
+  - apply Jsub.
+  - apply add_funspecs_frame.
   - apply juicy_dry_specs.
   - apply dry_spec_mem.
+  - intros; apply I.
   - apply CSHL_Sound.semax_prog_sound, prog_correct.
   - apply (proj2_sig init_mem_exists).
   - exists q.

--- a/veric/Clight_aging_lemmas.v
+++ b/veric/Clight_aging_lemmas.v
@@ -13,19 +13,15 @@ Require Import VST.veric.age_to_resource_at.
 
 Require Import VST.veric.aging_lemmas.
 
-Set Bullet Behavior "Strict Subproofs".
-
-Lemma jsafeN_age Z Jspec ge ora q n jm jmaged :
+Lemma jsafeN_age Z Jspec ge ora q jm jmaged :
   ext_spec_stable age (JE_spec _ Jspec) ->
   age jm jmaged ->
-  Peano.le n (level jmaged) ->
-  @jsafeN Z Jspec ge n ora q jm ->
-  @jsafeN Z Jspec ge n ora q jmaged.
+  @jsafeN Z Jspec ge ora q jm ->
+  @jsafeN Z Jspec ge ora q jmaged.
 Proof. intros. eapply jsafeN__age; eauto. Qed.
 
-Lemma jsafeN_age_to Z Jspec ge ora q n l jm :
+Lemma jsafeN_age_to Z Jspec ge ora q l jm :
   ext_spec_stable age (JE_spec _ Jspec) ->
-  Peano.le n l ->
-  @jsafeN Z Jspec ge n ora q jm ->
-  @jsafeN Z Jspec ge n ora q (age_to l jm).
+  @jsafeN Z Jspec ge ora q jm ->
+  @jsafeN Z Jspec ge ora q (age_to l jm).
 Proof. intros. eapply jsafeN__age_to; eauto. Qed.

--- a/veric/Clight_assert_lemmas.v
+++ b/veric/Clight_assert_lemmas.v
@@ -18,6 +18,10 @@ Qed.
 
 #[export] Hint Resolve corable_funassert : core.
 
+Section invs.
+
+Context {inv_names : invariants.invG}.
+
 Definition allp_fun_id (Delta : tycontext) (rho : environ): pred rmap :=
  ALL id : ident , ALL fs : funspec ,
   !! ((glob_specs Delta) ! id = Some fs) -->
@@ -138,6 +142,7 @@ Proof.
   intros. eapply derives_trans. apply funassert_allp_fun_id_sigcc.
   apply allp_fun_id_sigcc_sub; trivial.
 Qed.
+
 (*
 Lemma corable_jam: forall {B} {S': B -> Prop} (S: forall l, {S' l}+{~ S' l}) (P Q: B -> pred rmap),
     (forall loc, corable (P loc)) ->
@@ -338,3 +343,5 @@ destruct H0; subst; auto.
 Qed.
 
 End STABILITY.
+
+End invs.

--- a/veric/Clight_core.v
+++ b/veric/Clight_core.v
@@ -435,6 +435,6 @@ eapply mem_step_storebytes; eauto.
 *
  rewrite andb_true_iff in H; destruct H.
  eapply inline_external_call_mem_step; eauto.
-Qed.
+Defined.
 
 Definition at_external c := cl_at_external (fst (CC_state_to_CC_core c)). (* Temporary definition for compatibility between CompCert 3.3 and new-compcert *)

--- a/veric/Clight_evsem.v
+++ b/veric/Clight_evsem.v
@@ -1,0 +1,1075 @@
+(* adapted from concurrency/common/ClightSemanticsForMachines.v *)
+
+(* Event semantics for ClightCore *)
+
+Require Import compcert.common.Memory.
+Require Import VST.veric.compcert_rmaps.
+Require Import VST.veric.juicy_mem.
+Require Import VST.veric.res_predicates.
+
+Require Import List. Import ListNotations.
+Import compcert.lib.Maps.
+
+Import Ctypes. 
+Require Import compcert.cfrontend.Clight.
+Import Cop.
+Arguments sizeof {env} !t / .
+
+(*Semantics*)
+Require Import VST.veric.Clight_core.
+Require Import VST.sepcomp.semantics.
+Require Import VST.sepcomp.event_semantics.
+
+Lemma extcall_malloc_sem_inv: forall g v m t res m2 (E:Events.extcall_malloc_sem g v m t res m2),
+  exists m1 b (sz : ptrofs), v=[Vptrofs sz] /\ t= Events.E0 /\ res=Vptr b Ptrofs.zero /\
+                           Mem.alloc m (- size_chunk Mptr) (Ptrofs.unsigned sz) = (m1, b) /\
+                           Mem.store Mptr m1 b (- size_chunk Mptr) (Vptrofs sz) = Some m2. 
+Proof. intros.  inv E. exists m', b, sz. intuition. Qed.
+
+Inductive load_bitfieldT: type -> intsize -> signedness -> Z -> Z -> mem -> block -> ptrofs -> val -> list memval -> Prop :=
+  | load_bitfield_intro: forall sz sg1 attr sg pos width m b ofs c bytes,
+      0 <= pos -> 0 < width <= bitsize_intsize sz -> pos + width <= bitsize_carrier sz ->
+      sg1 = (if zlt width (bitsize_intsize sz) then Signed else sg) ->
+      (align_chunk (chunk_for_carrier sz) | (Ptrofs.unsigned ofs)) ->
+      Mem.loadbytes m b (Ptrofs.unsigned ofs) (size_chunk (chunk_for_carrier sz)) = Some bytes ->
+      decode_val (chunk_for_carrier sz) bytes = Vint c ->
+      load_bitfieldT (Tint sz sg1 attr) sz sg pos width m b ofs
+                    (Vint (bitfield_extract sz sg pos width c)) bytes.
+
+Inductive deref_locT (ty : type) (m : mem) (b : block) (ofs : ptrofs) : bitfield -> val -> list mem_event -> Prop :=
+    deref_locT_value : forall (chunk : memory_chunk) bytes,
+                      access_mode ty = By_value chunk ->
+                      (align_chunk chunk | (Ptrofs.unsigned ofs)) ->
+                      Mem.loadbytes m b (Ptrofs.unsigned ofs) (size_chunk chunk) = Some bytes ->
+(*                      Mem.load chunk m b (Ptrofs.unsigned ofs) = Some (decode_val chunk bytes) ->*)
+                      deref_locT ty m b ofs Full (decode_val chunk bytes) (Read b (Ptrofs.unsigned ofs) (size_chunk chunk) bytes :: nil)
+  | deref_locT_reference : access_mode ty = By_reference -> deref_locT ty m b ofs Full (Vptr b ofs) nil
+  | deref_locT_copy : access_mode ty = By_copy -> deref_locT ty m b ofs Full (Vptr b ofs) nil
+  | deref_locT_bitfield : forall (sz : intsize) 
+                           (sg : signedness) (pos width : Z) 
+                           (v : val) bytes,
+                         load_bitfieldT ty sz sg pos width m 
+                           b ofs v bytes ->
+                         deref_locT ty m b ofs (Bits sz sg pos width) v (Read b (Ptrofs.unsigned ofs) (size_chunk (chunk_for_carrier sz)) bytes :: nil)
+.
+
+Lemma deref_locT_ax1 a m loc ofs v bf T (D:deref_locT (typeof a) m loc ofs bf v T):
+      deref_loc (typeof a) m loc ofs bf v.
+Proof. 
+  inv D.
+  + eapply deref_loc_value; eauto. eapply Mem.loadbytes_load; eauto.
+  + apply deref_loc_reference; trivial.
+  + apply deref_loc_copy; trivial.
+  + inv H; apply deref_loc_bitfield; constructor; auto.
+    rewrite <- H7; apply Mem.loadbytes_load; auto.
+Qed.
+
+Lemma deref_locT_ax2 a m loc ofs bf v (D:deref_loc (typeof a) m loc ofs bf v):
+      exists T, deref_locT (typeof a) m loc ofs bf v T.
+Proof. 
+  inv D.
+  + exploit Mem.load_valid_access; eauto. intros [_ ALGN].
+    exploit Mem.load_loadbytes; eauto. intros [bytes [LD V]]; subst v.
+    eexists; eapply deref_locT_value; eauto. 
+  + eexists; apply deref_locT_reference; trivial.
+  + eexists; apply deref_locT_copy; trivial.
+  + inv H.
+    exploit Mem.load_valid_access; eauto. intros [_ ALGN].
+    exploit Mem.load_loadbytes; eauto. intros [bytes [LD V]].
+    eexists; apply deref_locT_bitfield; constructor; eauto.
+Qed.
+
+Lemma deref_locT_fun a m loc ofs bf v1 T1 (D1:deref_locT (typeof a) m loc ofs bf v1 T1)
+      v2 T2 (D2:deref_locT (typeof a) m loc ofs bf v2 T2): (v1,T1)=(v2,T2). 
+Proof. inv D1; inv D2; try congruence.
+  inv H; inv H6; congruence. Qed.
+
+Lemma deref_locT_elim  a m b ofs bf v T (D:deref_locT (typeof a) m b ofs bf v T):
+       ev_elim m T m /\
+       (forall mm mm' (E:ev_elim mm T mm'),
+           mm'=mm /\ deref_locT (typeof a) mm b ofs bf v T).
+Proof.
+  inv D; simpl.
+  - intuition. subst. eapply deref_locT_value; trivial.
+  - intuition. subst. eapply deref_locT_reference; trivial.
+  - intuition. subst. eapply deref_locT_copy; trivial.
+  - inv H. intuition. subst. apply deref_locT_bitfield; constructor; auto.
+Qed.
+
+Inductive alloc_variablesT (g: genv): PTree.t (block * type) -> mem -> list (ident * type) ->
+                                      PTree.t (block * type) -> mem -> (list mem_event) -> Prop :=
+    alloc_variablesT_nil : forall e m, alloc_variablesT g e m nil e m nil
+  | alloc_variablesT_cons :
+      forall e m id ty vars m1 b1 m2 e2 T,
+        Mem.alloc m 0 (@sizeof g ty) = (m1, b1) ->
+        alloc_variablesT g (PTree.set id (b1, ty) e) m1 vars e2 m2 T ->
+        alloc_variablesT g e m ((id, ty) :: vars) e2 m2 (Alloc b1 0 (@sizeof g ty) :: T).
+
+Lemma alloc_variablesT_ax1 g: forall e m l e' m' T (A:alloc_variablesT g e m l e' m' T),
+    alloc_variables g e m l e' m'.
+Proof. intros. induction A. constructor. econstructor; eauto. Qed. 
+
+Lemma alloc_variablesT_ax2 g: forall e m l e' m' (A:alloc_variables g e m l e' m'),
+    exists T, alloc_variablesT g e m l e' m' T.
+Proof. intros. induction A. exists nil. constructor.
+       destruct IHA. eexists. econstructor; eauto.
+Qed. 
+    
+Lemma alloc_variablesT_fun g: forall e m l e' m' T' (A:alloc_variablesT g e m l e' m' T')
+                                     e2 m2 T2 (A2:alloc_variablesT g e m l e2 m2 T2),
+     (e',m',T') = (e2,m2,T2).
+Proof. intros until T'. intros A; induction A; intros.
+       + inv A2. trivial.
+       + inv A2. rewrite H8 in H; inv H. apply IHA in H9; inv H9. trivial.
+Qed. 
+   
+Lemma alloc_variablesT_elim g:
+  forall e m l e' m' T (A:alloc_variablesT g e m l e' m' T),
+       ev_elim m T m' /\
+       (forall mm mm' (E:ev_elim mm T mm'),
+           (*exists e',*) alloc_variablesT g e mm l e' mm' T).
+Proof.
+  intros. induction A; simpl.
+  { split; [ trivial | intros; subst]. econstructor. }
+  { destruct IHA; split.
+    { eexists; split; [ eassumption | trivial]. }
+    { intros. destruct E as [mm'' [AA EE]].
+      specialize (H1 _ _ EE). econstructor; eassumption. } }
+Qed.
+
+Section EXPR_T.
+(** Extends Clight.eval_expr etc with event traces. *)
+
+Variable g: genv.
+Variable e: env.
+Variable le: temp_env.
+Variable m: mem.
+
+Inductive eval_exprT: expr -> val -> list mem_event-> Prop :=
+  | evalT_Econst_int:   forall i ty,
+      eval_exprT (Econst_int i ty) (Vint i) nil
+  | evalT_Econst_float:   forall f ty,
+      eval_exprT (Econst_float f ty) (Vfloat f) nil
+  | evalT_Econst_single:   forall f ty,
+      eval_exprT (Econst_single f ty) (Vsingle f) nil
+  | evalT_Econst_long:   forall i ty,
+      eval_exprT (Econst_long i ty) (Vlong i) nil
+  | evalT_Etempvar:  forall id ty v,
+      le!id = Some v ->
+      eval_exprT (Etempvar id ty) v nil
+  | evalT_Eaddrof: forall a ty loc ofs T,
+      eval_lvalueT a loc ofs Full T ->
+      eval_exprT (Eaddrof a ty) (Vptr loc ofs) T
+  | evalT_Eunop:  forall op a ty v1 v T,
+      eval_exprT a v1 T ->
+      sem_unary_operation op v1 (typeof a) m = Some v ->
+      (*unops at most check weak_valid_ptr, so don't create a trace event*)
+      eval_exprT (Eunop op a ty) v T
+  | evalT_Ebinop: forall op a1 a2 ty v1 v2 v T1 T2,
+      eval_exprT a1 v1 T1 ->
+      eval_exprT a2 v2 T2 ->
+      sem_binary_operation g op v1 (typeof a1) v2 (typeof a2) m = Some v ->
+      (*binops at most check weak_valid_ptr or cast, so don't create a trace event*)
+      eval_exprT (Ebinop op a1 a2 ty) v (T1++T2)
+  | evalT_Ecast:   forall a ty v1 v T,
+      eval_exprT a v1 T ->
+      sem_cast v1 (typeof a) ty m = Some v ->
+      eval_exprT (Ecast a ty) v T
+  | evalT_Esizeof: forall ty1 ty,
+      eval_exprT (Esizeof ty1 ty) (Vptrofs (Ptrofs.repr (@sizeof g ty1))) nil
+  | evalT_Ealignof: forall ty1 ty,
+      eval_exprT (Ealignof ty1 ty) (Vptrofs (Ptrofs.repr (@alignof g ty1))) nil
+  | evalT_Elvalue: forall a loc ofs bf v T1 T2 T,
+      eval_lvalueT a loc ofs bf T1 ->
+      deref_locT (typeof a) m loc ofs bf v T2 -> T=(T1 ++ T2) ->
+      eval_exprT a v T
+
+with eval_lvalueT: expr -> block -> ptrofs -> bitfield -> list mem_event-> Prop :=
+  | evalT_Evar_local:   forall id l ty,
+      e!id = Some(l, ty) ->
+      eval_lvalueT (Evar id ty) l Ptrofs.zero Full nil
+  | evalT_Evar_global: forall id l ty,
+      e!id = None ->
+      Genv.find_symbol g id = Some l ->
+      eval_lvalueT (Evar id ty) l Ptrofs.zero Full nil
+  | evalT_Ederef: forall a ty l ofs T,
+      eval_exprT a (Vptr l ofs) T ->
+      eval_lvalueT (Ederef a ty) l ofs Full T
+ | evalT_Efield_struct:   forall a i ty l ofs id co att delta bf T,
+      eval_exprT a (Vptr l ofs) T ->
+      typeof a = Tstruct id att ->
+      g.(genv_cenv)!id = Some co ->
+      field_offset g i (co_members co) = Errors.OK (delta, bf) ->
+      eval_lvalueT (Efield a i ty) l (Ptrofs.add ofs (Ptrofs.repr delta)) bf T
+ | evalT_Efield_union:   forall a i ty l ofs id co att delta bf T,
+      eval_exprT a (Vptr l ofs) T ->
+      typeof a = Tunion id att ->
+      g.(genv_cenv)!id = Some co ->
+      union_field_offset g i (co_members co) = Errors.OK (delta, bf) ->
+      eval_lvalueT (Efield a i ty) l (Ptrofs.add ofs (Ptrofs.repr delta)) bf T.
+
+Scheme eval_exprT_ind2 := Minimality for eval_exprT Sort Prop
+  with eval_lvalueT_ind2 := Minimality for eval_lvalueT Sort Prop.
+Combined Scheme eval_exprT_lvalue_ind from eval_exprT_ind2, eval_lvalueT_ind2.
+
+Inductive eval_exprTlist: list expr -> typelist -> list val -> list mem_event-> Prop :=
+  | eval_ETnil:
+      eval_exprTlist nil Tnil nil nil
+  | eval_ETcons:   forall a bl ty tyl v1 v2 vl T1 T2,
+      eval_exprT a v1 T1 ->
+      sem_cast v1 (typeof a) ty m = Some v2 ->
+      eval_exprTlist bl tyl vl T2 ->
+      eval_exprTlist (a :: bl) (Tcons ty tyl) (v2 :: vl) (T1++T2).
+
+Lemma eval_exprT_ax1: forall a v T, eval_exprT a v T -> eval_expr g e le m a v
+with eval_lvalueT_ax1: forall a b z bf T, eval_lvalueT a b z bf T -> eval_lvalue g e le m a b z bf.
+Proof.
+  + induction 1; econstructor; eauto. eapply deref_locT_ax1; eauto.
+  + induction 1; try solve [econstructor; eauto].
+Qed.
+
+Lemma eval_exprT_ax2: forall a v, eval_expr g e le m a v -> exists T, eval_exprT a v T
+with eval_lvalueT_ax2: forall a b z bf, eval_lvalue g e le m a b z bf -> exists T, eval_lvalueT a b z bf T.
+Proof.
+  + induction 1; try solve [eexists; econstructor; eauto].
+  - apply eval_lvalueT_ax2 in H; destruct H. eexists; eapply evalT_Eaddrof; eauto.
+  - destruct IHeval_expr. eexists; eapply evalT_Eunop; eauto.
+  - destruct IHeval_expr1. destruct IHeval_expr2. eexists; eapply evalT_Ebinop; eauto.
+  - destruct IHeval_expr. eexists; eapply evalT_Ecast; eauto.
+  - apply eval_lvalueT_ax2 in H; destruct H.
+    apply deref_locT_ax2 in H0. destruct H0. eexists; eapply evalT_Elvalue; eauto.
+  + induction 1; try solve [eexists; econstructor; eauto].
+  - apply eval_exprT_ax2 in H; destruct H as [T H]. eexists; eapply evalT_Ederef; eauto.
+  - apply eval_exprT_ax2 in H; destruct H as [T H]. eexists; eapply evalT_Efield_struct; eauto.
+  - apply eval_exprT_ax2 in H; destruct H as [T H]. eexists; eapply evalT_Efield_union; eauto.
+Qed.
+
+  Lemma eval_exprT_lvalueT_fun:
+    (forall a v1 T1 v2 T2, eval_exprT a v1 T1 -> eval_exprT a v2 T2 -> (v1,T1)=(v2,T2)) /\
+    (forall a b1 b2 i1 i2 bf1 bf2 T1 T2, eval_lvalueT a b1 i1 bf1 T1 -> eval_lvalueT a b2 i2 bf2 T2 ->
+                               (b1,i1,bf1,T1)=(b2,i2,bf2,T2)).
+Proof.
+ destruct (eval_exprT_lvalue_ind
+   (fun a v T =>  forall v' T', eval_exprT a v' T' -> (v,T)=(v',T'))
+   (fun a b i bf T => forall b' i' bf' T', eval_lvalueT a b' i' bf' T' -> (b,i,bf,T)=(b',i',bf',T')));
+   simpl; intros.
+ 
+ { inv H. trivial. inv H0. }
+ { inv H. trivial. inv H0. }
+ { inv H. trivial. inv H0. }
+ { inv H. trivial. inv H0. }
+ { inv H. inv H0. congruence. inv H. }
+ { inv H1. { apply H0 in H6; congruence. }
+           { inv H2. } }
+ { inv H2. { apply H0 in H8; congruence. } 
+           { inv H3. } }
+ { inv H4. { apply H0 in H11; inv H11. apply H2 in H12; congruence. }
+           { inv H5. } }
+ { inv H2. { apply H0 in H5; congruence. } 
+           { inv H3.  } }
+ { inv H. trivial. inv H0. }
+ { inv H. trivial. inv H0. }
+ { inv H. { inv H3. apply H0 in H; inv H. exploit deref_locT_fun. apply H1. apply H2. intros X; inv X; trivial. }
+          { inv H3. apply H0 in H; inv H. exploit deref_locT_fun. apply H1. apply H2. intros X; inv X; trivial. }
+          { inv H3. apply H0 in H; inv H. exploit deref_locT_fun. apply H1. apply H2. intros X; inv X; trivial. }
+          { inv H3. apply H0 in H; inv H. exploit deref_locT_fun. apply H1. apply H2. intros X; inv X; trivial. }
+          { inv H3. apply H0 in H; inv H. exploit deref_locT_fun. apply H1. apply H2. intros X; inv X; trivial. } }
+ { inv H0; congruence. }
+ { inv H1; congruence. }
+ { inv H1. apply H0 in H8; congruence. }
+ { inv H4. { apply H0 in H8; congruence. }
+           { congruence. } }
+ { inv H4. { congruence. }
+           { apply H0 in H8; congruence. } }
+
+ split; intros. apply (H _ _ _ H1 _ _ H2). apply (H0 _ _ _ _ _ H1 _ _ _ _ H2).
+Qed.
+
+Lemma eval_exprT_fun a v1 T1 v2 T2: eval_exprT a v1 T1 -> eval_exprT a v2 T2 -> (v1,T1)=(v2,T2).
+Proof. apply eval_exprT_lvalueT_fun. Qed.
+
+Lemma eval_lvalueT_fun a b1 b2 i1 i2 bf1 bf2 T1 T2: eval_lvalueT a b1 i1 bf1 T1 -> eval_lvalueT a b2 i2 bf2 T2 ->
+                               (b1,i1,bf1,T1)=(b2,i2,bf2,T2).
+Proof. apply eval_exprT_lvalueT_fun. Qed.
+
+Lemma eval_exprTlist_ax1: forall es ts vs T (E:eval_exprTlist es ts vs T),
+      eval_exprlist g e le m es ts vs.
+Proof.
+  intros; induction E; simpl; intros. econstructor.
+  apply eval_exprT_ax1 in H. econstructor; eauto.
+Qed.
+
+Lemma eval_exprTlist_ax2: forall es ts vs (E:eval_exprlist g e le m es ts vs),
+      exists T, eval_exprTlist es ts vs T.
+Proof.
+  intros; induction E; simpl; intros. eexists; econstructor.
+  apply eval_exprT_ax2 in H. destruct H as [T1 H]. destruct IHE as [T2 K].
+  eexists. econstructor; eauto.
+Qed.
+
+Lemma eval_exprTlist_fun: forall es ts vs1 T1 (E1:eval_exprTlist es ts vs1 T1)
+                          vs2 T2 (E2:eval_exprTlist es ts vs2 T2), (vs1,T1)=(vs2,T2).
+Proof.
+  intros es ts vs1 T1 E; induction E; simpl; intros; inv E2; trivial.
+  exploit eval_exprT_fun. apply H. apply H5. intros X; inv X. rewrite H8 in H0; inv H0.
+  apply IHE in H9; congruence. 
+Qed.
+
+End EXPR_T.
+
+
+Lemma eval_exprT_elim g e le:
+  forall m a v T (E:eval_exprT g e le m a v T), ev_elim m T m
+  with eval_lvalueT_elim g e le:
+         forall m a b z bf T (E:eval_lvalueT g e le m a b z bf T),
+           ev_elim m T m.
+Proof.
+  + clear eval_exprT_elim; induction 1; try solve [econstructor]; eauto.
+    { eapply ev_elim_app; eassumption. }
+    { subst. specialize (eval_lvalueT_elim _ _ _ _ _ _ _ _ _ H). 
+      exploit deref_locT_elim; eauto. intros [E2 EE2].
+      eapply ev_elim_app; eauto. }
+  + clear eval_lvalueT_elim; induction 1; try solve [econstructor]; eauto.
+Qed.
+
+Lemma eval_exprTlist_elim g e le : forall m es ts vs T
+                                  (E:eval_exprTlist g e le m es ts vs T),
+    ev_elim m T m.
+Proof.
+  induction 1; try solve [constructor].
+  exploit eval_exprT_elim. apply H. intros E1. 
+    eapply ev_elim_app; eassumption.
+Qed.
+
+Inductive store_bitfieldT: type -> intsize -> signedness -> Z -> Z -> mem -> block -> ptrofs -> val -> mem -> val -> list memval -> int -> int -> Prop :=
+  | store_bitfield_intro: forall sz sg1 attr sg pos width m b ofs c n m' bytes,
+      0 <= pos -> 0 < width <= bitsize_intsize sz -> pos + width <= bitsize_carrier sz ->
+      sg1 = (if zlt width (bitsize_intsize sz) then Signed else sg) ->
+      (align_chunk (chunk_for_carrier sz) | (Ptrofs.unsigned ofs)) ->
+      Mem.loadbytes m b (Ptrofs.unsigned ofs) (size_chunk (chunk_for_carrier sz)) = Some bytes ->
+      decode_val (chunk_for_carrier sz) bytes = Vint c ->
+      Mem.store (chunk_for_carrier sz) m b (Ptrofs.unsigned ofs)
+                 (Vint (Int.bitfield_insert (first_bit sz pos width) width c n)) = Some m' ->
+      store_bitfieldT (Tint sz sg1 attr) sz sg pos width m b ofs (Vint n)
+                     m' (Vint (bitfield_normalize sz sg width n)) bytes c n.
+
+Inductive assign_locT (ce : composite_env) (ty : type) (m : mem) (b : block) (ofs : ptrofs)
+  : bitfield -> val -> mem -> list mem_event -> Prop :=
+    assign_locT_value : forall (v : val) (chunk : memory_chunk) (m' : mem),
+                       access_mode ty = By_value chunk ->
+                       Mem.storev chunk m (Vptr b ofs) v = Some m' ->
+                       assign_locT ce ty m b ofs Full v m' (Write b (Ptrofs.unsigned ofs) (encode_val chunk v) ::nil)
+  | assign_locT_copy : forall (b' : block) (ofs' : ptrofs) (bytes : list memval) (m' : mem),
+                      access_mode ty = By_copy ->
+                      (@sizeof ce ty > 0 -> (alignof_blockcopy ce ty | Ptrofs.unsigned ofs')) ->
+                      (@sizeof ce ty > 0 -> (alignof_blockcopy ce ty | Ptrofs.unsigned ofs)) ->
+                      b' <> b \/
+                      Ptrofs.unsigned ofs' = Ptrofs.unsigned ofs \/
+                      Ptrofs.unsigned ofs' + @sizeof ce ty <= Ptrofs.unsigned ofs \/
+                      Ptrofs.unsigned ofs + @sizeof ce ty <= Ptrofs.unsigned ofs' ->
+                      Mem.loadbytes m b' (Ptrofs.unsigned ofs') (@sizeof ce ty) = Some bytes ->
+                      Mem.storebytes m b (Ptrofs.unsigned ofs) bytes = Some m' ->
+                      assign_locT ce ty m b ofs Full (Vptr b' ofs') m'
+                                  (Read b' (Ptrofs.unsigned ofs') (@sizeof ce ty) bytes ::
+                                   Write b (Ptrofs.unsigned ofs) bytes :: nil)
+  | assign_locT_bitfield : forall (sz : intsize) 
+                            (sg : signedness) (pos width : Z) 
+                            (v : val) (m' : mem) 
+                            (v' : val) bytes c n,
+                          store_bitfieldT ty sz sg pos width m
+                            b ofs v m' v' bytes c n ->
+                          assign_locT ce ty m b ofs
+                            (Bits sz sg pos width) v m'
+                                  (Read b (Ptrofs.unsigned ofs) (size_chunk (chunk_for_carrier sz)) bytes ::
+                                   Write b (Ptrofs.unsigned ofs) (encode_val (chunk_for_carrier sz)
+                                     (Vint (Int.bitfield_insert (first_bit sz pos width) width c n))) :: nil).
+
+Lemma assign_locT_ax1 ce ty m b ofs bf v m' T (A:assign_locT ce ty m b ofs bf v m' T):
+    assign_loc ce ty m b ofs bf v m'.
+Proof.
+  destruct A; [eapply assign_loc_value; eauto | eapply assign_loc_copy; eauto | eapply assign_loc_bitfield; eauto].
+  inv H; econstructor; eauto.
+  rewrite <- H6; apply Mem.loadbytes_load; auto.
+Qed.
+
+Lemma assign_locT_ax2 ce ty m b ofs bf v m' (A:assign_loc ce ty m b ofs bf v m'):
+    exists T, assign_locT ce ty m b ofs bf v m' T.
+Proof.
+  inv A; [eexists; eapply assign_locT_value; eauto | eexists; eapply assign_locT_copy; eauto|].
+  inv H.
+  exploit Mem.load_valid_access; eauto. intros [_ ALGN].
+  eapply Mem.load_loadbytes in H4 as (? & ? & ?).
+  eexists; econstructor; econstructor; eauto.
+Qed.
+
+Lemma assign_locT_fun ce ty m b ofs bf v m1 T1
+      (A1:assign_locT ce ty m b ofs bf v m1 T1) m2 T2 (A2:assign_locT ce ty m b ofs bf v m2 T2):
+      (m1,T1)=(m2,T2).
+Proof. inv A1; inv A2; try congruence.
+  inv H; inv H7; congruence. Qed.
+
+Lemma assign_locT_elim ce ty m b ofs bf v m1 T (A:assign_locT ce ty m b ofs bf v m1 T):
+  ev_elim m T m1 /\
+  forall mm mm1 (E: ev_elim mm T mm1),
+    assign_locT ce ty mm b ofs bf v mm1 T.
+Proof.
+  inv A; simpl.
+  - exploit Mem.store_valid_access_3; eauto. intros [_ A].
+    apply Mem.store_storebytes in H0.
+    split. { exists m1; split; trivial. }
+    intros. destruct E as [? [? ?]]; subst. econstructor; eauto.
+    apply Mem.storebytes_store; eassumption.
+  - split. { split; [trivial | exists m1; split; trivial]. }
+    intros. destruct E as [LD [? [? ?]]]; subst.
+    constructor; eassumption.
+  - inv H.
+    apply Mem.store_storebytes in H7.
+    split. { split; [trivial | exists m1; split; trivial]. }
+    intros. destruct E as [LD [? [? ?]]]; subst.
+    econstructor; constructor; eauto.
+    apply Mem.storebytes_store; auto.
+Qed. 
+
+Section CLC_SEM.
+  Definition F: Type := fundef.
+  Definition V: Type := type.
+  Definition G := genv.
+  Definition C := CC_core.
+  Definition getEnv (g:G): Genv.t F V := genv_genv g.
+(** Transition relation *)
+
+Inductive cl_evstep (ge: Clight.genv): forall (q: CC_core) (m: mem) (T:list mem_event) (q': CC_core) (m': mem), Prop :=
+
+  | evstep_assign:   forall f a1 a2 k e le m loc ofs bf v2 v m' T1 T2 T3,
+(*     type_is_volatile (typeof a1) = false ->*)
+      eval_lvalueT ge e le m a1 loc ofs bf T1 ->
+      eval_exprT ge e le m a2 v2 T2 ->
+      sem_cast v2 (typeof a2) (typeof a1) m = Some v ->
+      assign_locT ge (typeof a1) m loc ofs bf v m' T3 ->
+      cl_evstep ge (State f (Sassign a1 a2) k e le) m (T1++T2++T3) 
+                  (State f Sskip k e le) m'
+
+  | evstep_set:   forall f id a k e le m v T,
+      eval_exprT ge e le m a v T ->
+      cl_evstep ge (State f (Sset id a) k e le) m T
+              (State f Sskip k e (PTree.set id v le)) m
+
+  | evstep_call:   forall f optid a al k e le m tyargs tyres cconv vf vargs fd T1 T2,
+      classify_fun (typeof a) = fun_case_f tyargs tyres cconv ->
+      eval_exprT ge e le m a vf T1 ->
+      eval_exprTlist ge e le m al tyargs vargs T2 ->
+      Genv.find_funct ge vf = Some fd ->
+      type_of_fundef fd = Tfunction tyargs tyres cconv ->
+      cl_evstep ge (State f (Scall optid a al) k e le) m (T1++T2)
+                  (Callstate fd vargs (Kcall optid f e le k)) m
+
+  | evstep_builtin : forall (f : function)
+                     (optid : option ident) (ef : external_function)
+                     (tyargs : typelist) (al : list expr) 
+                     (k : cont) (e : env) (le : temp_env) 
+                     (m : mem) (vargs : list val) 
+                     (t : Events.trace) (vres : val) 
+                     (m' : mem) T (EFI : ef_inline ef = true) (EFC : Events.external_call ef ge vargs m t vres m'),
+                   ef_deterministic ef = true ->
+                   eval_exprTlist ge e le m al tyargs vargs T ->
+                   cl_evstep ge
+                     (State f (Sbuiltin optid ef tyargs al) k e le) m
+                     (T ++ proj1_sig (inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC))
+                     (State f Sskip k e (set_opttemp optid vres le)) m'
+
+  | evstep_seq:  forall f s1 s2 k e le m,
+      cl_evstep ge (State f (Ssequence s1 s2) k e le) m nil
+                 (State f s1 (Kseq s2 k) e le) m
+
+  | evstep_skip_seq: forall f s k e le m,
+      cl_evstep ge (State f Sskip (Kseq s k) e le) m nil
+              (State f s k e le) m
+
+  | evstep_continue_seq: forall f s k e le m,
+      cl_evstep ge (State f Scontinue (Kseq s k) e le) m nil
+             (State f Scontinue k e le) m
+
+  | evstep_break_seq: forall f s k e le m,
+      cl_evstep ge (State f Sbreak (Kseq s k) e le) m nil
+            (State f Sbreak k e le) m
+
+  | evstep_ifthenelse:  forall f a s1 s2 k e le m v1 b T,
+      eval_exprT ge e le m a v1 T ->
+      bool_val v1 (typeof a) m = Some b ->
+      cl_evstep ge (State f (Sifthenelse a s1 s2) k e le) m T
+            (State f (if b then s1 else s2) k e le) m
+
+  | evstep_loop: forall f s1 s2 k e le m,
+      cl_evstep ge (State f (Sloop s1 s2) k e le) m nil
+            (State f s1 (Kloop1 s1 s2 k) e le) m
+
+  | evstep_skip_or_continue_loop1:  forall f s1 s2 k e le m x,
+      x = Sskip \/ x = Scontinue ->
+      cl_evstep ge (State f x (Kloop1 s1 s2 k) e le) m nil
+            (State f s2 (Kloop2 s1 s2 k) e le) m
+
+  | evstep_break_loop1:  forall f s1 s2 k e le m,
+      cl_evstep ge (State f Sbreak (Kloop1 s1 s2 k) e le) m nil
+             (State f Sskip k e le) m
+
+  | evstep_skip_loop2: forall f s1 s2 k e le m,
+      cl_evstep ge (State f Sskip (Kloop2 s1 s2 k) e le) m nil
+             (State f (Sloop s1 s2) k e le) m
+
+  | evstep_break_loop2: forall f s1 s2 k e le m,
+      cl_evstep ge (State f Sbreak (Kloop2 s1 s2 k) e le) m nil
+            (State f Sskip k e le) m
+
+  | evstep_return_0: forall f k e le m m',
+      Mem.free_list m (blocks_of_env ge e) = Some m' ->
+      cl_evstep ge (State f (Sreturn None) k e le) m
+            (Free (Clight.blocks_of_env ge e)::nil)
+            (Returnstate Vundef (call_cont k)) m'
+
+  | evstep_return_1: forall f a k e le m v v' m' T,
+      eval_exprT ge e le m a v T ->
+      sem_cast v (typeof a) f.(fn_return) m = Some v' ->
+      Mem.free_list m (blocks_of_env ge e) = Some m' ->
+      cl_evstep ge (State f (Sreturn (Some a)) k e le) m
+            (T ++ Free (Clight.blocks_of_env ge e)::nil)
+           (Returnstate v' (call_cont k)) m'
+
+  | evstep_skip_call: forall f k e le m m',
+      is_call_cont k ->
+      Mem.free_list m (blocks_of_env ge e) = Some m' ->
+      cl_evstep ge (State f Sskip k e le) m
+              (Free (Clight.blocks_of_env ge e)::nil)
+              (Returnstate Vundef k) m'
+
+  | evstep_switch: forall f a sl k e le m v n T,
+      eval_exprT ge e le m a v T ->
+      sem_switch_arg v (typeof a) = Some n ->
+      cl_evstep ge (State f (Sswitch a sl) k e le) m T
+            (State f (seq_of_labeled_statement (select_switch n sl)) (Kswitch k) e le) m
+
+  | evstep_skip_break_switch: forall f x k e le m,
+      x = Sskip \/ x = Sbreak ->
+      cl_evstep ge (State f x (Kswitch k) e le) m nil
+             (State f Sskip k e le) m
+  | evstep_continue_switch: forall f k e le m,
+      cl_evstep ge (State f Scontinue (Kswitch k) e le) m nil
+             (State f Scontinue k e le) m
+
+  | evstep_label: forall f lbl s k e le m,
+      cl_evstep ge (State f (Slabel lbl s) k e le) m nil
+             (State f s k e le) m
+
+  | evstep_goto: forall f lbl k e le m s' k',
+      find_label lbl f.(fn_body) (call_cont k) = Some (s', k') ->
+      cl_evstep ge (State f (Sgoto lbl) k e le) m nil
+             (State f s' k' e le) m
+
+  | evstep_internal_function: forall f vargs k m e le m1 T,
+       list_norepet (var_names (fn_params f)) ->
+       list_disjoint (var_names (fn_params f)) (var_names (fn_temps f)) ->
+      forall (NRV: list_norepet (var_names f.(fn_vars))),
+      alloc_variablesT ge empty_env m (f.(fn_vars)) e m1 T ->
+      bind_parameter_temps f.(fn_params) vargs (create_undef_temps f.(fn_temps)) = Some
+le ->
+      cl_evstep ge (Callstate (Internal f) vargs k) m T
+            (State f f.(fn_body) k e le) m1
+
+  | evstep_external_function: forall ef targs tres cconv vargs k m t vres m' T
+          (EFI: ef_inline ef = true)
+          (EFD: ef_deterministic ef = true)
+          (EC: Events.external_call ef ge vargs m t vres m'),
+      T = proj1_sig (inline_external_call_mem_events _ _ _ _ _ _ _ EFI EC) ->
+      cl_evstep ge (Callstate (External ef targs tres cconv) vargs k) m T
+          (Returnstate vres k) m'
+
+  | evstep_returnstate: forall v optid f e le k m,
+      cl_evstep ge (Returnstate v (Kcall optid f e le k)) m nil
+           (State f Sskip k e (set_opttemp optid v le)) m.
+
+  Lemma CLC_evstep_ax1 ge : forall c m T c' m' (H: cl_evstep ge c m T c' m' ),
+    corestep (CLC_memsem ge) c m c' m'.
+  Proof.
+    induction 1; try solve [econstructor; eassumption].
+    +  apply eval_lvalueT_ax1 in H. apply eval_exprT_ax1 in H0.
+         apply assign_locT_ax1 in H2. econstructor; eauto.
+    +  apply eval_exprT_ax1 in H. econstructor; eauto.
+    + apply eval_exprT_ax1 in H0.
+      apply eval_exprTlist_ax1 in H1. econstructor; eauto.
+    + apply eval_exprTlist_ax1 in H0. econstructor; eauto.
+      apply andb_true_iff; auto.
+    + apply eval_exprT_ax1 in H. econstructor; eauto.
+    + apply eval_exprT_ax1 in H. econstructor; eauto.
+    + apply eval_exprT_ax1 in H. econstructor; eauto.
+    + apply alloc_variablesT_ax1 in H1. econstructor; eauto.
+         econstructor; eauto.
+    + econstructor; eauto.
+      rewrite EFI; auto.
+  Qed.
+
+  Lemma CLC_evstep_ax2 ge : forall c m c' m' (H:corestep (CLC_memsem ge) c m c' m'),
+      exists T : list mem_event, cl_evstep ge c m T c' m'.
+  Proof.
+    induction 1; try solve [ destruct IHcl_step as [T HT]; eexists; econstructor; eauto];
+      try solve [eexists; econstructor; eauto]. 
+  + apply eval_lvalueT_ax2 in H. destruct H as [T1 A1].
+      apply eval_exprT_ax2 in H0. destruct H0 as [T2 A2].
+      apply assign_locT_ax2 in H2. destruct H2 as [T3 A3].
+      eexists; econstructor; eauto.
+  + apply eval_exprT_ax2 in H; destruct H as [T H].
+      eexists; econstructor; eauto.
+  + apply eval_exprT_ax2 in H0. destruct H0 as [T1 K1].
+      apply eval_exprTlist_ax2 in H1. destruct H1 as [T2 K2].
+      eexists; econstructor; eauto.
+  + apply eval_exprTlist_ax2 in H0 as [??].
+      eexists; econstructor; eauto.
+      apply andb_true_iff in H as []; auto.
+  + apply eval_exprT_ax2 in H; destruct H as [T H].
+      eexists; econstructor; eauto.
+  + apply eval_exprT_ax2 in H; destruct H as [T H].
+      eexists; econstructor; eauto.
+  + apply eval_exprT_ax2 in H; destruct H as [T H].
+      eexists; econstructor; eauto.
+  + inv H. apply alloc_variablesT_ax2 in H3. destruct H3 as [T3 K3].
+      eexists; econstructor; eauto.
+  + apply andb_true_iff in H as []; eexists; econstructor; eauto.
+Unshelve.
+3, 6: eassumption.
+apply andb_true_iff in H as []; auto.
+auto.
+Qed.
+
+  Lemma CLC_evstep_fun ge : forall c m T' c' m' T'' c'' m''
+                                   (K: cl_evstep ge c m T' c' m') (K': cl_evstep ge c m T'' c'' m''), T' = T''.
+  Proof. intros. generalize dependent m''. generalize dependent c''. generalize dependent T''.
+         induction K; simpl; intros; try solve [ inv K'; eauto ].
+ - inv K'. exploit eval_exprT_fun. apply H14. apply H0. intros X; inv X.
+    exploit eval_lvalueT_fun. apply H13. apply H. intros X; inv X.
+    rewrite H15 in H1; inv H1.
+    exploit assign_locT_fun. apply H16. apply H2. intros X; inv X; trivial.
+   destruct H12; discriminate.
+   destruct H12; discriminate.
+ - inv K'. exploit eval_exprT_fun. apply H10. apply H. intros X; inv X. trivial.
+    destruct H9; discriminate.
+    destruct H9; discriminate.
+ - inv K'.
+    + rewrite H15 in H; inv H.
+      exploit eval_exprT_fun. eassumption. apply H0. intros X; inv X.
+      exploit eval_exprTlist_fun. eassumption. apply H1. intros X; inv X.
+      rewrite H18 in H2; inv H2.
+      rewrite H19 in H3; inv H3. auto.
+    + destruct H13; discriminate.
+    + destruct H13; discriminate.
+ - inv K'.
+   + exploit (eval_exprTlist_fun _ _ _ _ _ _ _ _ H0); try eassumption; intros X; inv X.
+    exploit ef_deterministic_fun; [eassumption | apply EFC | eassumption|].
+   intros X; inv X. f_equal; f_equal; f_equal; apply proof_irr.
+   + destruct H10; discriminate.
+   + destruct H10; discriminate.
+ - inv K'; auto. contradiction.
+ - inv K'. exploit eval_exprT_fun. eassumption. eapply H. intros X; inv X. auto.
+    destruct H10; discriminate.
+    destruct H10; discriminate.
+ - destruct H; subst x; inv K'; auto. contradiction.
+ - inv K'; auto; contradiction.
+ - inv K'; try solve [destruct H9; discriminate]. inversion2 H H8. auto.
+ - inv K'; try solve [destruct H11; discriminate].
+    exploit eval_exprT_fun. eassumption. eapply H. intros X; inv X. auto.
+ - inv K'; try contradiction. auto.
+ - inv K'; try solve [destruct H10; discriminate].
+    exploit eval_exprT_fun. eassumption. eapply H. intros X; inv X. auto.
+ - destruct H; subst x; inv K'; auto. contradiction.
+ - inv K'. 
+      exploit alloc_variablesT_fun. eassumption. apply H1. intros X; inv X. auto.
+ - inv K'. exploit ef_deterministic_fun; [eassumption | apply EC | eassumption|].
+   intros X; inv X. f_equal; f_equal; apply proof_irr.
+Qed.
+
+  Lemma CLC_evstep_elim ge : forall c m T c' m' (K: cl_evstep ge c m T c' m'),
+        ev_elim m T m'.
+  Proof.
+    induction 1; try solve [constructor];
+      try solve [ apply eval_exprT_elim in H; trivial]; trivial.
+  + eapply assign_locT_elim in H2. destruct H2 as [EV3 _ ].
+      eapply eval_lvalueT_elim in H.
+      eapply eval_exprT_elim in H0.
+      eapply ev_elim_app; eauto. eapply ev_elim_app; eauto.
+  + apply eval_exprT_elim in H0.
+      apply eval_exprTlist_elim in H1.
+      eapply ev_elim_app; eauto.
+  + apply eval_exprTlist_elim in H0.
+      eapply ev_elim_app; eauto.
+      apply proj2_sig.
+  + eexists; split; eauto. reflexivity.
+  + apply eval_exprT_elim in H.
+      eapply ev_elim_app; eauto.
+      eexists; split; eauto. reflexivity.
+  + eexists; split; eauto. reflexivity.
+  + apply alloc_variablesT_elim in H1.
+      destruct H1; auto.
+  + destruct  (inline_external_call_mem_events ef ge vargs m t
+         vres m' EFI EC). simpl in H. subst x. auto.
+  Qed.
+
+  Program Definition CLC_evsem ge : @EvSem C := {| msem := CLC_memsem ge; ev_step := cl_evstep ge |}.
+  Next Obligation. apply CLC_evstep_ax1. Qed.
+  Next Obligation. apply CLC_evstep_ax2. Qed.
+(*  Next Obligation. apply CLC_evstep_fun. Qed. *)
+  Next Obligation. apply CLC_evstep_elim. Qed.
+
+  Lemma CLC_msem : forall ge, msem (CLC_evsem ge) = CLC_memsem ge.
+  Proof. auto. Qed.
+End CLC_SEM.
+
+  Lemma at_external_SEM_eq:
+     forall ge c m, semantics.at_external (CLC_evsem ge) c m =
+     match c with
+     | Callstate (External ef _ _ _) args _ => 
+         if ef_inline ef then None else Some (ef, args)
+     | _ => None
+   end.
+  Proof. auto. Qed.
+
+  Inductive builtin_event: external_function -> mem -> list val -> list mem_event -> Prop :=
+  BE_malloc: forall m n m'' b m'
+         (ALLOC: Mem.alloc m (-size_chunk Mptr) (Ptrofs.unsigned n) = (m'', b))
+         (ALGN : (align_chunk Mptr | (-size_chunk Mptr)))
+         (ST: Mem.storebytes m'' b (-size_chunk Mptr) (encode_val Mptr (Vptrofs n)) = Some m'),
+         builtin_event EF_malloc m [Vptrofs n]
+               [Alloc b (-size_chunk Mptr) (Ptrofs.unsigned n);
+                Write b (-size_chunk Mptr) (encode_val Mptr (Vptrofs n))]
+| BE_free: forall m b lo bytes sz m'
+        (POS: Ptrofs.unsigned sz > 0)
+        (LB : Mem.loadbytes m b (Ptrofs.unsigned lo - size_chunk Mptr) (size_chunk Mptr) = Some bytes)
+        (FR: Mem.free m b (Ptrofs.unsigned lo - size_chunk Mptr) (Ptrofs.unsigned lo + Ptrofs.unsigned sz) = Some m')
+        (ALGN : (align_chunk Mptr | Ptrofs.unsigned lo - size_chunk Mptr))
+        (SZ : Vptrofs sz = decode_val Mptr bytes),
+        builtin_event EF_free m [Vptr b lo]
+              [Read b (Ptrofs.unsigned lo - size_chunk Mptr) (size_chunk Mptr) bytes;
+               Free [(b,Ptrofs.unsigned lo - size_chunk Mptr, Ptrofs.unsigned lo + Ptrofs.unsigned sz)]]
+| BE_memcpy: forall m al bsrc bdst sz bytes osrc odst m'
+        (AL: al = 1 \/ al = 2 \/ al = 4 \/ al = 8)
+        (POS : sz >= 0)
+        (DIV : (al | sz))
+        (OSRC : sz > 0 -> (al | Ptrofs.unsigned osrc))
+        (ODST: sz > 0 -> (al | Ptrofs.unsigned odst))
+        (RNG: bsrc <> bdst \/
+                Ptrofs.unsigned osrc = Ptrofs.unsigned odst \/
+                Ptrofs.unsigned osrc + sz <= Ptrofs.unsigned odst \/ Ptrofs.unsigned odst + sz <= Ptrofs.unsigned osrc)
+        (LB: Mem.loadbytes m bsrc (Ptrofs.unsigned osrc) sz = Some bytes)
+        (ST: Mem.storebytes m bdst (Ptrofs.unsigned odst) bytes = Some m'),
+        builtin_event (EF_memcpy sz al) m [Vptr bdst odst; Vptr bsrc osrc]
+              [Read bsrc (Ptrofs.unsigned osrc) sz bytes;
+               Write bdst (Ptrofs.unsigned odst) bytes]
+(*| BE_EFexternal: forall name sg m vargs,
+(*        I64Helpers.is_I64_helperS name sg ->*)
+         builtin_event (EF_external name sg) m vargs []
+| BE_EFbuiltin: forall name sg m vargs, (*is_I64_builtinS name sg ->*)
+         builtin_event (EF_builtin name sg) m vargs []*)
+| BE_other: forall ef m vargs,
+  match ef with EF_malloc | EF_free | EF_memcpy _ _ => False | _ => True end ->
+  builtin_event ef m vargs [].
+
+Lemma Vptrofs_inj : forall o1 o2, Vptrofs o1 = Vptrofs o2 ->
+  Ptrofs.unsigned o1 = Ptrofs.unsigned o2.
+Proof.
+  unfold Vptrofs; intros.
+  pose proof (Ptrofs.unsigned_range o1); pose proof (Ptrofs.unsigned_range o2).
+  destruct Archi.ptr64 eqn: H64.
+  - assert (Int64.unsigned (Ptrofs.to_int64 o1) = Int64.unsigned (Ptrofs.to_int64 o2)) by congruence.
+    unfold Ptrofs.to_int64 in *.
+    rewrite Ptrofs.modulus_eq64 in * by auto.
+    rewrite !Int64.unsigned_repr in * by (unfold Int64.max_unsigned; lia); auto.
+  - assert (Int.unsigned (Ptrofs.to_int o1) = Int.unsigned (Ptrofs.to_int o2)) by congruence.
+    unfold Ptrofs.to_int in *.
+    rewrite Ptrofs.modulus_eq32 in * by auto.
+    rewrite !Int.unsigned_repr in * by (unfold Int.max_unsigned; lia); auto.
+Qed.
+
+Lemma builtin_event_determ ef m vargs T1 (BE1: builtin_event ef m vargs T1) T2 (BE2: builtin_event ef m vargs T2): T1=T2.
+inversion BE1; inv BE2; try discriminate; try contradiction; simpl in *; trivial.
++ assert (Vptrofs n0 = Vptrofs n) as H by congruence.
+  rewrite H; rewrite (Vptrofs_inj _ _ H) in *.
+  rewrite ALLOC0 in ALLOC; inv ALLOC; trivial.
++ inv H5.
+  rewrite LB0 in LB; inv LB. rewrite <- SZ in SZ0. rewrite (Vptrofs_inj _ _ SZ0); trivial.
++ inv H3; inv H5.
+  rewrite LB0 in LB; inv LB; trivial.
+Qed.
+
+Inductive ev_star ge: state -> mem -> _ -> state -> mem -> Prop :=
+  | ev_star_refl: forall s m,
+      ev_star ge s m nil s m
+  | ev_star_step: forall s1 m1 ev1 s2 m2 ev2 s3 m3,
+      ev_step (CLC_evsem ge) s1 m1 ev1 s2 m2 -> ev_star ge s2 m2 ev2 s3 m3 ->
+      ev_star ge s1 m1 (ev1 ++ ev2) s3 m3.
+
+Lemma ev_star_one:
+  forall ge s1 m1 ev s2 m2, ev_step (CLC_evsem ge) s1 m1 ev s2 m2 -> ev_star ge s1 m1 ev s2 m2.
+Proof.
+  intros. rewrite <- (app_nil_r ev). eapply ev_star_step; eauto. apply ev_star_refl.
+Qed.
+
+Lemma ev_star_two:
+  forall ge s1 m1 ev1 s2 m2 ev2 s3 m3,
+  ev_step (CLC_evsem ge) s1 m1 ev1 s2 m2 -> ev_step (CLC_evsem ge) s2 m2 ev2 s3 m3 ->
+  ev_star ge s1 m1 (ev1 ++ ev2) s3 m3.
+Proof.
+  intros. eapply ev_star_step; eauto. apply ev_star_one; auto.
+Qed.
+
+Lemma ev_star_trans:
+  forall ge {s1 m1 ev1 s2 m2}, ev_star ge s1 m1 ev1 s2 m2 ->
+  forall {ev2 s3 m3}, ev_star ge s2 m2 ev2 s3 m3 -> ev_star ge s1 m1 (ev1 ++ ev2) s3 m3.
+Proof.
+  induction 1; intros; auto.
+  rewrite <- app_assoc.
+  eapply ev_star_step; eauto.
+Qed.
+
+
+Inductive ev_plus ge: state -> mem -> _ -> state -> mem -> Prop :=
+  | ev_plus_left: forall s1 m1 ev1 s2 m2 ev2 s3 m3,
+      ev_step (CLC_evsem ge) s1 m1 ev1 s2 m2 -> ev_star ge s2 m2 ev2 s3 m3 ->
+      ev_plus ge s1 m1 (ev1 ++ ev2) s3 m3.
+
+Lemma ev_plus_one:
+  forall ge s1 m1 ev s2 m2, ev_step (CLC_evsem ge) s1 m1 ev s2 m2 -> ev_plus ge s1 m1 ev s2 m2.
+Proof.
+  intros. rewrite <- (app_nil_r ev). eapply ev_plus_left; eauto. apply ev_star_refl.
+Qed.
+
+Lemma ev_plus_two:
+  forall ge s1 m1 ev1 s2 m2 ev2 s3 m3,
+  ev_step (CLC_evsem ge) s1 m1 ev1 s2 m2 -> ev_step (CLC_evsem ge) s2 m2 ev2 s3 m3 ->
+  ev_plus ge s1 m1 (ev1 ++ ev2) s3 m3.
+Proof.
+  intros. eapply ev_plus_left; eauto. apply ev_star_one; auto.
+Qed.
+
+Lemma ev_plus_star: forall ge s1 m1 ev s2 m2, ev_plus ge s1 m1 ev s2 m2 -> ev_star ge s1 m1 ev s2 m2.
+Proof.
+  intros. inv H. eapply ev_star_step; eauto.
+Qed.
+
+Lemma ev_plus_trans:
+  forall ge {s1 m1 ev1 s2 m2}, ev_plus ge s1 m1 ev1 s2 m2 ->
+  forall {ev2 s3 m3}, ev_plus ge s2 m2 ev2 s3 m3 -> ev_plus ge s1 m1 (ev1 ++ ev2) s3 m3.
+Proof.
+  intros.
+  inv H.
+  rewrite <- app_assoc.
+  eapply ev_plus_left. eauto.
+  eapply ev_star_trans; eauto.
+  apply ev_plus_star. auto.
+Qed.
+
+Lemma ev_star_plus_trans:
+  forall ge {s1 m1 ev1 s2 m2}, ev_star ge s1 m1 ev1 s2 m2 ->
+  forall {ev2 s3 m3}, ev_plus ge s2 m2 ev2 s3 m3 -> ev_plus ge s1 m1 (ev1 ++ ev2) s3 m3.
+Proof.
+  intros. inv H. auto.
+  rewrite <- app_assoc.
+  eapply ev_plus_left; eauto.
+  eapply ev_star_trans; eauto. apply ev_plus_star; auto.
+Qed.
+
+Lemma ev_plus_star_trans:
+  forall ge {s1 m1 ev1 s2 m2}, ev_plus ge s1 m1 ev1 s2 m2 ->
+  forall {ev2 s3 m3}, ev_star ge s2 m2 ev2 s3 m3 -> ev_plus ge s1 m1 (ev1 ++ ev2) s3 m3.
+Proof.
+  intros.
+  inv H.
+  rewrite <- app_assoc.
+  eapply ev_plus_left; eauto. eapply ev_star_trans; eauto.
+Qed.
+
+Require Import VST.veric.mem_lessdef.
+Require Import VST.veric.Clight_mem_lessdef.
+
+Transparent Mem.storebytes.
+
+Lemma storebytes_sub:
+  forall m1 m2 b ofs bytes m1',
+  mem_sub m1 m2 ->
+  Mem.storebytes m1 b ofs bytes = Some m1' ->
+  exists m2',
+     Mem.storebytes m2 b ofs bytes = Some m2'
+  /\ mem_sub m1' m2'.
+Proof.
+  unfold Mem.storebytes; intros.
+  destruct H as (? & ? & ?).
+  if_tac in H0; inv H0.
+  rewrite if_true by (intros ??; auto).
+  do 2 eexists; eauto.
+  split; auto; simpl.
+  rewrite H; auto.
+Qed.
+
+Transparent Mem.alloc.
+
+Lemma alloc_sub:
+  forall (m1 m2 : mem) (lo hi : Z) (b : block)  (m1' : Mem.mem'),
+  mem_sub m1 m2 ->
+  Mem.alloc m1 lo hi = (m1', b) ->
+  exists m2' : Mem.mem',
+    Mem.alloc m2 lo hi = (m2', b) /\ mem_sub m1' m2'.
+Proof.
+  intros ??????? Halloc1.
+  destruct (Mem.alloc m2 lo hi) eqn: Halloc2.
+  injection Halloc1; injection Halloc2; intros; subst.
+  destruct H as (? & ? & ?).
+  do 2 eexists; eauto.
+  split; [|split]; simpl; rewrite ?H, ?H0; auto.
+  intros.
+  pose H2 as Hperm; eapply Mem.perm_alloc_inv in Hperm; eauto.
+  if_tac in Hperm.
+  - eapply Mem.perm_implies, perm_F_any.
+    subst; rewrite H0; eapply Mem.perm_alloc_2; eauto.
+  - eapply Mem.perm_alloc_1; eauto.
+Qed.
+
+Opaque Mem.alloc.
+
+Transparent Mem.free.
+
+Lemma free_sub:
+  forall (m1 m2 : mem) b lo hi (m1' : Mem.mem'),
+  mem_sub m1 m2 ->
+  Mem.free m1 b lo hi = Some m1' ->
+  exists m2' : Mem.mem',
+    Mem.free m2 b lo hi = Some m2' /\ mem_sub m1' m2'.
+Proof.
+  intros ??????? Hfree1.
+  destruct H as (? & ? & ?).
+  pose proof Hfree1 as Hfree; unfold Mem.free in Hfree |- *.
+  if_tac in Hfree; inv Hfree.
+  rewrite if_true by (intros ??; auto).
+  do 2 eexists; eauto.
+  split; auto; split; auto; intros.
+  pose proof (Mem.perm_free_3 _ _ _ _ _ Hfree1 _ _ _ _ H3) as Hperm.
+  apply H1 in Hperm.
+  eapply Mem.perm_free_inv in Hperm; [|unfold Mem.free; rewrite if_true by (intros ??; eauto); eauto].
+  destruct Hperm as [[] | ?]; auto; subst.
+  exfalso; eapply Mem.perm_free_2; eauto.
+Qed.
+
+Opaque Mem.free.
+
+Lemma free_list_sub:
+  forall l (m1 m2 : mem) (m1' : Mem.mem'),
+  mem_sub m1 m2 ->
+  Mem.free_list m1 l = Some m1' ->
+  exists m2' : Mem.mem',
+    Mem.free_list m2 l = Some m2' /\ mem_sub m1' m2'.
+Proof.
+  induction l; simpl; intros.
+  { inv H0; eauto. }
+  destruct a as ((?, ?), ?).
+  destruct (Mem.free m1 _ _ _) eqn: Hfree; inv H0.
+  eapply free_sub in Hfree as (? & -> & ?); eauto.
+Qed.
+
+Lemma ev_elim_sub : forall T m m' m1, ev_elim m T m' -> mem_sub m m1 ->
+  exists m1', mem_sub m' m1' /\ ev_elim m1 T m1'.
+Proof.
+  induction T; simpl; intros; subst; eauto.
+  destruct a.
+  - destruct H as (? & ? & ?).
+    eapply storebytes_sub in H as (? & ? & Hsub'); eauto.
+    eapply IHT in Hsub' as (? & ? & ?); eauto.
+  - destruct H.
+    eapply mem_sub_loadbytes in H; eauto.
+    eapply IHT in H0 as (? & ? & ?); eauto.
+  - destruct H as (? & ? & ?).
+    eapply alloc_sub in H as (? & ? & Hsub'); eauto.
+    eapply IHT in Hsub' as (? & ? & ?); eauto.
+  - destruct H as (? & ? & ?).
+    eapply free_list_sub in H as (? & ? & Hsub'); eauto.
+    eapply IHT in Hsub' as (? & ? & ?); eauto.
+Qed.
+
+Lemma assign_locT_sub: forall ce ty m b ofs bf v m' T m1, assign_locT ce ty m b ofs bf v m' T ->
+  mem_sub m m1 -> exists m1', mem_sub m' m1' /\ assign_locT ce ty m1 b ofs bf v m1' T.
+Proof.
+  inversion 1; subst; intros.
+  - exploit Mem.store_valid_access_3; eauto; intros [].
+    eapply Mem.store_storebytes, storebytes_sub in H1 as (? & ? & ?); eauto.
+    do 2 eexists; eauto; constructor; auto.
+    apply Mem.storebytes_store; auto.
+  - eapply mem_sub_loadbytes in H4; eauto.
+    eapply storebytes_sub in H5 as (? & ? & ?); eauto.
+    do 2 eexists; eauto; constructor; auto.
+  - inv H0.
+    eapply mem_sub_loadbytes in H7; eauto.
+    eapply Mem.store_storebytes, storebytes_sub in H9 as (? & ? & ?); eauto.
+    do 2 eexists; eauto; econstructor; constructor; eauto.
+    apply Mem.storebytes_store; eauto.
+Qed.
+
+Lemma eval_exprT_sub: forall ge e le m a v T m1, eval_exprT ge e le m a v T -> mem_sub m m1 -> eval_exprT ge e le m1 a v T
+with eval_lvalueT_sub: forall ge e le m a b z bf T m1, eval_lvalueT ge e le m a b z bf T -> mem_sub m m1 -> eval_lvalueT ge e le m1 a b z bf T.
+Proof.
+  + intros until 1; intros Hm. induction H; try solve [econstructor; eauto].
+    * econstructor; eauto.
+      eapply unaryop_mem_sub; eauto.
+    * econstructor; eauto.
+      eapply binaryop_mem_sub; eauto.
+    * econstructor; eauto.
+      eapply sem_cast_mem_sub; eauto.
+    * apply deref_locT_elim in H0 as [HT Hderef].
+      eapply ev_elim_sub in HT as (? & ? & HT'); eauto.
+      eapply Hderef in HT' as []; subst.
+      econstructor; eauto.
+  + intros until 1; intros Hm. induction H; try solve [econstructor; eauto].
+Qed.
+
+Lemma eval_exprTlist_sub: forall ge e le m la lt lv T m1, eval_exprTlist ge e le m la lt lv T -> mem_sub m m1 -> eval_exprTlist ge e le m1 la lt lv T.
+Proof.
+  induction 1; intros; econstructor; eauto.
+  - eapply eval_exprT_sub; eauto.
+  - eapply sem_cast_mem_sub; eauto.
+Qed.
+
+(* a variant of the commented-out property in sepcomp/event_semantics.v *)
+Lemma cl_evstep_extends : forall ge c m T c' m' m1
+  (Hext : forall ef se lv m t v m' (EFI : ef_inline ef = true) m1 (EFC : Events.external_call ef se lv m t v m'),
+     mem_sub m m1 -> exists m1' (EFC1 : Events.external_call ef se lv m1 t v m1'), mem_sub m' m1' /\
+     proj1_sig (inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC1) = proj1_sig (inline_external_call_mem_events _ _ _ _ _ _ _ EFI EFC)), cl_evstep ge c m T c' m' ->
+  mem_sub m m1 -> exists m1', cl_evstep ge c m1 T c' m1' /\ mem_sub m' m1'.
+Proof.
+  intros until 2.
+  revert m1; induction H; intros;
+    repeat match goal with
+    | H : eval_exprT _ _ _ m _ _ _ |- _ => eapply eval_exprT_sub in H; eauto
+    | H : eval_lvalueT _ _ _ m _ _ _ _ _ |- _ => eapply eval_lvalueT_sub in H; eauto
+    | H : sem_cast _ _ _ m = _ |- _ => eapply sem_cast_mem_sub in H; eauto
+    | H : eval_exprTlist _ _ _ m _ _ _ _ |- _ => eapply eval_exprTlist_sub in H; eauto
+    end; try solve [do 2 eexists; [econstructor; eauto|]; eauto].
+  - eapply assign_locT_sub in H2 as (? & ? & ?); eauto.
+    do 2 eexists; eauto; econstructor; eauto.
+  - (* CompCert requires external calls to preserve extensions and injections.
+       They likely also preserve mem_sub. *)
+    edestruct Hext as (? & EFC1 & ? & Heq); eauto.
+    rewrite <- Heq.
+    do 2 eexists; eauto; eapply evstep_builtin; eauto.
+  - assert (bool_val v1 (typeof a) m1 = Some b).
+    { unfold bool_val in *.
+      destruct (classify_bool _); auto.
+      destruct v1; auto.
+      destruct (negb Archi.ptr64); try discriminate; destruct (Mem.weak_valid_pointer m _ _) eqn: Hweak; inv H0;
+        erewrite mem_sub_weak_valid_pointer; eauto. }
+    do 2 eexists; eauto; econstructor; eauto.
+  - eapply free_list_sub in H as (? & ? & ?); eauto.
+    do 2 eexists; eauto; econstructor; eauto.
+  - eapply free_list_sub in H1 as (? & ? & ?); eauto.
+    do 2 eexists; eauto; econstructor; eauto.
+  - eapply free_list_sub in H0 as (? & ? & ?); eauto.
+    do 2 eexists; eauto; econstructor; eauto.
+  - apply alloc_variablesT_elim in H1 as [Helim Hm1].
+    eapply ev_elim_sub in Helim as (? & ? & Helim'); eauto.
+    apply Hm1 in Helim'.
+    do 2 eexists; eauto; econstructor; eauto.
+  - edestruct Hext as (? & EFC1 & ? & Heq); eauto.
+    rewrite <- Heq in H.
+    do 2 eexists; eauto; econstructor; eauto.
+Qed.

--- a/veric/Clight_initial_world.v
+++ b/veric/Clight_initial_world.v
@@ -871,7 +871,7 @@ Proof.
   rewrite <- H5 in H7; clear H5.
   rewrite <- Q_ne in H7.
   destruct H7.
-  now apply fupd.fupd_intro.
+  auto.
 Qed.
 
 Lemma initial_jm_ext_matchfunspecs {Z} (ora : Z) prog m G n H H1 H2:
@@ -958,7 +958,7 @@ Proof.
   rewrite <- H5 in H7; clear H5.
   rewrite <- Q_ne in H7.
   destruct H7.
-  now apply fupd.fupd_intro.
+  auto.
 Qed.
 
 End invs.

--- a/veric/Clight_initial_world.v
+++ b/veric/Clight_initial_world.v
@@ -750,6 +750,10 @@ Proof.
   apply level_make_rmap.
 Qed.*)
 
+Section invs.
+
+Context {inv_names : invariants.invG}.
+
 Definition matchfunspecs (ge : genv) (G : funspecs) : pred rmap :=
   ALL b:block, ALL fs: funspec,
   func_at fs (b,0%Z) -->
@@ -832,7 +836,7 @@ Proof.
   assert (approx n' (P ts ftor garg) phi).
   split; auto.
   clear H3.
-  apply own.bupd_intro.
+  apply fupd.fupd_intro.
   exists ts.
   assert (H5 := equal_f_dep (equal_f_dep H8 ts) ftor). clear H8.
   simpl in H5.
@@ -867,7 +871,7 @@ Proof.
   rewrite <- H5 in H7; clear H5.
   rewrite <- Q_ne in H7.
   destruct H7.
-  now apply own.bupd_intro.
+  now apply fupd.fupd_intro.
 Qed.
 
 Lemma initial_jm_ext_matchfunspecs {Z} (ora : Z) prog m G n H H1 H2:
@@ -919,7 +923,7 @@ Proof.
   assert (approx n' (P ts ftor garg) phi).
   split; auto.
   clear H3.
-  apply own.bupd_intro.
+  apply fupd.fupd_intro.
   exists ts.
   assert (H5 := equal_f_dep (equal_f_dep H8 ts) ftor). clear H8.
   simpl in H5.
@@ -954,5 +958,7 @@ Proof.
   rewrite <- H5 in H7; clear H5.
   rewrite <- Q_ne in H7.
   destruct H7.
-  now apply own.bupd_intro.
+  now apply fupd.fupd_intro.
 Qed.
+
+End invs.

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -112,7 +112,7 @@ Qed.
   { fupd := fupd.fupd }.
 Next Obligation.
 Proof.
-  unseal_derives; apply fupd.fupd_mask_subseteq; auto.
+  unseal_derives; apply fupd.fupd_mask_union; auto.
 Qed.
 Next Obligation.
 Proof.

--- a/veric/SeparationLogicSoundness.v
+++ b/veric/SeparationLogicSoundness.v
@@ -56,6 +56,7 @@ Axiom semax_prog_rule :
          { jm |
            m_dry jm = m /\ level jm = n /\
            nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
+           (exists z, join (m_phi jm) (wsat_rmap (m_phi jm)) (m_phi z) /\ ext_order jm z) /\
            jsafeN (@OK_spec Espec) (globalenv prog) z q jm /\
            no_locks (m_phi jm) /\
            matchfunspecs (globalenv prog) G (m_phi jm) /\

--- a/veric/SeparationLogicSoundness.v
+++ b/veric/SeparationLogicSoundness.v
@@ -56,7 +56,7 @@ Axiom semax_prog_rule :
          { jm |
            m_dry jm = m /\ level jm = n /\
            nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
-           jsafeN (@OK_spec Espec) (globalenv prog) n z q jm /\
+           jsafeN (@OK_spec Espec) (globalenv prog) z q jm /\
            no_locks (m_phi jm) /\
            matchfunspecs (globalenv prog) G (m_phi jm) /\
            app_pred (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)

--- a/veric/SequentialClight.v
+++ b/veric/SequentialClight.v
@@ -431,18 +431,18 @@ Proof.
    instantiate (1 := (_, _)); constructor; simpl; constructor; auto.
    instantiate (1 := (Some _, _)); repeat constructor; simpl; auto. }
  clear - JDE DME H4 J H6.
-  rewrite <- H4 in H6|-*.
+  rewrite <- H4.
  assert (level jm <= n)%nat by lia.
  clear H4; rename H into H4.
  forget initial_oracle as ora.
  revert ora jm q H4 J H6; induction n; simpl; intros.
  assert (level (m_phi jm) = 0%nat) by lia. rewrite H; constructor.
  inv H6.
- - constructor.
+ - rewrite <- level_juice_level_phi, H; constructor.
  -
-   rewrite <- level_juice_level_phi in H4.
-   destruct H0 as (?&?&?&Hg).
-   eapply safeN_step.
+   rewrite <- level_juice_level_phi in H4 |- *.
+   destruct H as (?&?&Hl&Hg).
+   rewrite Hl; eapply safeN_step.
    + red. red. fold (globalenv prog). eassumption.
    + destruct (H1 (Some (ghost_PCM.ext_ref ora, compcert_rmaps.RML.R.NoneP) :: nil)) as (m'' & J'' & (? & ? & ?) & ?); auto.
      { eexists; apply join_comm, core_unit. }

--- a/veric/aging_lemmas.v
+++ b/veric/aging_lemmas.v
@@ -112,65 +112,24 @@ Proof.
     lia.
 Qed.
 
-Lemma jsafeN__age {G C Z HH Sem Jspec ge ora q n} jm jmaged :
+Lemma jsafeN__age {G C Z HH Sem Jspec ge ora q} jm jmaged :
   ext_spec_stable age (JE_spec _ Jspec) ->
   age jm jmaged ->
-  Peano.le n (level jmaged) ->
-  @jsafeN_ G Z C HH Sem Jspec ge n ora q jm ->
-  @jsafeN_ G Z C HH Sem Jspec ge n ora q jmaged.
+  @jsafeN_ G Z C HH Sem Jspec ge ora q jm ->
+  @jsafeN_ G Z C HH Sem Jspec ge ora q jmaged.
 Proof.
-  revert q jm jmaged; induction n.
-  - constructor 1.
-  - intros ??? heredspec A L Safe.
-    inv Safe.
-    + destruct (jstep_age_sim A H0 ltac:(lia)) as [jmaged' [A' step']].
-      econstructor 2; eauto.
-      intros gh Hg J.
-      rewrite (age1_ghost_of _ _ (age_jm_phi A')) in J.
-      destruct (own.ghost_joins_approx _ _ _ J) as (J' & Hd').
-      rewrite <- level_juice_level_phi in *.
-      rewrite <- (age_level _ _ A') in *.
-      rewrite level_juice_level_phi, ghost_of_approx in J'.
-      destruct (H1 (own.make_join (ghost_of (m_phi m')) gh)) as (b & ? & Hupd & Hsafe); auto.
-      { eapply make_join_ext; eauto. }
-      destruct (jm_update_age _ _ _ Hupd A') as (b' & Hupd' & Hage').
-      eapply IHn in Hsafe; eauto.
-      eexists; split; [|eauto].
-      rewrite (age1_ghost_of _ _ (age_jm_phi Hage')).
-      rewrite <- level_juice_level_phi.
-      destruct Hupd' as (_ & -> & _); auto.
-      { destruct Hupd' as (_ & -> & _).
-        apply age_level in A'.
-        destruct H0 as (? & ? & ? & ?).
-        apply age_level in A.
-        lia. }
-    + econstructor 3.
-      * unfold j_at_external in *; rewrite <- (age_jm_dry A); eassumption.
-      * eapply (proj1 heredspec); eauto.
-      * intros ret jm' z' n' Hargsty Hretty H rel post.
-        destruct (H2 ret jm' z' n' Hargsty Hretty H) as (c' & atex' & safe'); eauto.
-        unfold Hrel in *.
-        split;[|split]; try apply rel.
-        -- apply age_level in A; lia.
-        -- apply age_jm_phi in A.
-           unshelve eapply (pures_eq_unage _ A), rel.
-           do 2 rewrite <-level_juice_level_phi.
-           lia.
-    + econstructor 4. eauto.
-      eapply (proj2 heredspec); eauto.
+  intros; eapply age_safe; eauto.
 Qed.
 
-Lemma jsafeN__age_to {G C Z HH Sem Jspec ge ora q n} l jm :
+Lemma jsafeN__age_to {G C Z HH Sem Jspec ge ora q} l jm :
   ext_spec_stable age (JE_spec _ Jspec) ->
-  Peano.le n l ->
-  @jsafeN_ G Z C HH Sem Jspec ge n ora q jm ->
-  @jsafeN_ G Z C HH Sem Jspec ge n ora q (age_to l jm).
+  @jsafeN_ G Z C HH Sem Jspec ge ora q jm ->
+  @jsafeN_ G Z C HH Sem Jspec ge ora q (age_to l jm).
 Proof.
   intros Stable nl.
-  apply age_to_ind_refined.
+  apply age_to_ind_refined; auto.
   intros x y H L.
   apply jsafeN__age; auto.
-  lia.
 Qed.
 
 Lemma m_dry_age_to n jm : m_dry (age_to n jm) = m_dry jm.

--- a/veric/assert_lemmas.v
+++ b/veric/assert_lemmas.v
@@ -251,6 +251,10 @@ Proof.
   apply ext_level in E; congruence.
 Qed.
 
+Section invs.
+
+Context {inv_names : invariants.invG}.
+
 Lemma corable_funspec_sub_si f g: corable (funspec_sub_si f g).
 Proof.
  unfold funspec_sub_si; intros.
@@ -358,6 +362,8 @@ Proof.
   apply corable_andp. apply corable_prop.
   apply corable_func_at.
 Qed.
+
+End invs.
 
 #[export] Hint Resolve corable_func_ptr corable_func_ptr_si (*corable_func_ptr_early*) : core.
 

--- a/veric/bi.v
+++ b/veric/bi.v
@@ -83,32 +83,6 @@ Proof.
     pose proof (necR_level _ _ Ha'); apply ext_level in Hext; lia.
 Qed.
 
-Lemma wand_nonexpansive_l: forall P Q n,
-  approx n (P -* Q)%pred = approx n (approx n P  -* Q)%pred.
-Proof.
-  repeat intro.
-  apply predicates_hered.pred_ext; intros ? [? Hshift]; split; auto; intros ??????.
-  - destruct H2; eauto.
-  - eapply Hshift; eauto; split; auto.
-    apply necR_level in H0; apply join_level in H1 as []; lia.
-Qed.
-
-Lemma wand_nonexpansive_r: forall P Q n,
-  approx n (P -* Q)%pred = approx n (P  -* approx n Q)%pred.
-Proof.
-  repeat intro.
-  apply predicates_hered.pred_ext; intros ? [? Hshift]; split; auto; intros ??????.
-  - split; eauto.
-    apply necR_level in H0; apply join_level in H1 as []; lia.
-  - eapply Hshift; eauto.
-Qed.
-
-Lemma wand_nonexpansive: forall P Q n,
-  approx n (P -* Q)%pred = approx n (approx n P  -* approx n Q)%pred.
-Proof.
-  intros; rewrite wand_nonexpansive_l wand_nonexpansive_r; reflexivity.
-Qed.
-
 Lemma core_ext_ord : forall (a b : rmap), join_sub a b -> ext_order (core a) (core b).
 Proof.
   intros.

--- a/veric/bi.v
+++ b/veric/bi.v
@@ -326,21 +326,21 @@ Proof.
     contradiction (H _ H0).
 Qed.
 
-Definition fupd E1 E2 P := ghost_seplog.fupd (coPset_to_Ensemble E1) (coPset_to_Ensemble E2) P.
-
-Lemma mpred_fupd_mixin : BiFUpdMixin mpredI fupd.
+Lemma mpred_fupd_mixin : BiFUpdMixin mpredI (fun E1 E2 => ghost_seplog.fupd (coPset_to_Ensemble E1) (coPset_to_Ensemble E2)).
 Proof.
   split.
   - repeat intro; hnf in *.
     rewrite fupd_nonexpansive; setoid_rewrite fupd_nonexpansive at 2.
     rewrite H; auto.
-  - intros; apply fupd_mask_subseteq.
-    intros ?; unfold coPset_to_Ensemble, Ensembles.In.
-    set_solver.
+  - intros; unfold updates.fupd.
+    apply subseteq_disjoint_union_L in H as (E1' & ? & ?); subst.
+    rewrite coPset_to_Ensemble_union invariants.Union_comm.
+    apply fupd_mask_union, coPset_to_Ensemble_disjoint.
+    symmetry; auto.
   - intros; apply except_0_fupd.
   - intros; apply fupd_mono; auto.
   - intros; apply fupd_trans.
-  - intros; unfold updates.fupd, fupd.
+  - intros; unfold updates.fupd.
     iIntros "H".
     rewrite !coPset_to_Ensemble_union.
     rewrite <- coPset_to_Ensemble_disjoint in H |- *.
@@ -529,5 +529,7 @@ Canonical Structure env_mpredSI : sbi :=
 Ltac iVST := iStopProof; match goal with |-bi_entails ?P ?Q => change (P |-- Q) end;
   repeat match goal with |-context[bi_sep ?P ?Q] => change (bi_sep P Q) with (P * Q) end.
 
+Global Close Scope logic_upd. (* hide non-Iris update notation *)
 Global Open Scope Z.
 Global Open Scope logic.
+Global Open Scope bi_scope.

--- a/veric/bi.v
+++ b/veric/bi.v
@@ -15,8 +15,7 @@ Arguments Z.to_nat : simpl nomatch.
     (this is a bit annoying because of the difference in precedence of derives)
 *)
 
-Require Import VST.veric.compcert_rmaps.
-Require Import VST.veric.SeparationLogic.
+From VST.veric Require Import compcert_rmaps SeparationLogic.
 
 Notation "'emp'" := seplog.emp.
 

--- a/veric/compcert_rmaps.v
+++ b/veric/compcert_rmaps.v
@@ -307,6 +307,17 @@ Proof.
  exists (c x0); apply join_comm; apply H0.
 Qed.
 
+#[(*export, after Coq 8.13*)global] Instance Disj_resource: Disj_alg resource.
+Proof.
+intros ?? J.
+inv J.
+- apply join_self, identity_share_bot in RJ; subst.
+  apply NO_identity.
+- apply join_self, identity_share_bot in RJ; subst.
+  apply bot_unreadable in rsh0 as [].
+- apply PURE_identity.
+Qed.
+
 #[(*export, after Coq 8.13*)global] Instance Trip_resource: Trip_alg resource.
 Proof.
 intro; intros.

--- a/veric/expr.v
+++ b/veric/expr.v
@@ -1162,6 +1162,10 @@ Lemma binary_intersection_retty {phi1 phi2 phi} (BI : binary_intersection phi1 p
       rettype_of_funspec phi1 = rettype_of_funspec phi.
 Proof. unfold rettype_of_funspec. rewrite (binary_intersection_typesig BI); trivial. Qed.
 
+Section invs.
+
+Context {inv_names : invariants.invG}.
+
 (* If we were to require that a non-void-returning function must,
    at a function call, have its result assigned to a temp,
    then we could change "ret0_tycon" to "ret_tycon" in this
@@ -1229,6 +1233,8 @@ Proof.
   * intros. apply subsumespec_refl.
   * intros. eapply Annotation_sub_refl.
 Qed.
+
+End invs.
 
 (*************************************)
 

--- a/veric/expr_lemmas.v
+++ b/veric/expr_lemmas.v
@@ -484,6 +484,10 @@ match (temp_types Delta) ! id with
 | None => false
 end.
 
+Section invs.
+
+Context {inv_names : invariants.invG}.
+
 Lemma typecheck_tid_ptr_compare_sub:
    forall Delta Delta',
     tycontext_sub Delta Delta' ->
@@ -498,6 +502,8 @@ destruct ((temp_types Delta) ! id) as [? |]; try discriminate.
 destruct ((temp_types Delta') ! id) as [? |]; try contradiction.
  destruct H; subst; auto.
 Qed.
+
+End invs.
 
 Lemma int64_eq_e:
  forall i j, Int64.eq i j = true -> i=j.

--- a/veric/extend_tc.v
+++ b/veric/extend_tc.v
@@ -34,7 +34,7 @@ Definition tc_temp_id_load id tfrom Delta v : environ -> mpred  :=
 fun rho => !! (exists tto, (temp_types Delta) ! id = Some tto
                       /\ tc_val tto (eval_cast tfrom tto (v rho))).
 
-Lemma extend_prop: forall P, boxy extendM (prop P).
+Lemma extend_prop: forall P, boxy extendM (prop P : mpred).
 Proof.
 intros.
 hnf.
@@ -58,6 +58,8 @@ Proof.
 intros.
 rewrite denote_tc_assert_andp.
 apply boxy_andp; auto.
+intros ?; hnf.
+exists (core x); apply join_comm, core_unit.
 Qed.
 
 Lemma extend_tc_bool:
@@ -131,7 +133,7 @@ rewrite H1 in H.
 inv H; auto.
 Qed.
 
-Lemma extend_andp: forall P Q, 
+Lemma extend_andp: forall (P Q : mpred),
   boxy extendM P -> boxy extendM Q -> boxy extendM (andp P Q).
 Proof.
  intros.
@@ -140,7 +142,7 @@ Proof.
  destruct H2; split; eapply boxy_e; eauto.
 Qed.
 
-Lemma extend_orp: forall P Q, 
+Lemma extend_orp: forall (P Q : mpred), 
   boxy extendM P -> boxy extendM Q -> boxy extendM (orp P Q).
 Proof.
  intros.
@@ -325,6 +327,7 @@ Proof.
 intros.
 rewrite denote_tc_assert_orp.
 apply boxy_orp; auto.
+intros ?; eexists; apply join_comm, core_unit.
 Qed.
 
 
@@ -356,6 +359,7 @@ Lemma extend_tc_andp':
 Proof.
 intros.
 apply boxy_andp; auto.
+intros ?; eexists; apply join_comm, core_unit.
 Qed.
 
 Ltac extend_tc_prover := 

--- a/veric/fupd.v
+++ b/veric/fupd.v
@@ -316,16 +316,21 @@ Proof.
     constructor; auto.
 Qed.*)
 
-Lemma fupd_andp_prop : forall E1 E2 P Q, !! P && fupd E1 E2 Q |-- fupd E1 E2 (!!P && Q).
+Lemma fupd_andp_corable : forall E1 E2 P Q, corable P -> P && fupd E1 E2 Q |-- fupd E1 E2 (P && Q).
 Proof.
   unfold fupd; intros.
   rewrite <- wand_sepcon_adjoint.
-  rewrite sepcon_andp_prop1.
+  rewrite corable_andp_sepcon1 by auto.
   eapply derives_trans; [apply andp_derives; [apply derives_refl | rewrite sepcon_comm; apply modus_wand]|].
-  rewrite <- bupd_andp_prop; apply bupd_mono.
+  rewrite <- bupd_andp_corable by auto; apply bupd_mono.
   rewrite andp_comm, distrib_orp_andp; apply orp_derives.
   - apply andp_left1; auto.
-  - rewrite sepcon_andp_prop, andp_comm; auto.
+  - rewrite corable_sepcon_andp1, andp_comm; auto.
+Qed.
+
+Lemma fupd_andp_prop : forall E1 E2 P Q, !! P && fupd E1 E2 Q |-- fupd E1 E2 (!!P && Q).
+Proof.
+  intros; apply fupd_andp_corable, corable_prop.
 Qed.
 
 Lemma unfash_sepcon: forall P (Q : pred rmap), !P * Q |-- !P.
@@ -508,3 +513,6 @@ Global Opaque fupd.*)
 
 (* Consider putting rules for invariants and fancy updates in msl (a la ghost_seplog), and proofs
    in veric (a la own). *)
+
+Notation "|={ E1 , E2 }=> P" := (fupd E1 E2 P) (at level 99, E1 at level 50, E2 at level 50, P at level 200): pred.
+Notation "|={ E }=> P" := (fupd E E P) (at level 99, E at level 50, P at level 200): pred.

--- a/veric/fupd.v
+++ b/veric/fupd.v
@@ -11,6 +11,13 @@ Definition timeless' (P : pred rmap) := forall (a a' : rmap),
   predicates_hered.app_pred P a' -> age a a' ->
   predicates_hered.app_pred P a.
 
+Lemma list_set_replace : forall {A} n l (a : A), (n < length l)%nat ->
+  own.list_set l n a = replace_nth n l (Some a).
+Proof.
+  induction n; destruct l; unfold own.list_set; auto; simpl; try lia; intros.
+  setoid_rewrite IHn; auto; lia.
+Qed.
+
 Lemma own_timeless : forall {P : Ghost} g (a : G), timeless' (own(RA := P) g a NoneP).
 Proof.
   intros ????? (v & ? & Hg) ?.
@@ -18,30 +25,46 @@ Proof.
   split.
   + intros; eapply age1_resource_at_identity; eauto.
   + erewrite age1_ghost_of in Hg by eauto.
-    erewrite own.ghost_fmap_singleton in *.
-    apply own.ghost_fmap_singleton_inv in Hg as ([] & -> & Heq).
-    inv Heq.
-    destruct p; inv H3.
-    simpl; repeat f_equal.
-    extensionality l.
-    destruct (_f l); auto.
+    erewrite own.ghost_fmap_singleton in *; simpl in *.
+    destruct Hg as [? Hg]; apply singleton_join_inv_gen in Hg as (J & ? & Hnth & ?).
+    setoid_rewrite (map_nth _ _ None) in Hnth; setoid_rewrite (map_nth _ _ None) in J.
+    destruct (nth g (ghost_of a0) None) as [(?, ?)|] eqn: Hga; [|inv J].
+    rewrite <- (list_set_same _ _ _ Hga).
+    assert (g < length (ghost_of a0))%nat.
+    { destruct (lt_dec g (length (ghost_of a0))); auto.
+      rewrite -> nth_overflow in Hga by lia; discriminate. }
+    inv J.
+    * erewrite list_set_replace, <- replace_nth_replace_nth, <- list_set_replace; rewrite ?replace_nth_length; auto.
+      eexists; apply singleton_join_gen; rewrite -> nth_replace_nth by auto.
+      destruct p; inv H7.
+      replace _f with (fun _ : list Type => tt).
+      apply lower_None2.
+      { extensionality i; destruct (_f i); auto. }
+    * destruct a2, p, H6 as (? & ? & ?); simpl in *; subst.
+      inv H6.
+      erewrite list_set_replace, <- replace_nth_replace_nth, <- list_set_replace; rewrite ?replace_nth_length; auto.
+      eexists; apply singleton_join_gen; rewrite -> nth_replace_nth by auto.
+      constructor.
+      instantiate (1 := (_, _)).
+      split; simpl; [|split; auto]; eauto.
+      f_equal.
+      extensionality i; destruct (_f i); auto.
 Qed.
 
 Lemma address_mapsto_timeless : forall m v sh p, timeless' (res_predicates.address_mapsto m v sh p).
 Proof.
   repeat intro.
   simpl in *.
-  destruct H as (b & [? HYES] & ?); exists b; split; [split|]; auto.
+  destruct H as (b & [? HYES]); exists b; split; auto.
   intro b'; specialize (HYES b').
   if_tac.
   - destruct HYES as (rsh & Ha'); exists rsh.
     erewrite age_resource_at in Ha' by eauto.
     destruct (a @ b'); try discriminate; inv Ha'.
-    destruct p0; inv H6; simpl.
+    destruct p0; inv H5; simpl.
     f_equal.
     apply proof_irr.
   - rewrite age1_resource_at_identity; eauto.
-  - rewrite age1_ghost_of_identity; eauto.
 Qed.
 
 Lemma timeless_FF : timeless' FF.
@@ -55,31 +78,56 @@ Lemma nonlock_permission_bytes_timeless : forall sh l z,
 Proof.
   repeat intro.
   simpl in *.
-  destruct H; split.
-  intro b'; specialize (H b').
+  specialize (H b).
   if_tac.
   - erewrite age1_resource_at in H by (erewrite ?resource_at_approx; eauto).
-    destruct (a @ b'); auto.
+    destruct (a @ b); auto.
   - rewrite age1_resource_at_identity; eauto.
-  - rewrite age1_ghost_of_identity; eauto.
 Qed.
 
 Lemma emp_timeless : timeless' emp.
 Proof.
   intros ????.
-  apply all_resource_at_identity.
-  - intro.
-    eapply age1_resource_at_identity; eauto.
-    eapply resource_at_identity; eauto.
-  - eapply age1_ghost_of_identity; eauto.
-    eapply ghost_of_identity; eauto.
+  setoid_rewrite res_predicates.emp_no in H.
+  setoid_rewrite res_predicates.emp_no.
+  intros l.
+  eapply age1_resource_at_identity, H; auto.
 Qed.
 
-Local Set Universe Polymorphism.
+Lemma sepcon_timeless : forall P Q, timeless' P -> timeless' Q ->
+  timeless' (P * Q)%pred.
+Proof.
+  intros ?????? (? & ? & J & ? & ?) ?.
+  eapply unage_join2 in J as (? & ? & ? & ? & ?); eauto.
+  do 3 eexists; eauto.
+Qed.
+
+Lemma exp_timeless : forall {A} (P : A -> pred rmap), (forall x, timeless' (P x)) ->
+  timeless' (exp P).
+Proof.
+  intros ????? [? HP] Hage.
+  eapply H in Hage; eauto.
+  exists x; auto.
+Qed.
+
+Lemma andp_timeless : forall P Q, timeless' P -> timeless' Q ->
+  timeless' (P && Q)%pred.
+Proof.
+  intros ?????? [] ?; split; eauto.
+Qed.
 
 Section FancyUpdates.
 
 Context {inv_names : invG}.
+
+Lemma join_preds : forall a b c d e, join(Join := Join_lower (Join_prod _ ghost_elem_join _ preds_join)) (Some (a, b)) c (Some (d, e)) ->
+  b = e.
+Proof.
+  intros.
+  inv H; auto.
+  destruct H3 as [_ H]; simpl in H.
+  inv H; auto.
+Qed.
 
 Definition fupd E1 E2 P :=
   ((wsat * ghost_set g_en E1) -* |==> |>FF || (wsat * ghost_set g_en E2 * P))%pred.
@@ -153,12 +201,12 @@ Proof.
   intros; erewrite sepcon_comm, (sepcon_comm P Q); apply fupd_frame_r.
 Qed.
 
-(* This is a generally useful pattern. *)
+(*(* This is a generally useful pattern. *)
 Lemma bupd_mono' : forall P Q (a : rmap) (Himp : (P >=> Q)%pred (level a)),
   app_pred (bupd P) a -> app_pred (bupd Q) a.
 Proof.
   intros.
-  assert (app_pred ((|==> P * approx (S (level a)) emp)) a) as HP'.
+  assert (app_pred ((|==> P * approx (S (level a)) emp))%pred a) as HP'.
   { apply (bupd_frame_r _ _ a).
     do 3 eexists; [apply join_comm, core_unit | split; auto].
     split; [|apply core_identity].
@@ -186,7 +234,7 @@ Proof.
   destruct (join_level _ _ _ J).
   apply join_comm, Hemp in J; subst.
   eapply Himp in HP; try apply necR_refl; auto; lia.
-Qed.
+Qed.*)
 
 Lemma fupd_bupd : forall E1 E2 P Q, (P |-- (|==> (|={E1,E2}=> Q))) -> P |-- |={E1,E2}=> Q.
 Proof.
@@ -203,18 +251,7 @@ Proof.
   intros; eapply derives_trans, bupd_fupd; apply bupd_intro.
 Qed.
 
-(*Lemma fupd_nonexpansive: forall E1 E2 P n, approx n (|={E1,E2}=> P) = approx n (|={E1,E2}=> approx n P).
-Proof.
-  intros; unfold fupd.
-  rewrite wand_nonexpansive; setoid_rewrite wand_nonexpansive at 2.
-  f_equal; f_equal.
-  rewrite !approx_bupd; f_equal.
-  unfold sbi_except_0.
-  setoid_rewrite approx_orp; f_equal.
-  erewrite !approx_sepcon, approx_idem; reflexivity.
-Qed.
-
-Corollary fview_shift_nonexpansive : forall E1 E2 P Q n,
+(*Corollary fview_shift_nonexpansive : forall E1 E2 P Q n,
   approx n (P -* |={E1,E2}=> Q)%logic = approx n (approx n P  -* |={E1,E2}=> approx n Q)%logic.
 Proof.
   intros.
@@ -291,22 +328,60 @@ Proof.
   - rewrite sepcon_andp_prop, andp_comm; auto.
 Qed.
 
+Lemma unfash_sepcon: forall P (Q : pred rmap), !P * Q |-- !P.
+Proof.
+  intros ??? (? & ? & J & ? & ?); simpl in *.
+  apply join_level in J as [<- _]; auto.
+Qed.
+
+Lemma bupd_unfash: forall P, bupd (! P) |-- ! P.
+Proof.
+  repeat intro; simpl in *.
+  destruct (H (core (ghost_of a))) as (? & ? & ? & <- & ? & ? & ?); auto.
+  rewrite <- ghost_of_approx at 1; eexists; apply ghost_fmap_join, join_comm, core_unit.
+Qed.
+
+Lemma bupd_andp_unfash: forall P Q, (bupd (!P && Q) = !P && bupd Q)%pred.
+Proof.
+  intros; apply pred_ext.
+  - apply andp_right.
+    + eapply derives_trans; [apply bupd_mono, andp_left1, derives_refl|].
+      apply bupd_unfash.
+    + apply bupd_mono, andp_left2, derives_refl.
+  - intros ? [? HQ] ? J.
+    destruct (HQ _ J) as (? & ? & a' & Hl & ? & ? & ?); subst.
+    eexists; split; eauto.
+    exists a'; repeat (split; auto).
+    simpl in *.
+    rewrite Hl; auto.
+Qed.
+
 Lemma fupd_andp_unfash: forall E1 E2 P Q, !P && fupd E1 E2 Q |-- fupd E1 E2 (!P && Q).
 Proof.
   unfold fupd; intros.
   rewrite <- wand_sepcon_adjoint.
   eapply derives_trans; [apply andp_right|].
-  { eapply derives_trans, seplog.unfash_sepcon.
+  { eapply derives_trans, unfash_sepcon.
     apply sepcon_derives, derives_refl; apply andp_left1; auto. }
   { apply sepcon_derives, derives_refl; apply andp_left2, derives_refl. }
   eapply derives_trans; [apply andp_derives; [apply derives_refl | rewrite sepcon_comm; apply modus_wand]|].
-  rewrite <- seplog.bupd_andp_unfash.
+  rewrite <- bupd_andp_unfash.
   apply bupd_mono.
   rewrite andp_comm, distrib_orp_andp; apply orp_derives.
   - apply andp_left1; auto.
   - rewrite andp_comm, unfash_sepcon_distrib; apply sepcon_derives; auto.
     apply andp_left2; auto.
 Qed.
+
+Lemma subp_fupd : forall (G : pred nat) E (P P' : pred rmap),
+  (G |-- P >=> P' -> G |-- (fupd E E P) >=> (fupd E E P'))%pred.
+Proof.
+  intros; unfold fupd.
+  apply sub_wand; [apply subp_refl|].
+  apply subp_bupd, subp_orp; [apply subp_refl|].
+  apply subp_sepcon; auto; apply subp_refl.
+Qed.
+
 
 (*Lemma fupd_prop' : forall E1 E2 E2' P Q, subseteq E1 E2 ->
   (Q |-- (|={E1,E2'}=> !!P) ->

--- a/veric/fupd.v
+++ b/veric/fupd.v
@@ -538,19 +538,5 @@ Qed.*)
 
 End Invariants.
 
-(*Lemma inv_in : forall i, elem_of (Pos.of_nat (S i)) (inv i).
-Proof.
-  intros; rewrite elem_of_singleton; reflexivity.
-Qed.
-Hint Resolve inv_in : ghost.
-
-(* avoids some fragility in tactics *)
-Definition except0 : mpred -> mpred := sbi_except_0.
-
-Global Opaque fupd.*)
-
-(* Consider putting rules for invariants and fancy updates in msl (a la ghost_seplog), and proofs
-   in veric (a la own). *)
-
 Notation "|={ E1 , E2 }=> P" := (fupd E1 E2 P) (at level 99, E1 at level 50, E2 at level 50, P at level 200): pred.
 Notation "|={ E }=> P" := (fupd E E P) (at level 99, E at level 50, P at level 200): pred.

--- a/veric/fupd.v
+++ b/veric/fupd.v
@@ -298,8 +298,14 @@ Proof.
   { eapply derives_trans; [apply sepcon_derives, now_later; apply derives_refl|].
     rewrite <- later_sepcon; apply later_derives.
     rewrite FF_sepcon; auto. }
-  
-Admitted.
+  rewrite (sepcon_assoc _ _ (_ --> _)%pred), (sepcon_comm _ (_ --> _)%pred).
+  rewrite <- sepcon_assoc, sepcon_assoc, ghost_set_join.
+  rewrite sepcon_andp_prop; apply prop_andp_left; intros.
+  rewrite !sepcon_assoc; apply sepcon_derives; auto.
+  rewrite sepcon_comm; apply sepcon_derives; auto.
+  rewrite normalize.true_eq by auto.
+  intros ??; apply imp_lem0; auto.
+Qed.
 
 End FancyUpdates.
 

--- a/veric/fupd.v
+++ b/veric/fupd.v
@@ -262,20 +262,22 @@ Proof.
   rewrite FF_sepcon; auto.
 Qed.
 
-Lemma fupd_mask_subseteq : forall E1 E2, Included E2 E1 ->
-    emp |-- fupd E1 E2 (fupd E2 E1 emp).
+Lemma fupd_mask_union : forall E1 E2, Disjoint E1 E2 ->
+    emp |-- fupd (Union E1 E2) E2 (fupd E2 (Union E1 E2) emp).
 Proof.
   intros; unfold fupd.
   rewrite <- wand_sepcon_adjoint.
-  erewrite ghost_set_subset; eauto.
+  rewrite <- (prop_true_andp _ (ghost_set _ _) H) at 1.
+  rewrite <- ghost_set_join.
   eapply derives_trans, bupd_intro.
   apply orp_right2.
-  rewrite emp_sepcon, <- sepcon_assoc; apply sepcon_derives; auto.
+  rewrite emp_sepcon, (sepcon_comm _ (ghost_set _ _)), <- sepcon_assoc; apply sepcon_derives; auto.
   rewrite <- wand_sepcon_adjoint.
   eapply derives_trans, bupd_intro.
   apply orp_right2.
-  rewrite sepcon_comm, sepcon_emp; auto.
-Admitted. (* decision on nat -> Prop *)
+  rewrite sepcon_comm, sepcon_emp.
+  rewrite sepcon_assoc, (sepcon_comm (ghost_set _ _)), ghost_set_join, prop_true_andp; auto.
+Qed.
 
 Lemma except_0_fupd : forall E1 E2 P, ((|> FF) || fupd E1 E2 P) |-- fupd E1 E2 P.
 Proof.

--- a/veric/initial_world.v
+++ b/veric/initial_world.v
@@ -512,6 +512,126 @@ rewrite <- approx_oo_approx.
 auto.
 Qed.
 
+(* The initial state is compatible with the ghost-state machinery for invariants. *)
+
+Require Import VST.veric.invariants.
+Require Import VST.veric.juicy_extspec.
+
+Definition wsat_ghost : ghost :=
+  (None ::
+   Some (existT _ (ghosts.snap_PCM(ORD := list_order own.gname)) (exist _ (Tsh, nil) I), NoneP) ::
+   Some (existT _ set_PCM (exist _ Ensembles.Full_set I), NoneP) ::
+   Some (existT _ (list_PCM token_PCM) (exist _ nil I), NoneP) ::
+   nil).
+
+Program Definition wsat_rmap (r : rmap) :=
+  proj1_sig (make_rmap (resource_at (core r)) wsat_ghost (level r) _ _).
+Next Obligation.
+Proof.
+  extensionality l; unfold compose. rewrite <- core_resource_at. apply resource_fmap_core.
+Qed.
+
+Lemma wsat_rmap_wsat : forall r, (wsat * ghost_set g_en Ensembles.Full_set)%pred (wsat_rmap r).
+Proof.
+  intros.
+  unfold wsat.
+  do 3 (rewrite exp_sepcon1; exists nil).
+  rewrite prop_true_andp by auto.
+  rewrite !sepcon_assoc, (sepcon_comm (iter_sepcon _ _)).
+  rewrite <- (sepcon_assoc (ghost_set _ _)), ghost_set_join.
+  replace (fun i : iname => nth i nil None = Some false) with (Ensembles.Empty_set(U := iname)).
+  rewrite prop_true_andp, Union_Empty.
+  destruct (make_rmap (resource_at (core r)) (None :: Some (existT _ (ghosts.snap_PCM(ORD := list_order own.gname)) (exist _ (Tsh, nil) I), NoneP) :: nil) (level r))
+    as (r_inv & ? & Hr1 & Hg1).
+  { extensionality l; unfold compose. rewrite <- core_resource_at. apply resource_fmap_core. }
+  { auto. }
+  destruct (make_rmap (resource_at (core r)) (None :: None :: Some (existT _ set_PCM (exist _ Ensembles.Full_set I), NoneP) ::
+   Some (existT _ (list_PCM token_PCM) (exist _ nil I), NoneP) :: nil) (level r))
+    as (r_rest & ? & Hr2 & Hg2).
+  { extensionality l; unfold compose. rewrite <- core_resource_at. apply resource_fmap_core. }
+  { auto. }
+  exists r_inv, r_rest; split.
+  { unfold wsat_rmap; apply resource_at_join2; rewrite ?level_make_rmap, ?resource_at_make_rmap, ?ghost_of_make_rmap; auto.
+    + intros; rewrite Hr1, Hr2; apply resource_at_join, core_duplicable.
+    + rewrite Hg1, Hg2; unfold wsat_ghost; repeat constructor. }
+  split.
+  - simpl.
+    exists I.
+    rewrite Hr1, Hg1; split.
+    + apply resource_at_core_identity.
+    + apply join_sub_refl.
+  - destruct (make_rmap (resource_at (core r)) (None :: None :: Some (existT _ set_PCM (exist _ Ensembles.Full_set I), NoneP) ::
+     None :: nil) (level r))
+      as (r_en & ? & Hr3 & Hg3).
+    { extensionality l; unfold compose. rewrite <- core_resource_at. apply resource_fmap_core. }
+    { auto. }
+    destruct (make_rmap (resource_at (core r)) (None :: None :: None ::
+     Some (existT _ (list_PCM token_PCM) (exist _ nil I), NoneP) :: nil) (level r))
+      as (r_dis & ? & Hr4 & Hg4).
+    { extensionality l; unfold compose. rewrite <- core_resource_at. apply resource_fmap_core. }
+    { auto. }
+    exists r_dis, r_en; split.
+    { apply resource_at_join2; try congruence.
+      + intros; rewrite Hr2, Hr3, Hr4; apply resource_at_join, core_duplicable.
+      + rewrite Hg2, Hg3, Hg4; repeat constructor. }
+    simpl iter_sepcon; rewrite sepcon_emp.
+    split; simpl.
+    + exists I.
+      rewrite Hr4, Hg4; split.
+      * apply resource_at_core_identity.
+      * apply join_sub_refl.
+    + exists I.
+      rewrite Hr3, Hg3; split.
+      * apply resource_at_core_identity.
+      * eexists; repeat constructor.
+  - constructor; intros ? X; inv X.
+    inv H.
+  - apply Ensembles.Extensionality_Ensembles; split; intros; intros ??; unfold Ensembles.In in *.
+    + inv H.
+    + destruct x; inv H.
+Qed.
+
+Lemma wsat_no : forall r, (ALL l, noat l) (wsat_rmap r).
+Proof.
+  simpl; intros; unfold wsat_rmap.
+  rewrite resource_at_make_rmap; apply resource_at_core_identity.
+Qed.
+
+Corollary wsat_rmap_resource : forall r r', join r (wsat_rmap r) r' -> resource_at r' = resource_at r.
+Proof.
+  intros.
+  extensionality l; apply (resource_at_join _ _ _ l) in H.
+  apply join_comm, wsat_no in H; auto.
+Qed.
+
+Lemma wsat_rmap_ghost : forall r r', joins r (wsat_rmap r) -> level r' = level r -> ghost_of r' = ghost_of r ->
+  joins r' (wsat_rmap r').
+Proof.
+  intros ?? [z ?] Hl Hg.
+  destruct (make_rmap (resource_at r') (ghost_of z) (level r')) as (z' & ? & Hr' & Hg').
+  { extensionality l; apply resource_at_approx. }
+  { rewrite Hl; apply join_level in H as [->]; apply ghost_of_approx. }
+  exists z'; apply resource_at_join2; auto.
+  - unfold wsat_rmap; rewrite level_make_rmap; auto.
+  - intros l; apply (resource_at_join _ _ _ l) in H.
+    unfold wsat_rmap; rewrite resource_at_make_rmap, Hr'.
+    apply join_comm, resource_at_join, core_unit.
+  - rewrite Hg, Hg'.
+    apply ghost_of_join in H.
+    unfold wsat_rmap in *; rewrite ghost_of_make_rmap in *; auto.
+Qed.
+
+Lemma age_to_wsat_rmap : forall n r, (n <= level r)%nat -> age_to n (wsat_rmap r) = wsat_rmap (age_to n r).
+Proof.
+  intros; apply rmap_ext.
+  - unfold wsat_rmap; rewrite level_make_rmap, !level_age_to; auto.
+    rewrite level_make_rmap; auto.
+  - intros; unfold wsat_rmap; rewrite resource_at_make_rmap, <- core_resource_at, !age_to_resource_at,
+      resource_at_make_rmap.
+    rewrite <- core_resource_at, resource_fmap_core'; auto.
+  - unfold wsat_rmap; rewrite ghost_of_make_rmap, !age_to_ghost_of, ghost_of_make_rmap; auto.
+Qed.
+
 Lemma list_disjoint_rev2:
    forall A (l1 l2: list A), list_disjoint l1 (rev l2) = list_disjoint l1 l2.
 Proof.

--- a/veric/juicy_extspec.v
+++ b/veric/juicy_extspec.v
@@ -618,6 +618,8 @@ Section juicy_safety.
   | jsafeN_step:
       forall z c m c' m',
       jstep Hcore c m c' m' ->
+        (* For full generality, we'd parameterize by a mask E here, but that would
+           have to propagate all the way up to semax. *)
         jm_fupd z Ensembles.Full_set Ensembles.Full_set (jsafeN_ z c') m' ->
       jsafeN_ z c m
   | jsafeN_external:

--- a/veric/juicy_extspec.v
+++ b/veric/juicy_extspec.v
@@ -295,15 +295,11 @@ Proof.
 Qed.
 
 Lemma jm_bupd_mono : forall {Z} (ora : Z) (P1 P2 : juicy_mem -> Prop) m, jm_bupd ora P1 m ->
-  (forall m', level m' <= level m -> P1 m' -> P2 m') -> jm_bupd ora P2 m.
+  (forall m', jm_update m m' -> P1 m' -> P2 m') -> jm_bupd ora P2 m.
 Proof.
   intros ?????? Hmono.
   intros ? HC J.
   destruct (H _ HC J) as (? & ? & ? & ?); eauto.
-  assert (level x = level m) by (unfold jm_update in *; tauto).
-  eexists; split; eauto; split; auto.
-  apply Hmono; auto.
-  replace (level x) with (level m); reflexivity.
 Qed.
 
 Lemma ext_join_approx : forall {Z} (z : Z) n g,
@@ -372,115 +368,7 @@ Proof.
   rewrite <- Hl'', Hl'; eexists; eauto.
 Qed.
 
-(*(* Just like we reserve ghost name 0 for the external ghost, we reserve 1-3 for invariants/world satisfaction.
-  Presumably we'll have to prove that this isn't vacuous somewhere in the soundness proof.
-  We could delay the instantiation and be generic in inv_names, but since we know we'll always need it and we get to allocate it
-  before the program starts, I don't see any reason to hold off. *)
-#[(*export, after Coq 8.13*)global] Instance inv_names : invG := { g_inv := 1%nat; g_en := 2%nat; g_dis := 3%nat}.
-
-Polymorphic Definition jm_fupd {Z} (ora : Z) (E1 E2 : Ensembles.Ensemble gname) P m :=
-  forall m' w z, necR m m' -> join (m_phi m') w (m_phi z) -> app_pred (wsat * ghost_set g_en E1) w ->
-  jm_bupd ora (fun z2 => level z2 = 0 \/ exists m2 w2, join (m_phi m2) w2 (m_phi z2) /\
-    app_pred (wsat * ghost_set g_en E2) w2 /\ P m2) z.
-
-Polymorphic Lemma jm_fupd_intro: forall {Z} (ora : Z) E (P : juicy_mem -> Prop) m (HP : forall a b, P a -> necR a b -> P b),
-  P m -> jm_fupd ora E E P m.
-Proof.
-  intros.
-  intros ??????.
-  apply jm_bupd_intro; eauto 7.
-Qed.
-
-Polymorphic Lemma jm_fupd_age : forall {Z} (ora : Z) E1 E2 (P : juicy_mem -> Prop) m m', jm_fupd ora E1 E2 P m ->
-  age m m' -> jm_fupd ora E1 E2 P m'.
-Proof.
-  intros.
-  intros ??????.
-  eapply H; [|eauto | eauto].
-  eapply necR_trans; [|eauto].
-  constructor; auto.
-Qed.
-
-Polymorphic Lemma jm_fupd_mono : forall {Z} (ora : Z) E1 E2 (P1 P2 : juicy_mem -> Prop) m, jm_fupd ora E1 E2 P1 m ->
-  (forall m', level m' <= level m -> P1 m' -> P2 m') -> jm_fupd ora E1 E2 P2 m.
-Proof.
-  intros ???????? Hmono.
-  intros ??? Hlater J HW.
-  eapply H in HW; eauto.
-  eapply jm_bupd_mono; eauto.
-  intros ?? [|(? & ? & J2 & ? & ?)]; eauto.
-  right; do 3 eexists; eauto; split; auto.
-  apply Hmono; auto.
-  apply necR_level in Hlater.
-  apply join_level in J as [Hl ?].
-  rewrite <- !level_juice_level_phi in Hl.
-  apply join_level in J2 as [Hl2 ?].
-  rewrite <- !level_juice_level_phi in Hl2.
-  lia.
-Qed.*)
-
-Section juicy_safety.
-  Context {G C Z:Type}.
-  Context {genv_symb: G -> injective_PTree block}.
-  Context (Hcore:@CoreSemantics C mem).
-  Variable (Hspec : juicy_ext_spec Z).
-  Variable ge : G.
-
-  Definition Hrel n' m m' :=
-    n' = level m' /\
-    (level m' < level m)%nat /\
-    pures_eq (m_phi m) (m_phi m').
-
-  Inductive jsafeN_:
-    nat -> Z -> C -> juicy_mem -> Prop :=
-  | jsafeN_0: forall z c m, jsafeN_ O z c m
-  | jsafeN_step:
-      forall n z c m c' m',
-      jstep Hcore c m c' m' ->
-      jm_bupd z (jsafeN_ n z c') m' ->
-      jsafeN_ (S n) z c m
-  | jsafeN_external:
-      forall n z c m e args x,
-      j_at_external Hcore c m = Some (e,args) ->
-      ext_spec_pre Hspec e x (genv_symb ge) (sig_args (ef_sig e)) args z m ->
-      (forall ret m' z' n'
-         (Hargsty : Val.has_type_list args (sig_args (ef_sig e)))
-         (Hretty : Builtins0.val_opt_has_rettype  ret (sig_res (ef_sig e))),
-         (n' <= n)%nat ->
-         Hrel n' m m' ->
-         ext_spec_post Hspec e x (genv_symb ge) (sig_res (ef_sig e)) ret z' m' ->
-         exists c',
-           semantics.after_external Hcore ret c (m_dry m') = Some c' /\
-           jm_bupd z' (jsafeN_ n' z' c') m') ->
-      jsafeN_ (S n) z c m
-  | jsafeN_halted:
-      forall n z c m i,
-      semantics.halted Hcore c i ->
-      ext_spec_exit Hspec (Some (Vint i)) z m ->
-      jsafeN_ n z c m.
-
-  Lemma jsafe_downward1 :
-    forall n c m z,
-      jsafeN_ (S n) z c m -> jsafeN_ n z c m.
-  Proof.
-    induction n. econstructor; eauto.
-    intros c m z H. inv H.
-    + econstructor; eauto.
-      eapply jm_bupd_mono; eauto; simpl; intros.
-    + eapply jsafeN_external; eauto.
-    + eapply jsafeN_halted; eauto.
-  Qed.
-
-  Lemma jsafe_downward :
-    forall n n' c m z,
-      Peano.le n' n ->
-      jsafeN_ n z c m -> jsafeN_ n' z c m.
-  Proof.
-    do 6 intro. revert c m z. induction H; auto.
-    intros. apply IHle. apply jsafe_downward1. auto.
-  Qed.
-
-Lemma make_join_ext : forall (ora : Z) a c n,
+Lemma make_join_ext : forall {Z} (ora : Z) a c n,
   join_sub (Some (ext_ref ora, NoneP) :: nil) c ->
   joins (ghost_fmap (approx n) (approx n) a) (ghost_fmap (approx n) (approx n) c) ->
   join_sub (Some (ext_ref ora, NoneP) :: nil) (make_join a c).
@@ -521,93 +409,296 @@ Proof.
       rewrite <- H1; auto.
 Qed.
 
+Lemma jm_bupd_age : forall {Z} (ora : Z) (P : juicy_mem -> Prop) m m', jm_bupd ora P m ->
+  age m m' -> jm_bupd ora (fun m => exists m0, age m0 m /\ P m0) m'.
+Proof.
+  unfold jm_bupd; intros.
+  rewrite (age1_ghost_of _ _ (age_jm_phi H0)) in H2.
+  apply ghost_joins_approx in H2 as [J ?].
+  rewrite <- (age_level _ _ H0) in *.
+  rewrite level_juice_level_phi, ghost_of_approx in J.
+  apply H in J as (b & ? & ? & ?).
+  apply H2 in H3.
+  eapply jm_update_age in H4 as (b' & ? & Hage'); eauto.
+  exists b'; split; eauto.
+  rewrite (age1_ghost_of _ _ (age_jm_phi Hage')).
+  rewrite <- level_juice_level_phi; destruct H4 as (? & -> & _); auto.
+  { eapply make_join_ext; eauto. }
+Qed.
+
+Lemma ext_join_sub : forall (a b : rmap), ext_order a b -> join_sub a b.
+Proof.
+  intros.
+  rewrite rmap_order in H.
+  destruct H as (? & ? & g & ?).
+  destruct (make_rmap (resource_at (core a)) (own.ghost_approx a g) (level a)) as (c & Hl & Hr & Hg).
+  { extensionality l; unfold compose.
+    rewrite <- level_core.
+    apply resource_at_approx. }
+  { rewrite ghost_fmap_fmap, approx_oo_approx; auto. }
+  exists c; apply resource_at_join2; auto.
+  - congruence.
+  - intros; rewrite Hr, <- core_resource_at, H0.
+    apply join_comm, core_unit.
+  - rewrite Hg, <- (ghost_of_approx a), <- (ghost_of_approx b), <- H.
+    apply ghost_fmap_join; auto.
+Qed.
+
+Lemma necR_jm_dry : forall m1 m2, necR m1 m2 -> m_dry m1 = m_dry m2.
+Proof.
+  induction 1; auto.
+  - apply age_jm_dry; auto.
+  - congruence.
+Qed.
+
+Lemma age_to_dry : forall n m, m_dry (age_to.age_to n m) = m_dry m.
+Proof.
+  intros.
+  unfold age_to.age_to.
+  remember (level _ - _) as a eqn: Ha; clear Ha.
+  revert m; induction a; simpl; auto; intros.
+  unfold age_to.age1'; simpl.
+  destruct (age1_juicy_mem _) eqn: Hage; auto.
+  apply age1_juicy_mem_unpack in Hage as [? <-]; auto.
+Qed.
+
+Lemma age_to_phi : forall n m, m_phi (age_to.age_to n m) = age_to.age_to n (m_phi m).
+Proof.
+  intros.
+  unfold age_to.age_to.
+  rewrite level_juice_level_phi.
+  remember (level _ - _) as a eqn: Ha; clear Ha.
+  revert m; induction a; simpl; auto; intros.
+  rewrite <- IHa.
+  unfold age_to.age1'; simpl.
+  destruct (age1 (m_phi _)) eqn: Hage.
+  - edestruct can_age1_juicy_mem as [? Hage']; eauto.
+    setoid_rewrite Hage'.
+    apply age_jm_phi in Hage'.
+    unfold age in Hage'; congruence.
+  - rewrite age1_juicy_mem_None2; auto.
+Qed.
+
+Lemma necR_jm_phi : forall m1 m2, necR m1 m2 <-> m_dry m1 = m_dry m2 /\ necR (m_phi m1) (m_phi m2).
+Proof.
+  split.
+  - intros; split; [apply necR_jm_dry; auto|].
+    induction H; auto.
+    + constructor; apply age_jm_phi; auto.
+    + eapply rt_trans; eauto.
+  - intros [].
+    remember (m_phi m1) as jm1; remember (m_phi m2) as jm2.
+    revert dependent m2; revert dependent m1.
+    induction H0; intros; subst; auto.
+    + constructor.
+      apply age1_juicy_mem_unpack''; auto.
+    + erewrite juicy_mem_ext; [apply rt_refl | ..]; auto.
+    + assert (m_phi (age_to.age_to (level y) m1) = y).
+      { rewrite age_to_phi.
+        symmetry; apply age_to.necR_age_to; auto. }
+      eapply rt_trans; [apply (IHclos_refl_trans1 _ eq_refl (age_to.age_to (level y) m1)) | apply IHclos_refl_trans2]; auto;
+        rewrite age_to_dry; auto.
+Qed.
+
+(* Just like we reserve ghost name 0 for the external ghost, we reserve 1-3 for invariants/world satisfaction.
+  Presumably we'll have to prove that this isn't vacuous somewhere in the soundness proof.
+  We could delay the instantiation and be generic in inv_names, but since we know we'll always need it and we get to allocate it
+  before the program starts, I don't see any reason to hold off. *)
+#[(*export, after Coq 8.13*)global] Instance inv_names : invG := { g_inv := 1%nat; g_en := 2%nat; g_dis := 3%nat}.
+
+Definition jm_fupd {Z} (ora : Z) (E1 E2 : Ensembles.Ensemble gname) P m :=
+  forall m' w z, necR m m' -> join (m_phi m') w (m_phi z) -> app_pred (wsat * ghost_set g_en E1) w ->
+  jm_bupd ora (fun z2 => level z2 = 0 \/ exists m2 w2, join (m_phi m2) w2 (m_phi z2) /\
+    app_pred (wsat * ghost_set g_en E2) w2 /\ P m2) z.
+
+Lemma jm_fupd_intro: forall {Z} (ora : Z) E (P : juicy_mem -> Prop) m (HP : forall a b, P a -> necR a b -> P b),
+  P m -> jm_fupd ora E E P m.
+Proof.
+  intros.
+  intros ??????.
+  apply jm_bupd_intro; eauto 7.
+Qed.
+
+Lemma jm_fupd_age : forall {Z} (ora : Z) E1 E2 (P : juicy_mem -> Prop) m m', jm_fupd ora E1 E2 P m ->
+  age m m' -> jm_fupd ora E1 E2 P m'.
+Proof.
+  intros.
+  intros ??????.
+  eapply H; [|eauto | eauto].
+  eapply necR_trans; [|eauto].
+  constructor; auto.
+Qed.
+
+Lemma jm_fupd_mono : forall {Z} (ora : Z) E1 E2 (P1 P2 : juicy_mem -> Prop) m, jm_fupd ora E1 E2 P1 m ->
+  (forall m', level m' <= level m -> P1 m' -> P2 m') -> jm_fupd ora E1 E2 P2 m.
+Proof.
+  intros ???????? Hmono.
+  intros ??? Hlater J HW.
+  eapply H in HW; eauto.
+  eapply jm_bupd_mono; eauto.
+  intros ?? [|(? & ? & J2 & ? & ?)]; eauto.
+  right; do 3 eexists; eauto; split; auto.
+  apply Hmono; auto.
+  apply necR_level in Hlater.
+  apply join_level in J as [Hl ?].
+  rewrite <- !level_juice_level_phi in Hl.
+  apply join_level in J2 as [Hl2 ?].
+  rewrite <- !level_juice_level_phi in Hl2.
+  destruct H0; lia.
+Qed.
+
+Lemma jm_fupd_ext : forall {Z} (ora : Z) E1 E2 (P : juicy_mem -> Prop) m m', jm_fupd ora E1 E2 P m ->
+  ext_order m m' ->
+  (forall a b, level a <= level m -> ext_order a b -> joins (ghost_of (m_phi b)) (Some (ext_ref ora, NoneP) :: nil) ->
+      P a -> P b) ->
+  jm_fupd ora E1 E2 P m'.
+Proof.
+  intros ??????? H [? Hext] Hclosed ??? Hnec Hj Hwsat.
+  assert (exists z0, join (m_phi (age_to.age_to (level m'0) m)) w (m_phi z0) /\ ext_order z0 z) as (z0 & Hz0 & ?).
+  - eapply nec_ext_commut in Hext as [? Hext' Hnec']; [|apply necR_jm_phi; eauto].
+    eapply join_ext_commut in Hj as (z0 & ? & Hext''); eauto.
+    destruct (juicy_mem_resource z z0) as (jz0 & ? & ?); subst.
+    { apply rmap_order in Hext'' as (? & ? & ?); auto. }
+    apply age_to.necR_age_to in Hnec'.
+    apply rmap_order in Hext' as (Hl' & _); rewrite Hl' in Hnec'; subst.
+    rewrite age_to_phi in *.
+    exists jz0; split; auto; split; auto.
+  - specialize (H _ _ _ (age_to.age_to_necR _ _) Hz0 Hwsat).
+    eapply jm_bupd_ext; [eapply H; eauto | eauto |].
+    apply rmap_order in Hext as (Hl & _); intros ??? [? Hext] ? [? | (? & ? & Hsub & ? & HP)].
+    { rewrite level_juice_level_phi in *.
+      apply rmap_order in Hext as (<- & ? & ?); auto. }
+    pose proof (ext_join_sub _ _ Hext) as [g Hsub'].
+    apply rmap_order in Hext as (_ & Hr' & _).
+    destruct (join_assoc (join_comm Hsub) Hsub') as (? & J' & ?%join_comm).
+    assert (forall c d, join c g d -> resource_at c = resource_at d) as Hid.
+    { intros ?? J1; extensionality l.
+      apply (resource_at_join _ _ _ l) in J1.
+      apply (resource_at_join _ _ _ l) in Hsub'.
+      rewrite Hr' in Hsub'.
+      apply join_comm, unit_identity in Hsub'.
+      eapply Hsub'; eauto. }
+    destruct (juicy_mem_resource x x1) as (? & ? & ?); subst.
+    { symmetry; apply Hid; auto. }
+    right; do 3 eexists; eauto; split; auto.
+    eapply Hclosed, HP.
+    + rewrite !level_juice_level_phi in *; rewrite Hl.
+      apply join_level in Hj as [].
+      destruct H1 as [? Hext]; apply rmap_order in Hext as (? & _).
+      apply join_level in Hsub as [].
+      apply necR_level in Hnec.
+      rewrite !level_juice_level_phi in *; lia.
+    + split; auto.
+      apply rmap_order.
+      split; [apply join_level in J' as []; auto|].
+      split; [|eexists; apply ghost_of_join; eauto]; auto.
+    + eapply join_sub_joins_trans; [eexists; apply ghost_of_join; eauto | auto].
+Qed.
+
+Section juicy_safety.
+  Context {G C Z:Type}.
+  Context {genv_symb: G -> injective_PTree block}.
+  Context (Hcore:@CoreSemantics C mem).
+  Variable (Hspec : juicy_ext_spec Z).
+  Variable ge : G.
+
+  Definition Hrel m m' :=
+    (level m' < level m)%nat /\
+    pures_eq (m_phi m) (m_phi m').
+
+  (* try without N, using level instead *)
+  Inductive jsafeN_:
+    Z -> C -> juicy_mem -> Prop :=
+  | jsafeN_0: forall z c m, level m = 0 -> jsafeN_ z c m
+  (* c.f. iRC11's language, in which NA reads and writes are atomic
+     and can access invariants. All our concurrency features are
+     outside corestep/jstep, so they can provide their own specs
+     if they want to access invariants. So we just need to allow
+     fupds between steps. *)
+  | jsafeN_step:
+      forall z c m c' m',
+      jstep Hcore c m c' m' ->
+        jm_fupd z Ensembles.Full_set Ensembles.Full_set (jsafeN_ z c') m' ->
+      jsafeN_ z c m
+  | jsafeN_external:
+      forall z c m e args x,
+      j_at_external Hcore c m = Some (e,args) ->
+      ext_spec_pre Hspec e x (genv_symb ge) (sig_args (ef_sig e)) args z m ->
+      (forall ret m' z'
+         (Hargsty : Val.has_type_list args (sig_args (ef_sig e)))
+         (Hretty : Builtins0.val_opt_has_rettype  ret (sig_res (ef_sig e))),
+         Hrel m m' ->
+         ext_spec_post Hspec e x (genv_symb ge) (sig_res (ef_sig e)) ret z' m' ->
+         exists c',
+           semantics.after_external Hcore ret c (m_dry m') = Some c' /\
+           jm_fupd z' Ensembles.Full_set Ensembles.Full_set (jsafeN_ z' c') m') ->
+      jsafeN_ z c m
+  | jsafeN_halted:
+      forall z c m i,
+      semantics.halted Hcore c i ->
+      ext_spec_exit Hspec (Some (Vint i)) z m ->
+      jsafeN_ z c m.
+
+Lemma age_jstep : forall c m c' m' m1, jstep Hcore c m c' m' ->
+  age m m1 -> level m1 <> 0 -> exists m1', age m' m1' /\ jstep Hcore c m1 c' m1'.
+Proof.
+  unfold jstep.
+  intros ????? (? & ? & ? & Hg) Hage Hl.
+  destruct (level m') eqn: Hm'.
+  { apply age_level in Hage; lia. }
+  symmetry in Hm'; destruct (levelS_age _ _ Hm') as (m1' & Hage' & ?); subst.
+  exists m1'; split; auto.
+  rewrite <- (age_jm_dry Hage), <- (age_jm_dry Hage'); split; auto.
+  split; [|split].
+  - eapply age_resource_decay; eauto; try (apply age_jm_phi; auto).
+    rewrite <- !level_juice_level_phi; lia.
+  - apply age_level in Hage; lia.
+  - rewrite (age1_ghost_of _ _ (age_jm_phi Hage')), (age1_ghost_of _ _ (age_jm_phi Hage)), Hg.
+    rewrite !ghost_fmap_fmap.
+    apply age_level in Hage.
+    rewrite approx_oo_approx', approx'_oo_approx, approx_oo_approx', approx'_oo_approx; rewrite <- level_juice_level_phi; try lia; auto.
+Qed.
+
+Lemma age_pures_eq : forall m1 m2, age m1 m2 -> pures_eq m1 m2.
+Proof.
+  split; [unfold pures_sub|]; intros l; erewrite (age1_resource_at _ _ H); try (symmetry; apply resource_at_approx);
+    destruct (m1 @ l); simpl; eauto.
+Qed.
+
 Lemma age_safe:
   forall jm jm0, age jm0 jm ->
   forall ora c,
-   jsafeN_ (level jm0) ora c jm0 ->
-   jsafeN_ (level jm) ora c jm.
+   jsafeN_ ora c jm0 ->
+   jsafeN_ ora c jm.
 Proof.
- intros. rename H into H2.
- rewrite (age_level _ _ H2) in H0.
-   remember (level jm) as N.
-   revert c jm0 jm HeqN H2 H0; induction N; intros.
-   constructor.
- remember (S N) as SN.
-   subst SN.
+  intros.
+  remember (level jm) as N.
+  revert c jm0 jm HeqN H H0; induction N; intros.
+  { constructor; auto. }
   inv H0.
-  + pose proof (age_level _ _ H2).
-   destruct H1 as (? & ? & ? & Hg).
-   assert (level m' > 0) by lia.
-   assert (exists i, level m' = S i).
-   destruct (level m'). lia. eauto.
-   destruct H6 as [i Hl'].
-   symmetry in Hl'; pose proof (levelS_age _ _ Hl') as [jm1' []]; subst.
-   econstructor.
-   split.
-   rewrite <- (age_jm_dry H2), <- (age_jm_dry H6); eauto.
-   split.
-   rewrite <- (age_jm_dry H2).
-   eapply age_resource_decay; try eassumption; try apply age_jm_phi; auto.
-   destruct (age1_juicy_mem_unpack _ _ H2); auto.
-   destruct (age1_juicy_mem_unpack _ _ H6); auto.
-   split.
-   apply age_level in H6. rewrite <- H6.
-   lia.
-   rewrite (age1_ghost_of _ _ (age_jm_phi H6)), (age1_ghost_of _ _ (age_jm_phi H2)), Hg.
-   rewrite H in H4; inv H4.
-   rewrite !level_juice_level_phi; congruence.
-    intros ? HC J.
-   rewrite (age1_ghost_of _ _ (age_jm_phi H6)) in J.
-   destruct (ghost_joins_approx _ _ _ J) as (J1 & HC1).
-   rewrite <- (age_level _ _ (age_jm_phi H6)) in *.
-   rewrite ghost_of_approx in J1.
-   destruct (H3 (make_join (compcert_rmaps.R.ghost_of (m_phi m')) C0)) as (m'' & ? & Hupd & ?); auto.
-   { eapply make_join_ext; eauto. }
-   destruct (jm_update_age _ _ _ Hupd H6) as (jm1'' & Hupd1 & Hage1).
-   exists jm1''; split.
-   { rewrite (age1_ghost_of _ _ (age_jm_phi Hage1)).
-     replace (level (m_phi jm1'')) with (level (m_phi jm1')); auto.
-     destruct Hupd1 as (? & ? & ?); rewrite <- !level_juice_level_phi; auto. }
-   split; auto.
-   destruct Hupd1 as (? & ? & ?).
-   eapply IHN; eauto; lia.
-  + eapply jsafeN_external; [eauto | eapply JE_pre_hered; eauto |].
+  + apply age_level in H; congruence.
+  + edestruct age_jstep as (m1' & ? & Hstep); eauto.
+    { lia. }
+    eapply jsafeN_step; eauto.
+    eapply jm_fupd_mono; [eapply jm_fupd_age; eauto | auto].
+  + eapply jsafeN_external; eauto.
     { unfold j_at_external in *.
-      rewrite <- (age_jm_dry H2); eauto. }
+      rewrite <- (age_jm_dry H); eauto. }
+    { eapply JE_pre_hered; eauto. }
     intros.
-    destruct (H4 ret m' z' n') as [c' [? ?]]; auto.
+    destruct (H3 ret m' z') as [c' [? ?]]; auto.
     - assert (level (m_phi jm) < level (m_phi jm0)).
       {
-        apply age_level in H2.
+        apply age_level in H.
         do 2 rewrite <-level_juice_level_phi.
         destruct H0.
-        rewrite H2; lia.
+        rewrite H; lia.
       }
-      destruct H0 as (?&?&?).
-      split3; [auto | do 2 rewrite <-level_juice_level_phi in H6; lia |].
-      split.
-      * destruct H8 as [H8 _].
-        unfold pures_sub in H8. intros adr. specialize (H8 adr).
-        assert (Hage: age (m_phi jm0) (m_phi jm)) by (apply age_jm_phi; auto).
-        case_eq (m_phi jm0 @ adr); auto.
-        intros k p Hphi.
-        apply age1_resource_at with (loc := adr) (r := PURE k p) in Hage; auto.
-       ++ rewrite Hage in H8; rewrite  H8; simpl.
-          f_equal. unfold preds_fmap. destruct p. f_equal.
-          generalize (approx_oo_approx' (level m') (level jm)); intros H9.
-          spec H9; [lia |].
-          generalize (approx'_oo_approx (level m') (level jm)); intros H10.
-          spec H10; [lia |].
-          do 2 rewrite <-level_juice_level_phi.
-          rewrite fmap_app.
-          rewrite H9, H10; auto.
-       ++ rewrite <-resource_at_approx, Hphi; auto.
-      * intros adr. case_eq (m_phi m' @ adr); auto. intros k p Hm'.
-        destruct H8 as [_ H8].
-        specialize (H8 adr). rewrite Hm' in H8. destruct H8 as [pp H8].
-        apply age_jm_phi in H2.
-        assert (Hnec: necR (m_phi jm0) (m_phi jm)) by (apply rt_step; auto).
-        eapply necR_PURE' in Hnec; eauto.
+      destruct H0 as (?&?).
+      split; [do 2 rewrite <-level_juice_level_phi in H5; lia |].
+      eapply pures_eq_trans, H6.
+      { rewrite <- !level_juice_level_phi; lia. }
+      apply age_pures_eq, age_jm_phi; auto.
     - exists c'; split; auto.
   + unfold j_halted in *.
     eapply jsafeN_halted; eauto.
@@ -630,62 +721,78 @@ Proof.
   rewrite Hr, <- H1, Hl, <- H0; auto.
 Qed.
 
+Lemma ext_jstep : forall c m c' m' m1, jstep Hcore c m c' m' ->
+  ext_order m m1 -> exists m1', ext_order m' m1' /\ jstep Hcore c m1 c' m1'.
+Proof.
+  unfold jstep.
+  intros ????? (? & Hr & ? & Hg) [Hdry Hext].
+  apply rmap_order in Hext as (Hl1 & Hr1 & ? & Hg1).
+  eapply resource_decay_resource in Hr as (m1' & ? & Hl' & Hr' & Hg'); eauto.
+  symmetry in Hr'; destruct (juicy_mem_resource _ _ Hr') as (jm' & ? & Hdry'); subst.
+  exists jm'.
+  rewrite <- Hdry, Hdry'; split.
+  { split; [congruence|].
+    apply rmap_order; split; auto.
+    split; auto.
+    rewrite Hg, Hg', Hl', level_juice_level_phi.
+    eexists; apply ghost_fmap_join; eauto. }
+  split; auto; split; auto; split; auto.
+  rewrite !level_juice_level_phi in *; lia.
+Qed.
+
 Lemma ext_safe:
   forall jm jm0, ext_order jm0 jm ->
   forall ora c,
    joins (ghost_of (m_phi jm)) (Some (ext_ref ora, NoneP) :: nil) ->
-   jsafeN_ (level jm0) ora c jm0 ->
-   jsafeN_ (level jm) ora c jm.
+   jsafeN_ ora c jm0 ->
+   jsafeN_ ora c jm.
 Proof.
   intros ????? Hext ?.
   remember (level jm0) as N.
-  revert dependent c; revert dependent jm0; revert dependent jm; induction N; intros.
-  { destruct H as [_ H].
-    destruct (proj1 (rmap_order _ _) H) as (Hl & _ & _).
-    rewrite level_juice_level_phi, <- Hl, <- level_juice_level_phi, <- HeqN; constructor. }
-  destruct H as [Hdry H].
-  destruct (proj1 (rmap_order _ _) H) as (Hl & Hr & Hg).
+  revert dependent c; revert dependent jm0; revert dependent jm; induction N as [? IHN] using lt_wf_ind; intros.
   inv H0.
-  - destruct H2 as (? & ? & ? & Hg').
-    rewrite Hdry in *.
-    eapply resource_decay_resource in H1 as (? & Hdecay & ? & Hr' & Hg''); eauto.
-    rewrite level_juice_level_phi, <- Hl, <- level_juice_level_phi, H2.
-    symmetry in Hr'; destruct (juicy_mem_resource _ _ Hr') as (m'' & ? & Hdry'); subst.
-    eapply jsafeN_step.
-    + split; [rewrite Hdry'; eauto|].
-      split; auto; split; auto.
-      rewrite !level_juice_level_phi in *; congruence.
-    + rewrite H2 in HeqN; inv HeqN.
-      eapply jm_bupd_ext; eauto.
-      * simpl; rewrite rmap_order; repeat split; auto.
-        rewrite Hg', Hg'', level_juice_level_phi, H1.
-        destruct Hg; eexists; apply ghost_fmap_join; eauto.
-      * intros ?? Hl1 Hb ??. rewrite <- Hl1, (ext_level _ _ Hb). eauto.
-  - rewrite level_juice_level_phi, <- Hl, <- level_juice_level_phi, <- HeqN.
-    eapply jsafeN_external.
+  - constructor. destruct H as [_ H]; apply rmap_order in H as [? _].
+    rewrite <- !level_juice_level_phi in *; congruence.
+  - eapply ext_jstep in H as (? & ? & ?); eauto.
+    eapply jsafeN_step; eauto.
+    eapply jm_fupd_ext; eauto; intros.
+    eapply IHN; eauto.
+    destruct H1 as (_ & _ & ? & _).
+    rewrite !level_juice_level_phi in *; lia.
+  - eapply jsafeN_external; eauto.
     + unfold j_at_external in *.
-      rewrite <- Hdry; eauto.
-    + eapply JE_pre_ext, H3; auto.
-      split; auto.
+      destruct H as [<-]; eauto.
+    + eapply JE_pre_ext; eauto.
     + intros.
-      apply H4; auto.
+      apply H3; auto.
       unfold Hrel in *.
-      destruct H1 as (? & ? & ?); split; auto.
+      destruct H0 as (? & ?).
+      destruct H as [_ H]; apply rmap_order in H as (? & Hr & _).
       split; [rewrite !level_juice_level_phi in *; lia|].
       unfold pures_eq, pures_sub in *.
       rewrite Hr; auto.
   - eapply jsafeN_halted; eauto.
-    eapply JE_exit_ext; [|eauto].
-    split; auto.
+    eapply JE_exit_ext; eauto.
 Qed.
 
+Lemma necR_safe : forall jm jm0, necR jm0 jm ->
+  forall ora c,
+   jsafeN_ ora c jm0 ->
+   jsafeN_ ora c jm.
+Proof.
+  induction 1; auto.
+  apply age_safe; auto.
+Qed.
+
+
 Lemma jsafe_corestep_backward:
-    forall c m c' m' n z,
+    forall c m c' m' z,
     jstep Hcore c m c' m' ->
-    jsafeN_ n z c' m' -> jsafeN_ (S n) z c m.
+    jsafeN_ z c' m' -> jsafeN_ z c m.
   Proof.
     intros; eapply jsafeN_step; eauto.
-    intros; eexists; repeat split; eauto.
+    apply jm_fupd_intro; auto.
+    intros; eapply necR_safe; eauto.
   Qed.
 
 (*  Lemma jsafe_corestepN_forward:
@@ -714,34 +821,27 @@ Lemma jsafe_corestep_backward:
 
   Lemma jsafe_step'_back2 :
     forall
-      {ora st m st' m' n},
+      {ora st m st' m'},
       jstep Hcore st m st' m' ->
-      jsafeN_ (n-1) ora st' m' ->
-      jsafeN_ n ora st m.
+      jsafeN_ ora st' m' ->
+      jsafeN_ ora st m.
   Proof.
     intros.
-    destruct n.
-    constructor.
-    simpl in H0. replace (n-0)%nat with n in H0.
     eapply jsafe_corestep_backward; eauto.
-    lia.
   Qed.
 
   Lemma jsafe_corestepN_backward:
-    forall z c m c' m' n n0,
+    forall z c m c' m' n0,
       semantics_lemmas.corestepN (juicy_core_sem Hcore) n0 c m c' m' ->
-      jsafeN_ (n - n0) z c' m' ->
-      jsafeN_ n z c m.
+      jsafeN_ z c' m' ->
+      jsafeN_ z c m.
   Proof.
     simpl; intros.
-    revert c m c' m' n H H0.
+    revert c m c' m' H H0.
     induction n0; intros; auto.
-    simpl in H; inv H.
-    solve[assert (Heq: (n = n - 0)%nat) by lia; rewrite Heq; auto].
+    simpl in H; inv H; auto.
     simpl in H. destruct H as [c2 [m2 [STEP STEPN]]].
-    assert (H: jsafeN_ (n - 1 - n0) z c' m').
-    eapply jsafe_downward in H0; eauto. lia.
-    specialize (IHn0 _ _ _ _ (n - 1)%nat STEPN H).
+    specialize (IHn0 _ _ _ _ STEPN H0).
     solve[eapply jsafe_step'_back2; eauto].
   Qed.
 
@@ -753,47 +853,30 @@ Lemma jsafe_corestep_backward:
       (semantics.halted Hcore q1 = semantics.halted Hcore q2) ->
       (forall q' m', jstep Hcore q1 m q' m' ->
                      jstep Hcore q2 m q' m') ->
-      (forall n z, jsafeN_ n z q1 m -> jsafeN_ n z q2 m).
+      (forall z, jsafeN_ z q1 m -> jsafeN_ z q2 m).
   Proof.
-    intros. destruct n; simpl in *; try constructor.
+    intros.
     inv H3.
-    + econstructor; eauto.
+    + constructor; auto.
+    + eapply jsafeN_step; eauto.
     + eapply jsafeN_external; eauto.
       rewrite <-H; eauto.
-      intros ???? Hargsty Hretty ? H8 H9.
-      specialize (H7 _ _ _ _ Hargsty Hretty H3 H8 H9).
-      destruct H7 as [c' [? ?]].
+      intros ??? Hargsty Hretty ? H8.
+      specialize (H6 _ _ _ Hargsty Hretty H3 H8).
+      destruct H6 as [c' [? ?]].
       exists c'; split; auto.
     + eapply jsafeN_halted; eauto.
       rewrite <-H1; auto.
   Qed.
 
   Lemma wlog_jsafeN_gt0 : forall
-    n z q m,
-    (lt 0 n -> jsafeN_ n z q m) ->
-    jsafeN_ n z q m.
+    z q m,
+    (level m > 0 -> jsafeN_ z q m) ->
+    jsafeN_ z q m.
   Proof.
-    intros. destruct n. constructor.
+    intros. destruct (level m) eqn: Hl. constructor; auto.
     apply H. lia.
   Qed.
-
-(*Lemma jm_fupd_intro': forall {Z} (ora : Z) E n z q m,
-  jsafeN_ (min n (level m)) z q m -> jm_fupd ora E E (fun m' => jsafeN_ (min n (level m')) z q m') m.
-Proof.
-  intros; apply jm_fupd_intro, H.
-  intros; eapply necR_safe; eauto.
-Qed.*)
-
-(*Polymorphic Lemma jm_fupd_age' : forall {Z} (ora : Z) E1 E2 z q m m', jm_fupd ora E1 E2 (fun jm => jsafeN_ (min (level m) (level jm)) z q jm) m ->
-  age m m' -> jm_fupd ora E1 E2 (fun jm => jsafeN_ (min (level m') (level jm)) z q jm) m'.
-Proof.
-  intros.
-  eapply jm_fupd_mono; [eapply jm_fupd_age; eauto|].
-  simpl; intros.
-  apply age_level in H0.
-  rewrite !level_juice_level_phi in H0.
-  rewrite min_r in * by lia; auto.
-Qed.*)
 
 End juicy_safety.
 

--- a/veric/juicy_mem.v
+++ b/veric/juicy_mem.v
@@ -690,6 +690,27 @@ Proof.
   apply contents_default.
 Qed.
 
+(* There are plenty of other orders on memories, but they're all either
+   way too general (Mem.extends, mem_lessdef) or way too restrictive (mem_lessalloc). *)
+Definition mem_sub m1 m2 := mem_contents m1 = mem_contents m2 /\ nextblock m1 = nextblock m2 /\
+  forall b ofs k p, Mem.perm m1 b ofs k p -> Mem.perm m2 b ofs k p.
+
+Lemma mem_sub_valid_pointer : forall m1 m2 b ofs, mem_sub m1 m2 -> valid_pointer m1 b ofs = true ->
+  valid_pointer m2 b ofs = true.
+Proof.
+  unfold mem_sub, valid_pointer; intros.
+  destruct H as (_ & _ & Hp).
+  destruct (perm_dec m1 _ _ _ _); inv H0.
+  destruct (perm_dec m2 _ _ _ _); auto.
+Qed.
+
+Lemma mem_sub_weak_valid_pointer : forall m1 m2 b ofs, mem_sub m1 m2 -> weak_valid_pointer m1 b ofs = true ->
+  weak_valid_pointer m2 b ofs = true.
+Proof.
+  unfold weak_valid_pointer; intros.
+  apply orb_true_iff in H0 as [Hp | Hp]; rewrite (mem_sub_valid_pointer _ _ _ _ H Hp), ?orb_true_r; auto.
+Qed.
+
 Lemma join_sub_alloc_cohere : forall m jm, join_sub m (m_phi jm) ->
   alloc_cohere (m_dry jm) m.
 Proof.
@@ -701,7 +722,46 @@ Proof.
   apply identity_share_bot in RJ; subst; f_equal; apply proof_irr.
 Qed.
 
-Lemma juicy_mem_sub : forall jm m', join_sub m' (m_phi jm) -> exists jm', m_phi jm' = m'.
+Local Hint Resolve perm_refl : core.
+
+Lemma perm_of_sh_join_sub'': forall (sh1 sh2: Share.t),
+  join_sub sh1 sh2 ->
+  perm_order'' (perm_of_sh sh2) (perm_of_sh sh1).
+Proof.
+intros ?? [? J].
+unfold perm_of_sh.
+destruct (writable0_share_dec sh1).
+{ eapply join_writable01 in w; eauto.
+  rewrite (if_true _ _ _ _ _ w).
+  if_tac; if_tac; simpl; try constructor.
+  subst; rewrite (@only_bot_joins_top x) in J by (eexists; eauto).
+  apply join_comm, bot_identity in J; subst; contradiction. }
+if_tac; [repeat if_tac; constructor|].
+destruct (readable_share_dec sh1).
+{ eapply join_readable1 in r; eauto.
+  rewrite (if_true _ _ _ _ _ r); constructor. }
+repeat if_tac; try constructor.
+subst; apply split_identity, identity_share_bot in J; auto; contradiction.
+Qed.
+
+Lemma perm_of_res_sub_rmap : forall r1 r2 l, join_sub r1 r2 ->
+  perm_order'' (perm_of_res (r2 @ l)) (perm_of_res (r1 @ l)) /\
+  perm_order'' (perm_of_res' (r2 @ l)) (perm_of_res' (r1 @ l)).
+Proof.
+  intros ??? [? J].
+  apply (resource_at_join _ _ _ l) in J; inv J; simpl; auto.
+  - if_tac; if_tac; simpl; auto.
+    subst; apply split_identity, identity_share_bot in RJ; auto.
+  - lapply (perm_of_sh_join_sub'' sh1 sh3); [|eexists; eauto].
+    intros; destruct k; split; simpl; auto.
+  - destruct (perm_of_sh sh3) eqn: Hsh3.
+    destruct k; if_tac; split; simpl; constructor.
+    { apply perm_of_empty_inv in Hsh3; subst; contradiction bot_unreadable. }
+  - lapply (perm_of_sh_join_sub'' sh1 sh3); [|eexists; eauto].
+    intros; destruct k; split; simpl; auto.
+Qed.
+
+Lemma juicy_mem_sub : forall jm m', join_sub m' (m_phi jm) -> exists jm', m_phi jm' = m' /\ mem_sub (m_dry jm') (m_dry jm).
 Proof.
   intros ?? Hsub.
   unshelve eexists (mkJuicyMem (deflate_mem (m_dry jm) m' (join_sub_alloc_cohere _ _ Hsub)) m' _ _ _ _);
@@ -741,7 +801,30 @@ Proof.
     inv J; auto.
     apply split_identity in RJ; [|apply bot_identity].
     apply identity_share_bot in RJ; subst; f_equal; apply proof_irr.
-  - auto.
+  - repeat (split; auto).
+    unfold deflate_mem, perm; simpl; intros.
+    unfold PMap.get in H; simpl in H.
+    rewrite make_access_get in H.
+    destruct (perm_of_res_sub_rmap m' phi (b, ofs)) as [H1 H2].
+    { eexists; eauto. }
+    destruct (Pos.ltb_spec b (nextblock m)); [destruct k; simpl in H|].
+    + specialize (JMmax_access (b, ofs)).
+      unfold max_access_at, access_at in JMmax_access; simpl in *.
+      unfold perm_order'', perm_order' in *.
+      destruct (perm_of_res' (m' @ (b, ofs))) eqn: Hperm'; [|contradiction].
+      destruct (perm_of_res' (phi @ (b, ofs))) eqn: Hperm; [|contradiction].
+      destruct ((mem_access m) !! _ _ _); [|contradiction].
+      eapply perm_order_trans, perm_order_trans; eauto.
+    + specialize (JMaccess (b, ofs)).
+      unfold access_at in JMaccess; simpl in *.
+      unfold perm_order'', perm_order' in *.
+      destruct (perm_of_res (m' @ (b, ofs))) eqn: Hperm'; [|contradiction].
+      destruct (perm_of_res (phi @ (b, ofs))) eqn: Hperm; [|contradiction].
+      rewrite JMaccess.
+      eapply perm_order_trans; eauto.
+    + apply (resource_at_join _ _ _ (b, ofs)) in J.
+      lapply (JMalloc (b, ofs)); [|simpl; lia].
+      intros Hno; rewrite Hno in *; simpl in *; contradiction.
 Qed.
 
 #[(*export, after Coq 8.13*)global] Program Instance juicy_mem_ord: Ext_ord juicy_mem :=

--- a/veric/juicy_mem_lemmas.v
+++ b/veric/juicy_mem_lemmas.v
@@ -1194,4 +1194,3 @@ rewrite H in *; auto.
 apply ghost_of_approx.
 Defined.
 
-

--- a/veric/own.v
+++ b/veric/own.v
@@ -259,19 +259,40 @@ Proof.
     do 2 eexists; eauto.
 Qed.
 
-Lemma bupd_andp_prop : forall P Q, bupd (!! P && Q) = !! P && bupd Q.
+Lemma corable_resource_at : forall P, corable P ->
+  forall a b, level a = level b -> resource_at a = resource_at b -> P a -> P b.
+Proof.
+  intros.
+  apply (H (id_core a)); [eapply H; eauto|].
+  - right; left; eexists; apply id_core_unit.
+  - left. exists b.
+    apply resource_at_join2; auto.
+    + rewrite id_core_level; auto.
+    + intros; rewrite id_core_resource.
+      rewrite <- core_resource_at, H1; apply core_unit.
+    + rewrite id_core_ghost; constructor.
+Qed.
+
+Lemma bupd_andp_corable : forall P Q, corable P -> bupd (P && Q) = P && bupd Q.
 Proof.
   intros; apply pred_ext.
   - intros ??; simpl in *.
     split.
-    + destruct (H _ (joins_approx_core _)) as (? & ? & ? & ? & ? & ? & ? & ?); auto.
-    + intros ? J; destruct (H _ J) as (? & ? & m & ? & ? & ? & ? & ?).
+    + destruct (H0 _ (joins_approx_core _)) as (? & ? & ? & ? & ? & ? & ? & ?); auto.
+      eapply corable_resource_at; eauto.
+    + intros ? J; destruct (H0 _ J) as (? & ? & m & ? & ? & ? & ? & ?).
       do 2 eexists; eauto.
   - intros ? [? HQ] ? J.
     destruct (HQ _ J) as (? & ? & m & ? & ? & ? & ?).
     do 2 eexists; eauto.
     do 2 eexists; eauto.
     repeat split; auto.
+    eapply corable_resource_at, H0; auto.
+Qed.
+
+Lemma bupd_andp_prop : forall P Q, bupd (!! P && Q) = !! P && bupd Q.
+Proof.
+  intros; apply bupd_andp_corable, corable_prop.
 Qed.
 
 Lemma subp_bupd: forall (G : pred nat) (P P' : pred rmap), (G |-- P >=> P') ->

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -310,6 +310,7 @@ Lemma semax_external_funspec_sub {Espec argtypes rtype cc ef A1 P1 Q1 P1ne Q1ne 
                      (map typ_of_type argtypes)
                      (rettype_of_type rtype) cc):
   @semax.semax_external Espec ef A1 P1 Q1 |-- @semax.semax_external Espec ef A P Q.
+  (* This needs a fupd, but it's unclear how, since it's a pred nat. *)
 Proof.
 apply allp_derives; intros g.
 apply allp_right; intros ts.
@@ -318,12 +319,12 @@ destruct Hsub as [_ H]; simpl in H.
 intros n N m NM F typs vals y MY ? z YZ EZ [HT HP].
 simpl in HP.
 rewrite HSIG in HT; simpl in HT.
-eapply sepcon_derives, bupd_frame_r in HP; [| intros ??; eapply H; split; eauto | apply derives_refl].
+eapply sepcon_derives, fupd_frame_r in HP; [| intros ??; eapply H; split; eauto | apply derives_refl].
 2: { clear -HT. 
   apply has_type_list_Forall2 in HT.
   eapply Forall2_implication; [ | apply HT]; auto.
 }
-clear H.
+clear H. (*
 edestruct HP as (? & ? & z0 & ? & ? & ? & H); subst.
 { eexists. rewrite ghost_fmap_core. apply join_comm, core_unit. }
 destruct H as [z1 [z2 [JZ [[ts1 [x1 [FRM [[z11 [z12 [JZ1 [H_FRM H_P1]]]] HQ]]]] Z2]]]].
@@ -335,7 +336,7 @@ edestruct (N _ NM (sepcon F FRM) typs vals jm0) as [est [EST1 EST2]]; clear N; e
 { rewrite HSIG; simpl. split; trivial.
   exists z12, zz; split3. trivial. trivial.
   exists z2, z11; split3; trivial. }
-(*exists est; split.
+exists est; split.
 { simpl. intros. apply EST1; auto. apply necR_trans with z; auto.
   rewrite age_to.necR_age_to_iff. admit.
 simpl; intros.

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -14,6 +14,7 @@ Require Import VST.veric.tycontext.
 Require Import VST.veric.expr2.
 Require Import VST.veric.expr_lemmas.
 Require Import VST.veric.own.
+Require Import VST.veric.fupd.
 Import compcert.lib.Maps.
 
 Import Ctypes Clight_core.
@@ -86,28 +87,30 @@ Definition assert_safe'_
        match ctl with
        | Stuck => False
        | Cont (Kseq s ctl') => 
-             jsafeN (@OK_spec Espec) ge (level w) ora (State f s ctl' ve te) jm
+             jsafeN (@OK_spec Espec) ge ora (State f s ctl' ve te) jm
        | Cont (Kloop1 body incr ctl') =>
-             jsafeN (@OK_spec Espec) ge (level w) ora (State f Sskip (Kloop1 body incr ctl') ve te) jm
+             jsafeN (@OK_spec Espec) ge ora (State f Sskip (Kloop1 body incr ctl') ve te) jm
        | Cont (Kloop2 body incr ctl') =>
-             jsafeN (@OK_spec Espec) ge (level w) ora (State f (Sloop body incr) ctl' ve te) jm
+             jsafeN (@OK_spec Espec) ge ora (State f (Sloop body incr) ctl' ve te) jm
        | Cont (Kcall id' f' ve' te' k') => 
-               jsafeN (@OK_spec Espec) ge (level w) ora (State f (Sreturn None) (Kcall id' f' ve' te' k') ve te) jm
+               jsafeN (@OK_spec Espec) ge ora (State f (Sreturn None) (Kcall id' f' ve' te' k') ve te) jm
        | Cont Kstop =>
-               jsafeN (@OK_spec Espec) ge (level w) ora (State f (Sreturn None) Kstop ve te) jm
+               jsafeN (@OK_spec Espec) ge ora (State f (Sreturn None) Kstop ve te) jm
        | Cont _ => False
        | Ret None ctl' =>
-                jsafeN (@OK_spec Espec) ge (level w) ora (State f (Sreturn None) ctl' ve te) jm
+                jsafeN (@OK_spec Espec) ge ora (State f (Sreturn None) ctl' ve te) jm
        | Ret (Some v) ctl' =>  forall e v',
                   Clight.eval_expr ge ve te (m_dry jm) e v' ->
                   Cop.sem_cast v' (typeof e) (fn_return f) (m_dry jm) = Some v ->
-              jsafeN (@OK_spec Espec) ge (level w) ora (State f (Sreturn (Some e)) ctl' ve te) jm
+              jsafeN (@OK_spec Espec) ge ora (State f (Sreturn (Some e)) ctl' ve te) jm
        end.
+
+Notation fupd := (fupd Ensembles.Full_set Ensembles.Full_set).
 
 Program Definition assert_safe
      (Espec : OracleKind) (ge: genv) (f: function) (ve: env) (te: temp_env) 
      (ctl: contx) : assert :=
-  fun rho => bupd (assert_safe'_ (Espec : OracleKind) ge f ve te ctl rho).
+  fun rho => fupd (assert_safe'_ (Espec : OracleKind) ge f ve te ctl rho).
 Next Obligation.
   split; repeat intro.
    subst.

--- a/veric/semax.v
+++ b/veric/semax.v
@@ -85,7 +85,7 @@ Definition assert_safe'_
        m_phi jm = w ->
        forall (LW: level w > O),
        match ctl with
-       | Stuck => False
+       | Stuck => jm_fupd ora Ensembles.Full_set Ensembles.Full_set (fun _ => False) jm
        | Cont (Kseq s ctl') => 
              jm_fupd ora Ensembles.Full_set Ensembles.Full_set (jsafeN (@OK_spec Espec) ge ora (State f s ctl' ve te)) jm
        | Cont (Kloop1 body incr ctl') =>
@@ -122,13 +122,7 @@ Next Obligation.
    specialize (H0 (eq_refl _) H3).
    spec H0. apply age_level in H. lia.
   subst.
-  destruct ctl; auto. destruct c; try contradiction.
-  eapply jm_fupd_age; eauto.
-  eapply jm_fupd_age; eauto.
-  eapply jm_fupd_age; eauto.
-  eapply jm_fupd_age; eauto.
-  eapply jm_fupd_age; eauto.
-  eapply jm_fupd_age; eauto.
+  destruct ctl; [|destruct c|]; try (eapply jm_fupd_age; eauto).
   destruct o; intros; auto;
   eapply age_safe; eauto.
   rewrite (age_jm_dry H2) in *.
@@ -146,13 +140,8 @@ Next Obligation.
   subst.
   rewrite <- Hjm in *.
   assert (ext_order jm0 jm) by (split; auto; congruence).
-  destruct ctl; auto. destruct c; try contradiction.
-  eapply jm_fupd_ext; eauto; intros; eapply ext_safe; eauto.
-  eapply jm_fupd_ext; eauto; intros; eapply ext_safe; eauto.
-  eapply jm_fupd_ext; eauto; intros; eapply ext_safe; eauto.
-  eapply jm_fupd_ext; eauto; intros; eapply ext_safe; eauto.
-  eapply jm_fupd_ext; eauto; intros; eapply ext_safe; eauto.
-  eapply jm_fupd_ext; eauto; intros; eapply ext_safe; eauto.
+  destruct ctl; [|destruct c|];
+    try (eapply jm_fupd_ext; eauto; intros; eapply ext_safe; eauto).
   destruct o; intros; auto;
   eapply ext_safe; eauto.
   rewrite Hdry in *; eapply H0; eauto.
@@ -166,7 +155,7 @@ Lemma assert_safe_derives : forall (Espec : OracleKind) (ge ge': genv) (f f': fu
        m_phi jm = w ->
        forall (LW: level w > O), rho = construct_rho (filter_genv ge) ve te /\
       ((match ctl with
-       | Stuck => False
+       | Stuck => jm_fupd ora Ensembles.Full_set Ensembles.Full_set (fun _ => False) jm
        | Cont (Kseq s ctl') => 
              jm_fupd ora Ensembles.Full_set Ensembles.Full_set (jsafeN (@OK_spec Espec) ge ora (State f s ctl' ve te)) jm
        | Cont (Kloop1 body incr ctl') =>
@@ -186,7 +175,7 @@ Lemma assert_safe_derives : forall (Espec : OracleKind) (ge ge': genv) (f f': fu
               jsafeN (@OK_spec Espec) ge ora (State f (Sreturn (Some e)) ctl' ve te) jm
        end) ->
        match ctl' with
-       | Stuck => False
+       | Stuck => jm_fupd ora Ensembles.Full_set Ensembles.Full_set (fun _ => False) jm
        | Cont (Kseq s ctl') => 
              jm_fupd ora Ensembles.Full_set Ensembles.Full_set (jsafeN (@OK_spec Espec) ge' ora (State f' s ctl' ve' te')) jm
        | Cont (Kloop1 body incr ctl') =>

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -3309,13 +3309,13 @@ specialize (ClientAdaptation w2'). spec ClientAdaptation.
 assert (ARGS: app_pred (|> fupd (EX ts1 x1 G, F0 rho *
      (F rho * G) * deltaP ts1 x1 (ge_of rho, args) && !! (forall rho' : environ,
                             !! (ve_of rho' = Map.empty (block * type)) &&
-                            (G * nQ ts1 x1 rho') |-- fupd (Q ts x rho')))) w).
+                            (G * nQ ts1 x1 rho') |-- (Q ts x rho')))) w).
 { clear Hpost SpecOfID Prog_OK RhoID TC7' RGUARD funcatb. rewrite HARGS in *.
   assert (XX: (|> (F0 rho * F rho *
                    fupd (EX ts1 x1 G, G * deltaP ts1 x1 (ge_of rho, args) &&
               !! (forall rho' : environ,
                      !! (ve_of rho' = Map.empty (block * type)) &&
-                     (G * nQ ts1 x1 rho') |-- fupd (Q ts x rho'))))) w).
+                     (G * nQ ts1 x1 rho') |-- (Q ts x rho'))))) w).
   { rewrite later_sepcon.
     exists w1, w2; split. trivial. split. trivial. hnf; intros.
     destruct (age_later Age2 H); [ subst a' |].
@@ -3374,9 +3374,9 @@ rewrite HARGS; apply andp_derives; auto.
 intros ? HG2.
 clear - TRIV TC7' HG2.
 intros rho' u U ? m NEC Hext [v V].
+apply fupd.fupd_intro.
 hnf in TC7'.
 rewrite <- exp_sepcon1.
-apply fupd.fupd_frame_l.
 destruct ret.
 - remember ((temp_types Delta') ! i) as rr; destruct rr; try contradiction; subst t.
   simpl in V. destruct V as [m1 [m2 [JM [[u1 [u2 [JU [U1 U2]]]] M2]]]].
@@ -3385,37 +3385,16 @@ destruct ret.
   hnf in HG2. specialize (HG2 (get_result1 i rho') q1). destruct M2.
   spec HG2. {
     simpl. split; trivial. exists u2, m2; auto. }
-  eapply fupd.fupd_mono, HG2; simpl.
-  rewrite prop_true_andp; auto.
+  simpl; auto.
+(*  rewrite prop_true_andp; auto.*)
 - destruct V as [m1 [m2 [JM [[u1 [u2 [JU [U1 U2]]]] M2]]]].
   destruct (join_assoc JU JM) as [q1 [Q2 Q1]]. simpl in M2.
   exists u1, q1; split; trivial. split. exists v; apply U1.
-  hnf in HG2. destruct retty.
+  hnf in HG2. destruct retty; try solve [destruct M2 as [za [TCv M2]];
+    exists za; split; auto;
+    eapply HG2;
+    simpl; split; auto; exists u2, m2; auto].
   + apply HG2. simpl. split. hnf; simpl; intuition. exists u2, m2; auto.
-  + destruct M2 as [z [TCv M2]].
-    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
-                                simpl; split; auto; exists u2, m2; auto].
-  + destruct M2 as [z [TCv M2]].
-    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
-                                simpl; split; auto; exists u2, m2; auto].
-  + destruct M2 as [z [TCv M2]].
-    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
-                                simpl; split; auto; exists u2, m2; auto].
-  + destruct M2 as [z [TCv M2]].
-    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
-                                simpl; split; auto; exists u2, m2; auto].
-  + destruct M2 as [z0 [TCv M2]].
-    eapply fupd.fupd_mono, HG2; [apply exp_right with z0; apply prop_andp_right; auto |
-                                simpl; split; auto; exists u2, m2; auto].
-  + destruct M2 as [z [TCv M2]].
-    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
-                                simpl; split; auto; exists u2, m2; auto].
-  + destruct M2 as [z [TCv M2]].
-    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
-                                simpl; split; auto; exists u2, m2; auto].
-  + destruct M2 as [z [TCv M2]].
-    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
-                                simpl; split; auto; exists u2, m2; auto].
 Qed.
 
 Lemma semax_call_si {CS Espec}:
@@ -3594,10 +3573,10 @@ apply rmap_order in Hext as (Hl' & _ & _).
 rewrite Hl' in *; clear dependent a'.
 assert (ArgsW: app_pred (|> fupd (EX ts1 x1 G, F0 rho * (F rho * G) *
                deltaP ts1 x1 (ge_of rho, args) && (ALL rho' : environ,
-         ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> fupd (Q ts x rho'))))) w).
+         ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> (Q ts x rho'))))) w).
 { clear Hpost funcatb SpecOfID Prog_OK RhoID TC7' RGUARD. rewrite HARGS in *.
   assert (XX: (|> (F0 rho * F rho * fupd (EX ts1 x1 G, G * deltaP ts1 x1 (ge_of rho, args) && (ALL rho' : environ,
-         ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> fupd (Q ts x rho')))))) w).
+         ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> (Q ts x rho')))))) w).
   { rewrite later_sepcon.
     exists w1, w2; split. trivial. split. trivial. hnf; intros. specialize (age_later_nec _ _ _ Age2 H). intros.
     apply (pred_nec_hereditary _ _ a') in ClientAdaptation; auto.
@@ -3667,8 +3646,7 @@ destruct ret.
   specialize (HG2 (get_result1 i rho') _ LL _ _ (necR_refl _) (ext_refl _)). destruct Z2 as [Z21 Z22].
   spec HG2. {
     simpl. split; trivial. exists z1_2, z2; auto. }
-  eapply fupd.fupd_mono, HG2; simpl.
-  rewrite prop_true_andp; auto.
+  eapply fupd.fupd_intro; simpl; auto.
 - destruct Z as [z1 [z2 [JZ [Z1 Z2]]]];
     destruct (join_level _ _ _ JZ) as [Levz1 Levz2]. simpl in Z1, Z2.
   destruct Z1 as [z1_1 [z1_2 [JZ1 [Z11 Z12]]]]; destruct (join_level _ _ _ JZ1) as
@@ -3676,6 +3654,7 @@ destruct ret.
   destruct (join_assoc JZ1 JZ) as [y11 [JY1 JY2]]; destruct (join_level _ _ _ JY2) as
       [_ Levy11]. assert (LL: (level a0 >= level y11)%nat) by lia.
   exists z1_1, y11; split; trivial. split; [exists v; trivial|].
+  apply fupd.fupd_intro.
   destruct (type_eq retty Tvoid).
   + subst retty.
     apply (HG2 (globals_only rho') _ LL _ _ (necR_refl _) (ext_refl _)).
@@ -3689,7 +3668,6 @@ destruct ret.
     specialize (HG2 (env_set (globals_only rho') ret_temp vv) _ LL _ _ (necR_refl _) (ext_refl _)).
     spec HG2. {
       simpl; split. hnf; simpl; intuition. exists z1_2, z2; auto. }
-    eapply fupd.fupd_mono, HG2.
     destruct retty; try solve [congruence]; exists vv; split; trivial.
 Qed.
 

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -1351,7 +1351,7 @@ Proof.
   { eapply ext_compat_unnec; [apply necR_jm_phi; eauto|].
     eapply join_sub_joins_trans; [eexists; apply ghost_of_join; eauto|].
     eapply joins_comm, join_sub_joins_trans; [|apply joins_comm; eauto].
-    destruct H2 as [? J]; eapply ghost_fmap_join in J; eexists; eauto. }
+    destruct H3 as [? J]; eapply ghost_fmap_join in J; eexists; eauto. }
   specialize (AS _ _ Hext eq_refl eq_refl).
   spec AS; [lia|].
   destruct k; eapply jm_fupd_mono; eauto; intros ?? Hsafe; try contradiction.
@@ -1360,8 +1360,8 @@ Proof.
   intros.
   eapply age_safe; eauto.
   inv Hsafe; [constructor; auto | | discriminate | contradiction].
-  destruct H6.
-  inv H6.
+  destruct H7.
+  inv H7.
   eapply jsafeN_step.
   split. eapply step_skip_call; eauto. hnf; auto. auto. auto.
 -
@@ -1388,8 +1388,8 @@ Proof.
   intros.
   eapply age_safe; eauto.
   inv Hsafe; [constructor; auto | | discriminate | contradiction].
-  destruct H6.
-  inv H6.
+  destruct H7.
+  inv H7.
   eapply jsafeN_step.
   split. eapply step_skip_call; eauto. hnf; auto. auto. auto.
 Qed.
@@ -2867,7 +2867,7 @@ Proof.
   destruct Prog_OK' as [H5|H5].
   - pose proof (conj Funassert H14) as Hpre.
     apply fupd.fupd_andp_corable in Hpre; [|apply corable_funassert].
-    intros ????? Hw ?? J; eapply Hpre in Hw; try apply necR_jm_phi; eauto.
+    intros ?????? Hw ?? J; eapply Hpre in Hw; try apply necR_jm_phi; eauto.
     destruct (bupd_jm_bupd _ _ _ Hw J) as
         (jm' & Hupd & HR & J').
     exists jm'; repeat (split; auto).
@@ -2875,15 +2875,15 @@ Proof.
     destruct HR as [HF | (w1 & w2 & ? & ? & [Funassert' HR])].
     { symmetry in Hl; apply levelS_age in Hl as (? & Hage & ?).
       rewrite later_age in HF; apply age_jm_phi, HF in Hage; contradiction. }
-    edestruct (juicy_mem_sub jm' w2) as [jm0 ?]; subst.
+    edestruct (juicy_mem_sub jm' w2) as (jm0 & ? & ?); subst.
     { eexists; eauto. }
     destruct HR as (ts & x & F & H14' & HR).
-    right; do 3 eexists; eauto; split; auto.
+    right; do 3 eexists; eauto; split; auto; split; auto.
     assert (level jm0 <= level jm)%nat.
-    { apply join_level in H3 as []; destruct Hupd; apply join_level in H0 as []; apply necR_level in H; rewrite <- !level_juice_level_phi in *; lia. }
+    { apply join_level in H4 as []; destruct Hupd; apply join_level in H0 as []; apply necR_level in H; rewrite <- !level_juice_level_phi in *; lia. }
 
     eapply semax_call_external with (P:=deltaP)(Q:=Q)(fsig := (clientparams, retty)); try eassumption.
-    + apply (ext_join_sub_approx _ (level z)) in H1.
+    + apply (ext_join_sub_approx _ (level z)) in H3.
       eapply joins_comm, join_sub_joins_trans; eauto.
       eapply joins_comm, join_sub_joins_trans; eauto.
       eexists; apply ghost_of_join; eauto.
@@ -2905,7 +2905,7 @@ Proof.
 
     pose proof (conj Funassert H14) as Hpre.
     apply fupd.fupd_andp_corable in Hpre; [|apply corable_funassert].
-    intros ????? Hw ?? J; eapply Hpre in Hw; try apply necR_jm_phi; eauto.
+    intros ?????? Hw ?? J; eapply Hpre in Hw; try apply necR_jm_phi; eauto.
     destruct (bupd_jm_bupd _ _ _ Hw J) as
         (jm' & Hupd & HR & J').
     exists jm'; repeat (split; auto).
@@ -2913,10 +2913,10 @@ Proof.
     destruct HR as [HF | (w1 & w2 & ? & ? & [Funassert' HR])].
     { symmetry in Hl; apply levelS_age in Hl as (? & Hage & ?).
       rewrite later_age in HF; apply age_jm_phi, HF in Hage; contradiction. }
-    edestruct (juicy_mem_sub jm' w2) as [jm0 ?]; subst.
+    edestruct (juicy_mem_sub jm' w2) as (jm0 & ? & ?); subst.
     { eexists; eauto. }
     destruct HR as (ts & x & F & H14' & HR).
-    right; do 3 eexists; eauto; split; auto.
+    right; do 3 eexists; eauto; split; auto; split; auto.
     specialize (H19 Delta CS _ _ (necR_refl _) (ext_refl _)).
     spec H19. {
       intro; apply tycontext_sub_refl. }
@@ -2924,7 +2924,7 @@ Proof.
     red in H19.
 
     assert (necR (level jm) (level jm0)) as Hnec.
-    { apply nec_nat; apply join_level in H4 as []; destruct Hupd; apply join_level in H1 as []; apply necR_level in H0; rewrite <- !level_juice_level_phi in *; lia. }
+    { apply nec_nat; apply join_level in H5 as []; destruct Hupd; apply join_level in H1 as []; apply necR_level in H0; rewrite <- !level_juice_level_phi in *; lia. }
     destruct (level jm0) eqn:Hl0; [constructor; auto |].
     destruct (levelS_age1 _ _ Hl0) as [jm2 H13]. change (age jm0 jm2) in H13.
     rewrite <- Hl0 in *.
@@ -2946,7 +2946,7 @@ Proof.
     spec H19. {
       eapply semax_call_aux2 with (bl:=nil)(a:=Econst_int Int.zero tint)
                                   (Q:=Q)(fsig:=(clientparams,retty)); try apply HR; eauto.
-      + apply (ext_join_sub_approx _ (level z)) in H3.
+      + apply (ext_join_sub_approx _ (level z)) in H4.
         eapply joins_comm, join_sub_joins_trans; eauto.
         eapply joins_comm, join_sub_joins_trans; eauto.
         eexists; apply ghost_of_join; eauto.

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -1340,39 +1340,42 @@ Qed.
 Lemma assert_safe_jmupd_for_external_call {Espec psi curf vx ret ret0 tx k z' m'}
       (AS: assert_safe Espec psi curf vx (set_opttemp ret (force_val ret0) tx)
          (Cont k) (construct_rho (filter_genv psi) vx (set_opttemp ret (force_val ret0) tx)) (m_phi m')):
-  jm_bupd z' (jsafeN OK_spec psi (level m') z' (Returnstate (force_val ret0) (Kcall ret curf vx tx k))) m'.
+  jm_fupd z' Ensembles.Full_set Ensembles.Full_set (jsafeN OK_spec psi z' (Returnstate (force_val ret0) (Kcall ret curf vx tx k))) m'.
 Proof.
 (* this proof is like assert_safe_jsafe *)
-intros gh JS J.
-destruct (AS _ J) as (? & ? & ? & Hl & Hr & ? & Hsafe); subst.
-simpl in Hsafe.
-destruct (juicy_mem_resource _ _ Hr) as (jm' & ? & ?); subst.
-exists jm'; repeat split; auto.
-rewrite level_juice_level_phi, <- Hl.
-hnf in Hsafe.
-specialize (Hsafe z' jm').
-spec Hsafe. {
-    eapply joins_comm, join_sub_joins_trans, joins_comm, H.
-    destruct JS.
+  repeat intro.
+  eapply AS in H1; try apply necR_jm_phi; eauto.
+  destruct (H1 _ H3) as (? & ? & ? & Hl & Hr & ? & Hsafe); subst.
+  do 2 red in Hsafe.
+  destruct (juicy_mem_resource _ _ Hr) as (jm' & ? & ?); subst.
+  exists jm'; repeat split; auto.
+  rewrite level_juice_level_phi; destruct (level (m_phi jm')) eqn: Hl'; auto.
+  destruct Hsafe as [HF | Hsafe].
+  { symmetry in Hl'; apply levelS_age in Hl' as (? & Hage & ?).
+    rewrite later_age in HF; apply HF in Hage; contradiction. }
+  destruct Hsafe as (? & ? & ? & ? & Hsafe).
+  edestruct (juicy_mem_sub jm' x0) as [jm0 ?]; subst.
+  { eexists; eauto. }
+  right; do 3 eexists; eauto; split; auto.
+  specialize (Hsafe z' jm0).
+  spec Hsafe. {
+    eapply join_sub_joins_trans; [eexists; apply ghost_of_join; eauto|].
+    eapply joins_comm, join_sub_joins_trans, joins_comm; [|eauto].
     change (Some (ghost_PCM.ext_ref z', NoneP) :: nil) with
-      (own.ghost_approx (m_phi m') (Some (ghost_PCM.ext_ref z', NoneP) :: nil)).
-    eexists; apply ghost_fmap_join; eauto.
-  }
-do 2 (spec Hsafe; [auto|]).
-destruct (gt_dec (level (m_phi jm')) O).
-2: replace (level (m_phi jm')) with O by lia; constructor.
-spec Hsafe; [auto | clear - Hsafe].
-destruct k; try contradiction.
+      (own.ghost_approx (m_phi z) (Some (ghost_PCM.ext_ref z', NoneP) :: nil)).
+    destruct H2; eexists; apply ghost_fmap_join; eauto. }
+  do 2 (spec Hsafe; [auto|]).
+  destruct (level jm0) eqn: Hl0; [constructor; auto|].
+  spec Hsafe; [rewrite <- level_juice_level_phi; lia | clear - Hsafe].
+  destruct k; try contradiction.
 -
   eapply jsafeN_local_step. constructor.
   intros.
   eapply age_safe; eauto.
-  change (level (m_phi jm')) with (level jm') in Hsafe.
-  destruct (level jm'). constructor.
-  inv Hsafe; [ | discriminate | contradiction].
-  destruct H1.
+  inv Hsafe; [constructor; auto | | discriminate | contradiction].
+  destruct H0.
   inv H0.
-  econstructor.
+  eapply jsafeN_step.
   split. eapply step_skip_call; eauto. hnf; auto. auto. auto.
 -
   eapply jsafeN_local_step. constructor.
@@ -1397,12 +1400,10 @@ destruct k; try contradiction.
   eapply jsafeN_local_step. constructor.
   intros.
   eapply age_safe; eauto.
-  change (level (m_phi jm')) with (level jm') in Hsafe.
-  destruct (level jm'). constructor.
-  inv Hsafe; [ | discriminate | contradiction].
-  destruct H1.
+  inv Hsafe; [constructor; auto | | discriminate | contradiction].
+  destruct H0.
   inv H0.
-  econstructor.
+  eapply jsafeN_step.
   split. eapply step_skip_call; eauto. hnf; auto. auto. auto.
 Qed.
 
@@ -1444,8 +1445,8 @@ Lemma semax_call_external
       |> ! ((EX old : val,
              substopt ret (`old) F rho' *
              maybe_retval (Q ts x) (snd fsig) ret rho') >=>
-            own.bupd (RA_normal R rho'))) (m_phi jm))
- : jsafeN OK_spec psi (level jm) ora (Callstate ff args ctl) jm.
+            fupd (RA_normal R rho'))) (m_phi jm))
+ : jsafeN OK_spec psi ora (Callstate ff args ctl) jm.
 Proof.
 destruct TC3 as [TC3 TC3'].
 rename H5 into H15.
@@ -1459,7 +1460,7 @@ inversion H5. destruct fsig as [params retty].
 injection H2; clear H2; intros H8 H7. subst t0.
 rename t into tys. subst rho.
 destruct (age1 jm) as  [jm' |] eqn:Hage.
-2:{ rewrite (proj1 (age1_level0 jm) Hage). constructor. }
+2:{ constructor. apply age1_level0; auto. }
 specialize (H15 psi ts x (level jm)).
 spec H15. apply age_laterR. constructor.
 specialize (H15
@@ -1501,7 +1502,6 @@ elimtype False; clear - Hempty x.
 eapply Hempty. eassumption.
 }
 assert (Hty: typelist_of_type_list params = tys) by (rewrite H7, TTL3; trivial).
-rewrite (age_level _ _ Hage).
 eapply @jsafeN_external with (x := x'); eauto.
 
 + (*1/3*)
@@ -1534,11 +1534,11 @@ change ((ext_spec_post' Espec e x' (genv_symb_injective psi) (rettype_of_type re
               (F0 (construct_rho (filter_genv psi) vx tx) *
                F (construct_rho (filter_genv psi) vx tx)))) (level jm)) in H15.
 apply (pred_nec_hereditary _ _ (level m')) in H15.
- 2:{ clear - H6. destruct H6 as [? [? ?]]. apply nec_nat. lia. }
+ 2:{ destruct H0. apply nec_nat. lia. }
 apply (pred_nec_hereditary _ _ (level m')) in H15;
  [ | apply nec_nat; lia].
 rewrite Eef in *.
-specialize (H15 m' (le_refl _) _ _ (necR_refl _) (ext_refl _) H8).
+specialize (H15 m' (le_refl _) _ _ (necR_refl _) (ext_refl _) H6).
 assert (LAT: laterM (level (m_phi jm)) (level jm')). { simpl; apply laterR_level'. constructor. apply age_jm_phi. apply Hage. }
 apply (pred_nec_hereditary _ _ _ (laterR_necR LAT)) in H1.
 
@@ -1554,21 +1554,20 @@ assert (H1' : forall a' : rmap,
 { intros a' NEC Ha'.
   destruct Ha' as [[HA HB] HY].
   assert ((level (m_phi jm') >= level a')%nat).
-  { destruct H6 as [? [? ?]]; apply necR_level in NEC; subst. rewrite <- level_juice_level_phi in *. lia. }
-  assert (own.bupd (RA_normal R (construct_rho (filter_genv psi) vx tx') * F0 (construct_rho (filter_genv psi) vx tx')) a') as Ha'.
-  { apply own.bupd_frame_r.
+  { destruct H0; apply necR_level in NEC; subst. rewrite <- level_juice_level_phi in *. apply age_level in Hage. lia. }
+  assert (fupd (RA_normal R (construct_rho (filter_genv psi) vx tx') * F0 (construct_rho (filter_genv psi) vx tx')) a') as Ha'.
+  { apply fupd.fupd_frame_r.
     destruct HB as [a1 [a2 [J [A1 A2]]]]; exists a1, a2; split; auto; split; auto.
     eapply (HR (construct_rho (filter_genv psi) vx tx') _ LATER a1); auto.
     destruct (join_level _ _ _ J) as [-> ?]; auto. }
-  apply own.bupd_trans; intros ? J.
-  destruct (Ha' _ J) as (? & ? & a'' & Hl & ? & ? & Hret); subst.
-  eexists; split; eauto; exists a''; repeat (split; auto).
-  eapply H1; try apply necR_refl; try apply ext_refl.
-  { rewrite Hl; auto. }
-  split; [split|]; auto.
-  - rewrite proj_frame_ret_assert; unfold proj_ret_assert.
-    destruct Hret as (a1 & a2 & ? & ? & ?); exists a1, a2; repeat (split; auto).
-  - apply funassert_resource with a'; auto. }
+  eapply fupd.subp_fupd in H1; [|apply derives_refl].
+  eapply fupd.fupd_trans, H1; eauto.
+  rewrite andp_comm; apply fupd.fupd_andp_corable; [apply corable_funassert|].
+  split; auto.
+  apply fupd.fupd_andp_prop; split; auto.
+  rewrite proj_frame_ret_assert; unfold proj_ret_assert.
+  eapply fupd.fupd_mono, Ha'; simpl.
+  rewrite prop_true_andp; auto. }
 
 clear H1; rename H1' into H1. clear R HR.
 
@@ -1584,7 +1583,7 @@ assert (Htc: tc_option_val retty ret0).
   { apply join_level in Ha. destruct Ha as [? ?].
     rewrite H. cut ((level jm > level jm')%nat). intros.
     simpl. unfold natLevel. do 2 rewrite <-level_juice_level_phi.
-    destruct H6 as [? [? ?]].  lia.
+    destruct H0.  lia.
     apply age_level in Hage. lia.
   }
   specialize (Hretty phi1 phi1).
@@ -1594,7 +1593,7 @@ assert (Htc: tc_option_val retty ret0).
   simpl in Hretty. auto.
 }
 spec H1.
-{ clear H1. clear - TCret TC3 H0 TC5 H15 Hretty Hretty0 H6 H8 Hage TC3' tx' Htc H H4.
+{ clear H1. clear - TCret TC3 H0 TC5 H15 Hretty Hretty0 H0 H6 Hage TC3' tx' Htc H H4.
   split; [split; [split |] |].
   * (*1/4*)
     clear - TC3 Htc TCret Hretty0.
@@ -1616,10 +1615,10 @@ spec H1.
        F0 (construct_rho (filter_genv psi) vx tx))%pred (m_phi m')).
     { rewrite sepcon_assoc in H15|-*.
       destruct H15 as [w1 [w2 [H1 [H10 H12]]]]; exists w1; exists w2; split3; auto.
-      clear - H1 H6 H10  Hage Hretty Hretty0.
+      clear - H1 H0 H10  Hage Hretty Hretty0.
       specialize (Hretty ts x ret0 w1).
       spec Hretty. {
-        destruct H6 as [? [? ?]].
+        destruct H0.
         repeat rewrite <- level_juice_level_phi.
         apply age_level in Hage. rewrite Hage.
         apply join_level in H1. destruct H1.
@@ -1744,23 +1743,23 @@ spec H1.
       rewrite PTree.gso by auto.
       auto.
   * (*4/4*)
-    clear - H6 H4.
-    destruct H6 as (?&?&?).
+    clear - H0 H4.
+    destruct H0.
     destruct H4.
     split.
     + intros id fs ??? Hext ?.
-      specialize (H2 id fs (m_phi jm) _ (necR_refl _) (ext_refl _)).
-      spec H2; auto.
-      destruct H2 as [b [? ?]].
-      destruct H1 as [H1 H1'].
-      specialize (H1 (b,0)).
-      unfold func_at in H6. destruct fs; simpl in *.
-      rewrite H6 in H1.
-      apply (necR_PURE (m_phi m') a') in H1; eauto.
-      exists b. split; auto. apply rmap_order in Hext as (<- & <- & _). rewrite H1. simpl.
+      specialize (H1 id fs (m_phi jm) _ (necR_refl _) (ext_refl _)).
+      spec H1; auto.
+      destruct H1 as [b [? ?]].
+      destruct H0 as [H0 H0'].
+      specialize (H0 (b,0)).
+      unfold func_at in H5. destruct fs; simpl in *.
+      rewrite H5 in H0.
+      apply (necR_PURE (m_phi m') a') in H0; eauto.
+      exists b. split; auto. apply rmap_order in Hext as (<- & <- & _). rewrite H0. simpl.
       f_equal. f_equal.
       assert (Hlev1: (level (m_phi m') >= level a')%nat).
-      { apply necR_level in H4; auto. }
+      { apply necR_level in H3; auto. }
       extensionality ts x.
       extensionality b0 rho.
       rewrite !fmap_app.
@@ -1773,33 +1772,31 @@ spec H1.
       rewrite approx'_oo_approx by lia.
       auto.
     + intros b sig cc ??? Hext ?.
-      specialize (H3 b sig cc (m_phi jm)).
-      specialize (H3 _ (necR_refl _) (ext_refl _)); spec H3; auto.
-      destruct H1 as [H1 H1'].
-      specialize (H1' (b,0)).
+      specialize (H2 b sig cc (m_phi jm)).
+      specialize (H2 _ (necR_refl _) (ext_refl _)); spec H2; auto.
+      destruct H0 as [H0 H0'].
+      specialize (H0' (b,0)).
       simpl in *.
-      destruct H5 as [b0 ?].
-      apply rmap_order in Hext as (Hl & Hr & _); rewrite <- Hl, <- Hr in H5.
+      destruct H4 as [b0 ?].
+      apply rmap_order in Hext as (Hl & Hr & _); rewrite <- Hl, <- Hr in H4.
       destruct (m_phi m' @ (b,0)) eqn:?.
-      eapply necR_NOx in Heqr; try apply H4. inversion2 H5 Heqr.
-      eapply necR_YES in Heqr; try apply H4. inversion2 H5 Heqr.
-      destruct H1' as [pp ?].
-      rewrite H6.
+      eapply necR_NOx in Heqr; try apply H3. inversion2 H4 Heqr.
+      eapply necR_YES in Heqr; try apply H3. inversion2 H4 Heqr.
+      destruct H0' as [pp ?].
+      rewrite H5.
       exists pp.
-      assert (H9 := necR_PURE _ _ _ _ _ H4 Heqr).
-      rewrite H5 in H9. inv H9.
+      assert (H9 := necR_PURE _ _ _ _ _ H3 Heqr).
+      rewrite H4 in H9. inv H9.
       f_equal.
       pose proof (resource_at_approx (m_phi jm) (b,0)).
-      rewrite H6 in H; simpl in H.
-      injection H; intro. symmetry in H7. apply H7.
+      rewrite H5 in H6; simpl in H6.
+      injection H6; intro. symmetry in H7. apply H7.
   }
 
-clear - H6 Htc TCret TC5 tx' H1.
-destruct H6 as (AA&BB&CC).
-subst n'.
-rewrite level_juice_level_phi.
-change (jm_bupd z'
-  (jsafeN OK_spec psi (level m') z'
+clear - H0 Htc TCret TC5 tx' H1.
+destruct H0 as (AA&BB).
+change (jm_fupd z' Ensembles.Full_set Ensembles.Full_set
+  (jsafeN OK_spec psi z'
      (Returnstate (force_val ret0) (Kcall ret curf vx tx k))) m').
 replace tx' with (set_opttemp ret (force_val ret0) tx) in H1.
 2:{ subst tx'.
@@ -2240,22 +2237,17 @@ Lemma jsafeN_local_step':
   resource_decay (nextblock (m_dry m)) (m_phi m) (m_phi m2) ->
   level m = S (level m2) /\
    ghost_of (m_phi m2) =ghost_fmap (approx (level m2)) (approx (level m2)) (ghost_of (m_phi m)) ->
-  jsafeN (@OK_spec Espec) ge (level m2) ora s2 m2 ->
-  jsafeN (@OK_spec Espec) ge (level m) ora s1 m.
+  jsafeN (@OK_spec Espec) ge ora s2 m2 ->
+  jsafeN (@OK_spec Espec) ge ora s1 m.
 Proof.
-intros.
+  intros.
   rename H into Hstep.
-  remember (level m) as N.
-  destruct N; [constructor|].
   eapply jsafeN_step with
     (m' := m2).
-  split3.
+  split3; auto.
   apply Hstep.
-  auto.
-  rewrite HeqN in H1; auto.
-  apply jm_bupd_intro.
-  destruct H1. inv H.
-  apply H2.
+  apply jm_fupd_intro, H2; intros.
+  eapply necR_safe; eauto.
 Qed.
 
 Lemma call_cont_idem: forall k, call_cont (call_cont k) = call_cont k.
@@ -2296,7 +2288,7 @@ apply andp_derives; auto. apply andp_derives; auto.
 apply andp_left2; auto.
 simpl exit_cont.
 apply derives_subp.
-apply own.bupd_mono.
+apply fupd.fupd_mono.
 intros ?. simpl.
 destruct ctl; auto;
 elimtype False; clear - H; simpl in H; set (k:=ctl) in *;
@@ -2334,7 +2326,7 @@ Lemma semax_call_aux2
         |> ! ((EX old : val,
                substopt ret (`old) F rho' *
                maybe_retval (Q ts x) (snd fsig) ret rho') >=>
-              own.bupd (RA_normal R rho'))) (m_phi jm))
+              fupd (RA_normal R rho'))) (m_phi jm))
   (HGG : cenv_sub cenv_cs (genv_cenv psi))
   (H13 : age1 jm = Some jmx)
   (COMPLETE : Forall
@@ -2394,7 +2386,7 @@ apply guard_fallthrough_return; auto.
    apply le_trans with (level wx); auto.
    apply ext_level in Hext as <-; auto. }
  clear wx H8 H9.
- apply own.bupd_intro; simpl.
+ apply fupd.fupd_intro; simpl.
  intros ora' jm' Hora' VR ?.
  subst w'.
  intro.
@@ -2430,7 +2422,7 @@ apply guard_fallthrough_return; auto.
  subst m2.
  pose (rval := force_val vl).
  clear dependent a'.
- assert (jsafeN OK_spec psi (level jm2) ora'
+ assert (jsafeN OK_spec psi ora'
              (Returnstate rval (call_cont ctl)) jm2). {
    assert (LATER2': (level jmx > level (m_phi jm2))%nat). {
      apply age_level in H24.
@@ -2447,24 +2439,23 @@ apply guard_fallthrough_return; auto.
        clear - LATER2' LATER.
        eapply necR_laterR. apply laterR_necR; eassumption.
        apply later_nat. rewrite <- !level_juice_level_phi in *. lia. }
-     specialize (H1 _ Help0 EK_normal None (set_opttemp ret rval tx) vx); hnf in H1.
+     specialize (H1 _ Help0 EK_normal None (set_opttemp ret rval tx) vx).
      assert (Help1: (level (m_phi jm2) >= level (m_phi jm2))%nat) by lia.
     destruct H9 as [[? HB] ?].
-    assert (own.bupd (RA_normal R (construct_rho (filter_genv psi) vx (set_opttemp ret rval tx)) * F0 (construct_rho (filter_genv psi) vx (set_opttemp ret rval tx))) a') as Ha'.
-    { apply own.bupd_frame_r.
+    assert (fupd (RA_normal R (construct_rho (filter_genv psi) vx (set_opttemp ret rval tx)) * F0 (construct_rho (filter_genv psi) vx (set_opttemp ret rval tx))) a') as Ha'.
+    { apply fupd.fupd_frame_r.
       destruct HB as [a1 [a2 [J [A1 A2]]]]; simpl; exists a1, a2; split; auto; split; auto.
       assert (JMX: laterM (m_phi jm) (m_phi jmx)). { constructor. apply age_jm_phi. apply H13. }
       eapply (HR _ _ JMX a1); auto.
       destruct (join_level _ _ _ J) as [-> ?]; auto. apply necR_level in H8; rewrite <- level_juice_level_phi in *; lia. }
-    apply own.bupd_trans; intros ? J.
-    destruct (Ha' _ J) as (? & ? & a'' & Hl & ? & ? & Hret); subst.
-    eexists; split; eauto; exists a''; repeat (split; auto).
-    eapply H1; try apply necR_refl; try apply ext_refl.
-    { rewrite Hl; apply necR_level in H8; rewrite <- level_juice_level_phi in *; lia. }
-    split; [split|]; auto.
-    - rewrite proj_frame_ret_assert; unfold proj_ret_assert.
-      destruct Hret as (a1 & a2 & ? & ? & ?); exists a1, a2; repeat (split; auto).
-    - apply funassert_resource with a'; auto. }
+    eapply fupd.subp_fupd in H1; [|apply derives_refl].
+    eapply fupd.fupd_trans, H1; eauto.
+    rewrite andp_comm; apply fupd.fupd_andp_corable; [apply corable_funassert|].
+    split; auto.
+   apply fupd.fupd_andp_prop; split; auto.
+    rewrite proj_frame_ret_assert; unfold proj_ret_assert.
+    eapply fupd.fupd_mono, Ha'; simpl.
+    rewrite prop_true_andp; auto. }
    clear H1.
    specialize (HH1 _ (necR_refl _)). simpl in H5.
    spec HH1; [clear HH1 | ].
@@ -2573,7 +2564,7 @@ apply guard_fallthrough_return; auto.
      }
   -
     clear - HH1.
-    destruct (level jm2) eqn:H26; try solve [constructor];
+    destruct (level jm2) eqn:H26; try solve [constructor; auto];
     destruct (levelS_age _ _ (eq_sym H26)) as [jm2' [H27 ?]].
     subst n;
     apply jsafeN_step with (c' := State curf Sskip k vx (set_opttemp ret rval tx)) (m' := jm2');
@@ -2589,7 +2580,7 @@ apply guard_fallthrough_return; auto.
    clear H1.
     destruct H18 as [H18 H18b].
     simpl.
-    rewrite <- H21; clear n0 H21.
+    clear n0 H21.
     destruct vl; intros;
     (eapply jsafeN_local_step' with (m2 := jm2);
      [econstructor; eauto |  .. ]).
@@ -2756,23 +2747,22 @@ Lemma semax_call_aux {CS Espec}
   (PostAdapt: forall (ts: list Type) (x : dependent_type_functor_rec ts A mpred)
                      (vl : fconst environ mpred),
         (! |> (deltaQ ts x vl <=> nQ ts x vl)) (m_phi jm))
-  (PREHR: (|> own.bupd
+  (PREHR: (|> fupd
               (EX (ts: list Type) (x : dependent_type_functor_rec ts A mpred)
                   (F : environ -> pred rmap),
                (F0 rho * F rho * deltaP ts x (ge_of rho, args)) &&
                (ALL rho' : environ ,
                            |>
-                             !((EX old:val, substopt ret (`old) F rho' * maybe_retval (nQ ts x) retty ret rho') >=> own.bupd (RA_normal R rho') )))) (m_phi jm)):
-   jsafeN (@OK_spec Espec) psi (level (m_phi jm)) ora
+                             !((EX old:val, substopt ret (`old) F rho' * maybe_retval (nQ ts x) retty ret rho') >=> fupd (RA_normal R rho') )))) (m_phi jm)):
+   jsafeN (@OK_spec Espec) psi ora
      (State curf (Scall ret a bl) k vx tx) jm.
 Proof.
   destruct (believe_exists_fundef FindSymb Bel Spec) as [ff [H16 H16']].
   rewrite <- Genv.find_funct_find_funct_ptr in H16.
-  case_eq (level (m_phi jm)); [solve [simpl; constructor] | intros n H2].
+  case_eq (level (m_phi jm)); [solve [simpl; constructor; auto] | intros n H2].
   rewrite <- level_juice_level_phi in H2.
   destruct (levelS_age1 _ _ H2) as [jmx H13].
-  rewrite <- H2.
-  apply jsafeN_local_step_bupd
+  apply jsafeN_local_step_fupd
     with (s2 :=  Callstate ff (eval_exprlist clientparams bl rho)
                                      (Kcall ret curf vx tx k)). {
     eapply step_call with (vargs:=eval_exprlist clientparams bl rho);
@@ -2837,35 +2827,35 @@ Proof.
   unfold type_of_funspec, rettype_of_funspec in H16'; simpl in H16'.
   assert (H2 := I).
 
-  assert (H14':  own.bupd
+  assert (H14':  fupd
                  (EX ts (x : dependent_type_functor_rec ts A mpred) F,
                   F0 rho * F rho * deltaP ts x (ge_of rho, args) &&
                              (ALL rho' : environ,
                  |> ! ((EX old : val,
                                  substopt ret (` old) F rho' *
                                  maybe_retval (deltaQ ts x) retty ret rho') >=>
-            own.bupd (RA_normal R rho')))) (m_phi jm)). {
+            fupd (RA_normal R rho')))) (m_phi jm)). {
     clear - PREHR H11.
-    intros ? J; destruct  (PREHR _ J) as (? & J' & m' & Hl' & Hr' & Hg' & HR); subst.
-    eexists; split; eauto.
-    exists m'; repeat (split; auto).
-    destruct HR as (ts & x & F & [H14' HR]); exists ts, x, F; split; auto.
-    intros rho'; specialize (HR rho').
-    intros ? ? ? ? ? ? ? Hext [old ?].
-    apply (HR a' H y H0 _ _ H1 Hext); clear HR.
+    eapply fupd.subp_fupd, PREHR; eauto.
+    assert ((|> ALL ts x vl, (deltaQ ts x vl <=> nQ ts x vl)) (level (m_phi jm))) as H12.
+    { do 3 (rewrite later_allp; intro); apply H11. }
+    eapply subp_exp, H12; intros ts.
+    apply subp_exp; intros x.
+    apply subp_exp; intros F.
+    apply subp_andp; [apply subp_refl|].
+    apply subp_allp; intros rho'.
+    eapply derives_trans, subp_later1.
+    apply later_derives.
+    rewrite <- subp_eq, <- unfash_andp; apply unfash_derives.
+    clear; intros ? [? H0] ?????? [old ?]; eapply H0; eauto.
     exists old.
-    revert a'0 a'' H1 Hext H2.
-    eapply sepcon_subp'; try apply H0.
-    - apply derives_subp; apply derives_refl.
-    - intros ? ?. pose proof (laterR_level' H) as H'; rewrite Hl' in H'.
-      unfold maybe_retval; destruct ret.
-      + intros ? ? ? Hext. simpl. intros. destruct H3. split; auto. clear H3.
-        revert a'0 a'' H2 Hext H4. apply (H11 _ _ _ (level a')); auto; apply (laterR_level' H').
-      + destruct retty;
-          [apply (H11 _ _ _ (level a')); auto; apply (laterR_level' H') |
-           intros ? ? ? Hext [v ?]; simpl in H3; destruct H3; exists v; simpl;
-            split; auto; clear H3; revert a'0 a'' H2 Hext H4;
-            apply (H11 _ _ _ (level a')); auto; apply (laterR_level' H') ..]. }
+    destruct H4 as (? & b & ? & ? & Hret); do 3 eexists; eauto; split; auto.
+    specialize (H ts x).
+    assert (level b <= a)%nat.
+    { apply join_level in H4 as []; apply rmap_order in H3 as [? _]; apply necR_level in H2; lia. }
+    unfold maybe_retval; destruct ret; simpl in Hret.
+    + destruct Hret; split; auto. eapply H; eauto.
+    + destruct retty; [eapply H; eauto | destruct Hret as (? & ? & ?); do 2 eexists; eauto; eapply H; eauto ..]. }
 
   rewrite closed_wrt_modvars_Scall in CLosed.
   clear a bl Classify.
@@ -2890,18 +2880,33 @@ Proof.
   apply (pred_nec_hereditary _ _ _ H9) in Bel. clear H9.
 
   destruct Prog_OK' as [H5|H5].
-  - intros ? Hext J; destruct (bupd_jm_bupd _ _ _ H14 J) as
-        (jm' & Hupd & (ts & x & F & H14' & HR) & J').
+  - pose proof (conj Funassert H14) as Hpre.
+    apply fupd.fupd_andp_corable in Hpre; [|apply corable_funassert].
+    intros ????? Hw ?? J; eapply Hpre in Hw; try apply necR_jm_phi; eauto.
+    destruct (bupd_jm_bupd _ _ _ Hw J) as
+        (jm' & Hupd & HR & J').
     exists jm'; repeat (split; auto).
-    destruct Hupd as (Hm' & Hl' & Hr'); rewrite <- level_juice_level_phi, <- Hl' in *.
-    eapply (funassert_resource _ _ _ (m_phi jm')) in Funassert; eauto.
+    destruct (level jm') eqn: Hl; auto.
+    destruct HR as [HF | (w1 & w2 & ? & ? & [Funassert' HR])].
+    { symmetry in Hl; apply levelS_age in Hl as (? & Hage & ?).
+      rewrite later_age in HF; apply age_jm_phi, HF in Hage; contradiction. }
+    edestruct (juicy_mem_sub jm' w2) as [jm0 ?]; subst.
+    { eexists; eauto. }
+    destruct HR as (ts & x & F & H14' & HR).
+    right; do 3 eexists; eauto; split; auto.
+    assert (level jm0 <= level jm)%nat.
+    { apply join_level in H3 as []; destruct Hupd; apply join_level in H0 as []; apply necR_level in H; rewrite <- !level_juice_level_phi in *; lia. }
 
-    eapply semax_call_external with (P:=deltaP)(Q:=Q); try eassumption.
-    + apply ext_join_sub_approx with (n := level jm') in Hext.
+    eapply semax_call_external with (P:=deltaP)(Q:=Q)(fsig := (clientparams, retty)); try eassumption.
+    + apply (ext_join_sub_approx _ (level z)) in H1.
       eapply joins_comm, join_sub_joins_trans; eauto.
-      apply joins_comm; auto.
-    + simpl; auto.
-    + simpl; auto.
+      eapply joins_comm, join_sub_joins_trans; eauto.
+      eexists; apply ghost_of_join; eauto.
+    + reflexivity.
+    + eapply pred_nec_hereditary; [apply nec_nat | eauto].
+      rewrite <- !level_juice_level_phi; auto.
+    + eapply pred_nec_hereditary; [apply nec_nat | eauto].
+      lia.
   - apply (pred_nec_hereditary _ _ (level jm)) in H5.
     2: apply laterR_necR; apply age_laterR; constructor.
 
@@ -2913,23 +2918,37 @@ Proof.
     destruct H as [COMPLETE [H17 [H17' [Hvars [H18 H18']]]]].
     pose proof I.
 
-    intros ? Hext J; destruct (bupd_jm_bupd _ _ _ H14 J) as
-        (jm' & Hupd & (ts & x & F & H14' & HR) & J').
+    pose proof (conj Funassert H14) as Hpre.
+    apply fupd.fupd_andp_corable in Hpre; [|apply corable_funassert].
+    intros ????? Hw ?? J; eapply Hpre in Hw; try apply necR_jm_phi; eauto.
+    destruct (bupd_jm_bupd _ _ _ Hw J) as
+        (jm' & Hupd & HR & J').
     exists jm'; repeat (split; auto).
-    destruct Hupd as (Hm' & Hl' & Hr'); rewrite <- level_juice_level_phi, <- Hl' in *.
-    eapply (funassert_resource _ _ _ (m_phi jm')) in Funassert; eauto.
-    change (level (m_phi jm')) with (level jm') in *.
+    destruct (level jm') eqn: Hl; auto.
+    destruct HR as [HF | (w1 & w2 & ? & ? & [Funassert' HR])].
+    { symmetry in Hl; apply levelS_age in Hl as (? & Hage & ?).
+      rewrite later_age in HF; apply age_jm_phi, HF in Hage; contradiction. }
+    edestruct (juicy_mem_sub jm' w2) as [jm0 ?]; subst.
+    { eexists; eauto. }
+    destruct HR as (ts & x & F & H14' & HR).
+    right; do 3 eexists; eauto; split; auto.
     specialize (H19 Delta CS _ _ (necR_refl _) (ext_refl _)).
     spec H19. {
       intro; apply tycontext_sub_refl. }
     specialize (H19 _ _ (necR_refl _) (ext_refl _) (cenv_sub_refl) ts x).
     red in H19.
 
-    clear H2. destruct (level jm') eqn:H2; [constructor |].
-    destruct (levelS_age1 _ _ H2) as [jm2 H13]. change (age jm' jm2) in H13.
-    rewrite <- H2 in *. clear H2. pose proof I.
-    specialize (H19 _ (laterR_level' (age_laterR H13))).
+    assert (necR (level jm) (level jm0)) as Hnec.
+    { apply nec_nat; apply join_level in H4 as []; destruct Hupd; apply join_level in H1 as []; apply necR_level in H0; rewrite <- !level_juice_level_phi in *; lia. }
+    destruct (level jm0) eqn:Hl0; [constructor; auto |].
+    destruct (levelS_age1 _ _ Hl0) as [jm2 H13]. change (age jm0 jm2) in H13.
+    rewrite <- Hl0 in *.
+    assert (laterR (level jm) (level jm2)) as H13'.
+    { eapply necR_laterR; eauto. apply laterR_level', t_step; auto. }
+    specialize (H19 _ H13').
     rewrite semax_fold_unfold in H19.
+    set (rho := construct_rho (filter_genv psi) vx tx).
+    eapply pred_nec_hereditary in Bel; eauto.
     specialize (H19 _ _ _ _ _ (necR_refl _) (ext_refl _)
                     (conj (tycontext_sub_refl _) (conj cenv_sub_refl CSUB))
                     _ _ (necR_refl _) (ext_refl _)
@@ -2942,14 +2961,15 @@ Proof.
     spec H19. {
       eapply semax_call_aux2 with (bl:=nil)(a:=Econst_int Int.zero tint)
                                   (Q:=Q)(fsig:=(clientparams,retty)); try apply HR; eauto.
-      + apply @ext_join_sub_approx with (n := level jm') in Hext.
+      + apply (ext_join_sub_approx _ (level z)) in H3.
         eapply joins_comm, join_sub_joins_trans; eauto.
-        apply joins_comm; auto.
+        eapply joins_comm, join_sub_joins_trans; eauto.
+        eexists; apply ghost_of_join; eauto.
       + rewrite closed_wrt_modvars_Scall; auto.
       + tauto.
-      + apply now_later; auto. }
+      + apply now_later; eapply pred_nec_hereditary; eauto. }
 
-    remember (alloc_juicy_variables psi empty_env jm' (fn_vars f)) eqn:AJV.
+    remember (alloc_juicy_variables psi empty_env jm0 (fn_vars f)) eqn:AJV.
     destruct p as [ve' jm'']; symmetry in AJV.
     destruct (alloc_juicy_variables_e _ _ _ _ _ _ AJV) as [H15 [H20' CORE]].
     assert (MATCH := alloc_juicy_variables_match_venv _ _ _ _ _ AJV).
@@ -2962,8 +2982,7 @@ Proof.
         destruct clientparams; simpl; intros; try discriminate; auto.
         inv H0; f_equal; auto. }
     pose proof (age_twin' _ _ _ H20' H13) as [jm''' [_ H20x]].
-    rewrite (age_level _ _ H13).
-    apply jsafeN_step with (c' := State f (f.(fn_body)) ctl ve' te')
+    apply @jsafeN_step with (c' := State f (f.(fn_body)) ctl ve' te')
                            (m' := jm'''); auto.
     + split; auto.
       * apply step_internal_function.
@@ -2975,15 +2994,15 @@ Proof.
            apply age1_resource_decay; auto.
         -- split.
            ++ rewrite H20'; apply age_level; auto.
-           ++ erewrite <- (alloc_juicy_variables_ghost _ _ _ jm'), AJV; simpl.
+           ++ erewrite <- (alloc_juicy_variables_ghost _ _ _ jm0), AJV; simpl.
               apply age1_ghost_of, age_jm_phi; auto.
     + assert (H22: (level jm2 >= level jm''')%nat)
         by (apply age_level in H13; apply age_level in H20x; lia).
       pose (rho3 := mkEnviron (ge_of rho) (make_venv ve') (make_tenv te')).
       assert (H23: app_pred (funassert Delta rho3) (m_phi jm''')). {
-        apply (resource_decay_funassert _ _ (nextblock (m_dry jm')) _ (m_phi jm'''))
-          in Funassert. 2: apply laterR_necR; apply age_laterR; auto.
-        unfold rho3; clear rho3. apply Funassert.
+        apply (resource_decay_funassert _ _ (nextblock (m_dry jm0)) _ (m_phi jm'''))
+          in Funassert'. 2: apply laterR_necR; apply age_laterR; auto.
+        unfold rho3; clear rho3. apply Funassert'.
         rewrite CORE. apply age_core. apply age_jm_phi; auto.
         destruct H20;  apply resource_decay_trans with
                            (nextblock (m_dry jm'')) (m_phi jm''); auto.
@@ -2991,21 +3010,19 @@ Proof.
       specialize (H19 te' ve' _ H22 _ _ (necR_refl _) (ext_refl _)).
       spec H19; [clear H19|]. {
         split; [split |]; auto.
-        3:{ unfold rho3 in H23. unfold construct_rho. rewrite Hrho in H23.
-            simpl ge_of in H23. auto. }
         split; [ | simpl; split; [ | reflexivity]; apply MATCH ].
         - rewrite (age_jm_dry H20x) in H15.
-          clear - Hrho GuardEnv TC8 H18 H16 H21 H15 H23 H17 H17' H13.
+          clear - GuardEnv TC8 H18 H16 H21 H15 H23 H17 H17' H13.
           unfold rho3 in *. simpl in *. destruct H23.
-          destruct rho. inv Hrho. simpl in *.
+          destruct rho. simpl in *.
           remember (split (fn_params f)). destruct p.
           simpl in *. if_tac in H16; try congruence.
           destruct GuardEnv as [[_ [_ TC5]] _].
           eapply semax_call_typecheck_environ with (jm := jm2); try eassumption.
           + erewrite <- age_jm_dry by apply H13; auto.
-          + rewrite snd_split; apply TC8.
+          + rewrite snd_split, <- H18; apply TC8.
         - normalize.
-          split; auto. unfold rho3 in H23. unfold construct_rho. rewrite Hrho in H23.
+          split; auto. unfold rho3 in H23.
           simpl ge_of in H23. auto. unfold bind_args. unfold tc_formals.
           normalize. rewrite <- sepcon_assoc. normalize.
           simpl fst in H18; simpl snd in H18. split.
@@ -3021,11 +3038,12 @@ Proof.
             simpl. f_equal. unfold eval_id, construct_rho; simpl.
             inv H21. erewrite pass_params_ni; try eassumption.
             rewrite PTree.gss. reflexivity. eapply IHl; try eassumption.
-          + forget (F0 rho * F rho) as Frame.
+          + fold rho in H14'.
+            forget (F0 rho * F rho) as Frame.
              destruct H18' as [H18b H18']. simpl snd in *. rewrite H18 in *.
              simpl @fst in *. apply (alloc_juicy_variables_age H13 H20x) in AJV.
              forget (fn_params f) as fparams.
-             clear - H18 H21 H14' AJV H17 H17' Hrho Hvars
+             clear - H18 H21 H14' AJV H17 H17' Hvars
                          CSUB COMPLETE H13 ArgsNotVundef.
              assert (app_pred (Frame * close_precondition
                                          (map fst fparams) (deltaP ts x)
@@ -3034,10 +3052,10 @@ Proof.
                eapply pred_nec_hereditary.
                - apply laterR_necR. apply age_laterR. eapply age_jm_phi. apply H13.
                - eapply sepcon_derives; try apply H14'; auto.
-                 subst rho. eapply make_args_close_precondition; eauto.
+                 eapply make_args_close_precondition; eauto.
                  apply list_norepet_app in H17; intuition. }
              clear H14'.
-             forget (Frame *
+             subst rho; forget (Frame *
                      close_precondition (map fst fparams) (deltaP ts x)
                                         (construct_rho (filter_genv psi) ve' te')) as
                  Frame2.
@@ -3046,21 +3064,12 @@ Proof.
              eapply alloc_juicy_variables_lem2; eauto.
              unfold var_sizes_ok in Hvars;
                rewrite Forall_forall in Hvars, COMPLETE |- *.
-             intros. specialize (COMPLETE x H0). specialize (Hvars x H0).
+             intros v H0. specialize (COMPLETE v H0). specialize (Hvars v H0).
              rewrite (cenv_sub_sizeof CSUB); auto. }
       replace (level jm2) with (level jm''')
         by (clear - H13 H20x H20'; apply age_level in H13;
             apply age_level in H20x; lia).
-      eapply assert_safe_jsafe, own.bupd_mono, H19.
-      intros ? Hsafe ?? Hora0 ??.
-      subst; specialize (Hsafe ora0 _ Hora0 eq_refl eq_refl).
-      clear - Hsafe.
-      intros.
-      specialize (Hsafe LW).
-      simpl in Hsafe.
-      case_eq (@level rmap ag_rmap (m_phi jm0)); intros; [lia | clear LW ].
-      rewrite H in Hsafe.
-      auto.
+      eapply assert_safe_jsafe, H19.
 Qed.
 
 Lemma semax_call_aux' {CS Espec}
@@ -3084,12 +3093,12 @@ Lemma semax_call_aux' {CS Espec}
   (Hretty: retty =Tvoid -> ret=None)
   (CLosed: closed_wrt_modvars (Scall ret a bl) F0)
   nQ
-  (PREHR: (|> own.bupd
+  (PREHR: (|> fupd
               (EX (ts: list Type) (x : dependent_type_functor_rec ts A mpred)
                   (F : environ -> pred rmap),
                (F0 rho * F rho * deltaP ts x (ge_of rho, args)) &&
               (ALL rho' : environ ,
-       !((EX old:val, substopt ret (`old) F rho' * maybe_retval (nQ ts x) retty ret rho') >=> own.bupd (RA_normal R rho') )))) (m_phi jm))
+       !((EX old:val, substopt ret (`old) F rho' * maybe_retval (nQ ts x) retty ret rho') >=> fupd (RA_normal R rho') )))) (m_phi jm))
   (CSUB: cenv_sub (@cenv_cs CS) (genv_cenv psi))
   (Hrho: rho = construct_rho (filter_genv psi) vx tx)
   (EvalA: eval_expr a rho = Vptr b Ptrofs.zero)
@@ -3099,13 +3108,13 @@ Lemma semax_call_aux' {CS Espec}
   (PostAdapt: forall (ts: list Type) (x : dependent_type_functor_rec ts A mpred)
                      (vl : fconst environ mpred),
         (! |> (deltaQ ts x vl <=> nQ ts x vl)) (m_phi jm)):
-jsafeN (@OK_spec Espec) psi (level (m_phi jm)) ora
+jsafeN (@OK_spec Espec) psi ora
      (State curf (Scall ret a bl) k vx tx) jm.
 Proof.
   intros. apply now_later in RGUARD.
   eapply semax_call_aux; try eassumption.
   eapply later_derives, PREHR.
-  apply own.bupd_mono.
+  apply fupd.fupd_mono.
   apply exp_left; intros ts; apply exp_left; intros x; apply exp_left; intros FF;
     apply exp_right with ts; apply exp_right with x; apply exp_right with FF.
   apply andp_derives; auto.
@@ -3165,8 +3174,7 @@ normalize in pre. (*unfold func_ptr in *. hnf in pre.*)
 destruct pre as [preA preB]. destruct preA as [b [EvalA funcatb]].
 destruct preB as [z1 [z2 [JZ [HF0 pre]]]].
 destruct (level w) eqn: Hl.
-{ apply own.bupd_intro; repeat intro.
-  rewrite Hl; constructor. }
+{ apply fupd.fupd_intro; repeat intro; lia. }
 destruct (levelS_age w n) as (w' & Hage & Hw'); auto.
 
 hnf in funcatb.
@@ -3313,49 +3321,45 @@ specialize (ClientAdaptation w2'). spec ClientAdaptation.
   + apply age_laterR in Age2. apply (W2 _ Age2). }
     apply rmap_order in Hext as (Hl' & _ & _).
     rewrite Hl' in *; clear dependent a'.
-assert (ARGS: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho *
+assert (ARGS: app_pred (|> fupd (EX ts1 x1 G, F0 rho *
      (F rho * G) * deltaP ts1 x1 (ge_of rho, args) && !! (forall rho' : environ,
                             !! (ve_of rho' = Map.empty (block * type)) &&
-                            (G * nQ ts1 x1 rho') |-- own.bupd (Q ts x rho')))) w).
+                            (G * nQ ts1 x1 rho') |-- fupd (Q ts x rho')))) w).
 { clear Hpost SpecOfID Prog_OK RhoID TC7' RGUARD funcatb. rewrite HARGS in *.
   assert (XX: (|> (F0 rho * F rho *
-                   own.bupd (EX ts1 x1 G, G * deltaP ts1 x1 (ge_of rho, args) &&
+                   fupd (EX ts1 x1 G, G * deltaP ts1 x1 (ge_of rho, args) &&
               !! (forall rho' : environ,
                      !! (ve_of rho' = Map.empty (block * type)) &&
-                     (G * nQ ts1 x1 rho') |-- own.bupd (Q ts x rho'))))) w).
+                     (G * nQ ts1 x1 rho') |-- fupd (Q ts x rho'))))) w).
   { rewrite later_sepcon.
     exists w1, w2; split. trivial. split. trivial. hnf; intros.
     destruct (age_later Age2 H); [ subst a' |].
-    - intros ? J2. destruct (ClientAdaptation _ J2) as
-          (? & ? & w2b & Hlb & ? & ? & GS); subst.
-      destruct GS as [ts1 [x1 [G [HG1 HG2]]]].
-      exists (ghost_of w2b); split; auto; exists w2b; repeat (split; auto).
-      exists ts1, x1, G; split; auto.
-      destruct HG1 as [u1 [u2 [JU [U1 U2]]]];
-        destruct (join_level _ _ _ JU) as [LevU1 LevU2].
-      exists u1, u2; split; trivial. split; trivial.
-      assert (LatWU2: laterM (level w) (level u2)).
-      { rewrite LevU2, <- LevW2, Hlb. apply laterR_level'; trivial. }
-      specialize (Hpre ts1 x1 (ge_of rho, args)).
-      eapply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | apply ext_refl | trivial].
-      rewrite HARGS. subst rho. rewrite <- Hpsi. apply U2.
+    - assert ((ALL ts x vl, (deltaP ts x vl <=> nP ts x vl)) (level w2')) as Hpre'.
+      { intros ts1 x1 G1; apply Hpre.
+        apply join_level in J as [_ <-]; apply laterR_level'; auto. }
+      eapply fupd.subp_fupd, ClientAdaptation; try apply Hpre'; eauto.
+      apply subp_exp; intros ts1.
+      apply subp_exp; intros x1.
+      apply subp_exp; intros G.
+      apply subp_andp, subp_refl.
+      apply subp_sepcon; [apply subp_refl|].
+      rewrite HARGS. subst rho. rewrite <- Hpsi.
+      do 3 eapply allp_left. rewrite andp_comm; apply eqp_subp.
     - apply (pred_nec_hereditary _ _ a') in ClientAdaptation.
-      intros ? J2; destruct (ClientAdaptation _ J2) as
-          (? & ? & w2b & Hlb & ? & ? & GS); subst.
-      destruct GS as [ts1 [x1 [G [HG1 HG2]]]].
-      exists (ghost_of w2b); split; auto; exists w2b; repeat (split; auto).
-      exists ts1, x1, G; split; auto.
-      destruct HG1 as [u1 [u2 [JU [U1 U2]]]];
-        destruct (join_level _ _ _ JU) as [LevU1 LevU2].
-      exists u1, u2; split; trivial. split; trivial.
-      assert (LatWU2: laterM (level w) (level u2)).
-      { rewrite LevU2, <- LevW2, Hlb. apply laterR_level'; trivial. }
-      specialize (Hpre ts1 x1 (ge_of rho, args)).
-      eapply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | apply ext_refl | trivial].
-      + rewrite HARGS. subst rho. rewrite <- Hpsi. apply U2.
+      assert ((ALL ts x vl, (deltaP ts x vl <=> nP ts x vl)) (level a')) as Hpre'.
+      { intros ts1 x1 G1; apply Hpre.
+        apply join_level in J as [_ <-]; apply laterR_level'; auto. }
+      eapply fupd.subp_fupd, ClientAdaptation; try apply Hpre'; eauto.
+      apply subp_exp; intros ts1.
+      apply subp_exp; intros x1.
+      apply subp_exp; intros G.
+      apply subp_andp, subp_refl.
+      apply subp_sepcon; [apply subp_refl|].
+      rewrite HARGS. subst rho. rewrite <- Hpsi.
+      do 3 eapply allp_left. rewrite andp_comm; apply eqp_subp.
       + apply laterR_necR; trivial. }
   rewrite <- HARGS. clear - XX. eapply later_derives, XX.
-  eapply derives_trans; [apply own.bupd_frame_l | apply own.bupd_mono].
+  eapply derives_trans; [apply fupd.fupd_frame_l | apply fupd.fupd_mono].
   apply derives_refl'.
   rewrite !exp_sepcon2; f_equal; extensionality.
   rewrite !exp_sepcon2; f_equal; extensionality.
@@ -3363,7 +3367,7 @@ assert (ARGS: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho *
   rewrite <- !sepcon_assoc.
   rewrite !(andp_comm _ (!!_)), !sepcon_andp_prop.
   rewrite <- !sepcon_assoc; auto. }
-apply own.bupd_intro.
+apply fupd.fupd_intro.
 simpl; unfold assert_safe'_; intros; subst.
 assert (CSUBpsi:cenv_sub (@cenv_cs CS) psi).
 { destruct HGG as [CSUB' HGG]. apply (cenv_sub_trans CSUB' HGG). }
@@ -3372,22 +3376,22 @@ subst rho.
 rewrite (typecheck_expr_sound_cenv_sub CSUB Delta' _ TCD' w' a) in EvalA by
     (apply (TC1 w' (age_laterR  Hage))).
 
-eapply (@semax_call_aux' CS') with
-    (deltaP:=deltaP) (F0:=F0) (rho:=construct_rho (filter_genv psi) vx tx);
-  try eassumption; try trivial.
+eapply (@semax_call_aux' CS') with (deltaP:=deltaP)(F0:=F0)(rho:=construct_rho (filter_genv psi) vx tx)(Delta := Delta')
+  (clientparams := clientparams)(retty := retty)(cc := ncc)(id := id)(b := b)(NEP' := NEP')(NEQ' := NEQ');
+  try assumption; try trivial; [.. | eassumption].
 1: { clear - TC1 CSUB; intros w W. apply (tc_expr_cenv_sub CSUB _ _ _ _ (TC1 _ W)). }
 1: { clear - Espec TC2 CSUB. intros w W. specialize (TC2 _ W).
      apply (tc_exprlist_cenv_sub CSUB). apply TC2. }
-simpl RA_normal; auto. eapply later_derives, ARGS; apply own.bupd_mono.
-apply exp_left; intros ts1; apply exp_left; intros x1; apply exp_left; intros G; apply exp_right with ts1; apply exp_right with x1.
+simpl RA_normal; auto. eapply later_derives, ARGS; apply fupd.fupd_mono.
+apply exp_derives; intros ts1; apply exp_derives; intros x1; apply exp_left; intros G.
 apply exp_right with (fun rho => F rho * G).
-apply andp_derives; auto.
+rewrite HARGS; apply andp_derives; auto.
 intros ? HG2.
 clear - TRIV TC7' HG2.
 intros rho' u U ? m NEC Hext [v V].
 hnf in TC7'.
 rewrite <- exp_sepcon1.
-apply own.bupd_frame_l.
+apply fupd.fupd_frame_l.
 destruct ret.
 - remember ((temp_types Delta') ! i) as rr; destruct rr; try contradiction; subst t.
   simpl in V. destruct V as [m1 [m2 [JM [[u1 [u2 [JU [U1 U2]]]] M2]]]].
@@ -3396,37 +3400,36 @@ destruct ret.
   hnf in HG2. specialize (HG2 (get_result1 i rho') q1). destruct M2.
   spec HG2. {
     simpl. split; trivial. exists u2, m2; auto. }
-  hnf in HG2 |-* . intros. specialize (HG2 c H1). simpl.
-  destruct HG2 as [b [HJ [m' [HL [HR [HG HQ]]]]]]. exists b. split; auto. exists m'.
-  split; auto.
+  eapply fupd.fupd_mono, HG2; simpl.
+  rewrite prop_true_andp; auto.
 - destruct V as [m1 [m2 [JM [[u1 [u2 [JU [U1 U2]]]] M2]]]].
   destruct (join_assoc JU JM) as [q1 [Q2 Q1]]. simpl in M2.
   exists u1, q1; split; trivial. split. exists v; apply U1.
   hnf in HG2. destruct retty.
   + apply HG2. simpl. split. hnf; simpl; intuition. exists u2, m2; auto.
   + destruct M2 as [z [TCv M2]].
-    eapply own.bupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
+    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
                                 simpl; split; auto; exists u2, m2; auto].
   + destruct M2 as [z [TCv M2]].
-    eapply own.bupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
+    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
                                 simpl; split; auto; exists u2, m2; auto].
   + destruct M2 as [z [TCv M2]].
-    eapply own.bupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
+    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
                                 simpl; split; auto; exists u2, m2; auto].
   + destruct M2 as [z [TCv M2]].
-    eapply own.bupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
+    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
                                 simpl; split; auto; exists u2, m2; auto].
   + destruct M2 as [z0 [TCv M2]].
-    eapply own.bupd_mono, HG2; [apply exp_right with z0; apply prop_andp_right; auto |
+    eapply fupd.fupd_mono, HG2; [apply exp_right with z0; apply prop_andp_right; auto |
                                 simpl; split; auto; exists u2, m2; auto].
   + destruct M2 as [z [TCv M2]].
-    eapply own.bupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
+    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
                                 simpl; split; auto; exists u2, m2; auto].
   + destruct M2 as [z [TCv M2]].
-    eapply own.bupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
+    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
                                 simpl; split; auto; exists u2, m2; auto].
   + destruct M2 as [z [TCv M2]].
-    eapply own.bupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
+    eapply fupd.fupd_mono, HG2; [apply exp_right with z; apply prop_andp_right; auto |
                                 simpl; split; auto; exists u2, m2; auto].
 Qed.
 
@@ -3482,8 +3485,7 @@ normalize in pre. (*unfold func_ptr_si in *.*)
 destruct pre as [preA preB]. destruct preA as [b [EvalA funcatb]].
 destruct preB as [z1 [z2 [JZ [HF0 pre]]]].
 destruct (level w) eqn: Hl.
-{ apply own.bupd_intro; repeat intro.
-  rewrite Hl; constructor. }
+{ apply fupd.fupd_intro; repeat intro; lia. }
 destruct (levelS_age w n) as (w' & Hage & Hw'); auto.
 
 hnf in funcatb.
@@ -3605,26 +3607,27 @@ specialize (ClientAdaptation _ LW2' _ _ (necR_refl _) (ext_refl _)). spec Client
     constructor; eauto. }
 apply rmap_order in Hext as (Hl' & _ & _).
 rewrite Hl' in *; clear dependent a'.
-assert (ArgsW: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho * (F rho * G) *
+assert (ArgsW: app_pred (|> fupd (EX ts1 x1 G, F0 rho * (F rho * G) *
                deltaP ts1 x1 (ge_of rho, args) && (ALL rho' : environ,
-         ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> own.bupd (Q ts x rho'))))) w).
+         ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> fupd (Q ts x rho'))))) w).
 { clear Hpost funcatb SpecOfID Prog_OK RhoID TC7' RGUARD. rewrite HARGS in *.
-  assert (XX: (|> (F0 rho * F rho * own.bupd (EX ts1 x1 G, G * deltaP ts1 x1 (ge_of rho, args) && (ALL rho' : environ,
-         ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> own.bupd (Q ts x rho')))))) w).
+  assert (XX: (|> (F0 rho * F rho * fupd (EX ts1 x1 G, G * deltaP ts1 x1 (ge_of rho, args) && (ALL rho' : environ,
+         ! (!! (ve_of rho' = Map.empty (block * type)) && (G * nQ ts1 x1 rho') >=> fupd (Q ts x rho')))))) w).
   { rewrite later_sepcon.
     exists w1, w2; split. trivial. split. trivial. hnf; intros. specialize (age_later_nec _ _ _ Age2 H). intros.
     apply (pred_nec_hereditary _ _ a') in ClientAdaptation; auto.
-    intros ? J2; destruct (ClientAdaptation _ J2) as (? & ? & w2b & Hlb & ? & ? & GS'); subst.
-    destruct GS' as [ts1 [x1 [G [HG1 HG2]]]].
-    exists (ghost_of w2b); split; auto; exists w2b; repeat (split; auto).
-    exists ts1, x1, G; split; auto.
-    destruct HG1 as [u1 [u2 [JU [U1 U2]]]]; destruct (join_level _ _ _ JU) as [LevU1 LevU2].
-    exists u1, u2; split; trivial. split; trivial.
-    assert (LatWU2: laterM (level w) (level u2)). { rewrite LevU2, <- LevW2, Hlb. apply laterR_level'; trivial. }
-    specialize (Hpre ts1 x1 (ge_of rho, args)).
-    eapply (Hpre (level u2) LatWU2 u2); [lia | apply necR_refl | apply ext_refl | rewrite HARGS; trivial]. }
+    assert ((ALL ts x vl, (deltaP ts x vl <=> nP ts x vl)) (level a')) as Hpre'.
+    { intros ts1 x1 G1; apply Hpre.
+      apply join_level in J as [_ <-]; apply laterR_level'; auto. }
+    eapply fupd.subp_fupd, ClientAdaptation; try apply Hpre'; eauto.
+    apply subp_exp; intros ts1.
+    apply subp_exp; intros x1.
+    apply subp_exp; intros G.
+    apply subp_andp, subp_refl.
+    apply subp_sepcon; [apply subp_refl|].
+    rewrite HARGS. do 3 eapply allp_left. rewrite andp_comm; apply eqp_subp. }
   rewrite <- HARGS. clear - XX. eapply later_derives, XX.
-  eapply derives_trans; [apply own.bupd_frame_l | apply own.bupd_mono].
+  eapply derives_trans; [apply fupd.fupd_frame_l | apply fupd.fupd_mono].
   apply derives_refl'.
   rewrite !exp_sepcon2; f_equal; extensionality.
   rewrite !exp_sepcon2; f_equal; extensionality.
@@ -3632,7 +3635,7 @@ assert (ArgsW: app_pred (|> own.bupd (EX ts1 x1 G, F0 rho * (F rho * G) *
   rewrite !(andp_comm _ (allp _)), <- !unfash_allp', !sepcon_andp_unfash.
   rewrite <- !sepcon_assoc; auto. }
 apply now_later in RGUARD.
-apply own.bupd_intro; repeat intro; subst. rename H into ORA.
+apply fupd.fupd_intro; repeat intro; subst. rename H into ORA.
 
 assert (CSUBpsi:cenv_sub (@cenv_cs CS) psi).
 { destruct HGG as [CSUB' HGG]. apply (cenv_sub_trans CSUB' HGG). }
@@ -3647,13 +3650,13 @@ eapply (@semax_call_aux CS') with (deltaP:=deltaP) (F0:=F0) (rho:=construct_rho 
 { clear - Espec TC2 CSUB. intros w W. specialize (TC2 _ W).
   apply (tc_exprlist_cenv_sub CSUB). apply TC2. }
 simpl RA_normal; auto.
-eapply later_derives, ArgsW; apply own.bupd_mono.
+eapply later_derives, ArgsW; apply fupd.fupd_mono.
 apply exp_left; intros ts1; apply exp_left; intros x1; apply exp_left; intros G; apply exp_right with ts1; apply exp_right with x1.
 apply exp_right with (fun rho => F rho * G).
 apply andp_derives; auto.
 intros ? HG2.
 intros rho' l L y Y ? z YZ EZ [v Z].
-rewrite <- exp_sepcon1; apply own.bupd_frame_l.
+rewrite <- exp_sepcon1; apply fupd.fupd_frame_l.
 assert (TRIV: (forall rho, typecheck_temp_environ rho (PTree.empty type)) /\
               (typecheck_var_environ (Map.empty (block * type)) (PTree.empty type)) /\
               (forall rho, typecheck_glob_environ rho (PTree.empty type))).
@@ -3666,7 +3669,7 @@ assert (LEV2': (level a0 >= level a0)%nat) by lia.
 assert (LEVz: (level a0 >= level z)%nat).
 { apply necR_level in YZ.
   apply laterR_level in L; apply ext_level in EZ; lia. }
-destruct ret; simpl.
+destruct ret.
 - destruct Z as [z1 [z2 [JZ [Z1 Z2]]]]; destruct (join_level _ _ _ JZ) as
       [Levz1 Levz2]. simpl in Z1, Z2.
   destruct Z1 as [z1_1 [z1_2 [JZ1 [Z11 Z12]]]]; destruct (join_level _ _ _ JZ1) as
@@ -3678,8 +3681,8 @@ destruct ret; simpl.
   specialize (HG2 (get_result1 i rho') _ LL _ _ (necR_refl _) (ext_refl _)). destruct Z2 as [Z21 Z22].
   spec HG2. {
     simpl. split; trivial. exists z1_2, z2; auto. }
-  intros. specialize (HG2 c H). destruct HG2 as [b0 [HJ [m' [HL [HR [HG HQ]]]]]].
-  exists b0. split; auto. exists m'. split; auto.
+  eapply fupd.fupd_mono, HG2; simpl.
+  rewrite prop_true_andp; auto.
 - destruct Z as [z1 [z2 [JZ [Z1 Z2]]]];
     destruct (join_level _ _ _ JZ) as [Levz1 Levz2]. simpl in Z1, Z2.
   destruct Z1 as [z1_1 [z1_2 [JZ1 [Z11 Z12]]]]; destruct (join_level _ _ _ JZ1) as
@@ -3700,8 +3703,8 @@ destruct ret; simpl.
     specialize (HG2 (env_set (globals_only rho') ret_temp vv) _ LL _ _ (necR_refl _) (ext_refl _)).
     spec HG2. {
       simpl; split. hnf; simpl; intuition. exists z1_2, z2; auto. }
-    eapply own.bupd_mono, HG2.
-    destruct retty; try solve [ congruence]; exists vv; split; trivial.
+    eapply fupd.fupd_mono, HG2.
+    destruct retty; try solve [congruence]; exists vv; split; trivial.
 Qed.
 
 Lemma semax_call_alt {CS Espec}:
@@ -3750,9 +3753,8 @@ specialize (H2 y H5 _ _ H6 Hext H7).
 destruct H7 as[[? ?] _].
 hnf in H7.
 pose proof I.
-intros ? J; destruct (H2 _ J) as (? & J' & m' & Hl & Hr & ? & Hsafe); subst.
-eexists; split; eauto; exists m'; repeat split; auto.
-hnf in Hsafe|-*; intros ?? Hora ??.
+eapply fupd.fupd_mono, H2.
+intros ? Hsafe ?? Hora ???.
 specialize (Hsafe ora jm Hora H10).
 intros.
 spec Hsafe; auto.
@@ -3763,8 +3765,8 @@ reflexivity.
 simpl; intros ? ?. unfold cl_after_external. destruct ret0; auto.
 reflexivity.
 intros.
-destruct H8 as [w1 [w2 [H8' [_ ?]]]]. subst m'.
-assert (H8'': @extendM rmap _ _ _ _ _ _ rmap _ _ _ _ _ w2 a'') by (eexists; eauto). clear H8'.
+destruct H8 as [w1 [w2 [H8' [_ ?]]]].
+assert (H8'': @extendM rmap _ _ _ _ _ _ w2 a'') by (eexists; eauto). clear H8'.
 remember (construct_rho (filter_genv psi) vx tx) as rho.
 assert (H7': typecheck_environ Delta rho).
 destruct H7; eapply typecheck_environ_sub; eauto.
@@ -3775,15 +3777,18 @@ apply (boxy_e _ _ (extend_tc_expr _ _ _) _ _ H8'') in TCa.
 apply (boxy_e _ _ (extend_tc_exprlist _ _ _ _) _ _ H8'') in TCbl.
 apply (boxy_e _ _ (extend_tc_expr _ _ _) _ _ H8'') in TCa'.
 apply (boxy_e _ _ (extend_tc_exprlist _ _ _ _) _ _ H8'') in TCbl'.
-eapply @denote_tc_resource with (a' := m_phi jm) in TCa; auto.
+(*eapply @denote_tc_resource with (a' := m_phi jm) in TCa; auto.
 eapply @denote_tc_resource with (a' := m_phi jm) in TCa'; auto.
 eapply @denote_tc_resource with (a' := m_phi jm) in TCbl; auto.
-eapply @denote_tc_resource with (a' := m_phi jm) in TCbl'; auto.
+eapply @denote_tc_resource with (a' := m_phi jm) in TCbl'; auto.*)
 assert (forall vf, Clight.eval_expr psi vx tx (m_dry jm) a vf
                -> Clight.eval_expr psi vx tx (m_dry jm) a' vf). {
 clear - TCa TCa' H7 H7' H0 Heqrho HGG TS HGpsi.
 intros.
 eapply tc_expr_sub in TCa; [| eauto | eauto].
+(* In theory, we might have given up ownership of a relevant location
+   in the viewshift from a'' to jm. In practice, if we did,
+   surely the evaluation of a would fail too? *)
 pose proof (eval_expr_relate _ _ _ _ _ _ jm HGpsi Heqrho H7 TCa).
 pose proof (eval_expr_fun H H1). subst vf.
 rewrite H0.
@@ -3792,8 +3797,8 @@ eapply eval_expr_relate; eauto.
 assert (forall tyargs vargs,
              Clight.eval_exprlist psi vx tx (m_dry jm) bl tyargs vargs ->
              Clight.eval_exprlist psi vx tx (m_dry jm) bl' tyargs vargs). {
-clear - IF_ONLY TCbl TCbl' H11 Hbl H7' Heqrho HGpsi.
-revert bl bl' H11 Hbl TCbl TCbl'; induction tl; destruct bl, bl'; simpl; intros; auto;
+clear - IF_ONLY TCbl TCbl' H13 Hbl H7' Heqrho HGpsi.
+revert bl bl' H13 Hbl TCbl TCbl'; induction tl; destruct bl, bl'; simpl; intros; auto;
  try (clear IF_ONLY; contradiction).
  unfold tc_exprlist in TCbl,TCbl'. simpl in TCbl, TCbl'.
 repeat rewrite denote_tc_assert_andp in TCbl, TCbl'.
@@ -3808,8 +3813,8 @@ unfold force_val in H1.
 rewrite H9 in *.
 subst.
 clear H.
-unfold_lift in H11.
-inv H11.
+unfold_lift in H13.
+inv H13.
 specialize (IHtl _ _ H9 H8); clear H9 H8.
 assert (exists v1, Clight.eval_expr psi vx tx (m_dry jm) e0 v1 /\
                              Cop.sem_cast v1 (typeof e0) ty (m_dry jm) = Some v2). {
@@ -3824,8 +3829,8 @@ destruct H12; split; auto.
 inv H12.
 eapply step_call; eauto.
 rewrite <- H; auto.
-destruct H24 as [H24 | H24]; inv H24.
-destruct H24 as [H24 | H24]; inv H24.
+destruct H25 as [H25 | H25]; inv H25.
+destruct H25 as [H25 | H25]; inv H25.
 Qed.
 
 Definition cast_expropt {CS} (e: option expr) t : environ -> option val :=

--- a/veric/semax_conseq.v
+++ b/veric/semax_conseq.v
@@ -57,14 +57,14 @@ Proof.
   apply _guard_mono; auto.
 Qed.
 
-Definition bupd_ret_assert (Q: ret_assert): ret_assert :=
-          {| RA_normal := fun rho => bupd (RA_normal Q rho);
-             RA_break := fun rho => bupd (RA_break Q rho);
-             RA_continue := fun rho => bupd (RA_continue Q rho);
-             RA_return := fun v rho => bupd (RA_return Q v rho) |}.
+Definition fupd_ret_assert (Q: ret_assert): ret_assert :=
+          {| RA_normal := fun rho => fupd (RA_normal Q rho);
+             RA_break := fun rho => fupd (RA_break Q rho);
+             RA_continue := fun rho => fupd (RA_continue Q rho);
+             RA_return := fun v rho => fupd (RA_return Q v rho) |}.
 
-Lemma bupd_andp_prop:
-  forall P Q, bupd (!! P && Q) = !!P && bupd Q.
+Lemma fupd_andp_prop:
+  forall P Q, fupd (!! P && Q) = !!P && fupd Q.
 Proof.
 intros.
 apply pred_ext; repeat intro.
@@ -82,26 +82,26 @@ rewrite prop_true_andp in * by auto.
 auto.
 Qed.
 
-Lemma proj_bupd_ret_assert: forall Q ek vl,
-  proj_ret_assert (bupd_ret_assert Q) ek vl = fun rho => bupd (proj_ret_assert Q ek vl rho).
+Lemma proj_fupd_ret_assert: forall Q ek vl,
+  proj_ret_assert (fupd_ret_assert Q) ek vl = fun rho => fupd (proj_ret_assert Q ek vl rho).
 Proof.
   intros.
  extensionality rho.
   destruct ek; simpl; auto;
-  rewrite bupd_andp_prop; auto.
+  rewrite fupd_andp_prop; auto.
 Qed.
 
 (* The following four lemmas is not now used. but after deep embedded hoare logic (SL_as_Logic) is
 ported, the frame does not need to be quantified in the semantic definition of semax. Then,
 these two lemmas can replace the other two afterwards. *)
 
-Lemma assert_safe_bupd':
+Lemma assert_safe_fupd':
   forall {Espec: OracleKind} gx vx tx rho (P: environ -> pred rmap) Delta f k,
     let PP1 := !! guard_environ Delta f rho in
     let PP2 := funassert Delta rho in
     PP1 && (P rho) && PP2 >=>
     assert_safe Espec gx f vx tx k rho =
-    PP1 && (bupd (P rho)) && PP2 >=>
+    PP1 && (fupd (P rho)) && PP2 >=>
     assert_safe Espec gx f vx tx k rho.
 Proof.
   intros.
@@ -110,7 +110,7 @@ Proof.
     hnf; intros.
     intros ?? H1 Hext H2.
     destruct H2 as [[? ?] ?].
-    apply bupd_trans.
+    apply fupd_trans.
     hnf.
     intros.
     specialize (H3 _ H5).
@@ -130,47 +130,47 @@ Proof.
     eapply H; eauto.
     destruct H2 as [[? ?] ?].
     split; [split |]; auto.
-    apply bupd_intro; auto.
+    apply fupd_intro; auto.
 Qed.
 
-Lemma _guard_bupd':
+Lemma _guard_fupd':
   forall {Espec: OracleKind} ge Delta (P: environ -> pred rmap) f k,
-    _guard Espec ge Delta f P k = _guard Espec ge Delta f (fun rho => bupd (P rho)) k.
+    _guard Espec ge Delta f P k = _guard Espec ge Delta f (fun rho => fupd (P rho)) k.
 Proof.
   intros.
   unfold _guard.
   f_equal; extensionality tx.
   f_equal; extensionality vx.
-  apply assert_safe_bupd'.
+  apply assert_safe_fupd'.
 Qed.
   
-Lemma guard_bupd':
+Lemma guard_fupd':
   forall {Espec: OracleKind} ge Delta f (P: environ -> pred rmap) k,
-    guard Espec ge Delta f P k = guard Espec ge Delta f (fun rho => bupd (P rho)) k.
+    guard Espec ge Delta f P k = guard Espec ge Delta f (fun rho => fupd (P rho)) k.
 Proof.
   intros.
-  apply _guard_bupd'.
+  apply _guard_fupd'.
 Qed.
 
-Lemma rguard_bupd':
+Lemma rguard_fupd':
   forall {Espec: OracleKind} ge Delta f (P: ret_assert) k,
-    rguard Espec ge Delta f P k = rguard Espec ge Delta f (bupd_ret_assert P) k.
+    rguard Espec ge Delta f P k = rguard Espec ge Delta f (fupd_ret_assert P) k.
 Proof.
   intros.
   unfold rguard.
   f_equal; extensionality ek.
   f_equal; extensionality vl.
-  rewrite proj_bupd_ret_assert.
-  apply _guard_bupd'.
+  rewrite proj_fupd_ret_assert.
+  apply _guard_fupd'.
 Qed.
 
-Lemma assert_safe_bupd:
+Lemma assert_safe_fupd:
   forall {Espec: OracleKind} gx vx tx rho (F P: environ -> pred rmap) Delta f k,
     let PP1 := !! guard_environ Delta f rho in
     let PP2 := funassert Delta rho in
     PP1 && (F rho * P rho) && PP2 >=>
     assert_safe Espec gx f vx tx k rho =
-    PP1 && (F rho * bupd (P rho)) && PP2 >=>
+    PP1 && (F rho * fupd (P rho)) && PP2 >=>
     assert_safe Espec gx f vx tx k rho.
 Proof.
   intros.
@@ -179,10 +179,10 @@ Proof.
     hnf; intros.
     intros ?? H1 Hext H2.
     destruct H2 as [[? ?] ?].
-    apply bupd_trans.
+    apply fupd_trans.
     hnf.
     intros.
-    apply bupd_frame_l in H3.
+    apply fupd_frame_l in H3.
     specialize (H3 _ H5).
     destruct H3 as [b [? [m' [? [? [? ?]]]]]].
     exists b; split; auto.
@@ -202,39 +202,39 @@ Proof.
     split; [split |]; auto.
     revert H3.
     apply sepcon_derives; auto.
-    apply bupd_intro.
+    apply fupd_intro.
 Qed.
 
-Lemma _guard_bupd:
+Lemma _guard_fupd:
   forall {Espec: OracleKind} ge Delta f (F P: environ -> pred rmap) k,
-    _guard Espec ge Delta f (fun rho => F rho * P rho) k = _guard Espec ge Delta f (fun rho => F rho * bupd (P rho)) k.
+    _guard Espec ge Delta f (fun rho => F rho * P rho) k = _guard Espec ge Delta f (fun rho => F rho * fupd (P rho)) k.
 Proof.
   intros.
   unfold _guard.
   f_equal; extensionality tx.
   f_equal; extensionality vx.
-  apply assert_safe_bupd.
+  apply assert_safe_fupd.
 Qed.
   
-Lemma guard_bupd:
+Lemma guard_fupd:
   forall {Espec: OracleKind} ge Delta f (F P: environ -> pred rmap) k,
-    guard Espec ge Delta f (fun rho => F rho * P rho) k = guard Espec ge Delta f (fun rho => F rho * bupd (P rho)) k.
+    guard Espec ge Delta f (fun rho => F rho * P rho) k = guard Espec ge Delta f (fun rho => F rho * fupd (P rho)) k.
 Proof.
   intros.
-  apply _guard_bupd.
+  apply _guard_fupd.
 Qed.
 
-Lemma rguard_bupd:
+Lemma rguard_fupd:
   forall {Espec: OracleKind} ge Delta F f (P: ret_assert) k,
-    rguard Espec ge Delta f (frame_ret_assert P F) k = rguard Espec ge Delta f (frame_ret_assert (bupd_ret_assert P) F) k.
+    rguard Espec ge Delta f (frame_ret_assert P F) k = rguard Espec ge Delta f (frame_ret_assert (fupd_ret_assert P) F) k.
 Proof.
   intros.
   unfold rguard.
   f_equal; extensionality ek.
   f_equal; extensionality vl.
   rewrite !proj_frame.
-  rewrite proj_bupd_ret_assert.
-  apply _guard_bupd.
+  rewrite proj_fupd_ret_assert.
+  apply _guard_fupd.
 Qed.
 
 Definition except_0_ret_assert (Q: ret_assert): ret_assert :=
@@ -539,15 +539,15 @@ Qed.
 Lemma semax_conseq {CS: compspecs} {Espec: OracleKind}:
  forall Delta P' (R': ret_assert) P c (R: ret_assert) ,
    (forall rho,  seplog.derives (!!(typecheck_environ Delta rho) && (allp_fun_id Delta rho && P rho))
-                   (bupd (|> FF || P' rho)) ) ->
+                   (fupd (|> FF || P' rho)) ) ->
    (forall rho,  seplog.derives (!!(typecheck_environ Delta rho) && (allp_fun_id Delta rho && RA_normal R' rho))
-                   (bupd (|> FF || RA_normal R rho))) ->
+                   (fupd (|> FF || RA_normal R rho))) ->
    (forall rho, seplog.derives (!! (typecheck_environ Delta rho) && (allp_fun_id Delta rho && RA_break R' rho))
-                   (bupd (|> FF || RA_break R rho))) ->
+                   (fupd (|> FF || RA_break R rho))) ->
    (forall rho, seplog.derives (!! (typecheck_environ Delta rho) && (allp_fun_id Delta rho && RA_continue R' rho))
-                   (bupd (|> FF || RA_continue R rho))) ->
+                   (fupd (|> FF || RA_continue R rho))) ->
    (forall vl rho, seplog.derives (!! (typecheck_environ Delta rho) && (allp_fun_id Delta rho && RA_return R' vl rho))
-                   (bupd (|> FF || RA_return R vl rho))) ->
+                   (fupd (|> FF || RA_return R vl rho))) ->
    semax Espec Delta P' c R' ->  semax Espec Delta P c R.
 Proof.
   intros.
@@ -566,11 +566,11 @@ Proof.
  + erewrite (rguard_allp_fun_id _ _ _ _ _ R') by eauto.
     erewrite (rguard_tc_environ _ _ _ _ _ (conj_ret_assert R' _)) by eauto.
     eapply derives_trans; [apply  (rguard_except_0 _ _ _ _ R) |].
-    rewrite (rguard_bupd _ _ _ _ (except_0_ret_assert _)).
+    rewrite (rguard_fupd _ _ _ _ (except_0_ret_assert _)).
     apply rguard_mono.
     intros.
     rewrite proj_frame, proj_conj, proj_conj.
-    rewrite proj_frame, proj_bupd_ret_assert.
+    rewrite proj_frame, proj_fupd_ret_assert.
     apply sepcon_derives; auto.
     destruct rk;
          [rename H0 into Hx; pose (ek:=RA_normal)
@@ -587,7 +587,7 @@ all:    specialize (Hx rho); inv Hx; simpl in *;
   + erewrite (guard_allp_fun_id _ _ _ _ _ P) by eauto.
     erewrite (guard_tc_environ _ _ _ _ _ (fun rho => allp_fun_id Delta rho && P rho)) by eauto.
     rewrite (guard_except_0 _ _ _ _ P').
-    rewrite (guard_bupd _ _ _ _ (fun rho => |> FF || P' rho)).
+    rewrite (guard_fupd _ _ _ _ (fun rho => |> FF || P' rho)).
     apply guard_mono.
     intros.
     apply sepcon_derives; auto.
@@ -595,11 +595,11 @@ all:    specialize (Hx rho); inv Hx; simpl in *;
 Qed.
 
 (* Part 2: Deriving simpler and older version of consequence rules from semax_conseq. *)
-Lemma semax'_post_bupd:
+Lemma semax'_post_fupd:
  forall {CS: compspecs} {Espec: OracleKind} (R': ret_assert) Delta (R: ret_assert) P c,
    (forall ek vl rho,  !!(typecheck_environ Delta rho ) && 
                 proj_ret_assert R' ek vl rho 
-         |-- bupd (proj_ret_assert R ek vl rho)) ->
+         |-- fupd (proj_ret_assert R ek vl rho)) ->
    semax' Espec Delta P c R' |-- semax' Espec Delta P c R.
 Proof.
 intros.
@@ -622,7 +622,7 @@ apply allp_derives; intro ve.
 intros ? ?.
 intros ? ? ? ? ? Hext ?.
 destruct H3 as [[? HFP] ?].
-assert (bupd (proj_ret_assert (frame_ret_assert R F) ek vl
+assert (fupd (proj_ret_assert (frame_ret_assert R F) ek vl
   (construct_rho (filter_genv psi) ve te)) a'') as HFP'.
 { specialize (H ek vl (construct_rho (filter_genv psi) ve te)).
   rewrite prop_true_andp in H.
@@ -632,26 +632,26 @@ assert (bupd (proj_ret_assert (frame_ret_assert R F) ek vl
     destruct HFP as [Hvl HFP]. rewrite !prop_true_andp in H by auto.
     simpl proj_ret_assert. rewrite prop_true_andp by auto.
     eapply sepcon_derives in HFP; [| apply H | apply derives_refl].
-    apply bupd_frame_r in HFP.
+    apply fupd_frame_r in HFP.
     destruct R; auto.
   * destruct R'.
     destruct HFP as [Hvl HFP]. rewrite !prop_true_andp in H by auto.
     simpl proj_ret_assert. rewrite prop_true_andp by auto.
     eapply sepcon_derives in HFP; [| apply H | apply derives_refl].
-    apply bupd_frame_r in HFP.
+    apply fupd_frame_r in HFP.
     destruct R; auto.
   * destruct R'.
     destruct HFP as [Hvl HFP]. rewrite !prop_true_andp in H by auto.
     simpl proj_ret_assert. rewrite prop_true_andp by auto.
     eapply sepcon_derives in HFP; [| apply H | apply derives_refl].
-    apply bupd_frame_r in HFP.
+    apply fupd_frame_r in HFP.
     destruct R; auto.
   * destruct R'.
     eapply sepcon_derives in HFP; [| apply H | apply derives_refl].
-    apply bupd_frame_r in HFP.
+    apply fupd_frame_r in HFP.
     destruct R; auto.
   * destruct H3; eapply typecheck_environ_sub; eauto. }
-assert ((bupd (assert_safe Espec psi f ve te (exit_cont ek vl k)
+assert ((fupd (assert_safe Espec psi f ve te (exit_cont ek vl k)
   (construct_rho (filter_genv psi) ve te))) a'') as Hsafe.
 { intros ? J.
   destruct (HFP' _ J) as (b & ? & m' & ? & ? & ? & ?).
@@ -662,7 +662,7 @@ assert ((bupd (assert_safe Espec psi f ve te (exit_cont ek vl k)
   intro X; eapply X; auto.
   split; [split|]; auto.
   apply funassert_resource with (a := a''); auto. }
-eapply bupd_trans; eauto.
+eapply fupd_trans; eauto.
 Qed.
 
 Lemma semax'_post:
@@ -673,13 +673,13 @@ Lemma semax'_post:
    semax' Espec Delta P c R' |-- semax' Espec Delta P c R.
 Proof.
 intros.
-apply semax'_post_bupd.
-intros; eapply derives_trans, bupd_intro; auto.
+apply semax'_post_fupd.
+intros; eapply derives_trans, fupd_intro; auto.
 Qed.
 
-Lemma semax'_pre_bupd:
+Lemma semax'_pre_fupd:
  forall {CS: compspecs} {Espec: OracleKind} P' Delta R P c,
-  (forall rho, typecheck_environ Delta rho ->   P rho |-- bupd (P' rho))
+  (forall rho, typecheck_environ Delta rho ->   P rho |-- fupd (P' rho))
    ->   semax' Espec Delta P' c R |-- semax' Espec Delta P c R.
 Proof.
 intros.
@@ -700,8 +700,8 @@ intros ? ?.
 intros ? ? ? ? ? Hext ?.
 destruct H3 as [[? HFP] ?].
 eapply sepcon_derives in HFP; [| apply derives_refl | apply H].
-apply bupd_frame_l in HFP.
-apply bupd_trans; intros ? J.
+apply fupd_frame_l in HFP.
+apply fupd_trans; intros ? J.
 destruct (HFP _ J) as (b & ? & m' & ? & ? & ? & HFP').
 exists b; split; auto; exists m'; repeat split; auto.
 pose proof (necR_level _ _ H2).
@@ -718,23 +718,23 @@ Lemma semax'_pre:
   (forall rho, typecheck_environ Delta rho ->   P rho |-- P' rho)
    ->   semax' Espec Delta P' c R |-- semax' Espec Delta P c R.
 Proof.
-intros; apply semax'_pre_bupd.
-intros; eapply derives_trans, bupd_intro; auto.
+intros; apply semax'_pre_fupd.
+intros; eapply derives_trans, fupd_intro; auto.
 Qed.
 
-Lemma semax'_pre_post_bupd:
+Lemma semax'_pre_post_fupd:
  forall
       {CS: compspecs} {Espec: OracleKind} P' (R': ret_assert) Delta (R: ret_assert) P c,
-   (forall rho, typecheck_environ Delta rho ->   P rho |-- bupd (P' rho)) ->
+   (forall rho, typecheck_environ Delta rho ->   P rho |-- fupd (P' rho)) ->
    (forall ek vl rho, !!(typecheck_environ Delta rho) 
                        &&  proj_ret_assert R ek vl rho 
-                    |-- bupd (proj_ret_assert R' ek vl rho)) ->
+                    |-- fupd (proj_ret_assert R' ek vl rho)) ->
    semax' Espec Delta P' c R |-- semax' Espec Delta P c R'.
 Proof.
 intros.
 eapply derives_trans.
-apply semax'_pre_bupd; eauto.
-apply semax'_post_bupd; auto.
+apply semax'_pre_fupd; eauto.
+apply semax'_post_fupd; auto.
 Qed.
 
 Lemma semax'_pre_post:
@@ -752,36 +752,36 @@ apply semax'_pre; eauto.
 apply semax'_post; auto.
 Qed.
 
-Lemma semax_post'_bupd {CS: compspecs} {Espec: OracleKind}:
+Lemma semax_post'_fupd {CS: compspecs} {Espec: OracleKind}:
  forall (R': ret_assert) Delta (R: ret_assert) P c,
    (forall ek vl rho,  !!(typecheck_environ Delta rho) 
                       &&  proj_ret_assert R' ek vl rho
-                        |-- bupd (proj_ret_assert R ek vl rho)) ->
+                        |-- fupd (proj_ret_assert R ek vl rho)) ->
    semax Espec Delta P c R' ->  semax Espec Delta P c R.
 Proof.
 unfold semax.
 intros.
 specialize (H0 n). revert n H0.
-apply semax'_post_bupd.
+apply semax'_post_fupd.
 auto.
 Qed.
 
-Lemma semax_post_bupd {CS: compspecs} {Espec: OracleKind}:
+Lemma semax_post_fupd {CS: compspecs} {Espec: OracleKind}:
  forall (R': ret_assert) Delta (R: ret_assert) P c,
    (forall rho,  !!(typecheck_environ Delta rho) 
-                      &&  RA_normal R' rho |-- bupd (RA_normal R rho)) ->
+                      &&  RA_normal R' rho |-- fupd (RA_normal R rho)) ->
    (forall rho, !! (typecheck_environ Delta rho) 
-                      && RA_break R' rho |-- bupd (RA_break R rho)) ->
+                      && RA_break R' rho |-- fupd (RA_break R rho)) ->
    (forall rho, !! (typecheck_environ Delta rho) 
-                      && RA_continue R' rho |-- bupd (RA_continue R rho)) ->
+                      && RA_continue R' rho |-- fupd (RA_continue R rho)) ->
    (forall vl rho, !! (typecheck_environ Delta rho) 
-                      && RA_return R' vl rho |-- bupd (RA_return R vl rho)) ->
+                      && RA_return R' vl rho |-- fupd (RA_return R vl rho)) ->
    semax Espec Delta P c R' ->  semax Espec Delta P c R.
 Proof.
 unfold semax.
 intros.
 specialize (H3 n). revert n H3.
-apply semax'_post_bupd.
+apply semax'_post_fupd.
 intros; destruct ek; simpl;
 repeat (apply normalize.derives_extract_prop; intro); rewrite ?prop_true_andp by auto;
 specialize (H rho); specialize (H0 rho); specialize (H1 rho); specialize (H2 vl rho);
@@ -824,16 +824,16 @@ specialize (H rho); specialize (H0 rho); specialize (H1 rho); specialize (H2 vl 
 rewrite prop_true_andp in H, H0, H1, H2 by auto; auto.
 Qed.
 
-Lemma semax_pre_bupd {CS: compspecs} {Espec: OracleKind} :
+Lemma semax_pre_fupd {CS: compspecs} {Espec: OracleKind} :
  forall P' Delta P c R,
-   (forall rho,  !!(typecheck_environ Delta rho) &&  P rho |-- bupd (P' rho) )%pred ->
+   (forall rho,  !!(typecheck_environ Delta rho) &&  P rho |-- fupd (P' rho) )%pred ->
      semax Espec Delta P' c R  -> semax Espec Delta P c R.
 Proof.
 unfold semax.
 intros.
 specialize (H0 n).
 revert n H0.
-apply semax'_pre_bupd.
+apply semax'_pre_fupd.
 repeat intro. apply (H rho a); auto. split; auto.
 Qed.
 
@@ -850,22 +850,22 @@ apply semax'_pre.
 repeat intro. apply (H rho a). split; auto.
 Qed.
 
-Lemma semax_pre_post_bupd {CS: compspecs} {Espec: OracleKind}:
+Lemma semax_pre_post_fupd {CS: compspecs} {Espec: OracleKind}:
  forall P' (R': ret_assert) Delta P c (R: ret_assert) ,
-   (forall rho,  !!(typecheck_environ Delta rho) &&  P rho |-- bupd (P' rho) )%pred ->
+   (forall rho,  !!(typecheck_environ Delta rho) &&  P rho |-- fupd (P' rho) )%pred ->
    (forall rho,  !!(typecheck_environ Delta rho) 
-                      &&  RA_normal R' rho |-- bupd (RA_normal R rho)) ->
+                      &&  RA_normal R' rho |-- fupd (RA_normal R rho)) ->
    (forall rho, !! (typecheck_environ Delta rho) 
-                      && RA_break R' rho |-- bupd (RA_break R rho)) ->
+                      && RA_break R' rho |-- fupd (RA_break R rho)) ->
    (forall rho, !! (typecheck_environ Delta rho) 
-                      && RA_continue R' rho |-- bupd (RA_continue R rho)) ->
+                      && RA_continue R' rho |-- fupd (RA_continue R rho)) ->
    (forall vl rho, !! (typecheck_environ Delta rho) 
-                      && RA_return R' vl rho |-- bupd (RA_return R vl rho)) ->
+                      && RA_return R' vl rho |-- fupd (RA_return R vl rho)) ->
    semax Espec Delta P' c R' ->  semax Espec Delta P c R.
 Proof.
 intros.
-eapply semax_pre_bupd; eauto.
-eapply semax_post_bupd; eauto.
+eapply semax_pre_fupd; eauto.
+eapply semax_post_fupd; eauto.
 Qed.
 
 Lemma semax_pre_post {CS: compspecs} {Espec: OracleKind}:
@@ -886,11 +886,11 @@ eapply semax_pre; eauto.
 eapply semax_post; eauto.
 Qed.
 
-Lemma semax_bupd_elim {CS: compspecs} {Espec: OracleKind}:
+Lemma semax_fupd_elim {CS: compspecs} {Espec: OracleKind}:
  forall Delta P c R,
-  semax Espec Delta P c R -> semax Espec Delta (fun rho => bupd (P rho)) c R.
+  semax Espec Delta P c R -> semax Espec Delta (fun rho => fupd (P rho)) c R.
 Proof.
-intros ????; apply semax_pre_bupd.
+intros ????; apply semax_pre_fupd.
 intro; apply prop_andp_left; auto.
 Qed.
 
@@ -922,82 +922,82 @@ Qed.
 
 Lemma semax_adapt_frame {cs Espec} Delta c (P P': assert) (Q Q' : ret_assert)
    (H: forall rho,  derives (!!(typecheck_environ Delta rho) && (allp_fun_id Delta rho && P rho))
-                   (EX F: assert, (!!(closed_wrt_modvars c F) && bupd (P' rho * F rho) &&
-                         !!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_normal (frame_ret_assert Q' F) rho |-- bupd (RA_normal Q rho)) &&
-                         !!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_break (frame_ret_assert Q' F) rho |-- bupd (RA_break Q rho)) &&
-                         !!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_continue (frame_ret_assert Q' F) rho |-- bupd (RA_continue Q rho)) &&
-                         !!(forall vl rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_return (frame_ret_assert Q' F) vl rho |-- bupd (RA_return Q vl rho)))))
+                   (EX F: assert, (!!(closed_wrt_modvars c F) && fupd (P' rho * F rho) &&
+                         !!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_normal (frame_ret_assert Q' F) rho |-- fupd (RA_normal Q rho)) &&
+                         !!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_break (frame_ret_assert Q' F) rho |-- fupd (RA_break Q rho)) &&
+                         !!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_continue (frame_ret_assert Q' F) rho |-- fupd (RA_continue Q rho)) &&
+                         !!(forall vl rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_return (frame_ret_assert Q' F) vl rho |-- fupd (RA_return Q vl rho)))))
    (SEM: @semax cs Espec Delta P' c Q'):
    @semax cs Espec Delta P c Q.
 Proof. intros.
-apply (semax_conseq Delta (fun rho => EX F: assert, !!(closed_wrt_modvars c F) && (bupd (sepcon (P' rho) (F rho)) &&
-                         (!!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_normal (frame_ret_assert Q' F) rho |-- bupd (RA_normal Q rho)) &&
-                         (!!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_break (frame_ret_assert Q' F) rho |-- bupd (RA_break Q rho)) &&
-                         (!!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_continue (frame_ret_assert Q' F) rho |-- bupd (RA_continue Q rho)) &&
-                         (!!(forall vl rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_return (frame_ret_assert Q' F) vl rho |-- bupd (RA_return Q vl rho))))))))
+apply (semax_conseq Delta (fun rho => EX F: assert, !!(closed_wrt_modvars c F) && (fupd (sepcon (P' rho) (F rho)) &&
+                         (!!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_normal (frame_ret_assert Q' F) rho |-- fupd (RA_normal Q rho)) &&
+                         (!!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_break (frame_ret_assert Q' F) rho |-- fupd (RA_break Q rho)) &&
+                         (!!(forall rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_continue (frame_ret_assert Q' F) rho |-- fupd (RA_continue Q rho)) &&
+                         (!!(forall vl rho, (local (tc_environ Delta) rho) && ((allp_fun_id Delta rho)) && RA_return (frame_ret_assert Q' F) vl rho |-- fupd (RA_return Q vl rho))))))))
    Q).
 + intros. eapply seplog.derives_trans. constructor. apply H. clear H.
-  eapply seplog.derives_trans. 2: { constructor. apply own.bupd_intro. }
+  eapply seplog.derives_trans. 2: { constructor. apply own.fupd_intro. }
   constructor. apply orp_right2. apply exp_derives; intros F. 
   rewrite <- ! andp_assoc; trivial.
-+ clear H. intros. constructor. eapply derives_trans. 2: apply own.bupd_intro.
++ clear H. intros. constructor. eapply derives_trans. 2: apply own.fupd_intro.
   apply orp_right2. do 2 apply andp_left2; trivial.
-+ clear H. intros. constructor. eapply derives_trans. 2: apply own.bupd_intro.
++ clear H. intros. constructor. eapply derives_trans. 2: apply own.fupd_intro.
   apply orp_right2. do 2 apply andp_left2; trivial.
-+ clear H. intros. constructor. eapply derives_trans. 2: apply own.bupd_intro.
++ clear H. intros. constructor. eapply derives_trans. 2: apply own.fupd_intro.
   apply orp_right2. do 2 apply andp_left2; trivial.
-+ clear H. intros. constructor. eapply derives_trans. 2: apply own.bupd_intro.
++ clear H. intros. constructor. eapply derives_trans. 2: apply own.fupd_intro.
   apply orp_right2. do 2 apply andp_left2; trivial.
 + apply extract_exists_pre. intros F. clear H.
   apply semax_extract_prop. intros.
-  eapply semax_pre_bupd. 2:{ do 4 (apply semax_extract_prop; intros). 
+  eapply semax_pre_fupd. 2:{ do 4 (apply semax_extract_prop; intros). 
     eapply semax_conseq. 6:{ apply semax_frame. exact H. apply SEM. }
     2: {
-    intros; constructor. eapply derives_trans; [|apply bupd_mono; apply derives_refl].
+    intros; constructor. eapply derives_trans; [|apply fupd_mono; apply derives_refl].
     revert rho. exact H0. }
     2: {
-    intros; constructor. eapply derives_trans; [|apply bupd_mono; apply derives_refl].
+    intros; constructor. eapply derives_trans; [|apply fupd_mono; apply derives_refl].
     revert rho. exact H1. }
     2: {
-    intros; constructor. eapply derives_trans; [|apply bupd_mono; apply derives_refl].
+    intros; constructor. eapply derives_trans; [|apply fupd_mono; apply derives_refl].
     revert rho. exact H2. }
     2: {
-    intros; constructor. eapply derives_trans; [|apply bupd_mono; apply derives_refl].
+    intros; constructor. eapply derives_trans; [|apply fupd_mono; apply derives_refl].
     revert rho. revert vl. exact H3. }
     
   (* 2: { *)
-  (*  intros; constructor. eapply derives_trans; [ | apply own.bupd_intro]. *)
+  (*  intros; constructor. eapply derives_trans; [ | apply own.fupd_intro]. *)
   (*  apply orp_right2. revert rho. exact H1. } *)
   (* 2: { *)
-  (*  intros; constructor. eapply derives_trans; [ | apply own.bupd_intro].  *)
+  (*  intros; constructor. eapply derives_trans; [ | apply own.fupd_intro].  *)
   (*  apply orp_right2. revert rho. revert vl. exact H3. } *)
   
-   intros; constructor. eapply derives_trans; [ | apply own.bupd_intro]. 
+   intros; constructor. eapply derives_trans; [ | apply own.fupd_intro]. 
    apply orp_right2. apply andp_left2. apply andp_left2. apply derives_refl. }
   intros. unfold local, liftx, lift1, tc_environ; simpl. apply andp_left2.
-  rewrite (andp_comm (bupd (P' rho * F rho))). rewrite !bupd_andp_prop.
+  rewrite (andp_comm (fupd (P' rho * F rho))). rewrite !fupd_andp_prop.
   rewrite <- ! andp_assoc. repeat apply andp_derives; auto.
   * apply prop_derives. intros. rewrite <- andp_assoc.
-    apply derives_trans with (bupd (RA_normal Q rho0)); [apply H0|].
-    apply bupd_mono. apply orp_right2; auto.
+    apply derives_trans with (fupd (RA_normal Q rho0)); [apply H0|].
+    apply fupd_mono. apply orp_right2; auto.
   * apply prop_derives. intros. rewrite <- andp_assoc.
-    apply derives_trans with (bupd (RA_break Q rho0)); [apply H0|].
-    apply bupd_mono. apply orp_right2; auto.
+    apply derives_trans with (fupd (RA_break Q rho0)); [apply H0|].
+    apply fupd_mono. apply orp_right2; auto.
   * apply prop_derives. intros. rewrite <- andp_assoc.
-    apply derives_trans with (bupd (RA_continue Q rho0)); [apply H0|].
-    apply bupd_mono. apply orp_right2; auto.
+    apply derives_trans with (fupd (RA_continue Q rho0)); [apply H0|].
+    apply fupd_mono. apply orp_right2; auto.
   * apply prop_derives. intros. rewrite <- andp_assoc.
-    apply derives_trans with (bupd (RA_return Q vl rho0)); [apply H0|].
-    apply bupd_mono. apply orp_right2; auto.
+    apply derives_trans with (fupd (RA_return Q vl rho0)); [apply H0|].
+    apply fupd_mono. apply orp_right2; auto.
 Qed.
 
 Lemma semax_adapt_frame' {cs Espec} Delta c (P P': assert) (Q Q' : ret_assert)
    (H: forall rho,  !!(typecheck_environ Delta rho) && (allp_fun_id Delta rho && P rho)
-                   |-- EX F: assert, (!!(closed_wrt_modvars c F) && bupd (P' rho * F rho) &&
-                        !!(forall rho, RA_normal (frame_ret_assert Q' F) rho |-- bupd (RA_normal Q rho)) &&
-                        !!(forall rho, RA_break (frame_ret_assert Q' F) rho |-- bupd (RA_break Q rho)) &&
-                        !!(forall rho, RA_continue (frame_ret_assert Q' F) rho |-- bupd (RA_continue Q rho)) &&
-                        !!(forall vl rho, RA_return (frame_ret_assert Q' F) vl rho |-- bupd (RA_return Q vl rho))))
+                   |-- EX F: assert, (!!(closed_wrt_modvars c F) && fupd (P' rho * F rho) &&
+                        !!(forall rho, RA_normal (frame_ret_assert Q' F) rho |-- fupd (RA_normal Q rho)) &&
+                        !!(forall rho, RA_break (frame_ret_assert Q' F) rho |-- fupd (RA_break Q rho)) &&
+                        !!(forall rho, RA_continue (frame_ret_assert Q' F) rho |-- fupd (RA_continue Q rho)) &&
+                        !!(forall vl rho, RA_return (frame_ret_assert Q' F) vl rho |-- fupd (RA_return Q vl rho))))
    (SEM: @semax cs Espec Delta P' c Q'):
    @semax cs Espec Delta P c Q.
 Proof.
@@ -1018,11 +1018,11 @@ Qed.
 
 Lemma semax_adapt {cs Espec} Delta c (P P': assert) (Q Q' : ret_assert)
    (H: forall rho,  !!(typecheck_environ Delta rho) && (allp_fun_id Delta rho && P rho)
-                   |-- (bupd (P' rho) &&
-                        !!(forall rho, RA_normal Q' rho |-- bupd (RA_normal Q rho)) &&
-                        !!(forall rho, RA_break Q' rho |-- bupd (RA_break Q rho)) &&
-                        !!(forall rho, RA_continue Q' rho |-- bupd (RA_continue Q rho)) &&
-                        !!(forall vl rho, RA_return Q' vl rho |-- bupd (RA_return Q vl rho))))
+                   |-- (fupd (P' rho) &&
+                        !!(forall rho, RA_normal Q' rho |-- fupd (RA_normal Q rho)) &&
+                        !!(forall rho, RA_break Q' rho |-- fupd (RA_break Q rho)) &&
+                        !!(forall rho, RA_continue Q' rho |-- fupd (RA_continue Q rho)) &&
+                        !!(forall vl rho, RA_return Q' vl rho |-- fupd (RA_return Q vl rho))))
    (SEM: @semax cs Espec Delta P' c Q'):
    @semax cs Espec Delta P c Q.
 Proof.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -1499,7 +1499,7 @@ Proof.
   eapply ext_compat_unnec; [apply necR_jm_phi; eauto|].
   eapply join_sub_joins_trans; [eexists; apply ghost_of_join; eauto|].
   eapply joins_comm, join_sub_joins_trans; [|apply joins_comm; eauto].
-  destruct H3 as [? J]; eapply ghost_fmap_join in J; eexists; eauto.
+  destruct H4 as [? J]; eapply ghost_fmap_join in J; eexists; eauto.
 Qed.
 
 Lemma assert_safe_jsafe': forall {Espec: OracleKind} ge f ve te k ora jm,
@@ -1514,14 +1514,14 @@ Proof.
   { eapply ext_compat_unnec; [apply necR_jm_phi; eauto|].
     eapply join_sub_joins_trans; [eexists; apply ghost_of_join; eauto|].
     eapply joins_comm, join_sub_joins_trans; [|apply joins_comm; eauto].
-    destruct H3 as [? J]; eapply ghost_fmap_join in J; eexists; eauto. }
+    destruct H4 as [? J]; eapply ghost_fmap_join in J; eexists; eauto. }
   specialize (H _ _ Hext eq_refl eq_refl).
   spec H; [lia|].
   destruct k; eapply jm_fupd_mono; eauto; intros ? Hle Hsafe; try contradiction.
   inv Hsafe; try discriminate; try contradiction.
   constructor; auto.
   eapply jsafeN_step; eauto.
-  destruct H5; split; auto. inv H5; econstructor; simpl; eauto.
+  destruct H6; split; auto. inv H6; econstructor; simpl; eauto.
   eapply jsafeN_local_step. constructor.
   intros.
   eapply age_safe; eauto.
@@ -1531,7 +1531,7 @@ Proof.
   inv Hsafe; try discriminate; try contradiction.
   constructor; auto.
   eapply jsafeN_step; eauto.
-  destruct H5; split; auto. inv H5; econstructor; simpl; eauto.
+  destruct H6; split; auto. inv H6; econstructor; simpl; eauto.
 Qed.
 
 Lemma fupd_jm_fupd : forall {Espec: OracleKind} ge (ora : OK_ty) ve te P Q jm,
@@ -1544,7 +1544,7 @@ Lemma fupd_jm_fupd : forall {Espec: OracleKind} ge (ora : OK_ty) ve te P Q jm,
   jm_fupd ora Ensembles.Full_set Ensembles.Full_set (P ora) jm.
 Proof.
   intros.
-  intros ????? Hinv.
+  intros ?????? Hinv.
   pose proof Hinv; eapply H in Hinv; try apply necR_jm_phi; eauto.
   intros ???. edestruct Hinv as (? & ? & z' & ? & Hr & ? & Hsafe); eauto; subst.
   destruct (level z') eqn: Hl.
@@ -1553,7 +1553,7 @@ Proof.
   { symmetry in Hl; apply levelS_age in Hl as (? & Hage & ?).
     rewrite later_age in HF; apply HF in Hage; contradiction. }
   destruct (juicy_mem_resource _ _ Hr) as (jm0 & ? & ?); subst.
-  destruct (juicy_mem_sub jm0 m1) as [jm1 ?]; [eexists; eauto | subst].
+  destruct (juicy_mem_sub jm0 m1) as (jm1 & ? & ?); [eexists; eauto | subst].
   assert (level (m_phi jm1) > 0)%nat as LW1 by (apply join_level in J as []; lia).
   unfold app_pred in Hsafe; rewrite H0 in Hsafe.
   eapply Hsafe in LW1; eauto.
@@ -1567,7 +1567,7 @@ Proof.
   rewrite !level_juice_level_phi in *; congruence.
   + eapply join_sub_joins_trans; [eexists; apply ghost_of_join; eauto|].
     eapply joins_comm, join_sub_joins_trans; [|apply joins_comm; eauto].
-    destruct H4 as [? J']; eapply ghost_fmap_join in J'; eexists; eauto.
+    destruct H5 as [? J']; eapply ghost_fmap_join in J'; eexists; eauto.
 Qed.
 
 Lemma assert_safe_fupd : forall {Espec: OracleKind} ge f ve te c rho,

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -279,14 +279,6 @@ Proof.
   exists jm'; repeat split; auto.
 Qed.
 
-Lemma jm_fupd_intro' : forall {G C Z} {genv_symb : G -> injective_PTree block} coresem JE ge (ora : Z) E (c : C) m,
-  jsafeN_(genv_symb := genv_symb) coresem JE ge ora c m ->
-  jm_fupd ora E E (jsafeN_(genv_symb := genv_symb) coresem JE ge ora c) m.
-Proof.
-  intros; apply jm_fupd_intro; auto.
-  intros; eapply necR_safe; eauto.
-Qed.
-
 Lemma jsafeN_local_step:
   forall {Espec: OracleKind} ge ora s1 m s2,
   cl_step  ge s1 (m_dry m) s2 (m_dry m) ->
@@ -1476,60 +1468,6 @@ intros.
 eapply age_safe; eauto.
 Qed.
 
-Lemma denote_tc_resource: forall {cs: compspecs} rho a a' t, resource_at a = resource_at a' ->
-  denote_tc_assert t rho a -> denote_tc_assert t rho a'.
-Proof.
-  induction t; auto; intros; simpl in *.
-  - destruct H0; auto.
-  - destruct H0; auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho); auto; simpl in *; if_tac; auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho); auto; simpl in *; if_tac; auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho), (eval_expr e0 rho); auto; simpl in *.
-    + simple_if_tac; auto.
-      destruct H0; split; auto.
-      destruct H1; [left | right]; simpl in *; rewrite <- H; auto.
-    + simple_if_tac; auto.
-      destruct H0; split; auto.
-      destruct H1; [left | right]; simpl in *; rewrite <- H; auto.
-    + unfold test_eq_ptrs in *.
-      destruct (sameblock _ _), H0; split; simpl in *; rewrite <- H; auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho), (eval_expr e0 rho); auto; simpl in *.
-    unfold test_order_ptrs in *.
-    destruct (sameblock _ _), H0; split; simpl in *; rewrite <- H; auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho); auto; simpl in *; if_tac; auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho); auto; simpl in *; if_tac; auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho); auto; simpl in *.
-    + destruct (Zoffloat f); auto.
-    + destruct (Zofsingle f); auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho); auto; simpl in *.
-    + destruct (Zoffloat f); auto.
-    + destruct (Zofsingle f); auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (eval_expr e rho), (eval_expr e0 rho); auto.
-  - unfold liftx in *; simpl in *.
-    unfold lift in *; simpl in *.
-    destruct (typeof e) as [ | _ [ | ] _ | | | | | | | ],
-                  (typeof e0) as [ | _ [ | ] _ | | | | | | | ];
-    destruct (eval_expr e rho), (eval_expr e0 rho); auto.
-Qed.
-
 Lemma fupd_denote_tc: forall {cs: compspecs} P t rho a,
   denote_tc_assert t rho a -> fupd P a -> fupd (denote_tc_assert t rho && P) a.
 Proof.
@@ -1633,13 +1571,13 @@ Proof.
 Qed.
 
 Lemma assert_safe_fupd : forall {Espec: OracleKind} ge f ve te c rho,
-  (match c with Cont _ => True | _ => False end) ->
+  (match c with Ret _ _ => False | _ => True end) ->
   fupd (assert_safe Espec ge f ve te c rho) |-- assert_safe Espec ge f ve te c rho.
 Proof.
   intros.
-  destruct c; try contradiction; clear H.
-  intros ????????; subst.
-  destruct c; try (eapply fupd_jm_fupd with (P := fun ora => jsafeN OK_spec ge ora _); eauto; reflexivity).
+  destruct c; try contradiction; clear H;
+  intros ????????; subst;
+  [|destruct c; try (eapply fupd_jm_fupd with (P := fun ora => jsafeN OK_spec ge ora _); eauto; reflexivity)];
   eapply fupd_jm_fupd with (P := fun _ _ => False); eauto; reflexivity.
 Qed.
 

--- a/veric/semax_loop.v
+++ b/veric/semax_loop.v
@@ -116,25 +116,26 @@ assert (assert_safe Espec psi f vx tx (Cont (Kseq (if b' then c else d) k))
   rewrite denote_tc_assert_andp in TC2; destruct TC2.
   destruct b'; [apply H0 | apply H1]; split; subst; auto; split; auto; do 3 eexists; eauto; split;
     auto; split; auto; apply bool_val_strict; auto; eapply typecheck_expr_sound; eauto. }
-destruct HGG as [CSUB HGG]. apply (@tc_expr_cenv_sub _ _ CSUB) in TC2'. 
-eapply own.bupd_mono, bupd_denote_tc; eauto. 
-intros r [Htc Hr] ora jm Hora Hge Hphi ?. 
+destruct HGG as [CSUB HGG]. apply (@tc_expr_cenv_sub _ _ CSUB) in TC2'.
+apply fupd.fupd_intro.
+rename TC2' into Htc.
+intros ora jm Hora Hge Hphi ?.
 generalize (eval_expr_relate _ _ _ _ _ b jm HGG Hge (guard_environ_e1 _ _ _ TC)); intro.
 generalize LW; intro H9.
-subst r.
+subst w0.
 change (level (m_phi jm)) with (level jm) in H9.
 revert H9; case_eq (level jm); intros.
 lia.
 apply levelS_age1 in H9. destruct H9 as [jm' ?].
 clear H10.
-apply jsafe_step'_back2 with (st' := State f (if b' then c else d) k vx tx)
-  (m' := jm').
+eapply pred_hereditary in Hw0; [|eapply age_jm_phi; eauto].
+eapply jsafeN_step, assert_safe_jsafe, Hw0.
 split3.
 assert (TCS := typecheck_expr_sound _ _ (m_phi jm) _ (guard_environ_e1 _ _ _ TC) Htc). 
 unfold tc_expr in Htc.
 simpl in Htc.
 rewrite denote_tc_assert_andp in Htc.
-clear TC2'; destruct Htc as [TC2' TC2'a].
+destruct Htc as [TC2' TC2'a].
 rewrite <- (age_jm_dry H9); econstructor; eauto.
 {
  assert (exists b': bool, Cop.bool_val (@eval_expr CS' b rho) (typeof b) (m_dry jm) = Some b') as [].
@@ -163,11 +164,6 @@ apply age1_resource_decay; auto.
 split; [apply age_level; auto|].
 erewrite (age1_ghost_of _ _ (age_jm_phi H9)) by (symmetry; apply ghost_of_approx).
 repeat intro; auto.
-change (level (m_phi jm)) with (level jm).
-replace (level jm - 1)%nat with (level jm' ) by (apply age_level in H9; lia).
-eapply @age_safe; try apply H9.
-rewrite <- Hge in *.
-apply Hr; auto.
 Qed.
 
 Ltac inv_safe H :=
@@ -340,7 +336,7 @@ Proof.
   eapply semax_Delta_subsumption in H0; try apply TS; auto.
   clear Delta TS.
   generalize H; rewrite semax_unfold; intros H'.
-  apply own.bupd_intro.
+  apply fupd.fupd_intro.
   intros ora jm Hora RE ?; subst.
   destruct (can_age1_juicy_mem _ _ LEVa2) as [jm2 LEVa2'].
   unfold age in LEVa2.
@@ -352,7 +348,6 @@ Proof.
   }
   intro.
   subst a2.
-  rewrite (age_level _ _ LEVa2).
   apply jsafeN_step
    with (State f body (Kloop1 body incr k) vx tx)
           jm2.
@@ -522,7 +517,7 @@ Proof.
   rewrite proj_frame_ret_assert. simpl proj_ret_assert; simpl seplog.sepcon.
   rewrite sepcon_comm. rewrite (prop_true_andp (None=None)) by auto.
   eapply andp_derives; try apply H0; auto.
-  apply own.bupd_mono.
+  apply fupd.fupd_mono.
   intros ???? Hora ?? ?.
   specialize (H0 ora jm Hora H1 H2 LW). subst a.
   destruct (break_cont k) eqn:?H; try contradiction.
@@ -536,9 +531,8 @@ Proof.
     intros.
     eapply age_safe; eauto.
     change (level (m_phi jm)) with (level jm) in H0.
-    destruct (level jm). constructor.
-    inv H0; [ | discriminate | contradiction].
-    destruct H4.
+    inv H0; [constructor; auto | | discriminate | contradiction].
+    destruct H3.
     inv H0.
     eapply jsafeN_step.  split. econstructor; try eassumption.
     hnf; auto. auto. auto.
@@ -547,9 +541,8 @@ Proof.
     intros.
     eapply age_safe; eauto.
     change (level (m_phi jm)) with (level jm) in H0.
-    destruct (level jm). constructor.
-    inv H0; [ | discriminate | contradiction].
-    destruct H4.
+    inv H0; [constructor; auto | | discriminate | contradiction].
+    destruct H3.
     inv H0.
     eapply jsafeN_step.  split. econstructor; try eassumption.
     hnf; auto. auto. auto.
@@ -558,9 +551,8 @@ Proof.
     intros.
     eapply age_safe; eauto.
     change (level (m_phi jm)) with (level jm) in H0.
-    destruct (level jm). constructor.
-    inv H0; [ | discriminate | contradiction].
-    destruct H4.
+    inv H0; [constructor; auto | | discriminate | contradiction].
+    destruct H3.
     inv H0.
     eapply jsafeN_step.  split. econstructor; try eassumption.
     hnf; auto. auto. auto.
@@ -637,9 +629,8 @@ Proof.
     intros.
     eapply age_safe; eauto.
     change (level (m_phi jm)) with (level jm) in H0.
-    destruct (level jm). constructor.
-    inv H0; [ | discriminate | contradiction].
-    destruct H4.
+    inv H0; [constructor; auto | | discriminate | contradiction].
+    destruct H3.
     inv H0.
     eapply jsafeN_step.  split. econstructor; try eassumption.
     hnf; auto. auto. auto.
@@ -648,9 +639,8 @@ Proof.
     intros.
     eapply age_safe; eauto.
     change (level (m_phi jm)) with (level jm) in H0.
-    destruct (level jm). constructor.
-    inv H0; [ | discriminate | contradiction].
-    destruct H4.
+    inv H0; [constructor; auto | | discriminate | contradiction].
+    destruct H3.
     inv H0.
     eapply jsafeN_step.  split. econstructor; try eassumption.
     hnf; auto. auto. auto.
@@ -659,9 +649,8 @@ Proof.
     intros.
     eapply age_safe; eauto.
     change (level (m_phi jm)) with (level jm) in H0.
-    destruct (level jm). constructor.
-    inv H0; [ | discriminate | contradiction].
-    destruct H4.
+    inv H0; [constructor; auto | | discriminate | contradiction].
+    destruct H3.
     inv H0.
     eapply jsafeN_step.  split. econstructor; try eassumption.
     hnf; auto. auto. auto.
@@ -685,7 +674,7 @@ repeat intro.
 rewrite sepcon_comm.
 eapply andp_derives; try apply H0; auto.
 normalize.
-apply own.bupd_mono.
+apply fupd.fupd_mono.
 intros ???? Hora ???.
 specialize (H0 ora jm Hora H1 H2 LW). 
 subst a.

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -1568,7 +1568,7 @@ Lemma semax_prog_entry_point {CS: compspecs} V G prog b id_fun params args A
     app_pred (P ts a gargs) (m_phi jm) ->
     app_pred (fungassert (nofunc_tycontext V G) gargs ) (m_phi jm) ->
     nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) ->
-    jsafeN (@OK_spec Espec) (globalenv prog) (level jm) z q jm }.
+    jsafeN (@OK_spec Espec) (globalenv prog) z q jm }.
 Proof.
 intro retty.
 intros EXIT SP Findb id_in_G arg_p.
@@ -1716,7 +1716,7 @@ destruct H5 as [H5|H5].
  auto.
 }
  destruct (level jm) eqn:?H.
- constructor.
+ constructor; auto.
  destruct H5 as [x' [? H9]].
  clear H1 H3 m_funassert m_sat_Pa Ef Eb.
  eapply jsafeN_external.
@@ -1730,18 +1730,18 @@ destruct H5 as [H5|H5].
  rewrite H4 in *. simpl sig_res in *. simpl sig_args in *.
  assert (tc_option_val retty ret). {
   specialize (H9 (sig_res (ef_sig e)) ret z' m').
-  spec H9. destruct H3 as [? [? ?]];  lia.
+  spec H9. destruct H1 as [? ?];  lia.
   change (genv_symb_injective (Genv.globalenv prog)) 
-   with (genv_symb_injective psi) in H7.
+   with (genv_symb_injective psi) in H3.
   rewrite H4 in H9.
-  specialize (H9 _ _ (necR_refl _) (ext_refl _) H7).
+  specialize (H9 _ _ (necR_refl _) (ext_refl _) H3).
   specialize (H6 ts a ret).
   destruct H9 as [? [? [? [? _]]]].
   specialize (H6 x).
-  spec H6.  simpl. unfold natLevel. destruct H3 as [? [? ?]].
+  spec H6.  simpl. unfold natLevel. destruct H1 as [? ?].
   change (level (m_phi ?a)) with (level a).
-  apply join_level in H8. destruct H8.
-  change (level (m_phi ?a)) with (level a) in H8.
+  apply join_level in H7. destruct H7.
+  change (level (m_phi ?a)) with (level a) in H7.
   lia.
   specialize (H6 _ _ (necR_refl _) (ext_refl _)).
   spec H6. split; auto.
@@ -1749,22 +1749,13 @@ destruct H5 as [H5|H5].
  }
  clear H6.
  eexists. split. reflexivity.
- repeat intro.
- exists m'. split3; auto.
- split3; auto.
+ apply jm_fupd_intro_strong'; intros.
  hnf in H9.
- unfold retty in H8. destruct ret; try contradiction H8.
- destruct v; try contradiction H8.
+ unfold retty in H7. destruct ret; try contradiction H7.
+ destruct v; try contradiction H7.
  eapply jsafeN_halted with i.
  simpl. congruence.
- apply (EXIT (Some (Vint i)) z' m').
- reflexivity.
- clear - H10 H6.
- eapply joins_comm, join_sub_joins_trans, joins_comm, H10.
- destruct H6.
- change (Some (ghost_PCM.ext_ref z', NoneP) :: nil) with
-      (own.ghost_approx (m_phi m') (Some (ghost_PCM.ext_ref z', NoneP) :: nil)).
-  eexists; apply ghost_fmap_join; eauto.
+ apply (EXIT (Some (Vint i)) z' m'); auto.
 -
 (* internal case *)
 (*
@@ -1837,9 +1828,6 @@ cut ((!! guard_environ (func_tycontext' f Delta) f rhox &&
      rewrite predicates_sl.sepcon_assoc in H9.
     rewrite predicates_sl.sepcon_comm in H9. 
    rewrite Hret in *.
-   intros ? ?. exists (ghost_of a'); split; auto.
-   exists a'; split; auto. split; auto. split; auto.
-   simpl.
    hnf; intros.
    destruct (can_free_list Delta TT f jm0
                        psi ve te)
@@ -1852,7 +1840,6 @@ cut ((!! guard_environ (func_tycontext' f Delta) f rhox &&
     subst a'.
      eapply predicates_sl.sepcon_derives; try apply H9; auto.
   - 
-     clear H4.
      set (rho' := construct_rho (filter_genv psi)
             ve te) in *.
      destruct H10 as [COMPLETE [_ [H17' _]]].
@@ -1865,12 +1852,10 @@ cut ((!! guard_environ (func_tycontext' f Delta) f rhox &&
   pull_left (freeable_blocks (blocks_of_env (globalenv prog) ve)).
  intro H13.
   rewrite predicates_sl.sepcon_assoc in H13.
-  destruct (free_list_juicy_mem_i _ _ _ _ H12 H13) as [jm2 [? [? ?]]].
-  change (level (m_phi jm0)) with (level jm0).
+  destruct (free_list_juicy_mem_i _ _ _ _ H6 H13) as [jm2 [? [? ?]]].
   destruct (age1 jm0) as [jm0' | ] eqn:?.
-  2: apply age1_level0 in Heqo; destruct vl; intros; rewrite Heqo; constructor.
-   rewrite (age_level _ _ Heqo).
-   destruct (age_twin' _ _ _ H9 Heqo) 
+  2: apply age1_level0 in Heqo; destruct vl; intros; constructor; auto.
+   destruct (age_twin' _ _ _ H12 Heqo) 
        as [jm2' [? ?]].
    subst m2. 
  assert (resource_decay (nextblock (m_dry jm0)) (m_phi jm0) (m_phi jm2') /\
@@ -1882,19 +1867,18 @@ cut ((!! guard_environ (func_tycontext' f Delta) f rhox &&
   eapply resource_decay_trans.
   2: eapply free_list_resource_decay; eassumption.
   2: eapply age1_resource_decay; eassumption.
-  rewrite (mem_lemmas.nextblock_freelist _ _ _ H12).
+  rewrite (mem_lemmas.nextblock_freelist _ _ _ H6).
   apply Pos.le_refl.
   rewrite <- H14.
   apply age_level; auto.
   erewrite age1_ghost_of by (eapply age_jm_phi; eauto).
-  change (level (m_phi jm2')) with (level jm2').
   f_equal.
   eapply free_list_juicy_mem_ghost; eauto.
  }
  assert ((ext_compat ora0) (m_phi jm2)). {
    pose proof (free_list_juicy_mem_ghost _ _ _ H4).
-   clear - H16 H1.
-   hnf in H1|-*. rewrite H16; auto.
+   clear - H16 H.
+   hnf in H|-*. rewrite H16; auto.
  }
  eapply free_list_juicy_mem_lem in H4;[ | eassumption].
  apply (pred_nec_hereditary _ _ _ (laterR_necR (age_laterR (age_jm_phi H15)))) in H4.
@@ -1913,9 +1897,9 @@ cut ((!! guard_environ (func_tycontext' f Delta) f rhox &&
  destruct vl; try contradiction.
  destruct v; try contradiction.
  clear H17.
- intros; econstructor; try instantiate (1:=jm2').
+ intros; eapply jsafeN_step; try instantiate (1:=jm2').
  split; auto; rewrite <- (age_jm_dry H15); econstructor; eauto.
- apply jm_bupd_intro; eapply jsafeN_halted.
+ apply jm_fupd_intro'; eapply jsafeN_halted.
  instantiate (1:=i).
  simpl. clear; congruence.
  apply EXIT.
@@ -1937,12 +1921,11 @@ as [te' H21]; auto.
 }
 
 (*** split here ****)
-destruct (level jm) eqn:H2'; [constructor |].
+destruct (level jm) eqn:H2'; [constructor; auto |].
 
 destruct (levelS_age1 _ _ H2') as [jm2 H13]. change (age jm jm2) in H13.
 rewrite <- H2' in *. clear H2'.
 pose proof (age_twin' _ _ _ H20' H13) as [jm'' [_ H20x]].
-rewrite (age_level _ _ H13).
 destruct H10 as [COMPLETE [H17 [H17' [Hvars H18]]]].
 
 eapply jsafeN_step
@@ -2056,13 +2039,8 @@ assert (H23: app_pred (fungassert Delta (filter_genv psi, args)) (m_phi jm'')).
  specialize (Hvars x H1).
  rewrite (cenv_sub_sizeof HGG); auto.
 }
-replace (level jm2) with (level jm'').
 apply assert_safe_jsafe.
 apply H11.
-clear - H13 H20x H20'.
-apply age_level in H13.
-apply age_level in H20x.
-congruence.
 Qed.
 
 Lemma semax_prog_rule {CS: compspecs} :
@@ -2079,7 +2057,7 @@ Lemma semax_prog_rule {CS: compspecs} :
          { jm |
            m_dry jm = m /\ level jm = n /\
            nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
-           jsafeN (@OK_spec Espec) (globalenv prog) n z q jm /\
+           jsafeN (@OK_spec Espec) (globalenv prog) z q jm /\
            no_locks (m_phi jm) /\
            matchfunspecs (globalenv prog) G (m_phi jm) /\
            (funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))) (m_phi jm)
@@ -2148,8 +2126,7 @@ Proof.
     by (simpl; unfold inflate_initial_mem; rewrite ghost_of_make_rmap;
           unfold initial_core_ext; rewrite ghost_of_make_rmap;  auto).
   split3; [ | | split3; [ | | split3]]; auto.
-  + rewrite <- H7.
-    destruct H4 as [post [H4 H4']].
+  + destruct H4 as [post [H4 H4']].
     unfold main_spec_ext' in H4'.
     injection H4'; intros.  subst params A.
     apply inj_pair2 in H11.
@@ -2627,11 +2604,11 @@ Proof.
     EX ts1:list Type, EX x1 : dependent_type_functor_rec ts1 A mpred,
     EX FR: mpred,
     !!(forall rho' : environ,
-              !! tc_environ (rettype_tycontext (snd sig)) rho' && (FR * Q ts1 x1 rho') |-- own.bupd (Q' ts x rho')) &&
+              !! tc_environ (rettype_tycontext (snd sig)) rho' && (FR * Q ts1 x1 rho') |-- fupd (Q' ts x rho')) &&
       (stackframe_of f tau * FR * P ts1 x1 (ge_of tau, vals) &&
             !! (map (Map.get (te_of tau)) (map fst (fn_params f)) = map Some vals /\ tc_vals (map snd (fn_params f)) vals))).
  - intros rho m [TC [OM [m1 [m2 [JM [[vals [[MAP VUNDEF] HP']] M2]]]]]].
-   do 4 (split; [|simpl; intros; apply own.bupd_intro]).
+   do 4 (split; [|simpl; intros; try apply fupd.fupd_intro; auto]).
    specialize (Sub (ge_of rho, vals) m1). spec Sub. {
      split; trivial.
      simpl.
@@ -2648,8 +2625,8 @@ Proof.
          apply tc_val_has_type; apply Tw; trivial.
        * apply IHparams; simpl; trivial.
          intros. apply TE. right; trivial. }
-   eapply own.bupd_mono.
-   2: { eapply own.bupd_frame_r. exists m1, m2. split3;[apply JM|apply Sub|apply M2]. }
+   eapply fupd.fupd_mono.
+   2: { eapply fupd.fupd_frame_r. exists m1, m2. split3;[apply JM|apply Sub|apply M2]. }
    clear Sub. repeat intro.
    destruct H as [a1 [a2 [JA [[ts1 [x1 [FR1 [A1 RetQ]]]] A2]]]].
    exists vals, ts1, x1, FR1.
@@ -2691,10 +2668,10 @@ Proof.
       (fn_body f)
       (frame_ret_assert (function_body_ret_assert (fn_return f) (Q ts1 x1)) (stackframe_of f))
       (fun rho => FRM)) in SB3.
-    + eapply semax_pre_post_bupd.
+    + eapply semax_pre_post_fupd.
       6: apply SB3.
       all: clear SB3; intros; simpl; try solve [normalize]. 
-      * eapply derives_trans. 2: now apply own.bupd_intro.
+      * eapply derives_trans. 2: now apply fupd.fupd_intro.
         intros m [TC [[n1 [n2 [JN [N1 N2]]]] [VALS TCVals]]].
         unfold close_precondition. apply join_comm in JN. rewrite sepcon_assoc. 
         exists n2, n1; split3; trivial.
@@ -2702,15 +2679,14 @@ Proof.
         apply (tc_vals_Vundef TCVals).
       * destruct (fn_return f);
           try solve [apply prop_andp_left; intro; rewrite !predicates_sl.FF_sepcon;
-                     eapply derives_trans; [| now apply own.bupd_intro]; auto].
+                     eapply derives_trans; [| now apply fupd.fupd_intro]; auto].
         rewrite sepcon_comm, <- sepcon_assoc, <- sepcon_andp_prop1.
-        eapply derives_trans. 2: apply own.bupd_frame_r.
+        eapply derives_trans, fupd.fupd_frame_r.
         apply sepcon_derives; auto. eapply derives_trans; [|apply QPOST].
         apply andp_right; trivial.
         -- intros k K; clear; apply tc_environ_rettype.
         -- apply prop_andp_left; intros; auto.
       * apply andp_left2. rewrite sepcon_comm, <- sepcon_assoc.
-        eapply derives_trans. 2: apply own.bupd_frame_r.
         apply sepcon_derives; auto. 
         destruct vl; simpl; normalize.
         -- eapply derives_trans; [ | apply QPOST]; apply andp_right; trivial.

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -1556,7 +1556,7 @@ Lemma semax_prog_entry_point {CS: compspecs} V G prog b id_fun params args A
   tc_vals params args ->
   let gargs := (filter_genv (globalenv prog), args) in
   { q : CC_core |
-   (forall jm, 
+   (forall jm,
      Forall (fun v => Val.inject (Mem.flat_inj (nextblock (m_dry jm))) v v)  args->
      inject_neutral (nextblock (m_dry jm)) (m_dry jm) /\
      Coqlib.Ple (Genv.genv_next (Genv.globalenv prog)) (nextblock (m_dry jm)) ->
@@ -2057,6 +2057,7 @@ Lemma semax_prog_rule {CS: compspecs} :
          { jm |
            m_dry jm = m /\ level jm = n /\
            nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)) /\
+           (exists z, join (m_phi jm) (wsat_rmap (m_phi jm)) (m_phi z) /\ ext_order jm z) /\
            jsafeN (@OK_spec Espec) (globalenv prog) z q jm /\
            no_locks (m_phi jm) /\
            matchfunspecs (globalenv prog) G (m_phi jm) /\
@@ -2125,7 +2126,8 @@ Proof.
   assert (nth_error (ghost_of (m_phi jm)) 0 = Some (Some (ext_ghost z, NoneP)))
     by (simpl; unfold inflate_initial_mem; rewrite ghost_of_make_rmap;
           unfold initial_core_ext; rewrite ghost_of_make_rmap;  auto).
-  split3; [ | | split3; [ | | split3]]; auto.
+  split3; [ | | split3; [ | | split3; [ | | split]]]; auto.
+  + apply initial_jm_wsat.
   + destruct H4 as [post [H4 H4']].
     unfold main_spec_ext' in H4'.
     injection H4'; intros.  subst params A.

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -2604,7 +2604,7 @@ Proof.
     EX ts1:list Type, EX x1 : dependent_type_functor_rec ts1 A mpred,
     EX FR: mpred,
     !!(forall rho' : environ,
-              !! tc_environ (rettype_tycontext (snd sig)) rho' && (FR * Q ts1 x1 rho') |-- fupd (Q' ts x rho')) &&
+              !! tc_environ (rettype_tycontext (snd sig)) rho' && (FR * Q ts1 x1 rho') |-- (Q' ts x rho')) &&
       (stackframe_of f tau * FR * P ts1 x1 (ge_of tau, vals) &&
             !! (map (Map.get (te_of tau)) (map fst (fn_params f)) = map Some vals /\ tc_vals (map snd (fn_params f)) vals))).
  - intros rho m [TC [OM [m1 [m2 [JM [[vals [[MAP VUNDEF] HP']] M2]]]]]].
@@ -2670,8 +2670,8 @@ Proof.
       (fun rho => FRM)) in SB3.
     + eapply semax_pre_post_fupd.
       6: apply SB3.
-      all: clear SB3; intros; simpl; try solve [normalize]. 
-      * eapply derives_trans. 2: now apply fupd.fupd_intro.
+      all: clear SB3; intros; simpl; try solve [normalize].
+      * eapply derives_trans, fupd.fupd_intro.
         intros m [TC [[n1 [n2 [JN [N1 N2]]]] [VALS TCVals]]].
         unfold close_precondition. apply join_comm in JN. rewrite sepcon_assoc. 
         exists n2, n1; split3; trivial.
@@ -2682,7 +2682,9 @@ Proof.
                      eapply derives_trans; [| now apply fupd.fupd_intro]; auto].
         rewrite sepcon_comm, <- sepcon_assoc, <- sepcon_andp_prop1.
         eapply derives_trans, fupd.fupd_frame_r.
-        apply sepcon_derives; auto. eapply derives_trans; [|apply QPOST].
+        apply sepcon_derives; auto.
+        eapply derives_trans, fupd.fupd_intro.
+        eapply derives_trans, QPOST.
         apply andp_right; trivial.
         -- intros k K; clear; apply tc_environ_rettype.
         -- apply prop_andp_left; intros; auto.
@@ -2694,7 +2696,7 @@ Proof.
         -- destruct (fn_return f). 
            { eapply derives_trans; [ | apply QPOST]; apply andp_right; trivial.
            intros k K; clear; apply tc_environ_rettype. }
-           all: rewrite semax_lemmas.sepcon_FF; apply own.bupd_intro.
+           all: rewrite semax_lemmas.sepcon_FF; apply derives_refl.
     + do 2 red; intros; trivial.
 Qed.
 

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -60,7 +60,6 @@ apply (pred_nec_hereditary _ _ _ (necR_nat H)) in Hsafe.
 clear H w.
 rename w0 into w.
 apply assert_safe_last'; intro Hage.
-apply fupd.fupd_intro.
 intros ora jm Hora _ H2. subst w.
 destruct Hglob as [[TC' Hglob] Hglob'].
 apply can_age_jm in Hage; destruct Hage as [jm1 Hage].
@@ -73,6 +72,7 @@ change (@level rmap _  (m_phi jm) = S (level (m_phi jm'))) in H2.
 apply rmap_order in Hext as (Hl & Hr & _); rewrite Hl in *.
 rewrite H2 in Hsafe.
 rewrite <- level_juice_level_phi, (age_level _ _ Hage).
+intros; apply jm_fupd_intro'.
 econstructor; [eassumption | ].
 unfold rguard in Hsafe.
 specialize (Hsafe EK_normal None te' ve).

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -30,7 +30,7 @@ Section extensions.
 
 Lemma semax_straight_simple:
  forall Delta (B: assert) P c Q,
-  (forall rho, boxy (@extendM rmap _ _ _ _ _ _ rmap _ _ _ _ _) (B rho)) ->
+  (forall rho, boxy (@extendM rmap _ _ _ _ _ _) (B rho)) ->
   (forall jm jm1 Delta' ge ve te rho k F f,
               tycontext_sub Delta Delta' ->
               app_pred (B rho) (m_phi jm) ->
@@ -60,7 +60,7 @@ apply (pred_nec_hereditary _ _ _ (necR_nat H)) in Hsafe.
 clear H w.
 rename w0 into w.
 apply assert_safe_last'; intro Hage.
-apply own.bupd_intro.
+apply fupd.fupd_intro.
 intros ora jm Hora _ H2. subst w.
 destruct Hglob as [[TC' Hglob] Hglob'].
 apply can_age_jm in Hage; destruct Hage as [jm1 Hage].
@@ -90,11 +90,8 @@ split; auto.
 subst rho'; auto.
 rewrite sepcon_comm; subst rho'; auto.
 subst rho'.
-replace (level jm1) with (level jm').
 simpl exit_cont in Hsafe.
 apply assert_safe_jsafe'; auto.
-rewrite <- !level_juice_level_phi in H2.
-apply age_level in Hage; lia.
 Qed.
 
 Definition force_valid_pointers m v1 v2 :=

--- a/veric/semax_switch.v
+++ b/veric/semax_switch.v
@@ -217,23 +217,22 @@ Lemma assert_safe_step_nostore:
 |-- assert_safe Espec psi f vx tx (Cont (Kseq c1 k1)) (construct_rho (filter_genv psi) vx tx).
 Proof.
 intros.
-intros w [Hw Hw'] ? J.
-eexists; split; eauto; eexists; repeat split; eauto.
-intros ora jm Hora ? ? ?. subst.
+eapply derives_trans, fupd.fupd_intro.
+intros ? [Hw Hw'] ?? Hora ???; subst.
 destruct (level (m_phi jm)) eqn:?; try lia. clear LW.
-destruct (levelS_age1 _ _ Heqn) as [phi' H1].
-destruct (can_age1_juicy_mem _ _ H1) as [jm' H9].
-clear phi' H1.
+destruct (levelS_age1 _ _ Heqn) as [phi' Hage].
+destruct (can_age1_juicy_mem _ _ Hage) as [jm' Hage'].
+clear phi' Hage.
 simpl.
 econstructor 2 with (m' := jm').
 econstructor.
-rewrite <- (age_jm_dry H9).
-apply (H _ _ H9); auto.
+rewrite <- (age_jm_dry Hage').
+apply (H _ _ Hage'); auto.
 split.
 apply age1_resource_decay; assumption.
 split; [apply age_level; assumption|].
 apply age1_ghost_of, age_jm_phi; auto.
-pose  proof (age_level _ _ H9).
+pose  proof (age_level _ _ Hage').
 rewrite <- level_juice_level_phi in Heqn.
 rewrite Heqn in H1.
 inv H1. clear Heqn.

--- a/veric/semax_switch.v
+++ b/veric/semax_switch.v
@@ -216,9 +216,8 @@ Lemma assert_safe_step_nostore:
  && tc_expr Delta e rho
 |-- assert_safe Espec psi f vx tx (Cont (Kseq c1 k1)) (construct_rho (filter_genv psi) vx tx).
 Proof.
-intros.
-eapply derives_trans, fupd.fupd_intro.
-intros ? [Hw Hw'] ?? Hora ???; subst.
+intros. intros ? [Hw Hw'] ?? Hora ???; subst.
+apply jm_fupd_intro'.
 destruct (level (m_phi jm)) eqn:?; try lia. clear LW.
 destruct (levelS_age1 _ _ Heqn) as [phi' Hage].
 destruct (can_age1_juicy_mem _ _ Hage) as [jm' Hage'].

--- a/veric/seplog.v
+++ b/veric/seplog.v
@@ -278,7 +278,7 @@ match f1 with
          >=> fupd (EX ts1:_, EX x1:_, EX F:_, 
             (F * (P1 ts1 x1 gargs)) &&
             ALL rho':_, (     !( ((!!(ve_of rho' = Map.empty (block * type))) && (F * (Q1 ts1 x1 rho')))
-                         >=> fupd (Q2 ts2 x2 rho'))))))
+                         >=> (Q2 ts2 x2 rho'))))))
     end
 end.
 
@@ -295,7 +295,7 @@ match f1 with
                                (!! (forall rho',
                                            ((!!(ve_of rho' = Map.empty (block * type))) &&
                                                  (F * (Q1 ts1 x1 rho')))
-                                         |-- fupd (Q2 ts2 x2 rho')))))
+                                         |-- (Q2 ts2 x2 rho')))))
     end
 end.
 
@@ -330,7 +330,7 @@ Proof.
   destruct f; split; [ split; trivial | intros ts2 x2 rho w [T W]].
   apply fupd_intro.
   exists ts2, x2, emp. rewrite emp_sepcon. split; trivial. hnf; intros. 
-  rewrite emp_sepcon. apply andp_left2, fupd_intro.
+  rewrite emp_sepcon. apply andp_left2, derives_refl.
 Qed.
 
 Lemma funspec_sub_trans f1 f2 f3: funspec_sub f1 f2 -> 
@@ -361,12 +361,10 @@ Proof.
   rewrite <- andp_assoc, andp_comm; apply andp_derives.
   { rewrite sepcon_assoc; auto. }
   intros ? [H1 H2]; simpl in *.
-  intros rho'; eapply derives_trans, fupd_trans.
-  eapply derives_trans, fupd_mono, H1.
+  intros rho'; eapply derives_trans, H1.
   apply prop_andp_left; intros Hlocal'.
   unfold local; simpl; unfold lift1; simpl.
-  eapply derives_trans, fupd_andp_prop; apply andp_right; [intros ??; auto|].
-  eapply derives_trans, fupd_frame_l.
+  apply andp_right; [intros ??; auto|].
   rewrite sepcon_assoc; eapply sepcon_derives, derives_trans, H2; auto.
   apply andp_right; auto; intros ??; auto.
 Qed.
@@ -433,7 +431,7 @@ Proof.
   intros y Hy z ? Hz Hz' [_ ?]. apply fupd_intro.
   exists ts2, x2, emp; rewrite emp_sepcon. split; auto.
   intros rho' k WK u ? necKU E Z.
-  rewrite emp_sepcon in Z. apply fupd_intro, Z.
+  rewrite emp_sepcon in Z. apply Z.
 Qed.
 
 Lemma funspec_sub_si_trans f1 f2 f3: funspec_sub_si f1 f2 && funspec_sub_si f2 f3 |--
@@ -495,9 +493,6 @@ rewrite andp_comm, andp_assoc; apply subp_andp.
     rewrite <- (andp_dup (!! (ve_of rho' = Map.empty (block * type)))) at 2; rewrite andp_assoc; apply subp_andp; [apply subp_refl|].
     rewrite sepcon_assoc, <- (sepcon_andp_prop F).
     apply subp_sepcon, derives_refl; apply subp_refl. }
-  eapply derives_trans, subp_derives, fupd_trans.
-  2: { eapply andp_derives, fupd_frame_l; apply derives_refl. }
-  eapply derives_trans, subp_derives; [apply subp_fupd | apply fupd_andp_prop | apply derives_refl].
   apply andp_left2, allp_left with rho'; auto.
 Qed.
 
@@ -940,7 +935,6 @@ Proof.
     apply fupd_intro.
     exists ts2, a, emp. rewrite emp_sepcon; split. { apply approx_p in U2; trivial. }
     intros rho' y UY k ? YK EK K. rewrite emp_sepcon in K. simpl in K.
-    apply fupd_intro.
     destruct K; split; auto.
     apply necR_level in necU.  apply necR_level in YK. apply ext_level in extU. apply ext_level in EK.
     apply laterR_level in Hw'. lia.
@@ -955,7 +949,7 @@ Proof.
     - apply necR_level in necU. apply ext_level in extU. apply approx_lt; trivial.
       apply laterR_level in Hw'. lia.
     - intros rho' k UP j ? KJ EJ J.
-      rewrite emp_sepcon in J. simpl in J. apply fupd_intro, J.
+      rewrite emp_sepcon in J. simpl in J. apply J.
 Qed.
 
 Lemma approx_func_ptr_si: forall (A: Type) fsig0 cc (P: A -> argsEnviron -> mpred)
@@ -1080,11 +1074,11 @@ Proof.
   + split. split; trivial. intros. simpl. intros w [W1 W2].
     apply fupd_intro. exists ts2, (inl x2), emp. rewrite emp_sepcon.
     split. trivial. simpl; intros. rewrite emp_sepcon.
-    apply andp_left2, fupd_intro.
+    apply andp_left2, derives_refl.
   + split. split; trivial. intros. simpl. intros w [W1 W2].
     apply fupd_intro. exists ts2, (inr x2), emp. rewrite emp_sepcon.
     split. trivial. simpl; intros. rewrite emp_sepcon.
-    apply andp_left2, fupd_intro.
+    apply andp_left2, derives_refl.
 Qed.
 
 (*Rule S-inter3 from page 206 of TAPL*)
@@ -1118,7 +1112,7 @@ Proof.
   eapply derives_trans, fupd_intro.
   exists ts2, (existT A i x2), emp. rewrite emp_sepcon.
   split. apply H. simpl; intros. rewrite emp_sepcon.
-  intros u U. apply fupd_intro, U.
+  intros u U. apply U.
 Qed.
 
 (*Rule S-inter3 from page 206 of TAPL*)
@@ -1161,16 +1155,16 @@ Proof.
   + split. split; trivial. simpl; intros. destruct x2 as [i p].
     eapply derives_trans, fupd_intro. destruct i; simpl in *.
   - exists ts2, (inl p), emp. rewrite emp_sepcon. split; simpl. apply H.
-    intros. rewrite emp_sepcon. intros u U; apply fupd_intro, U.
+    intros. rewrite emp_sepcon. intros u U; apply U.
   - exists ts2, (inr p), emp. rewrite emp_sepcon. split; simpl. apply H.
-    intros. rewrite emp_sepcon. intros u U; apply fupd_intro, U.
+    intros. rewrite emp_sepcon. intros u U; apply U.
     + split. split; trivial. intros. intros u [L U]. destruct x2.
   - apply fupd_intro. exists ts2, (existT (BinarySigma_obligation_1 A B) true a), emp.
     rewrite emp_sepcon. simpl; split. apply U. intros. rewrite emp_sepcon.
-    apply andp_left2, fupd_intro.
+    apply andp_left2, derives_refl.
   - apply fupd_intro. exists ts2, (existT (BinarySigma_obligation_1 A B) false b), emp.
     rewrite emp_sepcon. simpl; split. apply U. intros. rewrite emp_sepcon.
-    apply andp_left2, fupd_intro.
+    apply andp_left2, derives_refl.
 Qed.
 
 Lemma Intersection_sameSigCC_Some sig cc A PA QA fsA PrfA B PB QB fsB PrfB:
@@ -1301,7 +1295,7 @@ Proof.
     exists (existT _ true x2), emp.
     rewrite emp_sepcon.
     split. apply H0.
-    simpl. intros rho'; rewrite emp_sepcon. apply andp_left2; apply fupd_intro.
+    simpl. intros rho'; rewrite emp_sepcon. apply andp_left2, derives_refl.
   + split; [split; reflexivity | intros].
     eapply derives_trans, fupd_intro. exists ts2.
     fold (@dependent_type_functor_rec ts2) in *.
@@ -1309,7 +1303,7 @@ Proof.
     exists (existT _ false x2), emp.
     rewrite emp_sepcon.
     split. apply H0.
-    simpl. intros rho'; rewrite emp_sepcon. apply andp_left2; apply fupd_intro.
+    simpl. intros rho'; rewrite emp_sepcon. apply andp_left2, derives_refl.
 Qed.
 
 Lemma BINARY_intersection_sub3  phi psi omega:
@@ -1479,7 +1473,6 @@ Proof.
     inv HD. apply inj_pair2 in H1; subst; trivial. 
   + intros; rewrite emp_sepcon. unfold intersectionPOST.
     intros x [X1 X2]. destruct (phi i).
-    apply fupd_intro.
     simpl in *; inv Heqzz.
     apply inj_pair2 in H5; apply inj_pair2 in H6; subst P0 Q0.
     inv HD. apply inj_pair2 in H1; subst; trivial. 
@@ -1649,7 +1642,6 @@ apply necR_level in H1, H5. apply ext_level in H2, H6. apply laterR_level in H3.
 intros ? ? ? ? ? ? ? [? Hpost].
 rewrite emp_sepcon in Hpost.
 destruct (H b1) as [_ Hpost'].
-apply fupd_intro.
 eapply (Hpost' b3); auto.
 apply necR_level in H1, H5, H10. apply ext_level in H2, H6, H11. apply laterR_level in H3. lia.
 Qed.

--- a/veric/seplog.v
+++ b/veric/seplog.v
@@ -10,6 +10,8 @@ Require Import VST.veric.address_conflict.
 Require Export VST.veric.shares.
 Require Import VST.veric.Cop2. (*for definition of tc_val'*)
 Require Import VST.veric.own.
+Require Import VST.veric.invariants.
+Require Import VST.veric.fupd.
 Import compcert.lib.Maps.
 
 Local Open Scope pred.
@@ -259,6 +261,11 @@ Qed.*)
 Definition argsHaveTyps (vals:list val) (types: list type): Prop:=
   Forall2 (fun v t => v<>Vundef -> Val.has_type v t) vals (map typ_of_type types).
 
+Notation fupd := (fupd Ensembles.Full_set Ensembles.Full_set).
+
+Section invs.
+Context {inv_names : invG}.
+
 Definition funspec_sub_si (f1 f2 : funspec):mpred :=
 match f1 with
 | mk_funspec tpsig1 cc1 A1 P1 Q1 _ _ =>
@@ -268,10 +275,10 @@ match f1 with
        |>  ! (ALL ts2 :_, ALL x2:dependent_type_functor_rec ts2 A2 mpred,
              ALL gargs:genviron * list val,
         ((!!(argsHaveTyps (snd gargs) (fst tpsig1)) && P2 ts2 x2 gargs)
-         >=> bupd (EX ts1:_, EX x1:_, EX F:_, 
+         >=> fupd (EX ts1:_, EX x1:_, EX F:_, 
             (F * (P1 ts1 x1 gargs)) &&
             ALL rho':_, (     !( ((!!(ve_of rho' = Map.empty (block * type))) && (F * (Q1 ts1 x1 rho')))
-                         >=> bupd (Q2 ts2 x2 rho'))))))
+                         >=> fupd (Q2 ts2 x2 rho'))))))
     end
 end.
 
@@ -283,12 +290,12 @@ match f1 with
         (tpsig1=tpsig2 /\ cc1=cc2) /\
         forall ts2 (x2:dependent_type_functor_rec ts2 A2 mpred) (gargs:argsEnviron),
         ((!! (argsHaveTyps(snd gargs)(fst tpsig1)) && P2 ts2 x2 gargs)
-         |-- bupd (EX ts1:_,  EX (x1:dependent_type_functor_rec ts1 A1 mpred), EX F:_, 
+         |-- fupd (EX ts1:_,  EX (x1:dependent_type_functor_rec ts1 A1 mpred), EX F:_, 
                            (F * (P1 ts1 x1 gargs)) &&
                                (!! (forall rho',
                                            ((!!(ve_of rho' = Map.empty (block * type))) &&
                                                  (F * (Q1 ts1 x1 rho')))
-                                         |-- bupd (Q2 ts2 x2 rho')))))
+                                         |-- fupd (Q2 ts2 x2 rho')))))
     end
 end.
 
@@ -297,12 +304,12 @@ Proof.
   intros. destruct f1; destruct f2; simpl in *.
   destruct H as [[? ?] H']; subst. intros w _. split; [split; trivial |].
   intros w' Hw'.
-  intros ts2 x2 rho y WY k YK N E K c J.
-  destruct (H' ts2 x2 rho _ K c J) as [c' [J' [m' [? [? [? H'']]]]]]; subst.
-  destruct H'' as [ts1 [x1 [F [HF1 HF2]]]]; clear H'.
-  eexists; split; eauto; exists m'; repeat (split; auto).
-  exists ts1, x1, F; split; trivial.
-  intros rho' v KV z VZ Z EZ. hnf in HF2. apply HF2; trivial.
+  intros ts2 x2 rho y WY k YK N E K.
+  apply H' in K.
+  eapply fupd_mono, K.
+  repeat (apply exp_derives; intros).
+  apply andp_derives; auto.
+  intros ? H rho' v KV z VZ Z EZ. apply H; trivial.
 Qed.
 
 Lemma funspec_sub_sub_si' f1 f2: !!(funspec_sub f1 f2) |-- funspec_sub_si f1 f2.
@@ -321,9 +328,9 @@ Qed.
 Lemma funspec_sub_refl f: funspec_sub f f.
 Proof.
   destruct f; split; [ split; trivial | intros ts2 x2 rho w [T W]].
-  apply bupd_intro.
+  apply fupd_intro.
   exists ts2, x2, emp. rewrite emp_sepcon. split; trivial. hnf; intros. 
-  rewrite emp_sepcon. apply andp_left2, bupd_intro.
+  rewrite emp_sepcon. apply andp_left2, fupd_intro.
 Qed.
 
 Lemma funspec_sub_trans f1 f2 f3: funspec_sub f1 f2 -> 
@@ -336,7 +343,7 @@ Proof.
   apply prop_andp_left; intro Hlocal.
   eapply derives_trans.
   { eapply derives_trans, H23; apply andp_right; eauto; intros ??; auto. }
-  eapply derives_trans, bupd_trans; apply bupd_mono.
+  eapply derives_trans, fupd_trans; apply fupd_mono.
   apply exp_left; intro ts1.
   apply exp_left; intro x1.
   apply exp_left; intro F.
@@ -344,7 +351,7 @@ Proof.
   { eapply sepcon_derives, derives_trans, H12; [apply derives_refl|].
     apply andp_right; eauto; intros ??; auto. }
   rewrite andp_comm, <- normalize.sepcon_andp_prop'.
-  eapply derives_trans; [apply bupd_frame_l | apply bupd_mono].
+  eapply derives_trans; [apply fupd_frame_l | apply fupd_mono].
   rewrite exp_sepcon2; apply exp_left; intros ts2.
   rewrite exp_sepcon2; apply exp_left; intros x2.
   rewrite exp_sepcon2; apply exp_left; intros G.
@@ -354,12 +361,12 @@ Proof.
   rewrite <- andp_assoc, andp_comm; apply andp_derives.
   { rewrite sepcon_assoc; auto. }
   intros ? [H1 H2]; simpl in *.
-  intros rho'; eapply derives_trans, bupd_trans.
-  eapply derives_trans, bupd_mono, H1.
+  intros rho'; eapply derives_trans, fupd_trans.
+  eapply derives_trans, fupd_mono, H1.
   apply prop_andp_left; intros Hlocal'.
   unfold local; simpl; unfold lift1; simpl.
-  rewrite bupd_andp_prop; apply andp_right; [intros ??; auto|].
-  eapply derives_trans, bupd_frame_l.
+  eapply derives_trans, fupd_andp_prop; apply andp_right; [intros ??; auto|].
+  eapply derives_trans, fupd_frame_l.
   rewrite sepcon_assoc; eapply sepcon_derives, derives_trans, H2; auto.
   apply andp_right; auto; intros ??; auto.
 Qed.
@@ -397,7 +404,7 @@ intros.
 apply pred_ext; intros ? []; split; auto.
 Qed.
 
-Lemma allp_sepcon1': forall {A} P Q, (ALL x : A, P x) * Q |-- ALL x : A, P x * Q.
+Lemma allp_sepcon1': forall {A} (P : A -> pred rmap) Q, (ALL x : A, P x) * Q |-- ALL x : A, P x * Q.
 Proof.
   intros.
   apply allp_right; intro x.
@@ -405,37 +412,7 @@ Proof.
   apply allp_left with x; auto.
 Qed.
 
-(* up *)
-Lemma bupd_allp: forall {A} P, bupd (ALL x : A, P x) |-- ALL x : A, bupd (P x).
-Proof.
-  intros.
-  apply allp_right; intro x.
-  apply bupd_mono, allp_left with x; auto.
-Qed.
-
-Lemma bupd_unfash: forall P, bupd (! P) |-- ! P.
-Proof.
-  repeat intro; simpl in *.
-  destruct (H (core (ghost_of a))) as (? & ? & ? & <- & ? & ? & ?); auto.
-  rewrite <- ghost_of_approx at 1; eexists; apply ghost_fmap_join, join_comm, core_unit.
-Qed.
-
-Lemma bupd_andp_unfash: forall P Q, bupd (!P && Q) = !P && bupd Q.
-Proof.
-  intros; apply pred_ext.
-  - apply andp_right.
-    + eapply derives_trans; [apply bupd_mono, andp_left1, derives_refl|].
-      apply bupd_unfash.
-    + apply bupd_mono, andp_left2, derives_refl.
-  - intros ? [? HQ] ? J.
-    destruct (HQ _ J) as (? & ? & a' & Hl & ? & ? & ?); subst.
-    eexists; split; eauto.
-    exists a'; repeat (split; auto).
-    simpl in *.
-    rewrite Hl; auto.
-Qed.
-
-Lemma unfash_sepcon: forall P Q, !P * Q |-- !P.
+Lemma unfash_sepcon: forall P (Q : pred rmap), !P * Q |-- !P.
 Proof.
   intros ??? (? & ? & J & ? & ?); simpl in *.
   apply join_level in J as [<- _]; auto.
@@ -453,10 +430,10 @@ Proof.
   destruct f; split; [split; trivial |].
   intros a' Ha'.
   clear H. intros ts2 x2 rho.
-  intros y Hy z ? Hz Hz' [_ ?]. apply bupd_intro.
+  intros y Hy z ? Hz Hz' [_ ?]. apply fupd_intro.
   exists ts2, x2, emp; rewrite emp_sepcon. split; auto.
   intros rho' k WK u ? necKU E Z.
-  rewrite emp_sepcon in Z. apply bupd_intro, Z.
+  rewrite emp_sepcon in Z. apply fupd_intro, Z.
 Qed.
 
 Lemma funspec_sub_si_trans f1 f2 f3: funspec_sub_si f1 f2 && funspec_sub_si f2 f3 |--
@@ -482,22 +459,23 @@ eapply subp_trans.
   rewrite <- (andp_dup (!! argsHaveTyps _ _)) at 2; rewrite andp_assoc; apply subp_andp, derives_refl; apply subp_refl. }
 eapply subp_trans.
 { apply andp_left2.
-  rewrite <- bupd_andp_prop; apply subp_bupd.
-  rewrite exp_andp2; apply subp_exp; intro ts1.
-  rewrite exp_andp2; apply subp_exp; intro x1.
-  rewrite exp_andp2; apply subp_exp; intro F.
+  intros ??. apply prop_andp_subp; intro.
+  eapply subp_fupd, H.
+  apply subp_exp; intro ts1.
+  apply subp_exp; intro x1.
+  apply subp_exp; intro F.
   apply allp_left with ts1; apply allp_left with x1; apply allp_left with rho.
-  rewrite <- andp_assoc, <- sepcon_andp_prop.
-  apply subp_andp, subp_refl; apply subp_sepcon, derives_refl; apply subp_refl. }
+  rewrite prop_true_andp by auto.
+  apply subp_andp, subp_refl. apply subp_sepcon, derives_refl; apply subp_refl. }
 apply derives_trans with TT; auto.
-eapply derives_trans, subp_derives, bupd_trans; [|apply derives_refl].
-apply subp_bupd.
+eapply derives_trans, subp_derives, fupd_trans; [|apply derives_refl].
+apply subp_fupd.
 apply subp_exp_left; intro ts1.
 apply subp_exp_left; intro x1.
 apply subp_exp_left; intro F.
 rewrite <- unfash_allp', andp_comm.
-eapply derives_trans, subp_derives, derives_refl; [|apply andp_derives, bupd_frame_l; apply derives_refl].
-rewrite <- bupd_andp_unfash; apply subp_bupd.
+eapply derives_trans, subp_derives, derives_refl; [ | apply andp_derives, fupd_frame_l; apply derives_refl].
+eapply derives_trans, subp_derives; [apply subp_fupd | apply fupd_andp_unfash | apply derives_refl].
 rewrite exp_sepcon2, exp_andp2; apply subp_exp_left; intro ts2.
 rewrite exp_sepcon2, exp_andp2; apply subp_exp_left; intro x2.
 rewrite exp_sepcon2, exp_andp2; apply subp_exp_left; intro G.
@@ -517,9 +495,9 @@ rewrite andp_comm, andp_assoc; apply subp_andp.
     rewrite <- (andp_dup (!! (ve_of rho' = Map.empty (block * type)))) at 2; rewrite andp_assoc; apply subp_andp; [apply subp_refl|].
     rewrite sepcon_assoc, <- (sepcon_andp_prop F).
     apply subp_sepcon, derives_refl; apply subp_refl. }
-  eapply derives_trans, subp_derives, bupd_trans.
-  2: { eapply andp_derives, bupd_frame_l; apply derives_refl. }
-  rewrite <- bupd_andp_prop; apply subp_bupd.
+  eapply derives_trans, subp_derives, fupd_trans.
+  2: { eapply andp_derives, fupd_frame_l; apply derives_refl. }
+  eapply derives_trans, subp_derives; [apply subp_fupd | apply fupd_andp_prop | apply derives_refl].
   apply andp_left2, allp_left with rho'; auto.
 Qed.
 
@@ -688,7 +666,6 @@ Lemma approx_sepcon: forall (P Q: mpred) n,
   approx n Q.
 Proof.
   intros.
-  change sepcon with predicates_sl.sepcon in *.
   apply predicates_hered.pred_ext.
   + intros w ?.
     simpl in *.
@@ -787,6 +764,15 @@ Proof.
     rewrite approx_oo_approx', approx'_oo_approx in Hg by lia; auto.
 Qed.
 
+Lemma invariant_super_non_expansive : forall n N P,
+  approx n (invariant N P) = approx n (invariant N (approx n P)).
+Proof.
+  intros; unfold invariant.
+  rewrite !approx_exp; f_equal; extensionality g.
+  rewrite !approx_sepcon; f_equal.
+  apply own_super_non_expansive.
+Qed.
+
 (*
 Lemma approx_func_ptr: forall (A: Type) fsig0 cc (P Q: A -> environ -> mpred) (v: val) (n: nat),
   approx n (func_ptr (NDmk_funspec fsig0 cc A P Q) v) = approx n (func_ptr (NDmk_funspec fsig0 cc A (fun a rho => approx n (P a rho)) (fun a rho => approx n (Q a rho))) v).
@@ -837,8 +823,51 @@ Proof.
       eexists; split; eauto; eexists; split; eauto; repeat split; auto.
 Qed.
 
+Lemma wand_nonexpansive_l: forall P Q n,
+  approx n (P -* Q)%pred = approx n (approx n P  -* Q)%pred.
+Proof.
+  repeat intro.
+  apply predicates_hered.pred_ext; intros ? [? Hshift]; split; auto; intros ??????.
+  - destruct H2; eauto.
+  - eapply Hshift; eauto; split; auto.
+    apply necR_level in H0; apply join_level in H1 as []; lia.
+Qed.
+
+Lemma wand_nonexpansive_r: forall P Q n,
+  approx n (P -* Q)%pred = approx n (P  -* approx n Q)%pred.
+Proof.
+  repeat intro.
+  apply predicates_hered.pred_ext; intros ? [? Hshift]; split; auto; intros ??????.
+  - split; eauto.
+    apply necR_level in H0; apply join_level in H1 as []; lia.
+  - eapply Hshift; eauto.
+Qed.
+
+Lemma wand_nonexpansive: forall P Q n,
+  approx n (P -* Q)%pred = approx n (approx n P  -* approx n Q)%pred.
+Proof.
+  intros; rewrite wand_nonexpansive_l, wand_nonexpansive_r; reflexivity.
+Qed.
+
+Lemma approx_idem : forall n P, approx n (approx n P) = approx n P.
+Proof.
+  intros.
+  change (approx n (approx n P)) with ((approx n oo approx n) P).
+  rewrite approx_oo_approx; auto.
+Qed.
+
+Lemma fupd_nonexpansive: forall E1 E2 P n, approx n (fupd.fupd E1 E2 P) = approx n (fupd.fupd E1 E2 (approx n P)).
+Proof.
+  intros; unfold fupd.
+  rewrite wand_nonexpansive; setoid_rewrite wand_nonexpansive at 2.
+  f_equal; f_equal.
+  rewrite !approx_bupd; f_equal.
+  rewrite !approx_orp; f_equal.
+  erewrite !approx_sepcon, approx_idem; reflexivity.
+Qed.
+
 Lemma approx_prop_andp {P Q:Prop} n:
-  approx n (prop (P /\ Q)) = (approx n (prop P)) && (approx n (prop Q)). 
+  approx n (prop (P /\ Q)) = (approx n (prop P)) && (approx n (prop Q)).
 Proof.
   apply predicates_hered.pred_ext.
   + intros w ?. simpl in *. destruct H as [? [? ?]]. split; split; trivial.
@@ -908,24 +937,25 @@ Proof.
     eapply funspec_sub_si_trans; split. apply Phi. clear Phi PHI; hnf.
     split. split; trivial.
     intros w' Hw' ts2 a rho m WM u ? necU extU [U1 U2]. simpl in U1.
-    apply bupd_intro.
+    apply fupd_intro.
     exists ts2, a, emp. rewrite emp_sepcon; split. { apply approx_p in U2; trivial. }
     intros rho' y UY k ? YK EK K. rewrite emp_sepcon in K. simpl in K.
-    rewrite <- approx_bupd.
+    apply fupd_intro.
+    destruct K; split; auto.
     apply necR_level in necU.  apply necR_level in YK. apply ext_level in extU. apply ext_level in EK.
-    split; [ | apply bupd_intro, K]. apply laterR_level in Hw'. lia.
+    apply laterR_level in Hw'. lia.
   + rewrite approx_andp, approx_exp in W. destruct W as [W1 [phi [Lev [Phi PHI]]]].
     rewrite approx_andp, approx_exp. split; trivial.
     exists phi; split3; trivial.
     eapply funspec_sub_si_trans; split. apply Phi. clear Phi PHI; hnf.
     split. split; trivial.
     intros w' Hw' ts2 a rho m WM u ? necU extU [U1 U2]. simpl in U1.
-    apply bupd_intro.
+    apply fupd_intro.
     exists ts2, a, emp. rewrite emp_sepcon; split. 
     - apply necR_level in necU. apply ext_level in extU. apply approx_lt; trivial.
       apply laterR_level in Hw'. lia.
     - intros rho' k UP j ? KJ EJ J.
-      rewrite emp_sepcon in J. simpl in J. apply bupd_intro, J.
+      rewrite emp_sepcon in J. simpl in J. apply fupd_intro, J.
 Qed.
 
 Lemma approx_func_ptr_si: forall (A: Type) fsig0 cc (P: A -> argsEnviron -> mpred)
@@ -947,22 +977,22 @@ Proof. intros. apply approx_func_ptr_si_general. Qed.
     eapply funspec_sub_si_trans; split. apply SUBS. clear SUBS H0; hnf.
     split. split; trivial. 
     intros w' Hw' ts2 a rho m WM u necU [U1 U2]. simpl in U1.
-    apply bupd_intro.
+    apply fupd_intro.
     exists ts2, a, emp. rewrite emp_sepcon; split. { apply approx_p in U2; trivial. }
     intros rho' y UY k YK K. rewrite emp_sepcon in K. simpl in K.
-    rewrite <- approx_bupd.
+    rewrite <- approx_fupd.
     apply necR_level in necU.  apply necR_level in YK.
-    split; [ | apply bupd_intro, K]. apply laterR_level in Hw'. lia.
+    split; [ | apply fupd_intro, K]. apply laterR_level in Hw'. lia.
   + destruct H0 as [gs [SUBS H0]]. exists gs; split; trivial.
     eapply funspec_sub_si_trans; split. apply SUBS. clear SUBS H0; hnf.
     split. split; trivial.
     intros w' Hw' ts2 a rho m WM u necU [U1 U2]. simpl in U1.
-    apply bupd_intro.
+    apply fupd_intro.
     exists ts2, a, emp. rewrite emp_sepcon; split. 
     - apply necR_level in necU. apply approx_lt; trivial.
       apply laterR_level in Hw'. lia.
     - intros rho' k UP j KJ J.
-      rewrite emp_sepcon in J. simpl in J. apply bupd_intro, J.
+      rewrite emp_sepcon in J. simpl in J. apply fupd_intro, J.
 Qed. *)
 
 Definition funspecs_assert (FunSpecs: PTree.t funspec): assert :=
@@ -1048,13 +1078,13 @@ Proof.
   destruct (eq_dec cA cB); [subst cB | discriminate]. inv I.
   split.
   + split. split; trivial. intros. simpl. intros w [W1 W2].
-    apply bupd_intro. exists ts2, (inl x2), emp. rewrite emp_sepcon.
+    apply fupd_intro. exists ts2, (inl x2), emp. rewrite emp_sepcon.
     split. trivial. simpl; intros. rewrite emp_sepcon.
-    apply andp_left2, bupd_intro.
+    apply andp_left2, fupd_intro.
   + split. split; trivial. intros. simpl. intros w [W1 W2].
-    apply bupd_intro. exists ts2, (inr x2), emp. rewrite emp_sepcon.
+    apply fupd_intro. exists ts2, (inr x2), emp. rewrite emp_sepcon.
     split. trivial. simpl; intros. rewrite emp_sepcon.
-    apply andp_left2, bupd_intro.
+    apply andp_left2, fupd_intro.
 Qed.
 
 (*Rule S-inter3 from page 206 of TAPL*)
@@ -1085,10 +1115,10 @@ Lemma funspec_Sigma_ND_sub fsig cc I A Pre Post i:
   funspec_sub (funspec_Sigma_ND fsig cc I A Pre Post) (NDmk_funspec fsig cc (A i) (Pre i) (Post i)).
 Proof.
   unfold funspec_Sigma_ND. split. split; trivial. intros; simpl in *.
-  eapply derives_trans, bupd_intro.
+  eapply derives_trans, fupd_intro.
   exists ts2, (existT A i x2), emp. rewrite emp_sepcon.
   split. apply H. simpl; intros. rewrite emp_sepcon.
-  intros u U. apply bupd_intro, U.
+  intros u U. apply fupd_intro, U.
 Qed.
 
 (*Rule S-inter3 from page 206 of TAPL*)
@@ -1129,18 +1159,18 @@ Proof.
   destruct (eq_dec ccA ccB); [ inv F; split; trivial | discriminate]. 
   split.
   + split. split; trivial. simpl; intros. destruct x2 as [i p].
-    eapply derives_trans, bupd_intro. destruct i; simpl in *.
+    eapply derives_trans, fupd_intro. destruct i; simpl in *.
   - exists ts2, (inl p), emp. rewrite emp_sepcon. split; simpl. apply H.
-    intros. rewrite emp_sepcon. intros u U; apply bupd_intro, U.
+    intros. rewrite emp_sepcon. intros u U; apply fupd_intro, U.
   - exists ts2, (inr p), emp. rewrite emp_sepcon. split; simpl. apply H.
-    intros. rewrite emp_sepcon. intros u U; apply bupd_intro, U.
+    intros. rewrite emp_sepcon. intros u U; apply fupd_intro, U.
     + split. split; trivial. intros. intros u [L U]. destruct x2.
-  - apply bupd_intro. exists ts2, (existT (BinarySigma_obligation_1 A B) true a), emp.
+  - apply fupd_intro. exists ts2, (existT (BinarySigma_obligation_1 A B) true a), emp.
     rewrite emp_sepcon. simpl; split. apply U. intros. rewrite emp_sepcon.
-    apply andp_left2, bupd_intro.
-  - apply bupd_intro. exists ts2, (existT (BinarySigma_obligation_1 A B) false b), emp.
+    apply andp_left2, fupd_intro.
+  - apply fupd_intro. exists ts2, (existT (BinarySigma_obligation_1 A B) false b), emp.
     rewrite emp_sepcon. simpl; split. apply U. intros. rewrite emp_sepcon.
-    apply andp_left2, bupd_intro.
+    apply andp_left2, fupd_intro.
 Qed.
 
 Lemma Intersection_sameSigCC_Some sig cc A PA QA fsA PrfA B PB QB fsB PrfB:
@@ -1265,21 +1295,21 @@ Proof.
   destruct (eq_dec c1 c2); inv H.
   apply inj_pair2 in H5. apply inj_pair2 in H4. subst P Q. split.
   + split; [split; reflexivity | intros].
-    eapply derives_trans, bupd_intro. exists ts2.
+    eapply derives_trans, fupd_intro. exists ts2.
     fold (@dependent_type_functor_rec ts2) in *.
     simpl in H; destruct H.
     exists (existT _ true x2), emp.
     rewrite emp_sepcon.
     split. apply H0.
-    simpl. intros rho'; rewrite emp_sepcon. apply andp_left2; apply bupd_intro.
+    simpl. intros rho'; rewrite emp_sepcon. apply andp_left2; apply fupd_intro.
   + split; [split; reflexivity | intros].
-    eapply derives_trans, bupd_intro. exists ts2.
+    eapply derives_trans, fupd_intro. exists ts2.
     fold (@dependent_type_functor_rec ts2) in *.
     simpl in H; destruct H.
     exists (existT _ false x2), emp.
     rewrite emp_sepcon.
     split. apply H0.
-    simpl. intros rho'; rewrite emp_sepcon. apply andp_left2; apply bupd_intro.
+    simpl. intros rho'; rewrite emp_sepcon. apply andp_left2; apply fupd_intro.
 Qed.
 
 Lemma BINARY_intersection_sub3  phi psi omega:
@@ -1434,7 +1464,7 @@ Proof.
   specialize (Hsig i); specialize (Hcc i); subst.
   unfold  general_intersection; simpl.
   remember (phi i) as zz; destruct zz. split; [ split; reflexivity | intros].
-  eapply derives_trans, bupd_intro.
+  eapply derives_trans, fupd_intro.
   exists ts2. simpl in H; destruct H.
   assert (exists D: (dependent_type_functor_rec ts2 (WithType_of_funspec (phi i))) mpred,
          JMeq.JMeq x2 D).
@@ -1449,7 +1479,7 @@ Proof.
     inv HD. apply inj_pair2 in H1; subst; trivial. 
   + intros; rewrite emp_sepcon. unfold intersectionPOST.
     intros x [X1 X2]. destruct (phi i).
-    apply bupd_intro.
+    apply fupd_intro.
     simpl in *; inv Heqzz.
     apply inj_pair2 in H5; apply inj_pair2 in H6; subst P0 Q0.
     inv HD. apply inj_pair2 in H1; subst; trivial. 
@@ -1506,7 +1536,7 @@ Proof.
       apply (make_context_t_get H).
 Qed.
 
-Lemma tc_environ_rettype t rho: tc_environ (rettype_tycontext t) (seplog.globals_only rho).
+Lemma tc_environ_rettype t rho: tc_environ (rettype_tycontext t) (globals_only rho).
 Proof.
   unfold rettype_tycontext; simpl. split3; intros; simpl.
   red; intros. rewrite PTree.gempty in H; congruence.
@@ -1516,7 +1546,7 @@ Qed.
 
 Lemma tc_environ_rettype_env_set t rho i v:
 tc_environ (rettype_tycontext t)
-         (env_set (seplog.globals_only rho) i v).
+         (env_set (globals_only rho) i v).
 Proof.
   unfold rettype_tycontext; simpl. split3; intros; simpl.
   red; intros. rewrite PTree.gempty in H; congruence.
@@ -1609,7 +1639,7 @@ clear gs H3 H4.
 split.
 split; auto.
 intros ? ? ? ? ? ? ? ? ? ? ? [? ?].
-apply bupd_intro.
+apply fupd_intro.
 exists nil, b1, emp.
 rewrite emp_sepcon.
 split.
@@ -1619,7 +1649,7 @@ apply necR_level in H1, H5. apply ext_level in H2, H6. apply laterR_level in H3.
 intros ? ? ? ? ? ? ? [? Hpost].
 rewrite emp_sepcon in Hpost.
 destruct (H b1) as [_ Hpost'].
-apply bupd_intro.
+apply fupd_intro.
 eapply (Hpost' b3); auto.
 apply necR_level in H1, H5, H10. apply ext_level in H2, H6, H11. apply laterR_level in H3. lia.
 Qed.
@@ -1756,3 +1786,5 @@ Check (HORec_sub). (predicates_hered.allp (fun x : T * val => |> B1 x <=> |> B2 
 
     Print funspec_sub. do_funspec_sub. Search  red in Sub simpl in Sub. destruct Sub. intros r. eapply eqp_prop. andp_subp. eapply prop_andp_subp. normalize.
 eapply (allp_left v).*)
+
+End invs.


### PR DESCRIPTION
This PR adds fancy updates (i.e., global invariant accesses) between steps to the juicy semantics. This allows us to access global invariants at any time in a proof using `viewshift_SEP`, and removes the need for some previously `Admitted` lemmas in `atomics/general_atomics`. We can also use the Iris `iInv` tactic to interact with invariants in IPM.

Limitations:

Because of an extra step in the return operation in VST's semantics vs. CompCert's, we can't do fancy updates after a function call. This means that some fancy functions (e.g., allocating a lock invariant) might return their postconditions under a modality (that the caller can immediately remove using `viewshift_SEP`).

Unlike ghost-state updates, fancy updates have a major impact on the soundness proof. From a per-thread perspective, we may have hidden some of our memory permissions in an invariant, and then proved safety with the reduced permissions. To recover soundness, we need some new frame-style properties of external calls. These are:

1. Inline external calls can be run on memories with increased permissions, and ignore the increased permissions. This is a variant of CompCert's `ec_mem_extends` axiom, but with a much tighter relation than `Mem.extends`. It seems like we need this as an axiom at the top level, but maybe I'm missing something.

2. A full frame rule for juicy extspecs. We prove that all extspecs derived from VST funspecs satisfy this frame rule, so this shouldn't be a problem in practice.

3. Exit specs ignore increased permissions. Our exit specs so far are always True, so this is trivial in all current examples.