### PR TITLE
Improve VSUpile makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 # # Choosing compcert #
 # COMPCERT=platform     (default, choose 32 or 64 bit platform supplied x86 variant, dependent on BITSIZE, ARCH can be left empty or must be x86)
 # COMPCERT=bundled      (build and use bundled 32 or 64 x86 variant, dependent on BITSIZE, ARCH can be left empty or must be x86)
-# COMPCERT=nundled_new  (build and use bundled compcert_new 32 or 64 x86 variant, dependent on BITSIZE, ARCH can be left empty or must be x86)
+# COMPCERT=bundled_new  (build and use bundled compcert_new 32 or 64 x86 variant, dependent on BITSIZE, ARCH can be left empty or must be x86)
 # COMPCERT=src_dir      (build and use in source folder COMPCERT_SRC_DIR the variant specified by ARCH and BITSIZE)
 # COMPCERT=inst_dir     (use prebuilt CompCert in COMPCERT_INST_DIR - BITSIZE and ARCH can be left empty or must match)
 #
@@ -79,15 +79,12 @@ ifeq ($(COMPCERT),platform)
   # Platform supplied CompCert
   ifeq ($(BITSIZE),)
     COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
-    REL_COMPCERT_INST_DIR=$(COMPCERT_INST_DIR)
     COMPCERT_EXPLICIT_PATH = false
   else ifeq ($(BITSIZE),64)
     COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
-    REL_COMPCERT_INST_DIR=$(COMPCERT_INST_DIR)
     COMPCERT_EXPLICIT_PATH = false
   else ifeq ($(BITSIZE),32)
     COMPCERT_INST_DIR = $(COQLIB)/../coq-variant/compcert32/compcert
-    REL_COMPCERT_INST_DIR=$(COMPCERT_INST_DIR)
   else 
     $(error ILLEGAL BITSIZE $(BITSIZE))
   endif
@@ -96,13 +93,11 @@ else ifeq ($(COMPCERT),bundled)
   # Bundled CompCert
   COMPCERT_SRC_DIR = compcert
   COMPCERT_INST_DIR = compcert
-  REL_COMPCERT_INST_DIR=../../compcert
   COMPCERT_BUILD_FROM_SRC = true
 else ifeq ($(COMPCERT),bundled_new)
   # Bundled CompCert (new variant)
   COMPCERT_SRC_DIR = compcert_new
   COMPCERT_INST_DIR = compcert_new
-  REL_COMPCERT_INST_DIR=../../compcert_new
   COMPCERT_NEW = true
   COMPCERT_INFO_PATH_REF = compcert_new
   COMPCERT_BUILD_FROM_SRC = true
@@ -112,8 +107,6 @@ else ifeq ($(COMPCERT),src_dir)
     $(error COMPCERT_SRC_DIR must not be empty if COMPCERT=src_dir)
   endif
   COMPCERT_INST_DIR = $(COMPCERT_SRC_DIR)
-  # this next line is a bit dicey . . .
-  REL_COMPCERT_INST_DIR=../../$(COMPCERT_INST_DIR)
   COMPCERT_BUILD_FROM_SRC = true
 else ifeq ($(COMPCERT),inst_dir)
   # Find CompCert in install dir
@@ -134,11 +127,12 @@ endif
 
 # Verify that the version of the supplied clightgen matches the version of the internal compcert
 
+COMPCERT_VERSION=$(subst version=,,$(shell grep version $(COMPCERT_INFO_PATH_REF)/VERSION))
+
 ifdef CLIGHTGEN
   VERSION1= $(lastword $(shell $(CLIGHTGEN) --version))
-  VERSION2= $(subst version=,,$(shell grep version $(COMPCERT_INFO_PATH_REF)/VERSION))
-  ifneq ($(VERSION1),$(VERSION2))
-    $(warning clightgen version $(VERSION1) does not match VST/$(COMPCERT_INFO_PATH_REF)/VERSION $(VERSION2))
+  ifneq ($(VERSION1),$(COMPCERT_VERSION))
+    $(warning clightgen version $(VERSION1) does not match VST/$(COMPCERT_INFO_PATH_REF)/VERSION $(COMPCERT_VERSION))
   endif
 endif
 
@@ -807,7 +801,7 @@ $(patsubst %.c,$(PROGSDIR)/%.v, $(SINGLE_C_FILES)): $(PROGSDIR)/%.v: $(PROGSDIR)
 endif
 
 veric/version.v:  VERSION $(MSL_FILES:%=msl/%) $(SEPCOMP_FILES:%=sepcomp/%) $(VERIC_FILES:%=veric/%) $(FLOYD_FILES:%=floyd/%)
-	sh util/make_version ${BITSIZE}
+	sh util/make_version ${BITSIZE} ${COMPCERT_VERSION}
 
 _CoqProject _CoqProject-export: Makefile util/coqflags $(COMPCERT_CONFIG)
 	echo $(COQFLAGS) > _CoqProject
@@ -883,7 +877,7 @@ progs64v: progs64c $(V64_ORDINARY:%.v=progs64/%.v) $(C64_ORDINARY:%.c=progs64/%.
 progs64: _CoqProject  $(PROGS64_FILES:%.v=progs64/%.vo)
 
 VSUpile: floyd/proofauto.vo floyd/library.vo floyd/VSU.vo
-	cd progs/VSUpile; $(MAKE) VST_LOC=../.. COMPCERT_LOC=$(REL_COMPCERT_INST_DIR)
+	cd progs/VSUpile; $(MAKE) BUNDLED=true
 
 # $(CC_TARGET): compcert/make
 #	(cd compcert; ./make)

--- a/progs/VSUpile/Makefile
+++ b/progs/VSUpile/Makefile
@@ -28,7 +28,6 @@ CFLAGS=-O
 
 # BEGINNING OF LOGIC TO HANDLE BUNDLED=true OPTION
 # Most of this is based on ../../Makefile, and documented there
-COQLIB=$(shell $(COQC) -where | tr -d '\r' | tr '\\' '/')
 -include CONFIGURE
 ifeq ($(BUNDLED),true)
 -include ../../CONFIGURE
@@ -39,6 +38,8 @@ COMPCERT_EXPLICIT_PATH = true
 COMPCERT_BUILD_FROM_SRC = false
 ifeq ($(COMPCERT),platform)
   # Platform supplied CompCert
+  COQLIB=$(shell coqc -where | tr -d '\r' | tr '\\' '/')
+  $(info COQLIB=$(COQLIB))
   ifeq ($(BITSIZE),)
     COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
     COMPCERT_EXPLICIT_PATH = false

--- a/progs/VSUpile/Makefile
+++ b/progs/VSUpile/Makefile
@@ -1,3 +1,12 @@
+#  This development can be built in either of two ways:
+# BUNDLED=true
+#   means that VST is located at ../..
+#   Furthermore, in this mode, the file ../../CONFIGURE gives information
+#   about how to access CompCert files
+# BUNDLED != true   (the default)
+#   means that coqc has access to VST without any -Q or -R flags,
+#   for example via opam or the Coq Platform
+
 HFILES = pile.h pile_private.h onepile.h apile.h triang.h stdlib.h \
          fast/fastpile_private.h
 CFILES = pile.c onepile.c apile.c triang.c main.c stdlib.c \
@@ -17,31 +26,115 @@ VFILES = PileModel.v spec_stdlib.v verif_stdlib.v spec_pile.v spec_pile_private.
 CC=ccomp
 CFLAGS=-O
 
+# BEGINNING OF LOGIC TO HANDLE BUNDLED=true OPTION
+# Most of this is based on ../../Makefile, and documented there
 -include CONFIGURE
-VST_LOC ?= ../..
+ifeq ($(BUNDLED),true)
+-include ../../CONFIGURE
+COMPCERT ?= platform
+COMPCERT_NEW = false
+COMPCERT_INFO_PATH_REF = compcert
+COMPCERT_EXPLICIT_PATH = true
+COMPCERT_BUILD_FROM_SRC = false
+ifeq ($(COMPCERT),platform)
+  # Platform supplied CompCert
+  ifeq ($(BITSIZE),)
+    COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
+    COMPCERT_EXPLICIT_PATH = false
+  else ifeq ($(BITSIZE),64)
+    COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
+    COMPCERT_EXPLICIT_PATH = false
+  else ifeq ($(BITSIZE),32)
+    COMPCERT_INST_DIR = $(COQLIB)/../coq-variant/compcert32/compcert
+  else 
+    $(error ILLEGAL BITSIZE $(BITSIZE))
+  endif
+  COMPCERT_SRC_DIR = __NONE__
+else ifeq ($(COMPCERT),bundled)
+  # Bundled CompCert
+  COMPCERT_SRC_DIR = ../../compcert
+  COMPCERT_INST_DIR = ../../compcert
+  COMPCERT_BUILD_FROM_SRC = true
+else ifeq ($(COMPCERT),bundled_new)
+  # Bundled CompCert (new variant)
+  COMPCERT_SRC_DIR = ../../compcert_new
+  COMPCERT_INST_DIR = ../../compcert_new
+  COMPCERT_NEW = true
+  COMPCERT_INFO_PATH_REF = ../../compcert_new
+  COMPCERT_BUILD_FROM_SRC = true
+else ifeq ($(COMPCERT),src_dir)
+  # Compile CompCert from source dir
+  ifeq ($(COMPCERT_SRC_DIR),)
+    $(error COMPCERT_SRC_DIR must not be empty if COMPCERT=src_dir)
+  endif
+  IS_ROOT    := $(if $(patsubst /%,,$(COMPCERT_SRC_DIR)),,yes)
+  IS_HOME    := $(if $(patsubst ~%,,$(COMPCERT_SRC_DIR)),,yes)
+  IS_NETWORK := $(if $(patsubst \\\\%,,$(COMPCERT_SRC_DIR)),,yes)
+  IS_DRIVE   := $(foreach d,A B C D E...Z,$(if $(patsubst $(d):/%,,$(COMPCERT_SRC_DIR)),,yes))
+  ifeq ($(strip $(IS_ROOT)$(IS_HOME)$(IS_NETWORK)$(IS_DRIVE)),)
+	# it's a relative path
+	COMPCERT_SRC_DIR := ../../$(COMPCERT_SRC_DIR)
+  endif
+  COMPCERT_INST_DIR = $(COMPCERT_SRC_DIR)
+  COMPCERT_BUILD_FROM_SRC = true
+else ifeq ($(COMPCERT),inst_dir)
+  # Find CompCert in install dir
+  COMPCERT_SRC_DIR = __NONE__
+  ifeq ($(COMPCERT_INST_DIR),)
+    $(error COMPCERT_INST_DIR must not be empty if COMPCERT=inst_dir)
+  endif
+endif
+ifneq ($(COMPCERT_SRC_DIR),__NONE__)
+  ARCH ?= x86
+  BITSIZE ?= 32
+else
+  include $(COMPCERT_INST_DIR)/compcert.config
+  ifneq ($(BITSIZE),)
+    ifneq ($(BITSIZE),$(COMPCERT_BITSIZE))
+      $(error The compcert found in $(COMPCERT_INST_DIR) has bitsize $(COMPCERT_BITSIZE) but you requested $(BITSIZE))
+    endif
+  else
+    BITSIZE = $(COMPCERT_BITSIZE)
+  endif
 
-ifdef COMPCERT_LOC
-CLIGHTGEN ?= $(COMPCERT_LOC)/clightgen
-COMPCERT_FLAGS= -R $(COMPCERT_LOC) compcert
-endif 
+  ifneq ($(ARCH),)
+    ifneq ($(ARCH),$(COMPCERT_ARCH))
+      $(error The compcert found in $(COMPCERT_INST_DIR) has bitsize $(COMPCERT_ARCH) but you requested $(ARCH))
+    endif
+  else
+    ARCH = $(COMPCERT_ARCH)
+  endif
+endif
+ifeq ($(wildcard $(COMPCERT_INST_DIR)/$(ARCH)_$(BITSIZE)),)
+  ARCHDIRS=$(ARCH)
+else
+  ARCHDIRS=$(ARCH)_$(BITSIZE) $(ARCH)
+endif
+COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend export
+COMPCERT_FLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT_INST_DIR)/$(d) compcert.$(d))
+VST_DIRS= msl sepcomp veric zlist floyd 
+else
+COMPCERTFLAGS=
+VST_DIRS=
+endif
+
+VST_LOC ?= ../..
 
 ifdef CLIGHTGEN
 VERSION1= $(lastword $(shell $(CLIGHTGEN) --version))
-VERSION2= $(subst version=,,$(shell grep version ../../compcert/VERSION))
+VERSION2= $(subst version=,,$(shell grep version $(COMPCERT_SRC_DIR)/VERSION))
 ifneq ($(VERSION1),$(VERSION2))
 $(warning clightgen version $(VERSION1) does not match VST/compcert/VERSION $(VERSION2))
 endif
 endif
 
-
 CVFILES = $(patsubst %.c,%.v,$(CFILES))
 OFILES = $(patsubst %.c,%.o,$(CFILES))
 VOFILES = $(patsubst %.v,%.vo,$(CVFILES) $(VFILES))
 
-
-VST_DIRS= msl sepcomp zlist veric floyd
 VSTFLAGS= $(COMPCERT_FLAGS) $(foreach d, $(VST_DIRS), -Q $(VST_LOC)/$(d) VST.$(d)) -R . pile
 
+# $(error VSTFLAGS=$(VSTFLAGS))
 
 target: _CoqProject verif_main.vo simple_verif_main.vo fast/verif_fastmain.vo incr/verif_incr.vo
 

--- a/progs/VSUpile/Makefile
+++ b/progs/VSUpile/Makefile
@@ -28,6 +28,7 @@ CFLAGS=-O
 
 # BEGINNING OF LOGIC TO HANDLE BUNDLED=true OPTION
 # Most of this is based on ../../Makefile, and documented there
+COQLIB=$(shell $(COQC) -where | tr -d '\r' | tr '\\' '/')
 -include CONFIGURE
 ifeq ($(BUNDLED),true)
 -include ../../CONFIGURE

--- a/progs/VSUpile/Makefile
+++ b/progs/VSUpile/Makefile
@@ -88,7 +88,7 @@ ifneq ($(COMPCERT_SRC_DIR),__NONE__)
   ARCH ?= x86
   BITSIZE ?= 32
 else
-  include $(COMPCERT_INST_DIR)/compcert.config
+  -include $(COMPCERT_INST_DIR)/compcert.config
   ifneq ($(BITSIZE),)
     ifneq ($(BITSIZE),$(COMPCERT_BITSIZE))
       $(warning The compcert found in $(COMPCERT_INST_DIR) has bitsize $(COMPCERT_BITSIZE) but you requested $(BITSIZE))

--- a/progs/VSUpile/Makefile
+++ b/progs/VSUpile/Makefile
@@ -91,7 +91,7 @@ else
   include $(COMPCERT_INST_DIR)/compcert.config
   ifneq ($(BITSIZE),)
     ifneq ($(BITSIZE),$(COMPCERT_BITSIZE))
-      $(error The compcert found in $(COMPCERT_INST_DIR) has bitsize $(COMPCERT_BITSIZE) but you requested $(BITSIZE))
+      $(warning The compcert found in $(COMPCERT_INST_DIR) has bitsize $(COMPCERT_BITSIZE) but you requested $(BITSIZE))
     endif
   else
     BITSIZE = $(COMPCERT_BITSIZE)
@@ -99,7 +99,7 @@ else
 
   ifneq ($(ARCH),)
     ifneq ($(ARCH),$(COMPCERT_ARCH))
-      $(error The compcert found in $(COMPCERT_INST_DIR) has bitsize $(COMPCERT_ARCH) but you requested $(ARCH))
+      $(warning The compcert found in $(COMPCERT_INST_DIR) has architecture $(COMPCERT_ARCH) but you requested $(ARCH))
     endif
   else
     ARCH = $(COMPCERT_ARCH)

--- a/progs/VSUpile/verif_main.v
+++ b/progs/VSUpile/verif_main.v
@@ -7,6 +7,12 @@ Require Import verif_core.
 Require Import main.
 Require Import spec_main.
 
+Require VST.veric.version.
+Lemma version_test: False.
+ assert (VST.veric.version.compcert_version = main.Info.version) by reflexivity.
+ assert (VST.veric.version.bitsize = main.Info.bitsize) by reflexivity.
+Abort.
+
 #[export] Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition main_QPprog := ltac:(QPprog prog).
 Definition whole_prog := ltac:(QPlink_progs main_QPprog (VSU_prog Core_VSU)).

--- a/progs/VSUpile/verif_stdlib.v
+++ b/progs/VSUpile/verif_stdlib.v
@@ -4,6 +4,12 @@ Require Import VST.floyd.library. (*for body_lemma_of_funspec *)
 Require Import stdlib.
 Require Import spec_stdlib.
 
+Require VST.veric.version.
+Lemma version_test: False.
+ assert (VST.veric.version.compcert_version = stdlib.Info.version) by reflexivity.
+ assert (VST.veric.version.bitsize = stdlib.Info.bitsize) by reflexivity.
+Abort.
+
 #[export] Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 
 Parameter M: MallocFreeAPD.

--- a/util/make_version
+++ b/util/make_version
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#usage:  util/make_version Bitsize Compcert-version
 F=veric/version.v
 set -e
 printf >$F 'Require Import ZArith Coq.Strings.String. Open Scope string.\n'
@@ -14,3 +15,4 @@ printf >>$F 'Definition date := "'
 date --rfc-3339=date | tr -d '[:cntrl:]' >>$F
 printf >>$F '".\n'
 printf >>$F 'Definition bitsize : Z := %d.\n' $1
+printf >>$F 'Definition compcert_version := "%s".' $2


### PR DESCRIPTION
1. VST/progs/VSUpile now builds in either BUNDLED=true mode, meaning that
  its VST comes from ../..  (and taking note of ../../CONFIGURE);
  or BUNDLED != true mode, in which case VST and CompCert come from
  the opam/platform.

2. VST/veric/version now records compcert_version as well as VST version

3. VST/progs/VSUpile/verif{main,stdlib}.v now check that
   CompCert version and bitsize are consistent between the AST files
   and the CompCert/VST platform.

closes #577 