### PR TITLE
tweak zlist

### DIFF
--- a/zlist/Zlist.v
+++ b/zlist/Zlist.v
@@ -1,3 +1,4 @@
+Require Export Coq.ZArith.Zcomplements.
 Require Export VST.zlist.sublist.
 Require Export VST.zlist.Zlength_solver.
 Require Export VST.zlist.list_solver.

--- a/zlist/list_solver.v
+++ b/zlist/list_solver.v
@@ -976,7 +976,7 @@ Proof.
   - destruct H as [i []]. subst x. apply Znth_In. auto.
 Qed.
 
-Lemma list_eq_forall_range2 : forall {A} {d : Inhabitant A} al bl,
+Lemma list_eq_forall_range2 : forall {A} {d : Inhabitant A} (al bl : list A),
   al = bl ->
   Zlength al = Zlength bl /\ forall_range2 0 (Zlength al) 0 al bl eq.
 Proof.
@@ -997,7 +997,7 @@ Lemma forall_triangle_fold : forall {A : Type} {da : Inhabitant A} {B : Type} {d
   (forall i j, x1 <= i < x2 /\ y1 <= j < y2 /\ i <= j + offset -> P (Znth i al) (Znth j bl)) = forall_triangle x1 x2 y1 y2 offset al bl P.
 Proof. auto. Qed.
 
-Lemma Forall_Znth : forall {A} {d : Inhabitant A} l P,
+Lemma Forall_Znth : forall {A} {d : Inhabitant A} (l : list A) P,
   Forall P l <-> forall i, 0 <= i < Zlength l -> P (Znth i l).
 Proof.
   intros *.
@@ -1015,7 +1015,7 @@ Proof.
     - fapply (H (i+1) ltac:(Zlength_solve)). list_form; Znth_solve.
 Qed.
 
-Lemma Forall_forall_range : forall {A} {d : Inhabitant A} l P,
+Lemma Forall_forall_range : forall {A} {d : Inhabitant A} (l : list A) P,
   Forall P l <-> forall_range 0 (Zlength l) l P.
 Proof.
   intros. rewrite Forall_Znth. reflexivity.

--- a/zlist/sublist.v
+++ b/zlist/sublist.v
@@ -2533,3 +2533,4 @@ Proof.
   - destruct H; intros ? [? | ?]; subst; auto.
 Qed.
 
+#[global] Hint Mode Inhabitant + : typeclass_instances.


### PR DESCRIPTION
#### Import `Zcomplements`
Add `Require Export Coq.ZArith.Zcomplements` to import `Zlength`.

#### Lazy `Inhabitant` resolution
Add `#[global] Hint Mode Inhabitant + : typeclass_instances` to let Coq resolve `Inhabitant A` only when `A` doesn't have evars. This prevents lemmas from being specified by a particular type. The trade off is Coq cannot infer type of `l` in `forall {A}{a: Inhabitant A} i l, 0 <= i < Zlength l -> In (Znth i l) l`
