### PR TITLE
Resolve OPAM conflict between VST and zlist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ endif
 # COMPCERT=src_dir      (build and use in source folder COMPCERT_SRC_DIR the variant specified by ARCH and BITSIZE)
 # COMPCERT=inst_dir     (use prebuilt CompCert in COMPCERT_INST_DIR - BITSIZE and ARCH can be left empty or must match)
 #
+# # Choosing VST zlist #
+# ZLIST=platform     (use zlist from installed library)
+# ZLIST=bundled      (default, build and use bundled zlist)
+#
 # # Choosing BITSIZE #
 # BITSIZE=32 
 # BITSIZE=64
@@ -62,6 +66,7 @@ endif
 
 # # User settable variables #
 COMPCERT ?= platform
+ZLIST ?= bundled
 ARCH ?= 
 BITSIZE ?=
 
@@ -235,7 +240,11 @@ endif
 
 # ########## Flags ##########
 
-VSTDIRS= msl sepcomp veric zlist floyd $(PROGSDIR) concurrency ccc26x86 atomics
+ifeq ($(ZLIST),platform)
+  VSTDIRS= msl sepcomp veric floyd $(PROGSDIR) concurrency ccc26x86 atomics
+else
+  VSTDIRS= msl sepcomp veric zlist floyd $(PROGSDIR) concurrency ccc26x86 atomics
+endif
 OTHERDIRS= wand_demo sha hmacfcf tweetnacl20140427 hmacdrbg aes mailbox boringssl_fips_20180730
 DIRS = $(VSTDIRS) $(OTHERDIRS)
 
@@ -302,6 +311,7 @@ $(info ===== CONFIGURATION SUMMARY =====)
 $(info COMPCERT=$(COMPCERT))
 $(info COMPCERT_SRC_DIR=$(COMPCERT_SRC_DIR))
 $(info COMPCERT_INST_DIR=$(COMPCERT_INST_DIR))
+$(info ZLIST=$(ZLIST))
 $(info BITSIZE=$(BITSIZE))
 $(info ARCH=$(ARCH))
 $(info INSTALLDIR=$(INSTALLDIR))

--- a/coq-vst-32.opam
+++ b/coq-vst-32.opam
@@ -19,16 +19,17 @@ dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
 bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
 build: [
-  [make "BITSIZE=32" "depend"]
-  [make "BITSIZE=32" "-j%{jobs}%" "vst"]
+  [make "ZLIST=platform" "BITSIZE=32" "depend"]
+  [make "ZLIST=platform" "BITSIZE=32" "-j%{jobs}%" "vst"]
 ]
-run-test: [make "BITSIZE=32" "-j%{jobs}%" "test"]
+run-test: [make "ZLIST=platform" "BITSIZE=32" "-j%{jobs}%" "test"]
 install: [
-	make "BITSIZE=32" "install"
+	make "ZLIST=platform" "BITSIZE=32" "install"
 	]
 depends: [
   "coq" {>= "8.13.0"}
   "coq-compcert-32" {= "3.10"}
+  "coq-vst-zlist" {= "dev"}
 ]
 synopsis: "Verified Software Toolchain"
 description:

--- a/coq-vst.opam
+++ b/coq-vst.opam
@@ -19,16 +19,17 @@ dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
 bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
 build: [
-  [make "BITSIZE=64" "depend"]
-  [make "BITSIZE=64" "-j%{jobs}%" "vst"]
+  [make "ZLIST=platform" "BITSIZE=64" "depend"]
+  [make "ZLIST=platform" "BITSIZE=64" "-j%{jobs}%" "vst"]
 ]
-run-test: [make "BITSIZE=64" "-j%{jobs}%" "test"]
+run-test: [make "ZLIST=platform" "BITSIZE=64" "-j%{jobs}%" "test"]
 install: [
-	make "BITSIZE=64" "install"
+	make "ZLIST=platform" "BITSIZE=64" "install"
 	]
 depends: [
   "coq" {>= "8.13.0"}
   "coq-compcert" {= "3.10"}
+  "coq-vst-zlist" {= "dev"}
 ]
 synopsis: "Verified Software Toolchain"
 description:


### PR DESCRIPTION
Currently the OPAM packages `coq-vst` and `coq-vst-zlist` are conflicting, because they are installed to the same directory. So I added a flag `ZLIST` (similar to `COMPCERT`) in Makefile. `ZLIST=bundled` by default, so for VST developers who don't explicitly set it, the source code in the repo will be used. The other possible value is `ZLIST=platform`, which means to use `zlist` from the installed library (e.g. OPAM). When installing VST from OPAM, it needs to depend on `zlist` and use the flag `ZLIST=platform`. I edited OPAM files accordingly. Also notice that, the OPAM files in the repo have `"coq-vst-zlist" {= "dev"}`, because they are the `dev` version as well. For released versions, we should depend on the same version number of zlist as VST.

I tested on Coq 8.15.2.