### PR TITLE
Makefile.bundled; memmgr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -698,7 +698,7 @@ test3: sha hmac
 test4: mailbox 
 test5: VSUpile
 tests: test test2 test3 test4 test5
-all: vst files tests hmacdrbg tweetnacl aes
+all: vst files tests memmgr hmacdrbg tweetnacl aes
 endif
 
 files: _CoqProject $(FILES:.v=.vo)
@@ -842,6 +842,7 @@ endif
 clean:
 	rm -f $(addprefix veric/version., v vo vos vok glob) .lia.cache .nia.cache floyd/floyd.coq .depend _CoqProject _CoqProject-export $(wildcard */.*.aux)  $(wildcard */*.glob) $(wildcard */*.vo */*.vos */*.vok) compcert/*/*.{vo,vos,vok} compcert/*/*/*.{vo,vos,vok}  compcert_new/*/*.{vo,vos,vok} compcert_new/*/*/*.{vo,vos,vok}
 	rm -f progs/VSUpile/{*,*/*}.{vo,vos,vok,glob}
+	rm -f progs/memmgr/*.{vo,vos,vok,glob}
 	rm -f coq-ext-lib/theories/*.{vo,vos,vok,glob} InteractionTrees/theories/{*,*/*}.{vo,vos,vok,glob}
 	rm -f paco/src/*.{vo,vos,vok,glob}
 	rm -f fcf/src/FCF/*.{vo,vos,vok,glob}
@@ -877,7 +878,9 @@ progs64v: progs64c $(V64_ORDINARY:%.v=progs64/%.v) $(C64_ORDINARY:%.c=progs64/%.
 progs64: _CoqProject  $(PROGS64_FILES:%.v=progs64/%.vo)
 
 VSUpile: floyd/proofauto.vo floyd/library.vo floyd/VSU.vo
-	cd progs/VSUpile; $(MAKE) BUNDLED=true
+	cd progs/VSUpile; $(MAKE) VST_LOC=../..
+memmgr:  floyd/proofauto.vo floyd/library.vo floyd/VSU.vo
+	cd progs/memmgr; $(MAKE) VST_LOC=../..
 
 nothing: # need this target for the degenerate case of "make -tk */*.vo" in coq-action.yml
 

--- a/Makefile.bundled
+++ b/Makefile.bundled
@@ -1,0 +1,147 @@
+# This Makefile.bundled is meant to be included in Makefiles for 
+# C program verifications that may want to use VST either
+# from an opam install _or_ from a local pathname to the .vo files.
+# In your own Makefile, put these lines at the top:
+#  ifdef VST_LOC
+#  include $(VST_LOC)/Makefile.bundled
+#  endif
+#
+# Inputs: Its main input is the VST_LOC variable, either undefined or a path
+# to the location of the VST .vo files.
+# Outputs: It defines VSTFLAGS, either empty or containing the
+# appropriate -Q options; $(VSTFLAGS) should be added to every coqc command
+# in the makefile that includes this one.
+#   The main Makefile should define a target called "all".
+
+-include CONFIGURE
+# Configuration is read from an optional CONFIGURATION file, or from
+# make command-line arguments (e.g., VST_LOC=../..)
+
+# VST_LOC undefined   (the default)
+#   means that coqc has access to VST without any -Q or -R flags,
+#   for example via opam or the Coq Platform
+# VST_LOC=path
+#   means that VST is located at "path", for example ../..
+#   Furthermore, in this mode, the file $(VST_LOC)/CONFIGURE gives information
+#   about how to access CompCert .vo files
+# When VST_LOC is nonempty, these features of the Makefile are useful:
+# 1. "make _CoqProject" creates a _CoqProject file useful for using coqide etc.
+# 2.  In the Makefile that includes this one, you can add the $(FLOYD)
+# dependency to each of your .vo make-targets that depends on such files as 
+# VST.float.proofauto, to cause appropriate recompilation if VST is recompiled.
+# 3. $(VSTFLAGS) should be added to every coqc command to include the
+# appropriate -Q options
+
+# BEGINNING OF LOGIC TO HANDLE VST_LOC OPTION
+# Most of this is based on VST's own Makefile, and documented there
+ifdef VST_LOC
+ ifeq ($(VST_LOC),"")
+    $(warning VST_LOC is defined as the empty string, which has different behavior than being undefined!)
+ endif    
+-include $(VST_LOC)/CONFIGURE
+COMPCERT ?= platform
+COMPCERT_NEW = false
+COMPCERT_INFO_PATH_REF = compcert
+COMPCERT_EXPLICIT_PATH = true
+COMPCERT_BUILD_FROM_SRC = false
+ifeq ($(COMPCERT),platform)
+  # Platform supplied CompCert
+  COQLIB=$(shell coqc -where | tr -d '\r' | tr '\\' '/')
+  $(info COQLIB=$(COQLIB))
+  ifeq ($(BITSIZE),)
+    COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
+    COMPCERT_EXPLICIT_PATH = false
+  else ifeq ($(BITSIZE),64)
+    COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
+    COMPCERT_EXPLICIT_PATH = false
+  else ifeq ($(BITSIZE),32)
+    COMPCERT_INST_DIR = $(COQLIB)/../coq-variant/compcert32/compcert
+  else 
+    $(error ILLEGAL BITSIZE $(BITSIZE))
+  endif
+  COMPCERT_SRC_DIR = __NONE__
+else ifeq ($(COMPCERT),bundled)
+  # Bundled CompCert
+  COMPCERT_SRC_DIR = $(VST_LOC)/compcert
+  COMPCERT_INST_DIR = $(VST_LOC)/compcert
+  COMPCERT_BUILD_FROM_SRC = true
+else ifeq ($(COMPCERT),bundled_new)
+  # Bundled CompCert (new variant)
+  COMPCERT_SRC_DIR = $(VST_LOC)/compcert_new
+  COMPCERT_INST_DIR = $(VST_LOC)/compcert_new
+  COMPCERT_NEW = true
+  COMPCERT_INFO_PATH_REF = $(VST_LOC)/compcert_new
+  COMPCERT_BUILD_FROM_SRC = true
+else ifeq ($(COMPCERT),src_dir)
+  # Compile CompCert from source dir
+  ifeq ($(COMPCERT_SRC_DIR),)
+    $(error COMPCERT_SRC_DIR must not be empty if COMPCERT=src_dir)
+  endif
+  IS_ROOT    := $(if $(patsubst /%,,$(COMPCERT_SRC_DIR)),,yes)
+  IS_HOME    := $(if $(patsubst ~%,,$(COMPCERT_SRC_DIR)),,yes)
+  IS_NETWORK := $(if $(patsubst \\\\%,,$(COMPCERT_SRC_DIR)),,yes)
+  IS_DRIVE   := $(foreach d,A B C D E...Z,$(if $(patsubst $(d):/%,,$(COMPCERT_SRC_DIR)),,yes))
+  ifeq ($(strip $(IS_ROOT)$(IS_HOME)$(IS_NETWORK)$(IS_DRIVE)),)
+	# it's a relative path
+	COMPCERT_SRC_DIR := $(VST_LOC)/$(COMPCERT_SRC_DIR)
+  endif
+  COMPCERT_INST_DIR = $(COMPCERT_SRC_DIR)
+  COMPCERT_BUILD_FROM_SRC = true
+else ifeq ($(COMPCERT),inst_dir)
+  # Find CompCert in install dir
+  COMPCERT_SRC_DIR = __NONE__
+  ifeq ($(COMPCERT_INST_DIR),)
+    $(error COMPCERT_INST_DIR must not be empty if COMPCERT=inst_dir)
+  endif
+endif
+ifneq ($(COMPCERT_SRC_DIR),__NONE__)
+  ARCH ?= x86
+  BITSIZE ?= 32
+else
+  -include $(COMPCERT_INST_DIR)/compcert.config
+  ifneq ($(BITSIZE),)
+    ifneq ($(BITSIZE),$(COMPCERT_BITSIZE))
+      $(warning The compcert found in $(COMPCERT_INST_DIR) has bitsize $(COMPCERT_BITSIZE) but you requested $(BITSIZE))
+    endif
+  else
+    BITSIZE = $(COMPCERT_BITSIZE)
+  endif
+
+  ifneq ($(ARCH),)
+    ifneq ($(ARCH),$(COMPCERT_ARCH))
+      $(warning The compcert found in $(COMPCERT_INST_DIR) has architecture $(COMPCERT_ARCH) but you requested $(ARCH))
+    endif
+  else
+    ARCH = $(COMPCERT_ARCH)
+  endif
+endif
+ifeq ($(wildcard $(COMPCERT_INST_DIR)/$(ARCH)_$(BITSIZE)),)
+  ARCHDIRS=$(ARCH)
+else
+  ARCHDIRS=$(ARCH)_$(BITSIZE) $(ARCH)
+endif
+COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend export
+COMPCERT_FLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT_INST_DIR)/$(d) compcert.$(d))
+VST_DIRS= msl sepcomp veric zlist floyd 
+else
+COMPCERTFLAGS=
+VST_DIRS=
+endif
+
+VSTFLAGS= $(COMPCERT_FLAGS) $(foreach d, $(VST_DIRS), -Q $(VST_LOC)/$(d) VST.$(d)) -R . pile
+
+ifdef CLIGHTGEN
+VERSION1= $(lastword $(shell $(CLIGHTGEN) --version))
+VERSION2= $(subst version=,,$(shell grep version $(COMPCERT_SRC_DIR)/VERSION))
+ifneq ($(VERSION1),$(VERSION2))
+$(warning clightgen version $(VERSION1) does not match VST/compcert/VERSION $(VERSION2))
+endif
+endif
+
+all:  # need this so that _CoqProject does not become the default target
+
+_CoqProject: Makefile
+	@echo $(VSTFLAGS) > _CoqProject
+
+FLOYD= $(VST_LOC)/floyd/proofauto.vo $(VST_LOC)/floyd/VSU.vo
+

--- a/progs/VSUpile/Makefile
+++ b/progs/VSUpile/Makefile
@@ -1,11 +1,6 @@
-#  This development can be built in either of two ways:
-# BUNDLED=true
-#   means that VST is located at ../..
-#   Furthermore, in this mode, the file ../../CONFIGURE gives information
-#   about how to access CompCert files
-# BUNDLED != true   (the default)
-#   means that coqc has access to VST without any -Q or -R flags,
-#   for example via opam or the Coq Platform
+ifdef VST_LOC
+include $(VST_LOC)/Makefile.bundled
+endif
 
 HFILES = pile.h pile_private.h onepile.h apile.h triang.h stdlib.h \
          fast/fastpile_private.h
@@ -26,119 +21,11 @@ VFILES = PileModel.v spec_stdlib.v verif_stdlib.v spec_pile.v spec_pile_private.
 CC=ccomp
 CFLAGS=-O
 
-# BEGINNING OF LOGIC TO HANDLE BUNDLED=true OPTION
-# Most of this is based on ../../Makefile, and documented there
--include CONFIGURE
-ifeq ($(BUNDLED),true)
--include ../../CONFIGURE
-COMPCERT ?= platform
-COMPCERT_NEW = false
-COMPCERT_INFO_PATH_REF = compcert
-COMPCERT_EXPLICIT_PATH = true
-COMPCERT_BUILD_FROM_SRC = false
-ifeq ($(COMPCERT),platform)
-  # Platform supplied CompCert
-  COQLIB=$(shell coqc -where | tr -d '\r' | tr '\\' '/')
-  $(info COQLIB=$(COQLIB))
-  ifeq ($(BITSIZE),)
-    COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
-    COMPCERT_EXPLICIT_PATH = false
-  else ifeq ($(BITSIZE),64)
-    COMPCERT_INST_DIR = $(COQLIB)/user-contrib/compcert
-    COMPCERT_EXPLICIT_PATH = false
-  else ifeq ($(BITSIZE),32)
-    COMPCERT_INST_DIR = $(COQLIB)/../coq-variant/compcert32/compcert
-  else 
-    $(error ILLEGAL BITSIZE $(BITSIZE))
-  endif
-  COMPCERT_SRC_DIR = __NONE__
-else ifeq ($(COMPCERT),bundled)
-  # Bundled CompCert
-  COMPCERT_SRC_DIR = ../../compcert
-  COMPCERT_INST_DIR = ../../compcert
-  COMPCERT_BUILD_FROM_SRC = true
-else ifeq ($(COMPCERT),bundled_new)
-  # Bundled CompCert (new variant)
-  COMPCERT_SRC_DIR = ../../compcert_new
-  COMPCERT_INST_DIR = ../../compcert_new
-  COMPCERT_NEW = true
-  COMPCERT_INFO_PATH_REF = ../../compcert_new
-  COMPCERT_BUILD_FROM_SRC = true
-else ifeq ($(COMPCERT),src_dir)
-  # Compile CompCert from source dir
-  ifeq ($(COMPCERT_SRC_DIR),)
-    $(error COMPCERT_SRC_DIR must not be empty if COMPCERT=src_dir)
-  endif
-  IS_ROOT    := $(if $(patsubst /%,,$(COMPCERT_SRC_DIR)),,yes)
-  IS_HOME    := $(if $(patsubst ~%,,$(COMPCERT_SRC_DIR)),,yes)
-  IS_NETWORK := $(if $(patsubst \\\\%,,$(COMPCERT_SRC_DIR)),,yes)
-  IS_DRIVE   := $(foreach d,A B C D E...Z,$(if $(patsubst $(d):/%,,$(COMPCERT_SRC_DIR)),,yes))
-  ifeq ($(strip $(IS_ROOT)$(IS_HOME)$(IS_NETWORK)$(IS_DRIVE)),)
-	# it's a relative path
-	COMPCERT_SRC_DIR := ../../$(COMPCERT_SRC_DIR)
-  endif
-  COMPCERT_INST_DIR = $(COMPCERT_SRC_DIR)
-  COMPCERT_BUILD_FROM_SRC = true
-else ifeq ($(COMPCERT),inst_dir)
-  # Find CompCert in install dir
-  COMPCERT_SRC_DIR = __NONE__
-  ifeq ($(COMPCERT_INST_DIR),)
-    $(error COMPCERT_INST_DIR must not be empty if COMPCERT=inst_dir)
-  endif
-endif
-ifneq ($(COMPCERT_SRC_DIR),__NONE__)
-  ARCH ?= x86
-  BITSIZE ?= 32
-else
-  -include $(COMPCERT_INST_DIR)/compcert.config
-  ifneq ($(BITSIZE),)
-    ifneq ($(BITSIZE),$(COMPCERT_BITSIZE))
-      $(warning The compcert found in $(COMPCERT_INST_DIR) has bitsize $(COMPCERT_BITSIZE) but you requested $(BITSIZE))
-    endif
-  else
-    BITSIZE = $(COMPCERT_BITSIZE)
-  endif
-
-  ifneq ($(ARCH),)
-    ifneq ($(ARCH),$(COMPCERT_ARCH))
-      $(warning The compcert found in $(COMPCERT_INST_DIR) has architecture $(COMPCERT_ARCH) but you requested $(ARCH))
-    endif
-  else
-    ARCH = $(COMPCERT_ARCH)
-  endif
-endif
-ifeq ($(wildcard $(COMPCERT_INST_DIR)/$(ARCH)_$(BITSIZE)),)
-  ARCHDIRS=$(ARCH)
-else
-  ARCHDIRS=$(ARCH)_$(BITSIZE) $(ARCH)
-endif
-COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend export
-COMPCERT_FLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT_INST_DIR)/$(d) compcert.$(d))
-VST_DIRS= msl sepcomp veric zlist floyd 
-else
-COMPCERTFLAGS=
-VST_DIRS=
-endif
-
-VST_LOC ?= ../..
-
-ifdef CLIGHTGEN
-VERSION1= $(lastword $(shell $(CLIGHTGEN) --version))
-VERSION2= $(subst version=,,$(shell grep version $(COMPCERT_SRC_DIR)/VERSION))
-ifneq ($(VERSION1),$(VERSION2))
-$(warning clightgen version $(VERSION1) does not match VST/compcert/VERSION $(VERSION2))
-endif
-endif
-
 CVFILES = $(patsubst %.c,%.v,$(CFILES))
 OFILES = $(patsubst %.c,%.o,$(CFILES))
 VOFILES = $(patsubst %.v,%.vo,$(CVFILES) $(VFILES))
 
-VSTFLAGS= $(COMPCERT_FLAGS) $(foreach d, $(VST_DIRS), -Q $(VST_LOC)/$(d) VST.$(d)) -R . pile
-
-# $(error VSTFLAGS=$(VSTFLAGS))
-
-target: _CoqProject verif_main.vo simple_verif_main.vo fast/verif_fastmain.vo incr/verif_incr.vo
+all: _CoqProject verif_main.vo simple_verif_main.vo fast/verif_fastmain.vo incr/verif_incr.vo
 
 cvfiles: $(CVFILES)
 
@@ -164,17 +51,12 @@ endif
 
 incr/verif_incr.vo: incr/verif_incr.v incr/incr.vo
 
-_CoqProject: Makefile
-	@echo $(VSTFLAGS) > _CoqProject
-
 clean:
 	rm -f *.vo *.o *.aux *.vok *.vos
 	rm -f fast/*.vo fast/*.o fast/*.aux fast/*.vok fast/*.vos
 
 # .depend depend:
 # 	coqdep $(VSTFLAGS) *.v >.depend
-
-FLOYD= $(VST_LOC)/floyd/proofauto.vo $(VST_LOC)/floyd/VSU.vo
 
 PileModel.vo: PileModel.v $(FLOYD)
 spec_apile.vo: apile.vo spec_stdlib.vo spec_pile.vo $(FLOYD)

--- a/progs/memmgr/ASI_malloc.v
+++ b/progs/memmgr/ASI_malloc.v
@@ -1,0 +1,254 @@
+Require Import VST.floyd.proofauto.
+Require Export malloc_lemmas. (*Exports the model (constants like WA , plus lemmas)*)
+
+(*Require Import malloc. needed for function and type names but not for compspecs 
+Update: Some UPenn grad students proposed to abstract over function identifiers -
+doing so in our setup makes ASIs source-program-independent!*)
+
+Global Open Scope funspec_scope.
+
+Record MallocTokenAPD := {
+  malloc_token': share -> Z -> val -> mpred;
+  malloc_token'_valid_pointer: forall sh sz p, 
+      malloc_token' sh sz p |-- valid_pointer p;
+  malloc_token'_local_facts:  forall sh sz p, 
+      malloc_token' sh sz p |-- !! malloc_compatible sz p;
+}.
+
+Record MallocFreeAPD := {
+  MF_Tok :> MallocTokenAPD;
+  mem_mgr: globals -> mpred;
+}.
+
+Definition malloc_token {cs:compspecs} M (sh: share) (t: type) (p: val): mpred := 
+   !! field_compatible t [] p && 
+   malloc_token' M sh (sizeof t) p.
+
+Lemma malloc_token_valid_pointer: forall {cs: compspecs} M sh t p, 
+      malloc_token M sh t p |-- valid_pointer p.
+Proof. intros. unfold malloc_token.
+ apply andp_left2. apply malloc_token'_valid_pointer.
+Qed.
+
+#[export] Hint Resolve malloc_token'_valid_pointer : valid_pointer.
+#[export] Hint Resolve malloc_token_valid_pointer : valid_pointer.
+
+Lemma malloc_token_local_facts:  forall {cs: compspecs} M sh t p,
+      malloc_token M sh t p |-- !! (field_compatible t [] p /\ malloc_compatible (sizeof t) p).
+Proof. intros.
+ unfold malloc_token.
+ normalize. rewrite prop_and.
+ apply andp_right. apply prop_right; auto.
+ apply malloc_token'_local_facts.
+Qed.
+
+#[export] Hint Resolve malloc_token'_local_facts : saturate_local.
+#[export] Hint Resolve malloc_token_local_facts : saturate_local.
+
+Section Malloc_ASI.
+Variable M: MallocFreeAPD.
+Variable mallocID:ident.
+Variable freeID:ident.
+
+Definition malloc_spec' := 
+   DECLARE (*_malloc*)mallocID
+   WITH n:Z, gv:globals
+   PRE [ size_t ]
+       PROP (0 <= n <= Ptrofs.max_unsigned - (WA+WORD))
+       PARAMS ((Vptrofs (Ptrofs.repr n))) GLOBALS (gv)
+       SEP ( mem_mgr M gv )
+   POST [ tptr tvoid ] EX p:_,
+       PROP ()
+       LOCAL (temp ret_temp p)
+       SEP ( mem_mgr M gv;
+             if eq_dec p nullval then emp
+             else (malloc_token' M Ews n p * memory_block Ews n p)).
+
+Definition free_spec' :=
+ DECLARE (*_free*)freeID
+   WITH n:Z, p:val, gv: globals
+   PRE [ tptr tvoid ]
+       PROP ()
+       PARAMS (p) GLOBALS (gv)
+       SEP (mem_mgr M gv;
+            if eq_dec p nullval then emp
+            else (malloc_token' M Ews n p * memory_block Ews n p))
+    POST [ Tvoid ]
+       PROP ()
+       LOCAL ()
+       SEP (mem_mgr M gv).
+
+Definition Malloc_ASI:funspecs := [malloc_spec'; free_spec'].
+End Malloc_ASI.
+
+Record MallocFree_R_APD := {
+  MF_Tok_R :> MallocTokenAPD;
+  mem_mgr_R: resvec -> globals -> mpred; (*changed order of arguments*)
+}.
+(*
+Definition malloc_token_R {cs:compspecs} M (sh: share) (t: type) (p: val): mpred := 
+   !! field_compatible t [] p && 
+   malloc_token_R' M sh (sizeof t) p.
+
+Lemma malloc_token_R_valid_pointer: forall {cs: compspecs} M sh t p, 
+      malloc_token_R M sh t p |-- valid_pointer p.
+Proof. intros. unfold malloc_token.
+ apply andp_left2. apply malloc_token_R'_valid_pointer.
+Qed.
+
+#[export] Hint Resolve malloc_token_R'_valid_pointer : valid_pointer.
+#[export] Hint Resolve malloc_token_R_valid_pointer : valid_pointer.
+
+Lemma malloc_token_R_local_facts:  forall {cs: compspecs} M sh t p,
+      malloc_token_R M sh t p |-- !! (field_compatible t [] p /\ malloc_compatible (sizeof t) p).
+Proof. intros.
+ unfold malloc_token_R.
+ normalize. rewrite prop_and.
+ apply andp_right. apply prop_right; auto.
+ apply malloc_token_R'_local_facts.
+Qed.
+
+#[export] Hint Resolve malloc_token_R'_local_facts : saturate_local.
+#[export] Hint Resolve malloc_token_R_local_facts : saturate_local.
+*)
+Require Import VST.floyd.VSU.
+
+Section Malloc_R_ASI.
+Variable M: MallocFree_R_APD.
+Variable prefillID:ident.
+Variable tryprefillID:ident.
+Variable mallocID:ident.
+Variable freeID:ident.
+
+Definition pre_fill_spec' :=
+ DECLARE (*_pre_fill*) prefillID
+   WITH n:Z, p:val, gv:globals, rvec:resvec
+   PRE [ tuint, tptr tvoid ]
+       PROP (0 <= n <= maxSmallChunk /\ malloc_compatible BIGBLOCK p)
+       PARAMS ((Vptrofs (Ptrofs.repr n)); p) GLOBALS (gv) 
+       SEP (mem_mgr_R M rvec gv; memory_block Tsh BIGBLOCK p) 
+    POST [ Tvoid ]
+       PROP ()
+       LOCAL ()
+       SEP (mem_mgr_R M (add_resvec rvec (size2binZ n) 
+                                     (chunks_from_block (size2binZ n))) gv).
+
+Definition try_pre_fill_spec' :=
+ DECLARE (*_try_pre_fill*) tryprefillID
+   WITH n:Z, req:Z, rvec:resvec, gv:globals
+   PRE [ tuint, tint ]
+       PROP (0 <= n <= maxSmallChunk /\ 0 <= req <= Int.max_signed)
+       PARAMS ((Vint (Int.repr n)); (Vint (Int.repr req))) GLOBALS (gv) 
+       SEP (mem_mgr_R M rvec gv) 
+   POST [ tint ] EX result: Z,
+     PROP ()
+     LOCAL (temp ret_temp (Vint (Int.repr result)))
+     SEP (mem_mgr_R M (add_resvec rvec (size2binZ n) result) gv).
+
+Definition malloc_spec_R' := 
+   DECLARE (*_malloc*)mallocID
+   WITH n:Z, gv:globals, rvec:resvec
+   PRE [ size_t ]
+       PROP (0 <= n <= Ptrofs.max_unsigned - (WA+WORD))
+       PARAMS ((* _nbytes *) (Vptrofs (Ptrofs.repr n))) GLOBALS (gv)
+       SEP ( mem_mgr_R M rvec gv)
+   POST [ tptr tvoid ] EX p:_, 
+       PROP ()
+       LOCAL (temp ret_temp p)
+       SEP ( if guaranteed rvec n
+             then mem_mgr_R M (add_resvec rvec (size2binZ n) (-1)) gv *
+                  malloc_token' M Ews n p * memory_block Ews n p
+             else if eq_dec p nullval 
+                  then mem_mgr_R M rvec gv
+                  else (if n <=? maxSmallChunk 
+                        then (EX rvec':_, !!(eq_except rvec' rvec (size2binZ n))
+                                            && (mem_mgr_R M rvec' gv))
+                        else mem_mgr_R M rvec gv) *
+                       malloc_token' M Ews n p * memory_block Ews n p).
+
+Definition free_spec_R' :=
+ DECLARE (*_free*)freeID
+   WITH n:Z, p:val, gv:globals, rvec:resvec
+   PRE [ tptr tvoid ]
+       PROP ()
+       PARAMS (p) GLOBALS (gv)
+       SEP (mem_mgr_R M rvec gv;
+            if eq_dec p nullval then emp
+            else (malloc_token' M Ews n p * memory_block Ews n p))
+    POST [ Tvoid ]
+       PROP ()
+       LOCAL ()
+       SEP (if eq_dec p nullval 
+            then mem_mgr_R M rvec gv
+            else if n <=? maxSmallChunk
+                 then mem_mgr_R M (add_resvec rvec (size2binZ n) 1) gv
+                 else mem_mgr_R M rvec gv).
+
+Definition Malloc_R_ASI:funspecs := [pre_fill_spec'; try_pre_fill_spec'; malloc_spec_R'; free_spec_R'].
+
+Definition ForgetR:MallocFreeAPD :=
+  Build_MallocFreeAPD (MF_Tok_R M) (fun gv => EX R, mem_mgr_R M R gv).
+
+Lemma malloc_spec_R_sub i: funspec_sub (snd malloc_spec_R') (snd (malloc_spec' ForgetR i)).
+Proof.
+do_funspec_sub. destruct w as [n gv]. clear H.
+unfold mem_mgr.
+Intros rvec.
+Exists (n, gv, rvec) emp. (* empty frame *)
+simpl; entailer!.
+intros tau ? ?. 
+set (p:=eval_id ret_temp tau).
+Exists p; entailer!.
+destruct (guaranteed rvec n) eqn:guar.
+- (* guaranteed *)
+  if_tac; auto.
+  Exists (add_resvec rvec (size2binZ n) (-1)); entailer!.
+  rewrite H4; entailer!.
+  Exists (add_resvec rvec (size2binZ n) (-1)); entailer!.
+- (* not guaranteed *)
+  bdestruct (n <=? maxSmallChunk).
+  + if_tac; auto. Exists rvec; entailer!. Intros rvec'; Exists rvec'; entailer!.
+  + if_tac; auto; Exists rvec; entailer!.
+Qed.
+
+Lemma free_spec_R_sub i: funspec_sub (snd free_spec_R') (snd (free_spec' ForgetR i)).
+Proof.
+do_funspec_sub. 
+destruct w as [[n p] gv]. clear H.
+unfold mem_mgr.
+Intros rvec. Exists (n,p,gv,rvec) emp.
+simpl; entailer!.
+intros tau ?.
+if_tac.
+Exists rvec; entailer!.
+bdestruct (n <=? maxSmallChunk).
+- (* small *)
+  Exists (add_resvec rvec (size2binZ n) 1); entailer!.
+- (* large *)
+  Exists rvec; entailer!.
+Qed.
+
+Variable distinctIDs: list_norepet [prefillID; tryprefillID; mallocID; freeID].
+
+Lemma MallocASI_sqsub_MallocR_ASI: 
+      funspecs_sqsub Malloc_R_ASI (Malloc_ASI ForgetR mallocID freeID).
+Proof. red; intros. simpl in H.
+  if_tac in H. inv H.
+  { eexists; split. simpl. rewrite 2 if_false. rewrite if_true by trivial.  reflexivity.
+    intros N; subst. inv distinctIDs. inv H2. apply H3. left; trivial.
+    intros N; subst. inv distinctIDs. apply H1. right; left; trivial.
+    apply (malloc_spec_R_sub mallocID).  }
+  if_tac in H. inv H.
+  { eexists; split. simpl. rewrite 3 if_false. rewrite if_true by trivial.  reflexivity.
+    intros N; subst. apply H0; trivial.
+    intros N; subst. inv distinctIDs. inv H3. apply H4. right; left; trivial.
+    intros N; subst. inv distinctIDs. inv H3. apply H2. do 2 right; left; trivial.
+    apply (free_spec_R_sub freeID). }
+  congruence.
+(*
+  repeat (if_tac in H. [ inv H; eexists; split; [ reflexivity |] |]).
+  repeat (if_tac in H; [ inv H; eexists; split; [ reflexivity |] |])
+  apply malloc_spec_R_sub. apply free_spec_R_sub. congruence.*)
+Qed.
+
+End Malloc_R_ASI.

--- a/progs/memmgr/ASI_mmap0.v
+++ b/progs/memmgr/ASI_mmap0.v
@@ -1,0 +1,49 @@
+Require Import VST.floyd.proofauto.
+ 
+(*Require Import mmap0. needed for function and type names but not for compspecs *)
+
+Global Open Scope funspec_scope.
+
+Section Mmap0_ASI.
+Variable mmap0ID:ident.
+Variable munmapID:ident.
+
+Definition mmap0_spec := 
+   DECLARE (*_mmap0*)mmap0ID
+   WITH n:Z
+   PRE [(*_addr*) (tptr tvoid), 
+        (*_len*) tuint, 
+(*        (*_prot*) tint,
+        (*_flags*) tint,*)
+        (*_fildes*) tint(*,
+(*        (*_off*) tlong*) (*_off*) tint*)]
+     PROP (0 <= n <= Ptrofs.max_unsigned)
+     PARAMS (nullval; 
+             Vptrofs (Ptrofs.repr n);
+(*             Vint (Int.repr 3); (* PROT_READ|PROT_WRITE *)
+             Vint (Int.repr 4098); (* MAP_PRIVATE|MAP_ANONYMOUS - platform-dependent *) *)
+             Vint (Int.repr (-1))(*;
+            Vlong (Int64.repr 0)Vint(Int.repr 0)*))
+     GLOBALS () SEP ()
+   POST [ tptr tvoid ] EX p:_, 
+     PROP ( if eq_dec p nullval
+            then True else malloc_compatible n p )
+     LOCAL (temp ret_temp p)
+     SEP ( if eq_dec p nullval
+           then emp else memory_block Tsh n p).
+
+Definition munmap_spec := 
+   DECLARE (*_munmap*)munmapID
+   WITH p:val, n:Z
+   PRE [ (*_addr*) (tptr tvoid), 
+         (*_len*) tuint ]
+     PROP (0 <= n <= Ptrofs.max_unsigned)
+     PARAMS (p; (Vptrofs (Ptrofs.repr n)) ) GLOBALS ()
+     SEP ( memory_block Tsh n p )
+   POST [ tint ] EX res: Z,
+     PROP ()
+     LOCAL (temp ret_temp (Vint (Int.repr res)))
+     SEP ( emp ).
+
+Definition Mmap0_ASI:= [mmap0_spec; munmap_spec].
+End Mmap0_ASI.

--- a/progs/memmgr/Makefile
+++ b/progs/memmgr/Makefile
@@ -1,0 +1,55 @@
+ifdef VST_LOC
+include $(VST_LOC)/Makefile.bundled
+endif
+
+HFILES= mmap0.h malloc.h
+CFILES= mmap0.c malloc.c
+VFILES = malloc_lemmas.v ASI_mmap0.v ASI_malloc.v malloc_shares.v malloc_sep.v \
+         VSU_malloc_definitions.v verif_malloc_free.v \
+         verif_bin2size2bin.v verif_list_from_block.v verif_fill_bin.v \
+         verif_malloc_small.v verif_malloc_large.v \
+         verif_free_small.v verif_free_large.v \
+         verif_pre_fill.v verif_try_pre_fill.v \
+         VSU_malloc.v VSU_mmap0.v VSU_MM.v
+
+CC=ccomp
+CFLAGS=-O
+
+CLIGHTGEN= $(COMPCERT_LOC)/clightgen
+
+CVFILES = $(patsubst %.c,%.v,$(CFILES))
+OFILES = $(patsubst %.c,%.o,$(CFILES))
+VOFILES = $(patsubst %.v,%.vo,$(CVFILES) $(VFILES))
+
+
+all: _CoqProject $(VOFILES) VSU_MM.vo 
+
+cvfiles: $(CVFILES)
+
+%.vo: %.v
+	@echo COQC $*.v
+	@coqc $(VSTFLAGS) $*.v
+
+$(CVFILES): $(CFILES) $(HFILES)
+	$(CLIGHTGEN) -short-idents -normalize $(CFILES)
+
+clean:
+	rm -f *.vo *.o .*.aux *.vok *.vos *.glob
+
+ASI_malloc.vo: malloc_lemmas.vo
+malloc_lemmas.vo: malloc.vo
+malloc_sep.vo: malloc_lemmas.vo malloc_shares.vo
+VSU_malloc_definitions.vo: malloc.vo malloc_lemmas.vo malloc_sep.vo ASI_mmap0.vo ASI_malloc.vo
+verif_malloc_free.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_bin2size2bin.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_list_from_block.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_fill_bin.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_malloc_small.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_malloc_large.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_free_small.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_free_large.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_pre_fill.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+verif_try_pre_fill.vo: malloc.vo ASI_malloc.vo malloc_lemmas.vo malloc_sep.vo VSU_malloc_definitions.vo
+VSU_malloc.vo: verif_malloc_free.vo verif_bin2size2bin.vo verif_list_from_block.vo verif_fill_bin.vo verif_malloc_small.vo verif_malloc_large.vo verif_free_small.vo verif_free_large.vo verif_pre_fill.vo verif_try_pre_fill.vo verif_malloc_free.vo
+VSU_mmap0.vo: mmap0.vo ASI_mmap0.vo
+VSU_MM.vo: VSU_malloc.vo VSU_mmap0.vo

--- a/progs/memmgr/VSU_MM.v
+++ b/progs/memmgr/VSU_MM.v
@@ -1,0 +1,27 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.floyd.VSU.
+Require Import VST.veric.initial_world.
+
+Require Import malloc.
+Require Import mmap0.
+Require Import ASI_malloc.
+Require Import ASI_mmap0.
+Require Import VSU_malloc_definitions.
+Require Import VSU_malloc.
+Require Import VSU_mmap0.
+
+Definition MM_VSU := privatizeExports (ltac:(linkVSUs MM0_VSU MF_VSU)) [_mmap0; _munmap].
+
+(*
+Definition mm_Exports:funspecs := Malloc_ASI (ForgetR R_APD) _malloc _free.
+Goal (VSU_Exports MM_VSU) = mm_Exports. reflexivity. Qed.
+Eval simpl in (VSU_GP MM_VSU).*)
+
+Definition MM_R_VSU:= privatizeExports (ltac:(linkVSUs MM0_VSU MF_R_VSU)) [(*_mmap0;*) _munmap(*; _try_pre_fill*)].
+
+(*Eval simpl in VSU_Imports MM_R_VSU. (* nil*)*)
+(*Eval simpl in (VSU_Exports MM_R_VSU). *) (*mmap0, pre_fill, try_pre_fill, malloc, free*)
+
+(*Print Assumptions MM_VSU.*)
+Print Assumptions MM_R_VSU.
+(* body_mmap0 and body_munmap are 'Parameters' in VSU_mmap0 - maybe turn them into imported specs that remain unresolved?*)

--- a/progs/memmgr/VSU_malloc.v
+++ b/progs/memmgr/VSU_malloc.v
@@ -1,0 +1,72 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.floyd.VSU.
+
+Require Import ASI_malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+
+Require Import verif_malloc_free.
+Require Import verif_bin2size2bin.
+Require Import verif_list_from_block.
+Require Import verif_fill_bin.
+Require Import verif_malloc_small.
+Require Import verif_malloc_large.
+Require Import verif_free_small.
+Require Import verif_free_large.
+Require Import verif_pre_fill.
+Require Import verif_try_pre_fill.
+
+  Lemma create_memmgr_R: VSU_initializer malloc.prog (mem_mgr_R emptyResvec).
+  Proof. InitGPred_tac.
+    eapply derives_trans. 2: apply create_mem_mgr_R. entailer!.
+  Qed. 
+(*Old proof
+Lemma create_memmgr_R gv: InitGPred (Vardefs malloc.prog) gv |-- mem_mgr_R emptyResvec gv.
+Proof. unfold Vardefs. simpl. unfold InitGPred. simpl; Intros. rewrite sepcon_emp.
+    eapply derives_trans. 2: apply create_mem_mgr_R. entailer!.
+    unfold globvar2pred. simpl.
+(*    unfold initialize.gv_globvar2pred. simpl.
+         unfold initialize.gv_lift2, initialize.gv_lift0; simpl.
+         rewrite predicates_sl.sepcon_emp. *) rewrite sepcon_emp.
+    destruct HP_bin as [b Hb]; rewrite Hb in *; clear.
+    eapply derives_trans. 
+    2:{ apply (mapsto_zeros_data_atTarrayTptr_nullval_N 50%nat Ews tvoid b Ptrofs.zero).
+        apply writable_readable; apply writable_Ews.
+        apply Z.divide_0_r. }
+    apply derives_refl.
+Qed.*)
+
+  Definition MF_R_VSU: @VSU NullExtension.Espec 
+      nil MF_Imports ltac:(QPprog malloc.prog)
+      (Malloc_R_ASI R_APD malloc._pre_fill malloc._try_pre_fill malloc._malloc malloc._free)
+      (mem_mgr_R emptyResvec).
+  Proof.
+    mkVSU malloc.prog MF_internal_specs.
+  + solve_SF_internal body_malloc_large.
+  + solve_SF_internal body_malloc_small.
+  + solve_SF_internal body_free_large.
+  + solve_SF_internal body_free_small.
+  + solve_SF_internal body_bin2size.
+  + solve_SF_internal body_size2bin.
+  + solve_SF_internal body_list_from_block.
+  + solve_SF_internal body_fill_bin.
+  + solve_SF_internal body_pre_fill.
+  + solve_SF_internal body_try_pre_fill.
+  + solve_SF_internal body_malloc.
+  + solve_SF_internal body_free.
+  + apply create_memmgr_R.
+  Qed.
+
+  Definition MF_VSU: @VSU NullExtension.Espec 
+      nil MF_Imports ltac:(QPprog malloc.prog)
+      (Malloc_ASI (ForgetR R_APD) malloc._malloc malloc._free) (mem_mgr (ForgetR R_APD)).
+  Proof.
+    eapply VSU_entail.
+    + eapply VSU_Exports_sub.
+      - apply MF_R_VSU.
+      - LNR_tac.
+      - apply MallocASI_sqsub_MallocR_ASI.
+        LNR_tac. 
+    + intros; simpl. Exists emptyResvec; trivial.
+  Qed.

--- a/progs/memmgr/VSU_malloc_definitions.v
+++ b/progs/memmgr/VSU_malloc_definitions.v
@@ -1,0 +1,139 @@
+Require Import VST.floyd.proofauto.
+Require Import ASI_mmap0.
+Require Import malloc.
+Require Import ASI_malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+
+Definition Tok_APD := Build_MallocTokenAPD malloc_token' malloc_token'_valid_pointer
+                    malloc_token'_local_facts.
+
+Definition R_APD := Build_MallocFree_R_APD Tok_APD mem_mgr_R.
+
+(*+ specs of private functions *)
+
+Definition bin2size_spec :=
+ DECLARE _bin2size
+  WITH b: Z
+  PRE [ tint ] 
+     PROP( 0 <= b < BINS ) 
+     PARAMS ((Vint (Int.repr b))) GLOBALS () SEP ()
+  POST [ tuint ] 
+     PROP() LOCAL(temp ret_temp (Vptrofs (Ptrofs.repr (bin2sizeZ b)))) SEP ().
+
+Definition size2bin_spec :=
+ DECLARE _size2bin
+  WITH s: Z
+  PRE [ tuint ]    
+     PROP( 0 <= s <= Ptrofs.max_unsigned ) 
+     PARAMS ((Vptrofs (Ptrofs.repr s))) GLOBALS () SEP ()
+  POST [ tint ]
+     PROP() LOCAL(temp ret_temp (Vint (Int.repr (size2binZ s)))) SEP ().
+
+
+Definition list_from_block_spec :=
+ DECLARE _list_from_block
+  WITH s: Z, p: val, tl: val, tlen: nat, b: Z
+  PRE [ tuint, tptr tschar, tptr tvoid ]    
+     PROP( 0 <= b < BINS /\ s = bin2sizeZ b /\ malloc_compatible BIGBLOCK p ) 
+     PARAMS ((Vptrofs (Ptrofs.repr s)); p; tl) GLOBALS ()
+     SEP ( memory_block Tsh BIGBLOCK p; mmlist s tlen tl nullval )
+  POST [ tptr tvoid ] EX res:_,
+     PROP() 
+     LOCAL(temp ret_temp res)
+     SEP ( mmlist s (Z.to_nat(chunks_from_block (size2binZ s)) + tlen) res nullval * TT ).
+
+
+(* The postcondition describes the list returned, together with
+   TT for the wasted space at the beginning and end of the big block from mmap. *)
+
+Definition fill_bin_spec :=
+ DECLARE _fill_bin
+  WITH b: _
+  PRE [ tint ]
+     PROP(0 <= b < BINS) PARAMS ((Vint (Int.repr b))) GLOBALS () SEP ()
+  POST [ (tptr tvoid) ] EX p:_, EX len:Z,
+     PROP( if eq_dec p nullval then True else len > 0 ) 
+     LOCAL(temp ret_temp p)
+     SEP ( if eq_dec p nullval then emp
+           else mmlist (bin2sizeZ b) (Z.to_nat len) p nullval * TT).
+
+Definition malloc_small_spec :=
+   DECLARE _malloc_small
+   WITH n:Z, gv:globals, rvec:resvec
+   PRE [ size_t ] 
+       PROP (0 <= n <= bin2sizeZ(BINS-1))
+       PARAMS ((Vptrofs (Ptrofs.repr n))) GLOBALS (gv)
+       SEP ( mem_mgr_R rvec gv)
+   POST [ tptr tvoid ] EX p:_, 
+       PROP ()
+       LOCAL (temp ret_temp p)
+       SEP ( if guaranteed rvec n
+             then mem_mgr_R (add_resvec rvec (size2binZ n) (-1)) gv *
+                  malloc_token' Ews n p * memory_block Ews n p
+             else if eq_dec p nullval 
+                  then mem_mgr_R rvec gv
+                  else (EX rvec':_, !!(eq_except rvec' rvec (size2binZ n))
+                                 && mem_mgr_R rvec' gv *
+                                    malloc_token' Ews n p * memory_block Ews n p) ).
+
+Definition malloc_large_spec :=
+   DECLARE _malloc_large
+   WITH n:Z, gv:globals, rvec:resvec
+   PRE [ size_t ]
+       PROP (bin2sizeZ(BINS-1) < n <= Ptrofs.max_unsigned - (WA+WORD))
+       PARAMS ((Vptrofs (Ptrofs.repr n))) GLOBALS (gv)
+       SEP ( mem_mgr_R rvec gv)
+   POST [ tptr tvoid ] EX p:_, 
+       PROP ()
+       LOCAL (temp ret_temp p)
+       SEP (mem_mgr_R rvec gv;
+            if eq_dec p nullval then emp 
+            else malloc_token' Ews n p * memory_block Ews n p).
+
+(* s is the stored chunk size and n is the original request amount. *)
+(* Note: the role of n in free_small_spec is merely to facilitate proof for free itself *)
+Definition free_small_spec :=
+   DECLARE _free_small
+   WITH p:_, s:_, n:_, gv:globals, rvec:resvec
+   PRE [ tptr tvoid, tuint ]
+       PROP (0 <= n <= bin2sizeZ(BINS-1) /\ s = bin2sizeZ(size2binZ n) /\ 
+             malloc_compatible s p)
+       PARAMS (p; (Vptrofs (Ptrofs.repr s))) GLOBALS (gv)
+       SEP ( data_at Tsh tuint (Vptrofs (Ptrofs.repr s)) (offset_val (- WORD) p); 
+            data_at_ Tsh (tptr tvoid) p;
+            memory_block Tsh (s - WORD) (offset_val WORD p);
+            mem_mgr_R rvec gv)
+   POST [ tvoid ]
+       PROP ()
+       LOCAL ()
+       SEP (mem_mgr_R (add_resvec rvec (size2binZ n) 1) gv).
+
+Definition free_large_spec :=
+   DECLARE _free_large
+   WITH p:_, s:_, gv:globals, rvec:resvec
+   PRE [ tptr tvoid, tuint ]
+       PROP (malloc_compatible s p /\ maxSmallChunk < s <= Ptrofs.max_unsigned - (WA+WORD))
+       PARAMS (p; (Vptrofs (Ptrofs.repr s))) GLOBALS (gv)
+       SEP ( data_at Tsh tuint (Vptrofs (Ptrofs.repr s)) (offset_val (- WORD) p); 
+            data_at_ Tsh (tptr tvoid) p;
+            memory_block Tsh (s - WORD) (offset_val WORD p);
+            memory_block Tsh WA (offset_val (- (WA+WORD)) p);
+            mem_mgr_R rvec gv)
+   POST [ tvoid ]
+       PROP ()
+       LOCAL ()
+       SEP (mem_mgr_R rvec gv).
+
+Definition MF_Vprog : varspecs. mk_varspecs prog. Defined.
+
+Definition MF_internal_specs: funspecs :=
+    [malloc_large_spec; malloc_small_spec; free_large_spec; free_small_spec;
+     bin2size_spec; size2bin_spec; list_from_block_spec; fill_bin_spec]
+   ++ Malloc_R_ASI R_APD _pre_fill _try_pre_fill _malloc _free.
+
+Definition MF_Imports:funspecs := Mmap0_ASI _mmap0 _munmap.
+
+Definition MF_Gprog:funspecs := MF_Imports ++ MF_internal_specs.
+
+Ltac start_function_hint ::= idtac. (* no hint reminder *)

--- a/progs/memmgr/VSU_mmap0.v
+++ b/progs/memmgr/VSU_mmap0.v
@@ -1,0 +1,60 @@
+Require Import VST.floyd.proofauto.
+Require Import mmap0.
+Require Import ASI_mmap0.
+Require Import VST.floyd.VSU.
+
+Local Instance CompSpecs : compspecs. make_compspecs prog. Defined. 
+
+Definition MM0_Vprog : varspecs. mk_varspecs prog. Defined.
+
+Definition placeholder_spec :=
+ DECLARE _mmap0_placeholder
+ WITH u: unit
+ PRE [ ]
+   PROP (False) PARAMS() GLOBALS() SEP()
+ POST [ tint ]
+   PROP() LOCAL() SEP().
+
+Definition MM0_internal_specs: funspecs := [mmap0_spec _mmap0; placeholder_spec].
+
+Definition MM0_Imports:funspecs := nil.
+
+Definition SYS: funspecs := [munmap_spec _munmap(*once mmap0 can be veried, we should should add  mmap_spec here*)] .
+
+Definition MM0_Gprog:funspecs := MM0_Imports ++ SYS++MM0_internal_specs.
+
+Lemma body_placeholder: semax_body MM0_Vprog MM0_Gprog f_mmap0_placeholder placeholder_spec.
+Proof.
+start_function.
+contradiction.
+Qed.
+
+(*See explanantion in AppelNaumann's paper, and in mmap0.c*)
+Parameter body_mmap0: semax_body MM0_Vprog MM0_Gprog f_mmap0 (mmap0_spec _mmap0).
+
+Require Import VST.floyd.library. (*for body_lemma_of_funspec *)
+Parameter body_munmap:
+ forall (*{Espec: OracleKind}*) {cs: compspecs},
+ @body_lemma_of_funspec NullExtension.Espec 
+    (EF_external "munmap"
+      (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default))
+    (snd (munmap_spec _munmap)).
+
+Definition MM0_VSU: @VSU NullExtension.Espec
+           SYS nil ltac:(QPprog prog) (Mmap0_ASI _mmap0 _munmap) emp.
+ Proof. 
+    mkVSU prog (SYS++MM0_internal_specs).
+  + (*external: munmap*)
+      clear; solve_SF_external body_munmap. simpl. Intros res.
+(*      destruct x. clear z v.
+      simpl; Intros res.*)
+      destruct ret; simpl in H; [ simpl | try contradiction].
+      - red in H.
+        destruct v; try contradiction; simpl. 
+        2: apply prop_right; trivial.
+        all: unfold PROPx, LOCALx, SEPx; simpl; unfold local, liftx; simpl; unfold lift1, lift, eval_id; simpl; Intros; try congruence.
+      - unfold PROPx, LOCALx, SEPx; simpl; unfold local, liftx; simpl; unfold lift1, lift, eval_id; simpl; Intros; try congruence.
+  + solve_SF_internal body_mmap0.
+  + solve_SF_internal body_placeholder.
+  Qed.

--- a/progs/memmgr/malloc.c
+++ b/progs/memmgr/malloc.c
@@ -1,0 +1,150 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <assert.h>
+#include <sys/mman.h> 
+#include "malloc.h"
+#include <limits.h>
+
+/* max data size for blocks in bin b (not counting header),
+   assuming 0<=b<BINS */
+static size_t bin2size(int b) {
+    return ((b+1)*ALIGN - 1)*WORD; 
+}
+
+/* bin index for blocks of size s (allowing for header and alignment) */
+static int size2bin(size_t s) {
+  if (s > bin2size(BINS-1))
+    return -1;
+  else
+    return (s+(WORD*(ALIGN-1)-1))/(WORD*ALIGN); 
+}
+
+/* for 0 <= b < BINS, bin[b] is null or points to 
+   the first 'link field' of a list of blocks (sz,lnk,dat) 
+   where sz is the length in bytes of (lnk,dat)
+   and the link pointers point to lnk field not to sz.
+*/
+static void *bin[BINS]; /* initially nulls */
+
+/* assuming p points to well aligned chunk of size BIGBLOCK and s in range for bin sizes
+   and tl points to a null-terminated lisk of s-chunks, 
+   return a list of s-chunks from p followed by those of tl. 
+*/
+static void *list_from_block(size_t s, char *p, void *tl) {
+  int Nblocks = (BIGBLOCK-WASTE) / (s+WORD);   
+  char *q = p + WASTE; /* align q+WORD, wasting WASTE bytes */  
+  int j = 0; 
+  while (j != Nblocks - 1) {
+    /* q points to start of (sz,lnk,dat), q+WORD (i.e., lnk) is aligned, q+s+WORD is allocated, and  0 <= j < Nblocks 
+    */
+    ((size_t *)q)[0] = s;
+    *((void **)(((size_t *)q)+1)) = q+WORD+(s+WORD); /* addr of next nxt field */
+    q += s+WORD; 
+    j++; 
+  }
+  /* finish last block, avoiding expression q+(s+WORD) going out of bounds */
+  ((size_t *)q)[0] = s; 
+  *((void **)(((size_t *)q)+1)) = tl; /* set lnk of last block */
+  return (void*)(p+WASTE+WORD); /* lnk of first block */
+}
+
+/* require p points to well aligned chunk of size BIGBLOCK 
+   and 0 <= n <= maxSmallChunk
+   ensure updated memmgr_res with additional chunks of size n available 
+The fixed size BIGBLOCK is a simplification that facilitated verification. 
+*/
+void pre_fill(size_t n, void *p) {
+  int b = size2bin(n);
+  bin[b] = list_from_block(bin2size(b), p, bin[b]);
+}
+
+/* requires 0 <= n and 0 <= req; only useful if n <= maxSmallChunk
+   ensures 0 <= result 
+           and result is how many chunks of size n have been pre-allocated 
+*/
+int try_pre_fill(size_t n, int req) {
+  if (bin2size(BINS-1) < n) 
+    return 0;
+  int b = size2bin(n);
+  int ful = 0; /* fulfilled part of request */
+  int chunks = (BIGBLOCK - WASTE) / (bin2size(b) + WORD); 
+  /* loop can be written with disjunctive guard but clight turns that into for(;;)/break */
+  while (0 < req - ful) {
+    if (INT_MAX - ful < chunks) /* would wrap */
+      return ful;  
+    char *p = (char *) mmap0(NULL, BIGBLOCK, -1);
+    if (p==NULL) 
+      return ful; 
+    else {
+      pre_fill(n,p);
+      ful += chunks; 
+    }
+  }
+  return ful; 
+}
+
+/* returns pointer to a null-terminated list of free blocks for bin b, obtained from mmap0 */
+static void *fill_bin(int b) {
+  size_t s = bin2size(b);
+  char *p = (char *) mmap0(NULL, BIGBLOCK, -1);
+  if (p==NULL) 
+    return NULL;
+  else 
+    return list_from_block(s, p, NULL);
+}     
+
+
+static void *malloc_small(size_t nbytes) {
+  int b = size2bin(nbytes);
+  void *q;
+  void *p = bin[b];
+  if (!p) {
+    p = fill_bin(b);
+    if (!p) 
+      return NULL;
+    else 
+      bin[b] = p;
+  }
+  q = *((void **)p);
+  bin[b] = q;
+  return p;
+}
+
+static void *malloc_large(size_t nbytes) {
+  char *p = (char *)mmap0(NULL, nbytes+WASTE+WORD, -1); 
+  if (p==NULL) 
+    return NULL;
+  else { 
+    ((size_t *)(p+WASTE))[0] = nbytes; 
+   return (void*) (p+WASTE+WORD);
+  }
+}
+
+
+static void free_small(void *p, size_t s) {
+  int b = size2bin(s);
+  void *q = bin[b];
+  *((void **)p) = q;
+  bin[b]=p;
+}
+
+static void free_large(void *p, size_t s) {
+    munmap( ((char*)p) - (WASTE + WORD), s+WASTE+WORD );
+}
+
+void free(void *p) {
+  if (p != NULL) {
+    size_t s = (size_t)(((size_t *)p)[-1]);
+    if (s <= bin2size(BINS-1))
+      free_small(p,s);
+    else
+      free_large(p,s);
+  }
+}
+
+void *malloc(size_t nbytes) {
+  if (nbytes > bin2size(BINS-1))
+    return malloc_large(nbytes);
+  else 
+    return malloc_small(nbytes);
+}

--- a/progs/memmgr/malloc.h
+++ b/progs/memmgr/malloc.h
@@ -1,0 +1,40 @@
+#include "mmap0.h"
+
+/* About format and alignment:
+malloc returns a pointer aligned modulo ALIGN*WORD, preceded by the chunk
+size as an unsigned integer in WORD bytes.  Given a well aligned large block
+from the operating system, the first (WORD*ALIGN - WORD) bytes are wasted
+in order to achieve the alignment.  The chunk size is at least the size
+given as argument to malloc.
+*/
+
+/* TODO WASTE and ALIGN probably not needed here */ 
+
+enum {WORD = sizeof(size_t)};
+
+enum {ALIGN = 2};
+
+enum {WASTE = WORD*ALIGN - WORD}; 
+
+enum {BIGBLOCK = (2<<16)*WORD};
+
+enum {BINS = 50};
+
+void *malloc(size_t);
+
+void free(void *);
+
+
+/* Pre-fill the free list for chunks of size n, adding as many
+chunks as can be obtained from the provided big block.
+Assumes 0 <= n <= maxSmallChunk. 
+Assumes p points to a well aligned block of size BIGBLOCK bytes. 
+*/
+void pre_fill(size_t n, void *p);
+
+/* Try to add at least r chunks to the free list for size n.
+Returns the actual number added.
+Assumes 0 <= n and 0 <= r.
+*/
+int try_pre_fill(size_t n, int r);
+

--- a/progs/memmgr/malloc.v
+++ b/progs/memmgr/malloc.v
@@ -1,0 +1,917 @@
+From Coq Require Import String List ZArith.
+From compcert Require Import Coqlib Integers Floats AST Ctypes Cop Clight Clightdefs.
+Import Clightdefs.ClightNotations.
+Local Open Scope Z_scope.
+Local Open Scope string_scope.
+Local Open Scope clight_scope.
+
+Module Info.
+  Definition version := "3.10".
+  Definition build_number := "".
+  Definition build_tag := "".
+  Definition build_branch := "".
+  Definition arch := "x86".
+  Definition model := "32sse2".
+  Definition abi := "standard".
+  Definition bitsize := 32.
+  Definition big_endian := false.
+  Definition source_file := "malloc.c".
+  Definition normalized := true.
+End Info.
+
+Definition _Nblocks : ident := 72%positive.
+Definition ___builtin_ais_annot : ident := 1%positive.
+Definition ___builtin_annot : ident := 18%positive.
+Definition ___builtin_annot_intval : ident := 19%positive.
+Definition ___builtin_bswap : ident := 3%positive.
+Definition ___builtin_bswap16 : ident := 5%positive.
+Definition ___builtin_bswap32 : ident := 4%positive.
+Definition ___builtin_bswap64 : ident := 2%positive.
+Definition ___builtin_clz : ident := 6%positive.
+Definition ___builtin_clzl : ident := 7%positive.
+Definition ___builtin_clzll : ident := 8%positive.
+Definition ___builtin_ctz : ident := 9%positive.
+Definition ___builtin_ctzl : ident := 10%positive.
+Definition ___builtin_ctzll : ident := 11%positive.
+Definition ___builtin_debug : ident := 37%positive.
+Definition ___builtin_expect : ident := 26%positive.
+Definition ___builtin_fabs : ident := 12%positive.
+Definition ___builtin_fabsf : ident := 13%positive.
+Definition ___builtin_fmadd : ident := 29%positive.
+Definition ___builtin_fmax : ident := 27%positive.
+Definition ___builtin_fmin : ident := 28%positive.
+Definition ___builtin_fmsub : ident := 30%positive.
+Definition ___builtin_fnmadd : ident := 31%positive.
+Definition ___builtin_fnmsub : ident := 32%positive.
+Definition ___builtin_fsqrt : ident := 14%positive.
+Definition ___builtin_membar : ident := 20%positive.
+Definition ___builtin_memcpy_aligned : ident := 16%positive.
+Definition ___builtin_read16_reversed : ident := 33%positive.
+Definition ___builtin_read32_reversed : ident := 34%positive.
+Definition ___builtin_sel : ident := 17%positive.
+Definition ___builtin_sqrt : ident := 15%positive.
+Definition ___builtin_unreachable : ident := 25%positive.
+Definition ___builtin_va_arg : ident := 22%positive.
+Definition ___builtin_va_copy : ident := 23%positive.
+Definition ___builtin_va_end : ident := 24%positive.
+Definition ___builtin_va_start : ident := 21%positive.
+Definition ___builtin_write16_reversed : ident := 35%positive.
+Definition ___builtin_write32_reversed : ident := 36%positive.
+Definition ___compcert_i64_dtos : ident := 50%positive.
+Definition ___compcert_i64_dtou : ident := 51%positive.
+Definition ___compcert_i64_sar : ident := 62%positive.
+Definition ___compcert_i64_sdiv : ident := 56%positive.
+Definition ___compcert_i64_shl : ident := 60%positive.
+Definition ___compcert_i64_shr : ident := 61%positive.
+Definition ___compcert_i64_smod : ident := 58%positive.
+Definition ___compcert_i64_smulh : ident := 63%positive.
+Definition ___compcert_i64_stod : ident := 52%positive.
+Definition ___compcert_i64_stof : ident := 54%positive.
+Definition ___compcert_i64_udiv : ident := 57%positive.
+Definition ___compcert_i64_umod : ident := 59%positive.
+Definition ___compcert_i64_umulh : ident := 64%positive.
+Definition ___compcert_i64_utod : ident := 53%positive.
+Definition ___compcert_i64_utof : ident := 55%positive.
+Definition ___compcert_va_composite : ident := 49%positive.
+Definition ___compcert_va_float64 : ident := 48%positive.
+Definition ___compcert_va_int32 : ident := 46%positive.
+Definition ___compcert_va_int64 : ident := 47%positive.
+Definition _addr : ident := 40%positive.
+Definition _b : ident := 66%positive.
+Definition _bin : ident := 70%positive.
+Definition _bin2size : ident := 67%positive.
+Definition _chunks : ident := 80%positive.
+Definition _fildes : ident := 42%positive.
+Definition _fill_bin : ident := 82%positive.
+Definition _free : ident := 88%positive.
+Definition _free_large : ident := 87%positive.
+Definition _free_small : ident := 86%positive.
+Definition _ful : ident := 79%positive.
+Definition _j : ident := 74%positive.
+Definition _len : ident := 41%positive.
+Definition _list_from_block : ident := 75%positive.
+Definition _main : ident := 65%positive.
+Definition _malloc : ident := 89%positive.
+Definition _malloc_large : ident := 85%positive.
+Definition _malloc_small : ident := 84%positive.
+Definition _mmap : ident := 38%positive.
+Definition _mmap0 : ident := 44%positive.
+Definition _mmap0_placeholder : ident := 45%positive.
+Definition _munmap : ident := 39%positive.
+Definition _n : ident := 76%positive.
+Definition _nbytes : ident := 83%positive.
+Definition _p : ident := 43%positive.
+Definition _pre_fill : ident := 77%positive.
+Definition _q : ident := 73%positive.
+Definition _req : ident := 78%positive.
+Definition _s : ident := 68%positive.
+Definition _size2bin : ident := 69%positive.
+Definition _tl : ident := 71%positive.
+Definition _try_pre_fill : ident := 81%positive.
+Definition _t'1 : ident := 90%positive.
+Definition _t'2 : ident := 91%positive.
+Definition _t'3 : ident := 92%positive.
+Definition _t'4 : ident := 93%positive.
+
+Definition f_bin2size := {|
+  fn_return := tuint;
+  fn_callconv := cc_default;
+  fn_params := ((_b, tint) :: nil);
+  fn_vars := nil;
+  fn_temps := nil;
+  fn_body :=
+(Sreturn (Some (Ebinop Omul
+                 (Ebinop Osub
+                   (Ebinop Omul
+                     (Ebinop Oadd (Etempvar _b tint)
+                       (Econst_int (Int.repr 1) tint) tint)
+                     (Econst_int (Int.repr 2) tint) tint)
+                   (Econst_int (Int.repr 1) tint) tint)
+                 (Econst_int (Int.repr 4) tint) tint)))
+|}.
+
+Definition f_size2bin := {|
+  fn_return := tint;
+  fn_callconv := cc_default;
+  fn_params := ((_s, tuint) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_t'1, tuint) :: nil);
+  fn_body :=
+(Ssequence
+  (Scall (Some _t'1)
+    (Evar _bin2size (Tfunction (Tcons tint Tnil) tuint cc_default))
+    ((Ebinop Osub (Econst_int (Int.repr 50) tint)
+       (Econst_int (Int.repr 1) tint) tint) :: nil))
+  (Sifthenelse (Ebinop Ogt (Etempvar _s tuint) (Etempvar _t'1 tuint) tint)
+    (Sreturn (Some (Eunop Oneg (Econst_int (Int.repr 1) tint) tint)))
+    (Sreturn (Some (Ebinop Odiv
+                     (Ebinop Oadd (Etempvar _s tuint)
+                       (Ebinop Osub
+                         (Ebinop Omul (Econst_int (Int.repr 4) tint)
+                           (Ebinop Osub (Econst_int (Int.repr 2) tint)
+                             (Econst_int (Int.repr 1) tint) tint) tint)
+                         (Econst_int (Int.repr 1) tint) tint) tuint)
+                     (Ebinop Omul (Econst_int (Int.repr 4) tint)
+                       (Econst_int (Int.repr 2) tint) tint) tuint)))))
+|}.
+
+Definition v_bin := {|
+  gvar_info := (tarray (tptr tvoid) 50);
+  gvar_init := (Init_space 200 :: nil);
+  gvar_readonly := false;
+  gvar_volatile := false
+|}.
+
+Definition f_list_from_block := {|
+  fn_return := (tptr tvoid);
+  fn_callconv := cc_default;
+  fn_params := ((_s, tuint) :: (_p, (tptr tschar)) :: (_tl, (tptr tvoid)) ::
+                nil);
+  fn_vars := nil;
+  fn_temps := ((_Nblocks, tint) :: (_q, (tptr tschar)) :: (_j, tint) :: nil);
+  fn_body :=
+(Ssequence
+  (Sset _Nblocks
+    (Ebinop Odiv
+      (Ebinop Osub (Econst_int (Int.repr 524288) tint)
+        (Econst_int (Int.repr 4) tint) tint)
+      (Ebinop Oadd (Etempvar _s tuint) (Econst_int (Int.repr 4) tint) tuint)
+      tuint))
+  (Ssequence
+    (Sset _q
+      (Ebinop Oadd (Etempvar _p (tptr tschar)) (Econst_int (Int.repr 4) tint)
+        (tptr tschar)))
+    (Ssequence
+      (Sset _j (Econst_int (Int.repr 0) tint))
+      (Ssequence
+        (Swhile
+          (Ebinop One (Etempvar _j tint)
+            (Ebinop Osub (Etempvar _Nblocks tint)
+              (Econst_int (Int.repr 1) tint) tint) tint)
+          (Ssequence
+            (Sassign
+              (Ederef
+                (Ebinop Oadd (Ecast (Etempvar _q (tptr tschar)) (tptr tuint))
+                  (Econst_int (Int.repr 0) tint) (tptr tuint)) tuint)
+              (Etempvar _s tuint))
+            (Ssequence
+              (Sassign
+                (Ederef
+                  (Ecast
+                    (Ebinop Oadd
+                      (Ecast (Etempvar _q (tptr tschar)) (tptr tuint))
+                      (Econst_int (Int.repr 1) tint) (tptr tuint))
+                    (tptr (tptr tvoid))) (tptr tvoid))
+                (Ebinop Oadd
+                  (Ebinop Oadd (Etempvar _q (tptr tschar))
+                    (Econst_int (Int.repr 4) tint) (tptr tschar))
+                  (Ebinop Oadd (Etempvar _s tuint)
+                    (Econst_int (Int.repr 4) tint) tuint) (tptr tschar)))
+              (Ssequence
+                (Sset _q
+                  (Ebinop Oadd (Etempvar _q (tptr tschar))
+                    (Ebinop Oadd (Etempvar _s tuint)
+                      (Econst_int (Int.repr 4) tint) tuint) (tptr tschar)))
+                (Sset _j
+                  (Ebinop Oadd (Etempvar _j tint)
+                    (Econst_int (Int.repr 1) tint) tint))))))
+        (Ssequence
+          (Sassign
+            (Ederef
+              (Ebinop Oadd (Ecast (Etempvar _q (tptr tschar)) (tptr tuint))
+                (Econst_int (Int.repr 0) tint) (tptr tuint)) tuint)
+            (Etempvar _s tuint))
+          (Ssequence
+            (Sassign
+              (Ederef
+                (Ecast
+                  (Ebinop Oadd
+                    (Ecast (Etempvar _q (tptr tschar)) (tptr tuint))
+                    (Econst_int (Int.repr 1) tint) (tptr tuint))
+                  (tptr (tptr tvoid))) (tptr tvoid))
+              (Etempvar _tl (tptr tvoid)))
+            (Sreturn (Some (Ecast
+                             (Ebinop Oadd
+                               (Ebinop Oadd (Etempvar _p (tptr tschar))
+                                 (Econst_int (Int.repr 4) tint)
+                                 (tptr tschar))
+                               (Econst_int (Int.repr 4) tint) (tptr tschar))
+                             (tptr tvoid))))))))))
+|}.
+
+Definition f_pre_fill := {|
+  fn_return := tvoid;
+  fn_callconv := cc_default;
+  fn_params := ((_n, tuint) :: (_p, (tptr tvoid)) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_b, tint) :: (_t'3, (tptr tvoid)) :: (_t'2, tuint) ::
+               (_t'1, tint) :: (_t'4, (tptr tvoid)) :: nil);
+  fn_body :=
+(Ssequence
+  (Ssequence
+    (Scall (Some _t'1)
+      (Evar _size2bin (Tfunction (Tcons tuint Tnil) tint cc_default))
+      ((Etempvar _n tuint) :: nil))
+    (Sset _b (Etempvar _t'1 tint)))
+  (Ssequence
+    (Ssequence
+      (Scall (Some _t'2)
+        (Evar _bin2size (Tfunction (Tcons tint Tnil) tuint cc_default))
+        ((Etempvar _b tint) :: nil))
+      (Ssequence
+        (Sset _t'4
+          (Ederef
+            (Ebinop Oadd (Evar _bin (tarray (tptr tvoid) 50))
+              (Etempvar _b tint) (tptr (tptr tvoid))) (tptr tvoid)))
+        (Scall (Some _t'3)
+          (Evar _list_from_block (Tfunction
+                                   (Tcons tuint
+                                     (Tcons (tptr tschar)
+                                       (Tcons (tptr tvoid) Tnil)))
+                                   (tptr tvoid) cc_default))
+          ((Etempvar _t'2 tuint) :: (Etempvar _p (tptr tvoid)) ::
+           (Etempvar _t'4 (tptr tvoid)) :: nil))))
+    (Sassign
+      (Ederef
+        (Ebinop Oadd (Evar _bin (tarray (tptr tvoid) 50)) (Etempvar _b tint)
+          (tptr (tptr tvoid))) (tptr tvoid)) (Etempvar _t'3 (tptr tvoid)))))
+|}.
+
+Definition f_try_pre_fill := {|
+  fn_return := tint;
+  fn_callconv := cc_default;
+  fn_params := ((_n, tuint) :: (_req, tint) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_b, tint) :: (_ful, tint) :: (_chunks, tint) ::
+               (_p, (tptr tschar)) :: (_t'4, (tptr tvoid)) ::
+               (_t'3, tuint) :: (_t'2, tint) :: (_t'1, tuint) :: nil);
+  fn_body :=
+(Ssequence
+  (Ssequence
+    (Scall (Some _t'1)
+      (Evar _bin2size (Tfunction (Tcons tint Tnil) tuint cc_default))
+      ((Ebinop Osub (Econst_int (Int.repr 50) tint)
+         (Econst_int (Int.repr 1) tint) tint) :: nil))
+    (Sifthenelse (Ebinop Olt (Etempvar _t'1 tuint) (Etempvar _n tuint) tint)
+      (Sreturn (Some (Econst_int (Int.repr 0) tint)))
+      Sskip))
+  (Ssequence
+    (Ssequence
+      (Scall (Some _t'2)
+        (Evar _size2bin (Tfunction (Tcons tuint Tnil) tint cc_default))
+        ((Etempvar _n tuint) :: nil))
+      (Sset _b (Etempvar _t'2 tint)))
+    (Ssequence
+      (Sset _ful (Econst_int (Int.repr 0) tint))
+      (Ssequence
+        (Ssequence
+          (Scall (Some _t'3)
+            (Evar _bin2size (Tfunction (Tcons tint Tnil) tuint cc_default))
+            ((Etempvar _b tint) :: nil))
+          (Sset _chunks
+            (Ebinop Odiv
+              (Ebinop Osub (Econst_int (Int.repr 524288) tint)
+                (Econst_int (Int.repr 4) tint) tint)
+              (Ebinop Oadd (Etempvar _t'3 tuint)
+                (Econst_int (Int.repr 4) tint) tuint) tuint)))
+        (Ssequence
+          (Swhile
+            (Ebinop Olt (Econst_int (Int.repr 0) tint)
+              (Ebinop Osub (Etempvar _req tint) (Etempvar _ful tint) tint)
+              tint)
+            (Ssequence
+              (Sifthenelse (Ebinop Olt
+                             (Ebinop Osub
+                               (Econst_int (Int.repr 2147483647) tint)
+                               (Etempvar _ful tint) tint)
+                             (Etempvar _chunks tint) tint)
+                (Sreturn (Some (Etempvar _ful tint)))
+                Sskip)
+              (Ssequence
+                (Ssequence
+                  (Scall (Some _t'4)
+                    (Evar _mmap0 (Tfunction
+                                   (Tcons (tptr tvoid)
+                                     (Tcons tuint (Tcons tint Tnil)))
+                                   (tptr tvoid) cc_default))
+                    ((Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) ::
+                     (Econst_int (Int.repr 524288) tint) ::
+                     (Eunop Oneg (Econst_int (Int.repr 1) tint) tint) :: nil))
+                  (Sset _p
+                    (Ecast (Etempvar _t'4 (tptr tvoid)) (tptr tschar))))
+                (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr tschar))
+                               (Ecast (Econst_int (Int.repr 0) tint)
+                                 (tptr tvoid)) tint)
+                  (Sreturn (Some (Etempvar _ful tint)))
+                  (Ssequence
+                    (Scall None
+                      (Evar _pre_fill (Tfunction
+                                        (Tcons tuint
+                                          (Tcons (tptr tvoid) Tnil)) tvoid
+                                        cc_default))
+                      ((Etempvar _n tuint) :: (Etempvar _p (tptr tschar)) ::
+                       nil))
+                    (Sset _ful
+                      (Ebinop Oadd (Etempvar _ful tint)
+                        (Etempvar _chunks tint) tint)))))))
+          (Sreturn (Some (Etempvar _ful tint))))))))
+|}.
+
+Definition f_fill_bin := {|
+  fn_return := (tptr tvoid);
+  fn_callconv := cc_default;
+  fn_params := ((_b, tint) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_s, tuint) :: (_p, (tptr tschar)) :: (_t'3, (tptr tvoid)) ::
+               (_t'2, (tptr tvoid)) :: (_t'1, tuint) :: nil);
+  fn_body :=
+(Ssequence
+  (Ssequence
+    (Scall (Some _t'1)
+      (Evar _bin2size (Tfunction (Tcons tint Tnil) tuint cc_default))
+      ((Etempvar _b tint) :: nil))
+    (Sset _s (Etempvar _t'1 tuint)))
+  (Ssequence
+    (Ssequence
+      (Scall (Some _t'2)
+        (Evar _mmap0 (Tfunction
+                       (Tcons (tptr tvoid) (Tcons tuint (Tcons tint Tnil)))
+                       (tptr tvoid) cc_default))
+        ((Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) ::
+         (Econst_int (Int.repr 524288) tint) ::
+         (Eunop Oneg (Econst_int (Int.repr 1) tint) tint) :: nil))
+      (Sset _p (Ecast (Etempvar _t'2 (tptr tvoid)) (tptr tschar))))
+    (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr tschar))
+                   (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) tint)
+      (Sreturn (Some (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid))))
+      (Ssequence
+        (Scall (Some _t'3)
+          (Evar _list_from_block (Tfunction
+                                   (Tcons tuint
+                                     (Tcons (tptr tschar)
+                                       (Tcons (tptr tvoid) Tnil)))
+                                   (tptr tvoid) cc_default))
+          ((Etempvar _s tuint) :: (Etempvar _p (tptr tschar)) ::
+           (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) :: nil))
+        (Sreturn (Some (Etempvar _t'3 (tptr tvoid))))))))
+|}.
+
+Definition f_malloc_small := {|
+  fn_return := (tptr tvoid);
+  fn_callconv := cc_default;
+  fn_params := ((_nbytes, tuint) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_b, tint) :: (_q, (tptr tvoid)) :: (_p, (tptr tvoid)) ::
+               (_t'2, (tptr tvoid)) :: (_t'1, tint) :: nil);
+  fn_body :=
+(Ssequence
+  (Ssequence
+    (Scall (Some _t'1)
+      (Evar _size2bin (Tfunction (Tcons tuint Tnil) tint cc_default))
+      ((Etempvar _nbytes tuint) :: nil))
+    (Sset _b (Etempvar _t'1 tint)))
+  (Ssequence
+    (Sset _p
+      (Ederef
+        (Ebinop Oadd (Evar _bin (tarray (tptr tvoid) 50)) (Etempvar _b tint)
+          (tptr (tptr tvoid))) (tptr tvoid)))
+    (Ssequence
+      (Sifthenelse (Eunop Onotbool (Etempvar _p (tptr tvoid)) tint)
+        (Ssequence
+          (Ssequence
+            (Scall (Some _t'2)
+              (Evar _fill_bin (Tfunction (Tcons tint Tnil) (tptr tvoid)
+                                cc_default)) ((Etempvar _b tint) :: nil))
+            (Sset _p (Etempvar _t'2 (tptr tvoid))))
+          (Sifthenelse (Eunop Onotbool (Etempvar _p (tptr tvoid)) tint)
+            (Sreturn (Some (Ecast (Econst_int (Int.repr 0) tint)
+                             (tptr tvoid))))
+            (Sassign
+              (Ederef
+                (Ebinop Oadd (Evar _bin (tarray (tptr tvoid) 50))
+                  (Etempvar _b tint) (tptr (tptr tvoid))) (tptr tvoid))
+              (Etempvar _p (tptr tvoid)))))
+        Sskip)
+      (Ssequence
+        (Sset _q
+          (Ederef (Ecast (Etempvar _p (tptr tvoid)) (tptr (tptr tvoid)))
+            (tptr tvoid)))
+        (Ssequence
+          (Sassign
+            (Ederef
+              (Ebinop Oadd (Evar _bin (tarray (tptr tvoid) 50))
+                (Etempvar _b tint) (tptr (tptr tvoid))) (tptr tvoid))
+            (Etempvar _q (tptr tvoid)))
+          (Sreturn (Some (Etempvar _p (tptr tvoid)))))))))
+|}.
+
+Definition f_malloc_large := {|
+  fn_return := (tptr tvoid);
+  fn_callconv := cc_default;
+  fn_params := ((_nbytes, tuint) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_p, (tptr tschar)) :: (_t'1, (tptr tvoid)) :: nil);
+  fn_body :=
+(Ssequence
+  (Ssequence
+    (Scall (Some _t'1)
+      (Evar _mmap0 (Tfunction
+                     (Tcons (tptr tvoid) (Tcons tuint (Tcons tint Tnil)))
+                     (tptr tvoid) cc_default))
+      ((Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) ::
+       (Ebinop Oadd
+         (Ebinop Oadd (Etempvar _nbytes tuint) (Econst_int (Int.repr 4) tint)
+           tuint) (Econst_int (Int.repr 4) tint) tuint) ::
+       (Eunop Oneg (Econst_int (Int.repr 1) tint) tint) :: nil))
+    (Sset _p (Ecast (Etempvar _t'1 (tptr tvoid)) (tptr tschar))))
+  (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr tschar))
+                 (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) tint)
+    (Sreturn (Some (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid))))
+    (Ssequence
+      (Sassign
+        (Ederef
+          (Ebinop Oadd
+            (Ecast
+              (Ebinop Oadd (Etempvar _p (tptr tschar))
+                (Econst_int (Int.repr 4) tint) (tptr tschar)) (tptr tuint))
+            (Econst_int (Int.repr 0) tint) (tptr tuint)) tuint)
+        (Etempvar _nbytes tuint))
+      (Sreturn (Some (Ecast
+                       (Ebinop Oadd
+                         (Ebinop Oadd (Etempvar _p (tptr tschar))
+                           (Econst_int (Int.repr 4) tint) (tptr tschar))
+                         (Econst_int (Int.repr 4) tint) (tptr tschar))
+                       (tptr tvoid)))))))
+|}.
+
+Definition f_free_small := {|
+  fn_return := tvoid;
+  fn_callconv := cc_default;
+  fn_params := ((_p, (tptr tvoid)) :: (_s, tuint) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_b, tint) :: (_q, (tptr tvoid)) :: (_t'1, tint) :: nil);
+  fn_body :=
+(Ssequence
+  (Ssequence
+    (Scall (Some _t'1)
+      (Evar _size2bin (Tfunction (Tcons tuint Tnil) tint cc_default))
+      ((Etempvar _s tuint) :: nil))
+    (Sset _b (Etempvar _t'1 tint)))
+  (Ssequence
+    (Sset _q
+      (Ederef
+        (Ebinop Oadd (Evar _bin (tarray (tptr tvoid) 50)) (Etempvar _b tint)
+          (tptr (tptr tvoid))) (tptr tvoid)))
+    (Ssequence
+      (Sassign
+        (Ederef (Ecast (Etempvar _p (tptr tvoid)) (tptr (tptr tvoid)))
+          (tptr tvoid)) (Etempvar _q (tptr tvoid)))
+      (Sassign
+        (Ederef
+          (Ebinop Oadd (Evar _bin (tarray (tptr tvoid) 50))
+            (Etempvar _b tint) (tptr (tptr tvoid))) (tptr tvoid))
+        (Etempvar _p (tptr tvoid))))))
+|}.
+
+Definition f_free_large := {|
+  fn_return := tvoid;
+  fn_callconv := cc_default;
+  fn_params := ((_p, (tptr tvoid)) :: (_s, tuint) :: nil);
+  fn_vars := nil;
+  fn_temps := nil;
+  fn_body :=
+(Scall None
+  (Evar _munmap (Tfunction (Tcons (tptr tvoid) (Tcons tuint Tnil)) tint
+                  cc_default))
+  ((Ebinop Osub (Ecast (Etempvar _p (tptr tvoid)) (tptr tschar))
+     (Ebinop Oadd (Econst_int (Int.repr 4) tint)
+       (Econst_int (Int.repr 4) tint) tint) (tptr tschar)) ::
+   (Ebinop Oadd
+     (Ebinop Oadd (Etempvar _s tuint) (Econst_int (Int.repr 4) tint) tuint)
+     (Econst_int (Int.repr 4) tint) tuint) :: nil))
+|}.
+
+Definition f_free := {|
+  fn_return := tvoid;
+  fn_callconv := cc_default;
+  fn_params := ((_p, (tptr tvoid)) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_s, tuint) :: (_t'1, tuint) :: (_t'2, tuint) :: nil);
+  fn_body :=
+(Sifthenelse (Ebinop One (Etempvar _p (tptr tvoid))
+               (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) tint)
+  (Ssequence
+    (Ssequence
+      (Sset _t'2
+        (Ederef
+          (Ebinop Oadd (Ecast (Etempvar _p (tptr tvoid)) (tptr tuint))
+            (Eunop Oneg (Econst_int (Int.repr 1) tint) tint) (tptr tuint))
+          tuint))
+      (Sset _s (Ecast (Etempvar _t'2 tuint) tuint)))
+    (Ssequence
+      (Scall (Some _t'1)
+        (Evar _bin2size (Tfunction (Tcons tint Tnil) tuint cc_default))
+        ((Ebinop Osub (Econst_int (Int.repr 50) tint)
+           (Econst_int (Int.repr 1) tint) tint) :: nil))
+      (Sifthenelse (Ebinop Ole (Etempvar _s tuint) (Etempvar _t'1 tuint)
+                     tint)
+        (Scall None
+          (Evar _free_small (Tfunction
+                              (Tcons (tptr tvoid) (Tcons tuint Tnil)) tvoid
+                              cc_default))
+          ((Etempvar _p (tptr tvoid)) :: (Etempvar _s tuint) :: nil))
+        (Scall None
+          (Evar _free_large (Tfunction
+                              (Tcons (tptr tvoid) (Tcons tuint Tnil)) tvoid
+                              cc_default))
+          ((Etempvar _p (tptr tvoid)) :: (Etempvar _s tuint) :: nil)))))
+  Sskip)
+|}.
+
+Definition f_malloc := {|
+  fn_return := (tptr tvoid);
+  fn_callconv := cc_default;
+  fn_params := ((_nbytes, tuint) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_t'3, tuint) :: (_t'2, (tptr tvoid)) ::
+               (_t'1, (tptr tvoid)) :: nil);
+  fn_body :=
+(Ssequence
+  (Scall (Some _t'3)
+    (Evar _bin2size (Tfunction (Tcons tint Tnil) tuint cc_default))
+    ((Ebinop Osub (Econst_int (Int.repr 50) tint)
+       (Econst_int (Int.repr 1) tint) tint) :: nil))
+  (Sifthenelse (Ebinop Ogt (Etempvar _nbytes tuint) (Etempvar _t'3 tuint)
+                 tint)
+    (Ssequence
+      (Scall (Some _t'1)
+        (Evar _malloc_large (Tfunction (Tcons tuint Tnil) (tptr tvoid)
+                              cc_default)) ((Etempvar _nbytes tuint) :: nil))
+      (Sreturn (Some (Etempvar _t'1 (tptr tvoid)))))
+    (Ssequence
+      (Scall (Some _t'2)
+        (Evar _malloc_small (Tfunction (Tcons tuint Tnil) (tptr tvoid)
+                              cc_default)) ((Etempvar _nbytes tuint) :: nil))
+      (Sreturn (Some (Etempvar _t'2 (tptr tvoid)))))))
+|}.
+
+Definition composites : list composite_definition :=
+nil.
+
+Definition global_definitions : list (ident * globdef fundef type) :=
+((___compcert_va_int32,
+   Gfun(External (EF_runtime "__compcert_va_int32"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons (tptr tvoid) Tnil) tuint cc_default)) ::
+ (___compcert_va_int64,
+   Gfun(External (EF_runtime "__compcert_va_int64"
+                   (mksignature (AST.Tint :: nil) AST.Tlong cc_default))
+     (Tcons (tptr tvoid) Tnil) tulong cc_default)) ::
+ (___compcert_va_float64,
+   Gfun(External (EF_runtime "__compcert_va_float64"
+                   (mksignature (AST.Tint :: nil) AST.Tfloat cc_default))
+     (Tcons (tptr tvoid) Tnil) tdouble cc_default)) ::
+ (___compcert_va_composite,
+   Gfun(External (EF_runtime "__compcert_va_composite"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     (tptr tvoid) cc_default)) ::
+ (___compcert_i64_dtos,
+   Gfun(External (EF_runtime "__compcert_i64_dtos"
+                   (mksignature (AST.Tfloat :: nil) AST.Tlong cc_default))
+     (Tcons tdouble Tnil) tlong cc_default)) ::
+ (___compcert_i64_dtou,
+   Gfun(External (EF_runtime "__compcert_i64_dtou"
+                   (mksignature (AST.Tfloat :: nil) AST.Tlong cc_default))
+     (Tcons tdouble Tnil) tulong cc_default)) ::
+ (___compcert_i64_stod,
+   Gfun(External (EF_runtime "__compcert_i64_stod"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons tlong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_utod,
+   Gfun(External (EF_runtime "__compcert_i64_utod"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons tulong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_stof,
+   Gfun(External (EF_runtime "__compcert_i64_stof"
+                   (mksignature (AST.Tlong :: nil) AST.Tsingle cc_default))
+     (Tcons tlong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_utof,
+   Gfun(External (EF_runtime "__compcert_i64_utof"
+                   (mksignature (AST.Tlong :: nil) AST.Tsingle cc_default))
+     (Tcons tulong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_sdiv,
+   Gfun(External (EF_runtime "__compcert_i64_sdiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_udiv,
+   Gfun(External (EF_runtime "__compcert_i64_udiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_smod,
+   Gfun(External (EF_runtime "__compcert_i64_smod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_umod,
+   Gfun(External (EF_runtime "__compcert_i64_umod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_shl,
+   Gfun(External (EF_runtime "__compcert_i64_shl"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tint Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_shr,
+   Gfun(External (EF_runtime "__compcert_i64_shr"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tint Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_sar,
+   Gfun(External (EF_runtime "__compcert_i64_sar"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tint Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_smulh,
+   Gfun(External (EF_runtime "__compcert_i64_smulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_umulh,
+   Gfun(External (EF_runtime "__compcert_i64_umulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___builtin_ais_annot,
+   Gfun(External (EF_builtin "__builtin_ais_annot"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_bswap64,
+   Gfun(External (EF_builtin "__builtin_bswap64"
+                   (mksignature (AST.Tlong :: nil) AST.Tlong cc_default))
+     (Tcons tulong Tnil) tulong cc_default)) ::
+ (___builtin_bswap,
+   Gfun(External (EF_builtin "__builtin_bswap"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap32,
+   Gfun(External (EF_builtin "__builtin_bswap32"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap16,
+   Gfun(External (EF_builtin "__builtin_bswap16"
+                   (mksignature (AST.Tint :: nil) AST.Tint16unsigned
+                     cc_default)) (Tcons tushort Tnil) tushort cc_default)) ::
+ (___builtin_clz,
+   Gfun(External (EF_builtin "__builtin_clz"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzl,
+   Gfun(External (EF_builtin "__builtin_clzl"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzll,
+   Gfun(External (EF_builtin "__builtin_clzll"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_ctz,
+   Gfun(External (EF_builtin "__builtin_ctz"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzl,
+   Gfun(External (EF_builtin "__builtin_ctzl"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzll,
+   Gfun(External (EF_builtin "__builtin_ctzll"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_fabs,
+   Gfun(External (EF_builtin "__builtin_fabs"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_fabsf,
+   Gfun(External (EF_builtin "__builtin_fabsf"
+                   (mksignature (AST.Tsingle :: nil) AST.Tsingle cc_default))
+     (Tcons tfloat Tnil) tfloat cc_default)) ::
+ (___builtin_fsqrt,
+   Gfun(External (EF_builtin "__builtin_fsqrt"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_sqrt,
+   Gfun(External (EF_builtin "__builtin_sqrt"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_memcpy_aligned,
+   Gfun(External (EF_builtin "__builtin_memcpy_aligned"
+                   (mksignature
+                     (AST.Tint :: AST.Tint :: AST.Tint :: AST.Tint :: nil)
+                     AST.Tvoid cc_default))
+     (Tcons (tptr tvoid)
+       (Tcons (tptr tvoid) (Tcons tuint (Tcons tuint Tnil)))) tvoid
+     cc_default)) ::
+ (___builtin_sel,
+   Gfun(External (EF_builtin "__builtin_sel"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tbool Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot,
+   Gfun(External (EF_builtin "__builtin_annot"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot_intval,
+   Gfun(External (EF_builtin "__builtin_annot_intval"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons (tptr tschar) (Tcons tint Tnil))
+     tint cc_default)) ::
+ (___builtin_membar,
+   Gfun(External (EF_builtin "__builtin_membar"
+                   (mksignature nil AST.Tvoid cc_default)) Tnil tvoid
+     cc_default)) ::
+ (___builtin_va_start,
+   Gfun(External (EF_builtin "__builtin_va_start"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___builtin_va_arg,
+   Gfun(External (EF_builtin "__builtin_va_arg"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_va_copy,
+   Gfun(External (EF_builtin "__builtin_va_copy"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                     cc_default))
+     (Tcons (tptr tvoid) (Tcons (tptr tvoid) Tnil)) tvoid cc_default)) ::
+ (___builtin_va_end,
+   Gfun(External (EF_builtin "__builtin_va_end"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___builtin_unreachable,
+   Gfun(External (EF_builtin "__builtin_unreachable"
+                   (mksignature nil AST.Tvoid cc_default)) Tnil tvoid
+     cc_default)) ::
+ (___builtin_expect,
+   Gfun(External (EF_builtin "__builtin_expect"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons tint (Tcons tint Tnil)) tint
+     cc_default)) ::
+ (___builtin_fmax,
+   Gfun(External (EF_builtin "__builtin_fmax"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil) AST.Tfloat
+                     cc_default)) (Tcons tdouble (Tcons tdouble Tnil))
+     tdouble cc_default)) ::
+ (___builtin_fmin,
+   Gfun(External (EF_builtin "__builtin_fmin"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil) AST.Tfloat
+                     cc_default)) (Tcons tdouble (Tcons tdouble Tnil))
+     tdouble cc_default)) ::
+ (___builtin_fmadd,
+   Gfun(External (EF_builtin "__builtin_fmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fmsub,
+   Gfun(External (EF_builtin "__builtin_fmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmadd,
+   Gfun(External (EF_builtin "__builtin_fnmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmsub,
+   Gfun(External (EF_builtin "__builtin_fnmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_read16_reversed,
+   Gfun(External (EF_builtin "__builtin_read16_reversed"
+                   (mksignature (AST.Tint :: nil) AST.Tint16unsigned
+                     cc_default)) (Tcons (tptr tushort) Tnil) tushort
+     cc_default)) ::
+ (___builtin_read32_reversed,
+   Gfun(External (EF_builtin "__builtin_read32_reversed"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons (tptr tuint) Tnil) tuint cc_default)) ::
+ (___builtin_write16_reversed,
+   Gfun(External (EF_builtin "__builtin_write16_reversed"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tushort) (Tcons tushort Tnil))
+     tvoid cc_default)) ::
+ (___builtin_write32_reversed,
+   Gfun(External (EF_builtin "__builtin_write32_reversed"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tuint) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_debug,
+   Gfun(External (EF_external "__builtin_debug"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tint Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (_mmap0,
+   Gfun(External (EF_external "mmap0"
+                   (mksignature (AST.Tint :: AST.Tint :: AST.Tint :: nil)
+                     AST.Tint cc_default))
+     (Tcons (tptr tvoid) (Tcons tuint (Tcons tint Tnil))) (tptr tvoid)
+     cc_default)) ::
+ (_munmap,
+   Gfun(External (EF_external "munmap"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     tint cc_default)) :: (_bin2size, Gfun(Internal f_bin2size)) ::
+ (_size2bin, Gfun(Internal f_size2bin)) :: (_bin, Gvar v_bin) ::
+ (_list_from_block, Gfun(Internal f_list_from_block)) ::
+ (_pre_fill, Gfun(Internal f_pre_fill)) ::
+ (_try_pre_fill, Gfun(Internal f_try_pre_fill)) ::
+ (_fill_bin, Gfun(Internal f_fill_bin)) ::
+ (_malloc_small, Gfun(Internal f_malloc_small)) ::
+ (_malloc_large, Gfun(Internal f_malloc_large)) ::
+ (_free_small, Gfun(Internal f_free_small)) ::
+ (_free_large, Gfun(Internal f_free_large)) ::
+ (_free, Gfun(Internal f_free)) :: (_malloc, Gfun(Internal f_malloc)) :: nil).
+
+Definition public_idents : list ident :=
+(_malloc :: _free :: _try_pre_fill :: _pre_fill :: _munmap :: _mmap0 ::
+ ___builtin_debug :: ___builtin_write32_reversed ::
+ ___builtin_write16_reversed :: ___builtin_read32_reversed ::
+ ___builtin_read16_reversed :: ___builtin_fnmsub :: ___builtin_fnmadd ::
+ ___builtin_fmsub :: ___builtin_fmadd :: ___builtin_fmin ::
+ ___builtin_fmax :: ___builtin_expect :: ___builtin_unreachable ::
+ ___builtin_va_end :: ___builtin_va_copy :: ___builtin_va_arg ::
+ ___builtin_va_start :: ___builtin_membar :: ___builtin_annot_intval ::
+ ___builtin_annot :: ___builtin_sel :: ___builtin_memcpy_aligned ::
+ ___builtin_sqrt :: ___builtin_fsqrt :: ___builtin_fabsf ::
+ ___builtin_fabs :: ___builtin_ctzll :: ___builtin_ctzl :: ___builtin_ctz ::
+ ___builtin_clzll :: ___builtin_clzl :: ___builtin_clz ::
+ ___builtin_bswap16 :: ___builtin_bswap32 :: ___builtin_bswap ::
+ ___builtin_bswap64 :: ___builtin_ais_annot :: ___compcert_i64_umulh ::
+ ___compcert_i64_smulh :: ___compcert_i64_sar :: ___compcert_i64_shr ::
+ ___compcert_i64_shl :: ___compcert_i64_umod :: ___compcert_i64_smod ::
+ ___compcert_i64_udiv :: ___compcert_i64_sdiv :: ___compcert_i64_utof ::
+ ___compcert_i64_stof :: ___compcert_i64_utod :: ___compcert_i64_stod ::
+ ___compcert_i64_dtou :: ___compcert_i64_dtos :: ___compcert_va_composite ::
+ ___compcert_va_float64 :: ___compcert_va_int64 :: ___compcert_va_int32 ::
+ nil).
+
+Definition prog : Clight.program := 
+  mkprogram composites global_definitions public_idents _main Logic.I.
+
+

--- a/progs/memmgr/malloc_lemmas.v
+++ b/progs/memmgr/malloc_lemmas.v
@@ -1,0 +1,817 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.msl.iter_sepcon.
+Require Import Lia.
+Require malloc. (*TODO: remove this dependency by making the constants parametrs of ASI_malloc,
+and nstantiate them in VSU_malloc*)
+
+(* This file has background for memmgr that's independent of the program file *)
+
+(*+ misc *)
+
+(* from VFA, for Z.ltb and Z.eqb *)
+Lemma beq_reflect : forall x y, reflect (x = y) (x =? y).
+Proof. intros x y. apply iff_reflect. symmetry. apply Z.eqb_eq. Qed.
+#[export] Hint Resolve Z.ltb_spec0 beq_reflect : bdestruct.
+(*  ReflOmegaCore.ZOmega.IP.beq_reflect beq_reflect : bdestruct. *)
+
+Lemma ble_reflect : forall x y, reflect (x <= y) (x <=? y).
+Proof. intros x y. apply iff_reflect. symmetry. apply Z.leb_le. Qed.
+#[export] Hint Resolve ble_reflect : bdestruct.
+
+Lemma andb_reflect : forall x y, reflect (x = true /\ y = true) (x && y).
+Proof.
+  intros. apply iff_reflect. split.
+  intros [Hx Hy]. subst. reflexivity.
+  unfold andb. simple_if_tac; intuition.
+Qed.
+
+Ltac bdestruct X :=
+  let H := fresh in let e := fresh "e" in
+   evar (e: Prop); assert (H: reflect e X); subst e;
+    [eauto with bdestruct
+    | destruct H as [H|H];
+       [ | try first [apply not_lt in H | apply not_le in H]]].
+
+
+(* A bit of infrastructure for brute force proof of claim3. 
+   TODO consider using Zseq in place of seq in mem_mgr. 
+*)
+Definition Zseq n := 
+  if n <? 0 then [] else map Z.of_nat (seq 0 (Z.to_nat n)).
+
+Lemma in_Zseq: forall len n : Z, len >= 0 -> ( In n (Zseq len) <-> (0 <= n < len) ). 
+Proof.
+  intros. unfold Zseq.  bdestruct (len <? 0); try lia. clear H0.
+  rewrite in_map_iff. split.
+  - intros. destruct H0. destruct H0. 
+    rewrite in_seq in H1.
+    rewrite <- H0. split. rep_lia. destruct H1. simpl in H2.
+    apply inj_lt in H2. rewrite Z2Nat.id in H2 by lia. auto.
+  - intro. exists (Z.to_nat n).
+    split; try rep_lia.
+    rewrite in_seq.
+    assert (0 <= Z.to_nat n)%nat by (destruct H0; lia). 
+    simpl. split; try lia.
+Qed.
+
+Lemma forall_Forall_range: 
+     forall (P : Z -> Prop) (n : Z), 0 <= n ->
+       ( (forall x, 0 <= x < n -> P x) <-> Forall P (Zseq n) ).
+Proof.
+  intros.
+  assert (Hi:  
+          (forall x : Z, 0 <= x < n -> P x) <->  (forall x : Z, In x (Zseq n) -> P x)).
+  { split. - intros; apply H0; rewrite <- in_Zseq; try lia; auto.
+    - intros; apply H0; rewrite in_Zseq; try lia. }
+  rewrite Hi. rewrite Forall_forall. reflexivity.
+Qed.
+
+(* background for upd_Znth_same_val, belongs in a library *)
+Lemma list_extensional {A}{d: Inhabitant A}: 
+  forall (xs ys: list A),
+  Zlength xs = Zlength ys ->
+  (forall i, 0 <= i < Zlength xs -> Znth i xs = Znth i ys) -> xs = ys.
+Proof.
+  intros xs.
+  induction xs. 
+  - intros [|w ws] H Hi. reflexivity.
+    rewrite Zlength_nil in H. rewrite Zlength_cons in H. 
+    assert (0 <= Zlength ws) by apply Zlength_nonneg. lia.
+  - intros [|w ws] H Hi. 
+    rewrite Zlength_nil in H; rewrite Zlength_cons in H. 
+    assert (H0: 0 <= Zlength xs) by apply Zlength_nonneg; lia.
+    specialize (IHxs ws). 
+    assert (H1: Zlength xs = Zlength ws) by 
+        ( do 2 rewrite Zlength_cons in H; apply Z.succ_inj in H; auto).
+    assert (H2: 0<=0<Zlength (a::xs)) by 
+        (split; try lia; rewrite Zlength_cons; rep_lia).
+    assert (H3: Znth 0 (a :: xs) = Znth 0 (w :: ws)) by (apply Hi; auto).
+    apply IHxs in H1.
+    + subst. apply Hi in H2. do 2 rewrite Znth_0_cons in H2. subst. reflexivity.
+    + apply Hi in H2. do 2 rewrite Znth_0_cons in H2.  subst. 
+      intros. specialize (Hi (i+1)).   do 2 rewrite Znth_pos_cons in Hi; try lia.
+      replace (i+1-1) with i in Hi by lia.
+      apply Hi. split; try lia. rewrite Zlength_cons; rep_lia.
+Qed.
+
+Lemma upd_Znth_same_val {A} {d: Inhabitant A}:
+  forall n (xs: list A), 0 <= n < Zlength xs ->
+   (upd_Znth n xs (Znth n xs)) = xs.
+Proof.
+  intros.  symmetry.  eapply list_extensional.
+  rewrite upd_Znth_Zlength; auto.
+  intros.  bdestruct (n =? i).
+  - subst. rewrite upd_Znth_same; auto. 
+  - rewrite upd_Znth_diff; auto.
+Qed.
+
+Lemma upd_Znth_twice {A} {d: Inhabitant A}:
+forall n x y (xs:list A),
+   0 <= n < Zlength xs ->
+   (upd_Znth n (upd_Znth n xs x) y) = (upd_Znth n xs y).
+Proof.
+  intros n x y xs H. symmetry.
+  eapply list_extensional.
+  repeat (rewrite upd_Znth_Zlength; auto).
+  intros. bdestruct (n =? i).
+  - subst. repeat rewrite upd_Znth_same; auto. 
+    rewrite upd_Znth_Zlength in *; auto.
+  - assert (0 <= i < Zlength xs) by (rewrite upd_Znth_Zlength in H0; auto). 
+    repeat rewrite upd_Znth_diff; auto;
+    rewrite upd_Znth_Zlength in *; auto.
+Qed. 
+
+
+Definition zip3 (bs:list nat) (cs:list val) (ds:list Z) := (combine (combine bs cs) ds).
+
+Lemma Zlength_zip3:
+   forall bs cs ds,
+   Zlength bs = Zlength cs -> Zlength cs = Zlength ds ->
+   Zlength (zip3 bs cs ds) = Zlength bs.
+Proof.
+  intros bs cs ds Hbc Hcd.  unfold zip3.  do 2 rewrite Zlength_correct in *.
+  do 2 rewrite combine_length.  
+  do 2 rewrite Nat2Z.inj_min. rewrite Hbc. rewrite <- Hcd.  
+  rewrite Z.min_r; try reflexivity.  rewrite Z.min_r; try reflexivity.
+Qed.
+
+Lemma Znth_zip3:
+   forall bs cs ds n,
+   Zlength bs = Zlength cs -> Zlength cs = Zlength ds ->
+   0 <= n < Zlength bs ->
+   Znth n (zip3 bs cs ds) = (Znth n bs, Znth n cs, Znth n ds).
+Proof.
+  intros bs cs ds n Hbc Hcd Hn. 
+  pose proof (Zlength_zip3 bs cs ds Hbc Hcd) as Hz.
+  unfold zip3. rewrite <- nth_Znth.
+- rewrite combine_nth. rewrite combine_nth.
+  rewrite nth_Znth; try lia. rewrite nth_Znth; try lia.
+  rewrite nth_Znth; try lia; reflexivity.
+  repeat rewrite Zlength_correct in *; lia. rewrite combine_length. 
+  assert (H3: length bs = length cs) by (repeat rewrite Zlength_correct in *; lia).
+  assert (H4: length cs = length ds) by (repeat rewrite Zlength_correct in *; lia).
+  rewrite H3; rewrite H4; rewrite Nat.min_id; reflexivity.
+- unfold zip3 in Hz; lia.
+Qed.
+
+
+Lemma sublist_zip3:
+forall i j bs cs ds, 
+  0 <= i <= j -> j <= Zlength bs ->
+  Zlength bs = Zlength cs -> Zlength cs = Zlength ds ->
+(sublist i j (zip3 bs cs ds)) = 
+(zip3 (sublist i j bs) (sublist i j cs) (sublist i j ds)).
+Proof. 
+  intros.  destruct H as [Hi Hij]. 
+  apply list_extensional.
+  - repeat (try rewrite Zlength_sublist; try rewrite Zlength_zip3; try lia).
+  - intros.  destruct H as [Hi0lo Hi0hi].
+  assert (Hi0: i0 < j - i) by
+    (rewrite Zlength_sublist in Hi0hi; auto; rewrite Zlength_zip3; try lia).
+  repeat (try rewrite Znth_sublist; try rewrite Znth_zip3; try rewrite Zlength_sublist; 
+          try lia); auto.
+Qed.
+
+Lemma In_zip3:
+  forall x bs cs ds,
+    In x (zip3 bs cs ds) -> 
+    In (fst (fst x)) bs /\ In (snd (fst x)) cs /\ In (snd x) ds.
+Proof.
+intros.
+assert (Hx: In (fst x) (combine bs cs)).
+{ unfold zip3 in *.
+eapply in_combine_l with (y:=snd x).
+rewrite <- surjective_pairing. apply H.
+}
+split3.
+- eapply in_combine_l with (y:=snd (fst x)).
+  rewrite <- surjective_pairing. apply Hx.
+- unfold zip3 in *.
+  eapply in_combine_r with (x:=fst (fst x)).
+  rewrite <- surjective_pairing. apply Hx.
+- unfold zip3 in *.
+  eapply in_combine_r with (x:=fst x).
+  rewrite <- surjective_pairing. 
+  apply H.
+Qed.
+
+Lemma Zdiv_prod:
+  forall a b c, (a*b|c) -> (a|c).
+Proof.
+  intros. unfold Z.divide in *. destruct H as [z Hz]. exists (z*b)%Z. lia.
+Qed.
+
+Ltac simple_if_tac' H := 
+  match goal with |- context [if ?A then _ else _] => 
+    lazymatch type of A with
+    | bool => destruct A eqn: H
+    | sumbool _ _ => fail "Use if_tac instead of simple_if_tac, since your expression "A" has type sumbool"
+    | ?t => fail "Use simple_if_tac only for bool; your expression"A" has type" t
+  end end.
+Ltac simple_if_tac'' := let H := fresh in simple_if_tac' H.
+
+
+(*+ VST related *)
+
+
+(* maybe some of the next lemmas belong in floyd *)
+
+Lemma malloc_compatible_prefix:
+  forall n s p, 0 <= n <= s -> 
+  malloc_compatible s p -> malloc_compatible n p.
+Proof.
+  intros n s p H H0; unfold malloc_compatible in *; destruct p; try auto.
+  destruct H0. split; try assumption; rep_lia.
+Qed.
+
+Lemma malloc_compatible_offset:
+  forall n m p, 0 <= n -> 0 <= m ->
+  malloc_compatible (n+m) p -> (natural_alignment | m) -> 
+  malloc_compatible n (offset_val m p).
+Proof.
+  intros n m p Hn Hm Hp Ha. unfold malloc_compatible in *.
+  destruct p; try auto. destruct Hp as [Hi Hinm]. simpl.  split.
+- replace (Ptrofs.unsigned (Ptrofs.add i (Ptrofs.repr m)))
+     with (m + (Ptrofs.unsigned i)).
+  apply Z.divide_add_r; auto.
+  rewrite Ptrofs.add_unsigned;
+  rewrite Ptrofs.unsigned_repr; rewrite Ptrofs.unsigned_repr;
+     try lia; try split; try rep_lia. 
+- replace (Ptrofs.unsigned (Ptrofs.add i (Ptrofs.repr m)))
+     with (m + (Ptrofs.unsigned i)); try rep_lia. 
+  rewrite Ptrofs.add_unsigned;
+  rewrite Ptrofs.unsigned_repr; rewrite Ptrofs.unsigned_repr;
+     try lia; try split; try rep_lia. 
+Qed. 
+
+Lemma malloc_compatible_offset_isptr:
+  forall n m q, malloc_compatible n (offset_val m q) -> isptr q.
+Proof. intros. destruct q; auto. unfold isptr; auto. 
+Qed.
+
+Ltac mcoi_tac := 
+  eapply malloc_compatible_offset_isptr;  
+  match goal with | H: malloc_compatible _ _ |- _ => apply H end.
+
+(* variations on VST's memory_block_split *)
+Local Open Scope logic.
+
+Lemma memory_block_split_repr:
+  forall (sh : share) (b : block) (ofs : ptrofs) (n m : Z), 0 <= n -> 0 <= m ->
+       n + m <= n + m + (Ptrofs.unsigned ofs) < Ptrofs.modulus -> 
+       memory_block sh (n + m) (Vptr b ofs) =
+       memory_block sh n (Vptr b ofs) *
+       memory_block sh m (Vptr b (Ptrofs.add ofs (Ptrofs.repr n))).
+Proof.
+  intros sh b ofs n m Hn Hm Hnm.
+  assert (Hofs: ofs = (Ptrofs.repr (Ptrofs.unsigned ofs)))
+    by (rewrite Ptrofs.repr_unsigned; auto). 
+  rewrite Hofs.
+  normalize.
+  erewrite memory_block_split; try assumption.
+  reflexivity.
+Qed.
+
+Lemma memory_block_split_offset:
+  forall (sh : share) (p : val) (n m : Z), 0 <= n -> 0 <= m ->
+       memory_block sh (n + m) p =
+       memory_block sh n p *
+       memory_block sh m (offset_val n p).
+Proof.
+  intros sh p n m Hn Hm.
+  apply pred_ext. (* to enable use of entailer - at cost of duplicate proof *)
+  - (* LHS |-- RHS *)
+    destruct p; try entailer!.
+    rewrite <- offset_val_unsigned_repr.
+    simpl.
+    rewrite memory_block_split_repr; try assumption. 
+    + entailer!. 
+      rewrite Ptrofs.unsigned_repr. cancel.
+      unfold size_compatible' in *; rep_lia. 
+    + unfold size_compatible' in *; rep_lia.
+  - (* RHS |-- LHS 
+       TODO almost same proof, followed by clumsy finish *)
+    destruct p; try entailer!. 
+    rewrite <- offset_val_unsigned_repr.
+    simpl.  rewrite memory_block_split_repr; try assumption. 
+    entailer!. rewrite Ptrofs.unsigned_repr. cancel.
+    unfold size_compatible' in *. rep_lia. 
+    unfold size_compatible' in *.
+    split. rep_lia. 
+    simpl in *.
+    rewrite Ptrofs.modulus_eq32; try unfold Archi.ptr64; auto.
+    replace (n+m+Ptrofs.unsigned i) with ((n + Ptrofs.unsigned i)+m) by lia.
+    assert (Hni: 
+              n + Ptrofs.unsigned i = (Ptrofs.unsigned (Ptrofs.add i (Ptrofs.repr n)))).
+    { rewrite Ptrofs.add_unsigned. rewrite Ptrofs.unsigned_repr; try rep_lia.
+      rewrite Ptrofs.unsigned_repr; try rep_lia. 
+      split; try rep_lia. rewrite Ptrofs.unsigned_repr; rep_lia. 
+    }
+    rewrite Hni; rep_lia.
+Qed.
+
+(* Two lemmas from hashtable exercise *)
+Lemma iter_sepcon_1:
+  forall {A}{d: Inhabitant A} (a: A) (f: A -> mpred), iter_sepcon f [a] = f a.
+Proof. intros. unfold iter_sepcon. normalize. 
+Qed.
+
+Lemma iter_sepcon_split3: 
+  forall {A}{d: Inhabitant A} (i: Z) (al: list A) (f: A -> mpred),
+   0 <= i < Zlength al   -> 
+  iter_sepcon f al = 
+  iter_sepcon f (sublist 0 i al) * f (Znth i al) * iter_sepcon f (sublist (i+1) (Zlength al) al).
+Proof. 
+  intros. rewrite <- (sublist_same 0 (Zlength al) al) at 1 by auto.
+  rewrite (sublist_split 0 i (Zlength al)) by rep_lia.
+  rewrite (sublist_split i (i+1) (Zlength al)) by rep_lia.
+  rewrite sublist_len_1 by rep_lia.
+  rewrite iter_sepcon_app. rewrite iter_sepcon_app. rewrite iter_sepcon_1.
+  rewrite sepcon_assoc. reflexivity.
+Qed.
+
+(* Pointer misc *)
+
+Lemma weak_valid_pointer_end:
+forall p,
+valid_pointer (offset_val (-1) p) |-- weak_valid_pointer p.
+Proof.
+intros.
+unfold valid_pointer, weak_valid_pointer.
+change predicates_hered.orp with orp. (* delete me *)
+apply orp_right2.
+destruct p; try solve [simpl; auto].
+all: try apply derives_refl.
+simpl.
+change predicates_hered.FF with FF. apply FF_left.
+unfold offset_val.
+hnf.
+Transparent Nveric.
+red.
+Opaque Nveric.
+red.
+hnf; intros; try contradiction.
+simpl.
+replace (Ptrofs.unsigned i + -1)
+with (Ptrofs.unsigned (Ptrofs.add i (Ptrofs.repr (-1))) + 0); auto.
+(*clear H.
+rewrite Z.add_0_r. *)
+Abort.  (* Not true *)
+
+Lemma max_unsigned_32: Ptrofs.max_unsigned = Int.max_unsigned.
+Proof.
+  unfold Ptrofs.max_unsigned, Int.max_unsigned.
+  unfold Ptrofs.modulus, Int.modulus.
+  unfold Ptrofs.wordsize, Int.wordsize.
+  unfold Wordsize_Ptrofs.wordsize, Wordsize_32.wordsize.
+  unfold Archi.ptr64.
+  reflexivity.
+Qed.
+
+Lemma ptrofs_add_for_alignment:
+   forall poff n, 0 <= n -> Ptrofs.unsigned poff + n <= Ptrofs.max_unsigned ->
+     Ptrofs.unsigned (Ptrofs.add poff (Ptrofs.repr n))
+     = Ptrofs.unsigned poff + n. 
+Proof.
+  intros.
+  replace poff with (Ptrofs.repr(Ptrofs.unsigned poff)) at 1
+    by (rewrite Ptrofs.repr_unsigned; reflexivity).
+  rewrite ptrofs_add_repr.
+  rewrite Ptrofs.unsigned_repr; try reflexivity.
+  split.
+  assert (0 <= Ptrofs.unsigned poff) by apply Ptrofs.unsigned_range.
+  rep_lia.
+  assumption.
+Qed.
+
+
+(*+ constants *)
+
+(* These constants should have the same values as the same-named constants
+   in the code. *)
+
+Definition WORD: Z := 4.  (* sizeof(size_t) is 4 for 32bit Clight *)
+Definition ALIGN: Z := 2.
+Definition BINS: Z.
+   let x := constr:(gvar_info malloc.v_bin) in
+   let x := eval simpl in x in 
+   match x with tarray _ ?B => exact B
+   end.
+Defined.
+
+Definition BIGBLOCK: Z := ((Z.pow 2 17) * WORD).
+Definition WA: Z := (WORD*ALIGN) - WORD. (* WASTE at start of block *)
+
+(* Note re CompCert 3: I'm currently using tuint for what in the code
+is size_t.  That works for 32bit mode.  To generalize the proof
+to 64bit as well, it may work to replace tuint by t_size_t defined like 
+t_size_t := if Archi.ptr64 then tulong else tuint
+*)
+
+Lemma WORD_ALIGN_aligned:
+  (natural_alignment | WORD * ALIGN)%Z.
+Proof. unfold natural_alignment, WORD, ALIGN; simpl. apply Z.divide_refl. Qed.
+
+
+(* The following hints empower rep_lia and lessen the need for 
+   manually unfolding the constant definitions. *)
+
+Ltac compute_eq A := let x := eval vm_compute in A in
+    exact (A = x).
+
+Lemma BINS_eq: ltac:(compute_eq BINS).  Proof. reflexivity. Qed.
+#[export] Hint Rewrite BINS_eq : rep_lia.
+Global Opaque BINS. (* make rewrites only happen in rep_lia *)
+
+Lemma BIGBLOCK_eq: ltac:(compute_eq BIGBLOCK).  Proof. reflexivity. Qed.
+#[export] Hint Rewrite BIGBLOCK_eq : rep_lia.
+Global Opaque BIGBLOCK.
+
+Lemma WORD_eq: ltac:(compute_eq WORD).  Proof. reflexivity. Qed.
+#[export] Hint Rewrite WORD_eq : rep_lia.
+Global Opaque WORD.
+
+Lemma ALIGN_eq: ltac:(compute_eq ALIGN).  Proof. reflexivity. Qed.
+#[export] Hint Rewrite ALIGN_eq : rep_lia.
+Global Opaque ALIGN.
+
+Lemma WA_eq: ltac:(compute_eq WA).  Proof. reflexivity. Qed.
+#[export] Hint Rewrite WA_eq : rep_lia.
+Global Opaque WA.
+
+(*+ bin/size conversions and their properties *)
+
+Definition bin2sizeZ := fun b: Z => (((b+1)*ALIGN - 1) * WORD)%Z. 
+
+Definition size2binZ : Z -> Z := fun s => 
+   if (bin2sizeZ(BINS-1)) <? s 
+   then -1 
+   else (s+(WORD * (ALIGN-1))-1) / (WORD * ALIGN).
+
+Lemma bin2size_range: 
+  forall b, 0 <= b < BINS -> 
+    WORD <= bin2sizeZ b <= bin2sizeZ(BINS-1). 
+Proof. intros. unfold bin2sizeZ in *. split; simpl in *; try rep_lia. Qed.
+
+Lemma  bin2sizeBINS_eq: ltac:(compute_eq (bin2sizeZ(BINS-1))).
+Proof. reflexivity. Qed.
+#[export] Hint Rewrite bin2sizeBINS_eq: rep_lia.
+
+Lemma bin2size_align:
+  forall b, 0 <= b < BINS -> (natural_alignment | bin2sizeZ b + WORD).
+Proof. (* by counting in unary *)
+  apply forall_Forall_range; try rep_lia; rewrite BINS_eq; rewrite WORD_eq.
+  unfold natural_alignment.
+  cbn.
+  repeat constructor;
+  (apply Zmod_divide; [intro Hx; inv Hx | reflexivity ]).
+Qed.
+
+
+Lemma size2bin_range: 
+  forall s, 0 <= s <= bin2sizeZ(BINS-1) -> 0 <= size2binZ s < BINS.
+Proof. 
+  intros. unfold size2binZ. 
+  bdestruct (bin2sizeZ (BINS - 1) <? s); try lia.
+  rewrite bin2sizeBINS_eq in *.
+  rewrite WORD_eq. rewrite ALIGN_eq. rewrite BINS_eq. simpl. 
+  replace (s + 4 - 1) with (s + 3) by lia.
+  split.
+  - apply Z.div_pos; rep_lia.
+  - apply Z.div_lt_upper_bound; rep_lia.
+Qed.
+
+Fact small_chunks_nonempty: bin2sizeZ(size2binZ(0)) > 0.
+Proof. reflexivity. Qed.
+
+Lemma claim1: forall s, 
+  s <= bin2sizeZ(BINS-1) -> s <= bin2sizeZ(size2binZ s).
+Proof. 
+  intros s H. 
+  unfold bin2sizeZ, size2binZ in *. 
+  bdestruct (bin2sizeZ (BINS - 1) <? s); try rep_lia.
+  rewrite WORD_eq in *; rewrite ALIGN_eq in *; rewrite BINS_eq in *.
+  simpl in *; clear H0.
+  replace ((((s + 4 - 1) / 8 + 1) * 2 - 1) * 4)%Z
+     with ((s + 4 - 1) / 8 * 8 + 4)%Z by lia.
+  replace (s + 4 - 1)%Z with (s + 3) by lia.
+ (*OLD proof
+  assert (Zmod_eq': forall a b, b > 0 -> (a / b * b)%Z = a - a mod b) 
+     by (intros; rewrite Zmod_eq; lia);
+  rewrite Zmod_eq' by lia; clear Zmod_eq'.
+  replace (s + 3 - (s + 3) mod 8 + 4)%Z  with (s + 7 - (s + 3) mod 8)%Z by lia.
+  assert ( 0 <= (s+3) mod 8 < 8 ) by (apply Z_mod_lt; lia); lia.*)
+
+  (*NOW:*)
+  specialize (Z_div_mod (s + 3) 8); intros X.
+  destruct (Z.div_eucl (s + 3) 8) as [eu1 eu2]; lia.
+Qed.
+
+Lemma claim2: forall s, 
+  0 <= s <= bin2sizeZ(BINS-1) -> 0 <= size2binZ s < BINS.
+Proof. 
+  intros; unfold bin2sizeZ in *; unfold size2binZ.
+  rewrite WORD_eq in *;  rewrite ALIGN_eq in *.
+  bdestruct (bin2sizeZ (BINS - 1) <? s); try rep_lia.
+  rewrite Z.sub_add in H.
+  change (4*(2-1))%Z with 4.
+  simpl.
+  split.
+  apply Z.div_pos; try lia.
+  apply Z.div_lt_upper_bound; try lia.
+Qed.
+
+Lemma claim3: forall s, 0 <= s <= bin2sizeZ(BINS-1) 
+    -> size2binZ(bin2sizeZ(size2binZ(s))) = size2binZ(s).
+Proof. 
+  intros. 
+  pose proof ((size2bin_range s) H). 
+  pose proof ((bin2size_range (size2binZ(s))) H0).
+  unfold size2binZ.
+  bdestruct (bin2sizeZ (BINS - 1) <? s).
+  bdestruct (bin2sizeZ (BINS - 1) <? bin2sizeZ (-1)); try lia.
+  bdestruct (bin2sizeZ (BINS - 1) <?
+             bin2sizeZ ((s + WORD * (ALIGN - 1) - 1) / (WORD * ALIGN))).
+  - rewrite WORD_eq in *;  rewrite ALIGN_eq in *;  simpl.
+    replace (s + 4 - 1) with (s + 3) by lia.
+    exfalso; clear H2.
+    replace  ((s + 4 * (2 - 1) - 1) / (4 * 2)) with (size2binZ s) in H3; try lia. 
+    unfold size2binZ; bdestruct (bin2sizeZ (BINS - 1) <? s); try lia.
+    rewrite WORD_eq in *; rewrite ALIGN_eq in *; lia.
+  - unfold bin2sizeZ; rewrite WORD_eq in *;  rewrite ALIGN_eq in *; simpl.
+    (* gave up fumbling with algebra; 
+       finish by evaluation, of enumerating the values of s in a list *)
+    assert (Htest: forall s,  0 <= s < bin2sizeZ(BINS-1) + 1 -> 
+      ((((s + 4 - 1) / 8 + 1) * 2 - 1) * 4 + 4 - 1) / 8  = (s + 4 - 1) / 8).
+    { set (Q:=fun t => 
+                ((((t + 4 - 1) / 8 + 1) * 2 - 1) * 4 + 4 - 1) / 8  = (t + 4 - 1) / 8).
+      assert (Hs: 0 <= s < bin2sizeZ(BINS - 1) + 1) by lia.
+      assert (Hb: 0 <= bin2sizeZ(BINS - 1) + 1) by lia.
+      pose proof (forall_Forall_range Q ((bin2sizeZ (BINS - 1))+1) Hb). 
+      clear H1 H2 H3 Hb; unfold Q in H4; rewrite H4.
+      rewrite bin2sizeBINS_eq. simpl. cbn.
+      repeat constructor.
+    }
+    apply (Htest s); lia.
+Qed.
+
+(* TODO another brute force proof; can use this and claim2 to prove claim3 *)
+Lemma bin2size2bin_id: 
+  forall b, 0 <= b < BINS -> size2binZ (bin2sizeZ b) = b.
+Proof.
+  set (Q:= fun x => size2binZ(bin2sizeZ x) = x).
+  assert (HB: 0 <= BINS) by rep_lia.
+  pose proof (forall_Forall_range Q BINS HB). 
+  unfold  Q in H. rewrite H. rewrite BINS_eq.
+  cbn. repeat constructor.
+Qed.
+
+Lemma bin2size2bin_small:
+  forall s, s >= 0 -> s <= bin2sizeZ(BINS - 1) -> size2binZ s < BINS.
+Proof. intros. apply claim2; rep_lia. Qed.
+
+Lemma bin2siz2e2bin_large:
+  forall s, bin2sizeZ(BINS - 1) < s -> size2binZ s = -1.
+Proof.
+  intros. unfold size2binZ. bdestruct (bin2sizeZ(BINS-1) <? s). reflexivity. contradiction.
+Qed.
+
+(* BIGBLOCK needs to be big enough for at least one chunk of the 
+largest size, because list_from_bin unconditionally initializes the last chunk. *)
+Lemma BIGBLOCK_enough: (* and not too big *)
+  forall s, 0 <= s <= bin2sizeZ(BINS-1) ->  
+            0 < (BIGBLOCK - WA) / (s + WORD) < Int.max_signed.
+Proof.
+  intros; rewrite bin2sizeBINS_eq in *; split. 
+  apply Z.div_str_pos; rep_lia.
+  rewrite Z_div_lt; rep_lia.
+Qed.
+
+Lemma BIGBLOCK_enough_j: 
+  forall s j, 0 <= s -> j < (BIGBLOCK-WA) / (s+WORD) ->
+              (s+WORD) <= (BIGBLOCK-WA) - (j * (s+WORD)).
+Proof.
+  assert (Hlem: forall sw j bw, 0 < sw -> 0 < bw -> j < bw / sw -> sw <= bw - j*sw).
+  { intros. assert (j+1 <= bw/sw) by lia.
+    assert (bw/sw*sw <= bw) by (rewrite Z.mul_comm; apply Z.mul_div_le; rep_lia).
+    assert ((j+1)*sw <= bw/sw*sw) by (apply Zmult_le_compat_r; rep_lia).
+    assert ((j+1)*sw <= bw) by rep_lia.
+    replace ((j+1)*sw)%Z with (sw + j*sw)%Z in *.
+    rep_lia. replace (j+1) with (Z.succ j) by lia; rewrite Z.mul_succ_l; lia.
+  }
+  intros; apply Hlem; try rep_lia.
+Qed.
+
+Lemma malloc_compat_WORD_q:
+(* consequence of the list_from_block loop invariant: remainder of big block is aligned *)
+forall N j p s q,
+  malloc_compatible BIGBLOCK p ->
+  N = (BIGBLOCK-WA) / (s+WORD) -> 
+  0 <= j < N ->
+  0 <= s <= bin2sizeZ(BINS-1) ->  
+  q = (offset_val (WA+(j*(s+WORD))) p) -> 
+  (natural_alignment | (s + WORD)) -> 
+  malloc_compatible (BIGBLOCK - (WA + j * (s + WORD)) - WORD) (offset_val WORD q).
+Proof.
+  intros N j p s q H HN Hj Hs Hq Ha.
+  replace (offset_val (WA + (j*(s+WORD))) p) with
+          (offset_val WA (offset_val (j*(s+WORD)) p)) in Hq.
+  2: (rewrite offset_offset_val; 
+      replace (j * (s + WORD) + WA) with (WA + j * (s + WORD)) by lia; reflexivity).
+  subst q. do 2 rewrite offset_offset_val.
+  apply malloc_compatible_offset.
+  - pose proof (BIGBLOCK_enough_j s j) as He.
+    destruct Hj as [Hj0 Hj1]; destruct Hs as [Hs0 Hs1]; subst N.
+    apply He in Hs0 as H0; auto.
+    replace (BIGBLOCK - (WA + j * (s + WORD)) - WORD)
+      with (BIGBLOCK - WA - j * (s + WORD) - WORD) by lia.
+    apply Zle_minus_le_0.
+    rep_lia.
+  - apply Z.add_nonneg_nonneg; try rep_lia.
+(*    apply Z.mul_nonneg_nonneg; try rep_lia.*)
+  - replace (BIGBLOCK - (WA + j * (s + WORD)))%Z
+      with (BIGBLOCK - WA - j * (s + WORD))%Z by lia.
+    replace (BIGBLOCK - WA - j * (s + WORD) - WORD + (j * (s + WORD) + (WA + WORD)))%Z
+    with BIGBLOCK by lia; auto.
+  - assert ((natural_alignment | WA+WORD)) 
+      by (pose proof WORD_ALIGN_aligned; change (WA+WORD) with (WORD*ALIGN)%Z; auto).
+    apply Z.divide_add_r; try auto. 
+    apply Z.divide_mul_r; try auto. 
+Qed.
+
+(*+ resource vectors to support pre_fill *) 
+
+(* Note on design: 
+The interface specs could be done in terms of a vector indexed on request sizes.
+Instead we index on bin number.  
+The bin size corresponds to the free list length; we use Z bin size, for 
+compatibility with other VST interfaces.
+
+TODO maxSmallChunk should be constant in the C code too, at least in free.  
+*)
+
+Definition resvec := list Z. (* resource vector *)
+
+Definition no_neg rvec : Prop := Forall (fun n => 0 <= n) rvec.
+
+Definition emptyResvec : resvec := repeat 0 (Z.to_nat BINS).  
+
+Definition maxSmallChunk := bin2sizeZ(BINS-1).
+
+Lemma maxSmallChunk_eq: ltac:(compute_eq maxSmallChunk).  Proof. reflexivity. Qed.
+#[export] Hint Rewrite maxSmallChunk_eq : rep_lia.
+Global Opaque maxSmallChunk. (* make rewrites only happen in rep_lia *)
+
+(* requested size n fits a bin and the bin is nonempty *)
+Definition guaranteed (rvec: resvec) (n: Z): bool :=
+  (Zlength rvec =? BINS) && (0 <=? n) && (n <=? maxSmallChunk) &&   
+  (0 <? Znth (size2binZ n) rvec).
+
+(* add m to size of bin b *)
+Definition add_resvec (rvec: resvec) (b: Z) (m: Z): resvec :=
+   if ((Zlength rvec =? BINS) && (0 <=? b) && (b <? BINS))%bool
+   then upd_Znth b rvec (Znth b rvec + m)
+   else rvec.
+
+Definition eq_except (rv rv': resvec) (b: Z): Prop :=
+  Zlength rv = Zlength rv' /\
+  forall i, 0 <= i < Zlength rv -> i <> b -> Znth i rv = Znth i rv'.
+
+(* number of chunks obtained from one BIGBLOCK, for bin b *)
+Definition chunks_from_block (b: Z): Z := 
+   if ((0 <=? b) && (b <? BINS))%bool
+   then (BIGBLOCK - WA) / ((bin2sizeZ b) + WORD)
+   else 0.
+
+Lemma chunks_from_block_nonneg:
+  forall b, 0 <= chunks_from_block b.
+Proof.
+intros.
+unfold chunks_from_block.
+bdestruct (0 <=? b); simpl; [ | lia].
+bdestruct (b <? BINS); simpl; [ | lia].
+exploit (bin2size_range b); intros. lia.
+exploit (BIGBLOCK_enough (bin2sizeZ b)); intros. rep_lia.
+(*Old proof: rep_lia.*)
+(*Now*)
+  specialize (Z_div_mod (BIGBLOCK - WA) (bin2sizeZ b + WORD)); intros X.
+  destruct (Z.div_eucl (BIGBLOCK - WA) (bin2sizeZ b + WORD)) as [eu1 eu2]; rep_lia.
+Qed.
+
+Lemma chunks_from_block_pos:
+  forall b, 0 <= b < BINS -> 0 < chunks_from_block b.
+Proof.
+intros.
+unfold chunks_from_block.
+bdestruct (0 <=? b); simpl; [ | lia].
+bdestruct (b <? BINS); simpl; [ | lia].
+exploit (bin2size_range b); intros. lia.
+exploit (BIGBLOCK_enough (bin2sizeZ b)); intros. rep_lia.
+(*Old proof: rep_lia.*)
+(*Now*)
+  specialize (Z_div_mod (BIGBLOCK - WA) (bin2sizeZ b + WORD)); intros X.
+  destruct (Z.div_eucl (BIGBLOCK - WA) (bin2sizeZ b + WORD)) as [eu1 eu2]; rep_lia.
+Qed.
+
+Lemma Zlength_add_resvec:
+  forall rvec b m,
+  Zlength (add_resvec rvec b m) = Zlength rvec.
+Proof.
+intros. unfold add_resvec.
+bdestruct (Zlength rvec =? BINS); simpl; auto.
+bdestruct (0 <=? b); simpl; auto.
+bdestruct (b <? BINS); simpl; auto.
+apply upd_Znth_Zlength.
+lia.
+Qed.
+
+Lemma add_resvec_no_neg:
+  forall rvec b m, no_neg rvec -> 0 <= m + Znth b rvec -> no_neg (add_resvec rvec b m).
+Proof.
+intros.
+unfold add_resvec.
+bdestruct (Zlength rvec =? BINS); simpl; auto.
+bdestruct (0 <=? b); simpl; auto.
+bdestruct (b <? BINS); simpl; auto.
+unfold no_neg. rewrite Z.add_comm.
+unfold upd_Znth. if_tac.
++ apply Forall_app.
+  split.
+  - apply Forall_sublist; auto.
+  - constructor. lia.
+    apply Forall_sublist; auto.
++ lia.
+Qed.
+
+Lemma add_resvec_eq_except:
+  forall rvec b m, eq_except (add_resvec rvec b m) rvec b.
+Proof.
+intros. unfold eq_except. split.
+rewrite Zlength_add_resvec; auto.
+intros. unfold add_resvec.
+bdestruct (Zlength rvec =? BINS); simpl; auto.
+bdestruct (0 <=? b); simpl; auto.
+bdestruct (b <? BINS); simpl; auto.
+rewrite upd_Znth_diff; try rep_lia. rewrite Zlength_add_resvec in *; auto.
+Qed.
+
+Lemma eq_except_reflexive:
+  forall rvec b, eq_except rvec rvec b.
+Proof.
+  intros. unfold eq_except. split; reflexivity.
+Qed.
+
+Lemma guaranteed_reflect:
+  forall lens n, 
+    reflect (Zlength lens = BINS /\ 0 <= n <= maxSmallChunk /\ 0 < Znth (size2binZ n) lens)
+            (guaranteed lens n).
+Proof.
+intros.
+apply iff_reflect.
+split; intros.
+- destruct H as [Hlen [[Hn Hnb] Hnz]].
+  unfold guaranteed.
+ bdestruct (Zlength lens =? BINS); try contradiction.
+ bdestruct (0 <=? n); try contradiction.
+ bdestruct (n <=? maxSmallChunk); try contradiction.
+ bdestruct (0 <? Znth (size2binZ n) lens); try contradiction.
+ auto.
+- unfold guaranteed in H.
+ bdestruct (Zlength lens =? BINS); try discriminate.
+ bdestruct (0 <=? n); try discriminate.
+ bdestruct (n <=? maxSmallChunk); try discriminate.
+ bdestruct (0 <? Znth (size2binZ n) lens); try discriminate.
+ auto.
+Qed.
+
+(* TODO are the following three lemmas useful to clients?
+   Otherwise they can go in the code verifications where each is used once. *)
+
+Lemma is_guaranteed: forall lens n, 
+   guaranteed lens n = true -> 0 < Znth (size2binZ n) lens.
+Proof.
+  intros. destruct (guaranteed_reflect lens n) as [Ht|Hf].
+  destruct Ht as [Hlen [[Hn Hnb] Hnz]]. assumption. inv H.
+Qed.
+
+Lemma large_not_guaranteed: forall lens n,
+  maxSmallChunk < n -> guaranteed lens n = false.
+Proof.
+  intros. destruct (guaranteed_reflect lens n) as [Ht|Hf].
+  destruct Ht as [Hlen [[Hn Hnb] Hnz]]. rep_lia. reflexivity.
+Qed.
+
+Lemma small_not_guaranteed_zero:
+  forall rvec n, Zlength rvec = BINS -> 0 <= n <= maxSmallChunk -> no_neg rvec ->
+            guaranteed rvec n = false -> Znth (size2binZ n) rvec = 0.
+Proof.
+intros. unfold guaranteed in *.
+unfold no_neg in *.
+bdestruct (Zlength rvec =? BINS); try contradiction.
+bdestruct (0 <=? n); try lia.
+bdestruct (n <=? maxSmallChunk); try lia.
+bdestruct (0 <? Znth (size2binZ n) rvec); try discriminate.
+assert (0 <= Znth (size2binZ n) rvec).
+{ apply Forall_Znth. apply H1. rewrite H. apply size2bin_range. apply H0. }
+rep_lia.
+Qed.

--- a/progs/memmgr/malloc_sep.v
+++ b/progs/memmgr/malloc_sep.v
@@ -1,0 +1,873 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.msl.iter_sepcon.
+Require Import Lia. (* for lia tactic (nonlinear integer arithmetic) *) 
+Require Import malloc_lemmas. (* background *)
+Require Import malloc_shares. (* for comp_Ews *)
+
+(* this file has results that depend on the code and are used in its verification *)
+
+(*Ltac start_function_hint ::= idtac. (* no hint reminder *)*)
+
+Require Import malloc. (* the program *)
+
+#[export] Instance CompSpecs : compspecs. make_compspecs prog. Defined. 
+
+Local Open Scope Z.
+Local Open Scope logic.  
+
+Definition comp := VST.msl.shares.Share.comp.
+
+Definition malloc_tok (sh: share) (n: Z) (s: Z) (p: val): mpred :=
+   !! (0 <= n <= s /\ s + WA + WORD <= Ptrofs.max_unsigned /\ 
+       (s <= bin2sizeZ(BINS-1) -> s = bin2sizeZ(size2binZ n)) /\
+       (s > bin2sizeZ(BINS-1) -> s = n) /\
+       malloc_compatible s p ) &&
+    data_at Tsh tuint (Vptrofs (Ptrofs.repr s)) (offset_val (- WORD) p) (* stored size *)
+  * memory_block (comp Ews) s p                               (* retainer *)
+  * memory_block Ews (s - n) (offset_val n p)                 (* waste at end of small *)
+  * (if zle s (bin2sizeZ(BINS-1))  
+    then emp
+    else memory_block Tsh WA (offset_val (-(WA+WORD)) p)).  (* waste at start of large *)
+
+(* for export *)
+Definition malloc_token' (sh: share) (n: Z) (p: val): mpred := 
+   EX s:Z, malloc_tok sh n s p.
+
+(* recovered in ASI_malloc.v
+for export 
+Definition malloc_token {cs: compspecs} (sh: share) (t: type) (p: val): mpred := 
+   !! field_compatible t [] p && 
+   malloc_token' sh (sizeof t) p.
+
+
+Lemma malloc_token'_valid_pointer_size: 
+  forall sh n p, malloc_token sh n p |-- valid_pointer (offset_val (- WORD) p).
+Proof.
+  intros; unfold malloc_token, malloc_token', malloc_tok; entailer!.
+  sep_apply (data_at_valid_ptr Tsh tuint (Vint (Int.repr s)) (offset_val(-WORD) p)).
+  apply top_share_nonidentity.
+  entailer!.
+Qed.
+
+
+Lemma malloc_token_valid_pointer_size: 
+  forall sh t p, malloc_token sh t p |-- valid_pointer (offset_val (- WORD) p).
+Proof.
+  intros; unfold malloc_token, malloc_token', malloc_tok; entailer!.
+  sep_apply (data_at_valid_ptr Tsh tuint (Vint (Int.repr s)) (offset_val(-WORD) p)).
+  apply top_share_nonidentity.
+  entailer!.
+Qed.*)
+
+(* for export *)
+Lemma malloc_token'_local_facts_strong:
+  forall sh n p, malloc_token' sh n p 
+  |-- !!( malloc_compatible n p /\ 0 <= n <= Ptrofs.max_unsigned - (WA+WORD)).
+Proof.
+  intros; unfold malloc_token'; Intro s; unfold malloc_tok; entailer!.
+  apply (malloc_compatible_prefix n s p); try lia; try assumption.
+Qed.
+
+(* for export *)
+Lemma malloc_token'_local_facts:
+  forall sh n p, malloc_token' sh n p 
+  |-- !!( malloc_compatible n p).
+Proof. intros. sep_apply malloc_token'_local_facts_strong. entailer!. Qed.
+
+(* for export *)
+Lemma malloc_token'_valid_pointer:
+  forall sh n p, malloc_token' sh n p |-- valid_pointer p.
+Proof.
+  intros.  unfold malloc_token'.
+  entailer!.
+  unfold malloc_tok.
+  assert_PROP (s > 0). { 
+    entailer!. bdestruct(bin2sizeZ (BINS-1) <? s). rep_lia.
+    match goal with | HA: not(bin2sizeZ _ < _) |- _ => 
+      (apply Znot_lt_ge in HA; apply Z.ge_le in HA; apply H1 in HA) end.
+    pose proof (bin2size_range (size2binZ n)). subst.
+    pose proof (size2bin_range n). rep_lia.
+  }
+  sep_apply (memory_block_valid_pointer (comp Ews) s p 0); try lia.
+  apply nonidentity_comp_Ews.
+  entailer.
+Qed.
+
+(* rederived in ASI_malloc
+(* for export *)
+Lemma malloc_token_local_facts:
+  forall {cs: compspecs} sh t p, malloc_token sh t p 
+  |-- !!( malloc_compatible (sizeof t) p /\ 
+          0 <= (sizeof t) <= Ptrofs.max_unsigned - (WA+WORD) /\
+          field_compatible t [] p).
+Proof.
+  intros; unfold malloc_token, malloc_token'; Intro s; unfold malloc_tok; entailer!.
+  apply (malloc_compatible_prefix (sizeof t) s p); try lia; try assumption.
+Qed.
+
+
+(* for export *)
+Lemma malloc_token_valid_pointer:
+  forall {cs: compspecs} sh t p, malloc_token sh t p |-- valid_pointer p.
+Proof.
+  intros.  unfold malloc_token, malloc_token'.
+  entailer!.
+  unfold malloc_tok.
+  assert_PROP (s > 0). { 
+    entailer!. bdestruct(bin2sizeZ (BINS-1) <? s). rep_lia.
+    match goal with | HA: not(bin2sizeZ _ < _) |- _ => 
+      (apply Znot_lt_ge in HA; apply Z.ge_le in HA; apply H2 in HA) end.
+    pose proof (bin2size_range (size2binZ (sizeof t))). subst.
+    pose proof (size2bin_range (sizeof t)). rep_lia.
+  }
+  sep_apply (memory_block_valid_pointer (comp Ews) s p 0); try lia.
+  apply nonidentity_comp_Ews.
+  entailer.
+Qed.*)
+
+(*#[export] Hint Resolve malloc_token'_valid_pointer_size : valid_pointer.*)
+#[export] Hint Resolve malloc_token'_valid_pointer : valid_pointer.
+#[export] Hint Resolve malloc_token'_local_facts : saturate_local.
+#[export] Hint Resolve malloc_token'_local_facts_strong: saturate_local.
+(*
+#[export] Hint Resolve malloc_token_local_facts : saturate_local.
+#[export] Hint Resolve malloc_token_valid_pointer_size : valid_pointer.
+#[export] Hint Resolve malloc_token_valid_pointer : valid_pointer.
+#[export] Hint Resolve malloc_token'_local_facts : saturate_local.*)
+
+(*+ free lists *)
+
+(* TODO 'link' versus 'nxt' in the comments *)
+
+(* linked list segment, for free chunks of a fixed size.
+
+p points to a linked list of len chunks, terminated at r.
+
+Chunks are viewed as (sz,nxt,remainder) where nxt points to the
+next chunk in the list.  Each chunk begins with the stored size
+value sz.  Each pointer, including p, points to the nxt field, 
+not to sz.
+The value of sz is the number of bytes in (nxt,remainder).
+
+A segment predicate is used, to cater for fill_bin which grows 
+the list at its tail. For non-empty segment, terminated at r means 
+that r is the value in the nxt field of the last chunk -- which 
+may be null or a valid pointer to not-necessarily-initialized memory. 
+
+The definition uses nat, for ease of termination check, at cost 
+of Z conversions.  I tried using the Function mechanism, with len:Z
+and {measure Z.to_nat len}, but this didn't work.
+
+Note on range of sz:  Since the bins are for moderate sizes,
+there's no need for sz > Int.max_unsigned, but the malloc/free API
+uses size_t for the size, and jumbo chunks need to be parsed by
+free even though they won't be in a bin, so this spec uses 
+Ptrofs in conformance with the code's use of size_t.
+TODO - parsing of big chunks has nothing to do with mmlist. 
+
+Note: in floyd/field_at.v there's a todo note related to revising
+defs assoc'd with malloc_compatible.
+*)
+
+Fixpoint mmlist (sz: Z) (len: nat) (p: val) (r: val): mpred :=
+ match len with
+ | O => !! (0 < sz <= bin2sizeZ(BINS - 1) /\ p = r /\ is_pointer_or_null p) && emp 
+ | (S n) => EX q:val, 
+         !! (p <> r /\ malloc_compatible sz p) &&  
+         data_at Tsh tuint (Vptrofs (Ptrofs.repr sz)) (offset_val (- WORD) p) *
+         data_at Tsh (tptr tvoid) q p *
+         memory_block Tsh (sz - WORD) (offset_val WORD p) *
+         mmlist sz n q r
+ end.
+
+(* an uncurried variant, caters for use with iter_sepcon *)
+Definition mmlist' (it: nat * val * Z) :=
+  mmlist (bin2sizeZ (snd it)) (fst (fst it)) (snd (fst it)) nullval. 
+
+(*+ module invariant mem_mgr *)
+
+(* There is an array, its elements point to null-terminated lists 
+of right size chunks, and there is some wasted memory.
+*) 
+
+(* with Resource accounting *)
+(*Order of arhuments swapped*)
+Definition mem_mgr_R (rvec: resvec) (gv: globals): mpred := 
+  EX bins: list val, EX idxs: list Z, EX lens: list nat,
+    !! (Zlength bins = BINS /\ Zlength lens = BINS /\
+        lens = map Z.to_nat rvec /\
+        idxs = map Z.of_nat (seq 0 (Z.to_nat BINS)) /\  
+        no_neg rvec ) &&
+  data_at Ews (tarray (tptr tvoid) BINS) bins (gv _bin) * 
+  iter_sepcon mmlist' (zip3 lens bins idxs) * 
+  TT. (* waste, which arises due to alignment in bins *)
+
+Ltac simple_if_tac' H := 
+  match goal with |- context [if ?A then _ else _] => 
+    lazymatch type of A with
+    | bool => destruct A eqn: H
+    | sumbool _ _ => fail "Use if_tac instead of simple_if_tac, since your expression "A" has type sumbool"
+    | ?t => fail "Use simple_if_tac only for bool; your expression"A" has type" t
+  end end.
+Ltac simple_if_tac'' := let H := fresh in simple_if_tac' H.
+
+
+(*+ mmlist *)
+
+Lemma mmlist_local_facts:
+  forall sz len p r,
+   mmlist sz len p r |--
+   !! (0 <= sz <= Ptrofs.max_unsigned /\ 
+        is_pointer_or_null p /\ is_pointer_or_null r /\ (p = r <-> len=O)). 
+Proof.
+  intros; generalize dependent p; induction len.
+  - (* len 0 *)
+    destruct p; try contradiction; simpl; entailer!;
+    try (split; intro; reflexivity).
+  - (* len > 0 *) 
+    intros p; unfold mmlist; fold mmlist.
+    Intro q. specialize (IHlen q); entailer. 
+    sep_apply IHlen; entailer.
+    assert (p = r <-> S len = 0%nat) by
+        (split; intro; try contradiction; try lia).
+    entailer.
+Qed.
+#[export] Hint Resolve mmlist_local_facts : saturate_local.
+
+
+Lemma mmlist_ne_valid_pointer:
+  forall sz len p r,  (len > 0)%nat ->
+   mmlist sz len p r |-- valid_pointer p.
+Proof.
+  destruct len; unfold mmlist; fold mmlist; intros; normalize.
+  lia.  auto with valid_pointer.
+Qed.
+#[export] Hint Resolve mmlist_ne_valid_pointer : valid_pointer.
+
+
+Lemma mmlist_ne_len:
+  forall sz len p q, p<>q ->
+    mmlist sz (Z.to_nat len) p q |-- !! (len > 0).
+Proof. 
+  intros. destruct len.
+  simpl; normalize. entailer!; lia. simpl. entailer!.
+Qed.
+
+Lemma mmlist_ne_nonnull:
+  forall sz len p, (len > 0)%nat ->
+    mmlist sz len p nullval |-- !! (p <> nullval).
+Proof.
+  intros. destruct len. inversion H. unfold mmlist; fold mmlist. entailer.
+Qed.
+
+(* The following is formulated as an equality so it can be used in 
+both directions.  It's written using Nat.pred instead of len-1 because
+Coq couldn't infer the type for len-1 in scripts that rely on this lemma.
+(One workaround would involve replacing len by (Z.to_nat len).)
+
+Note that by type of len, and mmlist_local_facts, 
+p <> nullval and (mmlist sz len p nullval) imply (Z.of_nat len) > 0,
+so that antecedent is only needed for the RHS-to-LHS direction.
+*)
+
+Lemma mmlist_unroll_nonempty:
+  forall sz len p r, (Z.of_nat len) > 0 ->
+      mmlist sz len p r
+  =   EX q:val,
+      !!(malloc_compatible sz p /\ p <> r) && 
+      data_at Tsh tuint (Vptrofs (Ptrofs.repr sz)) (offset_val (- WORD) p) *
+      data_at Tsh (tptr tvoid) q p *
+      memory_block Tsh (sz - WORD) (offset_val WORD p) *
+      mmlist sz (Nat.pred len) q r.
+Proof.
+  intros. apply pred_ext.
+  - (* LHS |-- RHS *)
+    destruct len. elimtype False; simpl in *; lia.
+    simpl. Intros q; Exists q. entailer.
+  - (* RHS |-- LHS *)
+    Intros q. destruct len. elimtype False; simpl in *; lia.
+    simpl. Exists q. entailer!.
+Qed.
+
+
+Lemma mmlist_empty: 
+  forall sz, 0 < sz <= bin2sizeZ(BINS - 1) ->
+             mmlist sz 0 nullval nullval = emp.
+Proof.
+  intros. apply pred_ext; simpl; entailer!.
+Qed.
+
+(* lemmas on constructing an mmlist from a big block (used in fill_bin) *)
+
+
+Lemma mmlist_fold_last: 
+(* Adding tail chunk. 
+Formulated in the manner of lseg_app' in vst/progs/verif_append2.v.
+The preserved chunk is just an idiom for list segments, because we have
+seg p q * q|->r * r|-> s entails seg p r * r|-> s
+but not 
+seg p q * q|->r entails seg p r (owing to potential cycle) 
+
+This lemma is for folding at the end, in the non-null case, so the
+length of the preserved chunk can be assumed to be at least s+WORD. *)
+  forall s n r q m,  malloc_compatible s (offset_val WORD q) -> 
+                WORD < m -> m - WORD <= Ptrofs.max_unsigned -> 
+                s <= bin2sizeZ(BINS-1) ->
+  mmlist s n r (offset_val WORD q) * 
+  data_at Tsh (tarray tuint 1) [(Vint (Int.repr s))] q * 
+  data_at Tsh (tptr tvoid) (offset_val (s+WORD+WORD) q) (offset_val WORD q) *
+  memory_block Tsh (s - WORD) (offset_val (WORD + WORD) q) *
+  memory_block Tsh m (offset_val (s + WORD) q) (* preserved *)
+  |-- mmlist s (n+1) r (offset_val (s + WORD + WORD) q ) *
+      memory_block Tsh m (offset_val (s + WORD) q). (* preserved *)
+Proof.
+(* By induction.  For the ind step, unroll at the start of the lists,
+in both antecedent and consequent, in order to apply the ind hyp. *)
+intros. generalize dependent r. induction n. 
+- intros. unfold mmlist; fold mmlist. rewrite Nat.add_1_r. 
+  assert_PROP( r = (offset_val WORD q)) by entailer!; subst. 
+  rewrite mmlist_unroll_nonempty; change (Nat.pred 1) with 0%nat; 
+    try (change 0 with (Z.of_nat 0); rewrite <- Nat2Z.inj_gt; lia).
+  Exists (offset_val (s + WORD + WORD) q).
+  unfold mmlist; fold mmlist.
+  replace ((offset_val (- WORD) (offset_val WORD q))) with q
+    by (normalize; rewrite isptr_offset_val_zero; auto; try mcoi_tac).
+
+  assert_PROP(offset_val WORD q <> offset_val (s + WORD + WORD) q).
+  { (* use memory_block_conflict to prove this disequality *)
+    (* similar to Andrew's proof steps in induction case below *)
+    apply not_prop_right; intro; subst.
+    simpl; normalize.
+    replace m with (WORD + (m-WORD)) by lia.
+    rewrite memory_block_split_offset; normalize; try rep_lia.
+    match goal with | |- context[data_at ?sh (tptr tvoid) ?Vs ?op] => 
+                  sep_apply (data_at_memory_block sh (tptr tvoid) Vs op) end.
+    match goal with | HA: offset_val _ _ = offset_val _ _ |- _ => rewrite <- HA end.
+    normalize.
+    match goal with | |- context[ 
+                      memory_block ?sh1 ?sz1 (offset_val WORD q) * (_ * (_ * (_ *
+                      memory_block ?sh2 ?sz2 (offset_val WORD q) )))] => 
+        sep_apply (memory_block_conflict sh1 sz1 sz2 (offset_val WORD q)) end.
+    apply top_share_nonunit; try rep_lia.
+    split.
+    change (sizeof(tptr tvoid)) with WORD; rep_lia.
+    change (sizeof(tptr tvoid)) with WORD; rep_lia.
+    simpl; rep_lia.
+    entailer!.  
+  }
+  erewrite data_at_singleton_array_eq; try reflexivity.  entailer!. cancel.
+- intros. rewrite Nat.add_1_r.
+  rewrite (mmlist_unroll_nonempty s (S(S n)));  
+    try auto; try (change 0 with (Z.of_nat 0); rewrite <- Nat2Z.inj_gt; lia).
+  rewrite (mmlist_unroll_nonempty s (S n));
+    try auto; try (change 0 with (Z.of_nat 0); rewrite <- Nat2Z.inj_gt; lia).
+  Intro p; Exists p.
+  assert_PROP (r <> (offset_val (s+WORD+WORD) q)).
+  { (* use memory_block_conflict to prove this disequality *)
+    replace m with (WORD+(m-WORD)) by lia.
+    destruct q; auto; try entailer.
+    replace (offset_val (s + WORD) (Vptr b i))
+      with (Vptr b (Ptrofs.add (Ptrofs.repr (s+WORD)) i))
+      by (simpl; f_equal; rewrite Ptrofs.add_commut; reflexivity).
+    rewrite memory_block_split_repr; try rep_lia. 
+    2: { split; try rep_lia.
+         unfold size_compatible' in *; simpl in *;
+         rewrite Ptrofs.add_commut; rep_lia.
+    }
+    replace (Ptrofs.add (Ptrofs.add (Ptrofs.repr (s + WORD)) i) (Ptrofs.repr WORD)) 
+      with (Ptrofs.add i (Ptrofs.repr (s + WORD + WORD))) 
+      by ( rewrite <- Ptrofs.add_commut; rewrite Ptrofs.add_assoc; 
+           rewrite (Ptrofs.add_commut i); rewrite <- Ptrofs.add_assoc; normalize).
+    replace (offset_val (s + WORD + WORD) (Vptr b i))
+      with (Vptr b (Ptrofs.add i (Ptrofs.repr (s + WORD + WORD))))
+        by (simpl; reflexivity).
+    clear IHn H2 H4 H5 H6 H7 H8 H9 H10 H12 H13 H14 H15 H16 H17.
+    assert (m - WORD > 0) by lia.
+    (* Andrew's heroic proof of the disequality: *)
+    apply not_prop_right; intro; subst.
+    simpl. normalize.
+    replace (s + WORD + WORD + - WORD) with (s + WORD) by lia.
+    rewrite <- !(Ptrofs.add_commut i).  (* rewrite at least once *)
+    sep_apply (data_at_memory_block Tsh tuint (Vint (Int.repr s)) (Vptr b (Ptrofs.add i (Ptrofs.repr (s + WORD)))) ).
+    change (sizeof tuint) with WORD.
+    sep_apply (memory_block_conflict Tsh WORD WORD (Vptr b (Ptrofs.add i (Ptrofs.repr (s + WORD))))); try rep_lia.
+    apply top_share_nonunit; try rep_lia.
+    entailer!.
+  } 
+  entailer.  (* avoid cancelling trailing block needed by IHn *)
+  change (Nat.pred (S n)) with n; change (Nat.pred (S(S n))) with (S n).
+  replace (S n) with (n+1)%nat by lia.
+  specialize (IHn p).
+  sep_apply IHn; entailer!.
+Qed.
+
+
+
+Lemma mmlist_app_null: 
+  forall s p r m n, mmlist s n p r * mmlist s m r nullval |-- mmlist s (m+n) p nullval.
+Proof.
+  intros. revert p. induction n.
+  - intros. simpl. replace (m+0)%nat with m%nat by lia. entailer!.
+  - intros. rewrite mmlist_unroll_nonempty; try lia.
+    change (Nat.pred(S n)) with n.
+    Intros q. sep_apply (IHn q).
+    eapply derives_trans.
+    2: { rewrite mmlist_unroll_nonempty. apply derives_refl. lia. }
+    Exists q.
+    replace (Nat.pred (m + S n)) with (m+n)%nat by lia.
+    entailer!.
+Qed.
+
+(*+ mem_mgr *) 
+
+Lemma mem_mgr_split':
+ forall b:Z, forall bins lens idxs,
+     0 <= b < BINS -> Zlength bins = BINS -> Zlength lens = BINS -> 
+     idxs = map Z.of_nat (seq 0 (Z.to_nat BINS)) ->
+ iter_sepcon mmlist' (sublist 0 b (zip3 lens bins idxs)) * 
+ iter_sepcon mmlist' (sublist (b+1) BINS (zip3 lens bins idxs)) *
+ mmlist (bin2sizeZ b) (Znth b lens) (Znth b bins) nullval 
+  =
+ iter_sepcon mmlist' (zip3 lens bins idxs). 
+Proof. 
+  intros.
+  replace (mmlist (bin2sizeZ b) (Znth b lens) (Znth b bins) nullval)
+     with (mmlist' ((Znth b lens), (Znth b bins), b)) by (unfold mmlist'; auto).
+  assert (Hassoc: 
+      iter_sepcon mmlist' (sublist 0 b (zip3 lens bins idxs)) *
+      iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens bins idxs)) *
+      mmlist' (Znth b lens, Znth b bins, b) 
+    = 
+      iter_sepcon mmlist' (sublist 0 b (zip3 lens bins idxs)) *
+      mmlist' (Znth b lens, Znth b bins, b) * 
+      iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens bins idxs)) )
+    by ( apply pred_ext; entailer!).
+  rewrite Hassoc; clear Hassoc.
+  assert (Hidxs: Zlength idxs = BINS) 
+    by  (subst; rewrite Zlength_map; rewrite Zlength_correct; 
+         rewrite seq_length; try rep_lia).
+  replace (Znth b lens, Znth b bins, b) with (Znth b (zip3 lens bins idxs)).
+  replace BINS with (Zlength (zip3 lens bins idxs)).
+  erewrite <- (iter_sepcon_split3 b _ mmlist'); auto.
+  split.
+  - lia.
+  - rewrite Zlength_zip3; try rep_lia. 
+  - rewrite Zlength_zip3; try rep_lia. 
+  - rewrite Znth_zip3 by rep_lia. replace b with (Znth b idxs) at 6; auto.
+    subst. rewrite Znth_map. unfold Znth. if_tac. lia.
+    rewrite seq_nth. simpl. rep_lia. rep_lia.
+    rewrite Zlength_correct. rewrite seq_length. rep_lia.
+Qed.
+
+
+Lemma mem_mgr_split_R: 
+ forall gv:globals, forall b:Z, forall rvec: resvec, 0 <= b < BINS ->
+   mem_mgr_R rvec gv
+ = 
+  EX bins: list val, EX idxs: list Z, EX lens: list nat,
+    !! (Zlength bins = BINS /\ Zlength lens = BINS /\ Zlength idxs = BINS 
+        /\ lens = map Z.to_nat rvec
+        /\ idxs = map Z.of_nat (seq 0 (Z.to_nat BINS))
+        /\ no_neg rvec ) &&
+  data_at Ews (tarray (tptr tvoid) BINS) bins (gv _bin) * 
+  iter_sepcon mmlist' (sublist 0 b (zip3 lens bins idxs)) * 
+  mmlist (bin2sizeZ b) (Znth b lens) (Znth b bins) nullval * 
+  iter_sepcon mmlist' (sublist (b+1) BINS (zip3 lens bins idxs)) *  
+  TT. 
+Proof. 
+  intros. apply pred_ext.
+  - (* LHS -> RHS *)
+    (*unfold mem_mgr.*) unfold mem_mgr_R.
+    Intros bins idxs lens. Exists bins idxs lens. entailer!.
+    rewrite <- (mem_mgr_split' b); try assumption. 
+    entailer!. reflexivity.
+  - (* RHS -> LHS *)
+    Intros bins idxs lens. 
+    (*unfold mem_mgr;*) unfold mem_mgr_R. Exists bins idxs lens. 
+    entailer!.
+    set (idxs:=(map Z.of_nat (seq 0 (Z.to_nat BINS)))).
+
+    set (lens:=(map Z.to_nat rvec)).
+
+    replace (
+        iter_sepcon mmlist' (sublist 0 b (zip3 lens bins idxs)) *
+        mmlist (bin2sizeZ b) (Znth b lens) (Znth b bins) nullval *
+        iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens bins idxs)) )
+      with (
+          iter_sepcon mmlist' (sublist 0 b (zip3 lens bins idxs)) *
+          iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens bins idxs)) *
+          mmlist (bin2sizeZ b) (Znth b lens) (Znth b bins) nullval )
+      by (apply pred_ext; entailer!).  
+    rewrite (mem_mgr_split' b); try assumption.
+    cancel.  auto.
+Qed.
+
+(*+ splitting/joining memory blocks +*)
+
+Lemma memory_block_Ews_join:
+forall (n : Z) (p : val),
+  memory_block (comp Ews) n p * memory_block Ews n p = memory_block Tsh n p.
+Proof.
+  intros.
+  rewrite (memory_block_share_join (comp Ews) Ews Tsh). reflexivity.
+  apply sepalg.join_comm. 
+  replace comp with Share.comp by normalize.
+  rewrite comp_Ews.  
+  apply join_Ews.
+Qed.
+
+
+(* The following results involve memory predicates that depend on compspecs *)
+
+(* notes towards possibly subsuming lemmas:
+- malloc_large uses malloc_large_chunk to split off size and waste parts.
+- malloc_small uses to_malloc_token_and_block to change a bin chunk into token plus user chunk.
+- free uses from_malloc_token_and_block to access the size, for both large
+  and small chunks; the lemma also exposes nxt which is helpful for free_small
+- free free_large_chunk to reassemble block to give to munmap; this includes
+  the nxt field (could simplify by not exposing that in the first place).  
+- fill_bin uses memory_block_split_block to split off size, next, and remainder for a chunk, from a big block.
+*)
+
+Lemma memory_block_split_block:
+(* Note: an equality but only used in this direction. *) 
+  forall s m q, WORD <= s -> s+WORD <= m -> malloc_compatible (m - WORD) (offset_val WORD q) ->
+   align_compatible (tarray tuint 1) q ->
+   memory_block Tsh m q |-- 
+   data_at_ Tsh (tarray tuint 1) q * (*size*)
+   data_at_ Tsh (tptr tvoid) (offset_val WORD q) * (*nxt*)   
+   memory_block Tsh (s - WORD) (offset_val (WORD+WORD) q) * (*rest of chunk*)
+   memory_block Tsh (m-(s+WORD)) (offset_val (s+WORD) q). (*rest of large*)
+Proof.
+  intros s m q Hs Hm Hmcq Hacq.
+  (* split antecedent memory block into right sized pieces *)
+  replace m with (WORD + (m - WORD)) at 1 by lia. 
+  rewrite (memory_block_split_offset _ q WORD (m - WORD)) by rep_lia.
+  replace (m - WORD) with (WORD + (m - (WORD+WORD))) by lia.
+  rewrite (memory_block_split_offset 
+             _ (offset_val WORD q) WORD (m - (WORD+WORD))) by rep_lia.
+  replace (offset_val WORD (offset_val WORD q)) with (offset_val (WORD+WORD) q) by normalize.
+  replace (m - (WORD+WORD)) with ((s - WORD) + (m - (s+WORD))) by rep_lia.
+  rewrite (memory_block_split_offset 
+             _ (offset_val (WORD+WORD) q) (s - WORD) (m - (s+WORD))) by rep_lia.
+  (* rewrite into data_at_ *)
+  normalize.
+  change WORD with (sizeof (tarray tuint 1)) at 1.
+  change WORD with (sizeof (tptr tvoid)) at 1.
+  replace (WORD + WORD + (s - WORD)) with (s + WORD) by lia.
+  entailer!. 
+  rewrite memory_block_data_at_.
+  rewrite memory_block_data_at_.
+  cancel.
+  - (* field_compatible (offset_val WORD q) *)
+    hnf. repeat split; auto.
+    destruct q; try auto.
+    eapply align_compatible_rec_by_value; try reflexivity. simpl in *.
+    destruct Hmcq as [Halign Hbound].
+    assert (H48: (4|natural_alignment)).
+    { unfold natural_alignment; replace 8 with (2*4)%Z by lia. 
+      apply Z.divide_factor_r; auto. }
+    eapply Z.divide_trans. apply H48. auto.
+  - (* field_compatible q *)
+    hnf. repeat split; auto.
+Qed.
+
+
+Lemma free_large_chunk: 
+  forall s p, WORD <= s <= Ptrofs.max_unsigned -> 
+  data_at Tsh tuint (Vint (Int.repr s)) (offset_val (- WORD) p) * 
+  data_at_ Tsh (tptr tvoid) p *                                    
+  memory_block Tsh (s - WORD) (offset_val WORD p) *
+  memory_block Tsh WA (offset_val (- (WA + WORD)) p)
+  |-- memory_block Tsh (s + WA + WORD) (offset_val (- (WA + WORD)) p) .
+Proof.
+  intros.
+  assert_PROP(field_compatible (tptr tvoid) [] p ) by entailer.
+  assert_PROP(field_compatible tuint [] (offset_val (- WORD) p)) by entailer.
+  assert(Hsiz: sizeof (tptr tvoid) = WORD) by auto.
+  rewrite <- memory_block_data_at_; auto.
+  match goal with | |- context[data_at ?sh ?t ?Vs ?op] => 
+                    sep_apply (data_at_data_at_ sh t Vs op) end.
+  rewrite <- memory_block_data_at_; auto.
+  change (sizeof tuint) with WORD.
+  rewrite Hsiz; clear Hsiz.
+  do 2 rewrite <- sepcon_assoc.
+  replace (
+      memory_block Tsh WORD (offset_val (- WORD) p) * memory_block Tsh WORD p *
+      memory_block Tsh (s - WORD) (offset_val WORD p) *
+      memory_block Tsh WA (offset_val (- (WA + WORD)) p) 
+    )with(
+         memory_block Tsh WORD p *
+         memory_block Tsh (s - WORD) (offset_val WORD p) *
+         memory_block Tsh WORD (offset_val (- WORD) p) *
+         memory_block Tsh WA (offset_val (- (WA + WORD)) p) 
+       ) by (apply pred_ext; entailer!);
+    rewrite <- memory_block_split_offset; try rep_lia.
+  replace (WORD+(s-WORD)) with s by lia;
+    replace p with (offset_val WORD (offset_val (- WORD) p)) at 1 by normalize;
+    replace(
+        memory_block Tsh s (offset_val WORD (offset_val (- WORD) p)) *
+        memory_block Tsh WORD (offset_val (- WORD) p) 
+      )with(
+           memory_block Tsh WORD (offset_val (- WORD) p) *
+           memory_block Tsh s (offset_val WORD (offset_val (- WORD) p))
+         ) by (apply pred_ext; entailer!);
+    rewrite <- (memory_block_split_offset _ (offset_val (- WORD) p)); try rep_lia.
+  replace (offset_val (-WORD) p) 
+    with (offset_val WA (offset_val (-(WA+WORD)) p)) by normalize;
+    replace (
+        memory_block Tsh (WORD + s) (offset_val WA (offset_val (- (WA + WORD)) p)) *
+        memory_block Tsh WA (offset_val (- (WA + WORD)) p)
+      )with( 
+           memory_block Tsh WA (offset_val (- (WA + WORD)) p) *
+           memory_block Tsh (WORD + s) (offset_val WA (offset_val (- (WA + WORD)) p)) 
+         ) by (apply pred_ext; entailer!);
+    rewrite <- memory_block_split_offset; try rep_lia.
+  replace (WA+(WORD+s)) with (s+WA+WORD) by lia;
+    entailer!.
+Qed.
+
+
+(* following only used L to R but this form enables simple rewrite *)
+Lemma malloc_large_chunk: 
+  forall n p, 0 <= n -> n + WA + WORD <= Ptrofs.max_unsigned -> 
+         malloc_compatible (n + WA + WORD) p -> 
+  memory_block Tsh (n + WA + WORD) p
+  = 
+  memory_block Tsh WA p *                      (* waste *)
+  data_at_ Tsh tuint (offset_val WA p) *       (* size *)
+  memory_block Tsh n (offset_val (WA+WORD) p). (* data *)
+Proof. 
+  intros n p H H0 H1. destruct p; try normalize.
+  apply pred_ext.
+  - (* L to R where (p is Vptr b i) *)
+    rewrite data_at__memory_block.
+    normalize.
+    entailer!.
+    -- (* field_compatible *)
+      hnf. 
+      assert (H4: Ptrofs.unsigned (Ptrofs.add i (Ptrofs.repr WA))
+               = Ptrofs.unsigned i + WA ). 
+      { replace i with (Ptrofs.repr(Ptrofs.unsigned i)) at 1
+          by (rewrite Ptrofs.repr_unsigned; reflexivity).
+        rewrite ptrofs_add_repr.
+        rewrite Ptrofs.unsigned_repr; try reflexivity.
+        split.
+        assert (0 <= Ptrofs.unsigned i) by apply Ptrofs.unsigned_range.
+        rep_lia. unfold size_compatible' in *. rep_lia.
+      }
+      repeat split; auto.
+      --- (* size *)
+        simpl; simpl in H1.
+        replace ( Ptrofs.unsigned (Ptrofs.add i (Ptrofs.repr WA)) )
+          with ( Ptrofs.unsigned i + WA ). 
+        replace (Ptrofs.unsigned i + (n + WA + WORD))
+          with (n + Ptrofs.unsigned i + WA + 4)
+          in H1 by rep_lia.
+        assert (0 + Ptrofs.unsigned i + WA + 4 <= n + Ptrofs.unsigned i + WA + 4)
+          by (do 3 apply Z.add_le_mono_r; auto).
+        rep_lia. 
+      --- (* align *)
+        simpl.
+        eapply align_compatible_rec_by_value; try reflexivity. simpl in *.
+        rewrite H4.
+        apply Z.divide_add_r.
+        destruct H1 as [Hal ?]. 
+        assert (H48: (4|natural_alignment)).
+        { unfold natural_alignment; replace 8 with (2*4)%Z by lia. 
+          apply Z.divide_factor_r; auto. }
+        eapply Z.divide_trans. apply H48. auto.
+        rewrite WA_eq. 
+        apply Z.divide_refl.
+    -- 
+      replace (sizeof tuint) with WORD by normalize. 
+      change (sizeof tuint) with WORD.
+      replace (n + WORD + WORD) with (WORD + (n + WORD)) by lia.
+      erewrite (memory_block_split_offset _ _ WORD (n+WORD)); try rep_lia.
+      replace (n+WORD) with (WORD+n) by lia.
+      change (sizeof tuint) with WORD.
+      erewrite memory_block_split_offset; try rep_lia. 
+      entailer!; rep_lia.
+      
+  - (* R to L *)
+    rewrite data_at__memory_block; normalize.
+    erewrite <- memory_block_split_offset; try rep_lia.
+    replace (sizeof tuint) with WORD by normalize.
+    erewrite <- memory_block_split_offset; try rep_lia.
+    replace (WORD+WORD+n) with (n+WORD+WORD) by lia.
+    cancel; rep_lia.
+    change (sizeof tuint) with WORD; rep_lia.
+Qed.
+
+
+
+Lemma to_malloc_token'_and_block:
+forall n p q s, 0 <= n <= bin2sizeZ(BINS-1) -> s = bin2sizeZ(size2binZ(n)) -> 
+     malloc_compatible s p -> 
+  ( data_at Tsh tuint (Vptrofs (Ptrofs.repr s)) (offset_val (- WORD) p) *
+     ( data_at Tsh (tptr tvoid) q p *   
+     memory_block Tsh (s - WORD) (offset_val WORD p) )
+|--  malloc_token' Ews n p * memory_block Ews n p).
+Proof.
+  intros n p q s Hn Hs Hmc.
+  unfold malloc_token'.
+  Exists s.
+  unfold malloc_tok.
+  if_tac.
+  - (* small chunk *)
+    entailer!. 
+    split.
+    -- pose proof (claim1 n (proj2 Hn)). rep_lia.
+    -- match goal with | HA: field_compatible _ _ _ |- _ => 
+                         unfold field_compatible in H2;
+                           destruct H2 as [? [? [? [? ?]]]] end.
+       destruct p; auto; try (apply claim1; rep_lia).
+    -- set (s:=(bin2sizeZ(size2binZ n))).
+       sep_apply (data_at_memory_block Tsh (tptr tvoid) q p).
+       simpl.
+       rewrite <- memory_block_split_offset; try rep_lia.
+       --- 
+       replace (WORD+(s-WORD)) with s by lia.
+       rewrite sepcon_assoc.
+       replace (
+           memory_block Ews (s - n) (offset_val n p) *
+           memory_block Ews n p)
+         with (memory_block Ews s p).
+       + rewrite memory_block_Ews_join. cancel.
+       + rewrite sepcon_comm.
+         rewrite <- memory_block_split_offset; try rep_lia.
+         replace (n + (s - n)) with s by lia. reflexivity.
+         destruct Hn; auto.
+         subst s.
+         assert (n <= bin2sizeZ (size2binZ n)) by (apply claim1; rep_lia).
+         rep_lia.
+       --- 
+       subst s.
+       pose proof (size2bin_range n Hn) as Hn'.
+       pose proof (bin2size_range (size2binZ n) Hn').
+       rep_lia.
+  - (* large chunk - contradicts antecedents *)
+    exfalso.
+    assert (size2binZ n < BINS) by (apply size2bin_range; lia).
+    assert (size2binZ n <= BINS - 1 ) by lia.
+    rewrite Hs in H.
+    assert (bin2sizeZ (size2binZ n) <= bin2sizeZ (BINS-1)) by
+        (apply bin2size_range; apply size2bin_range; rep_lia).
+    rep_lia.
+Qed.
+
+
+Lemma from_malloc_token'_and_block:  
+forall n p, 0 <= n <= Ptrofs.max_unsigned - WORD ->  
+    (malloc_token' Ews n p * memory_block Ews n p)
+  |--  (EX s:Z,
+      !! ( n <= s /\ s + WA + WORD <= Ptrofs.max_unsigned /\ 
+           malloc_compatible s p /\ 
+           (s <= bin2sizeZ(BINS-1) -> s = bin2sizeZ(size2binZ(n))) /\ 
+           (s > bin2sizeZ(BINS-1) -> s = n)) && 
+      data_at Tsh tuint (Vptrofs (Ptrofs.repr s)) (offset_val (- WORD) p) * (* size *)
+      data_at_ Tsh (tptr tvoid) p *                                         (* nxt *)
+      memory_block Tsh (s - WORD) (offset_val WORD p) *                     (* data *)
+      (if zle s (bin2sizeZ(BINS-1)) then emp                                (* waste *)
+       else memory_block Tsh WA (offset_val (-(WA+WORD)) p))).
+(* Note that part labelled data can itself be factored into the user-visible
+part of size n - WORD and, for small chunks, waste of size s - n *)
+Proof.
+  intros.
+  unfold malloc_token'.
+  Intros s; Exists s.
+  unfold malloc_tok.
+  entailer!.
+  assert (WORD <= s). { 
+    destruct H0 as [Hn Hns]. 
+    pose proof (zle s (bin2sizeZ (BINS-1))) as Hsmall.
+    destruct Hsmall as [Hsmall | Hsbig]; try rep_lia.
+    match goal with | HA: s<=bin2sizeZ(BINS-1) -> _ |- _ => apply HA in Hsmall end. 
+    pose proof (bin2size_range (size2binZ n)); subst.
+    pose proof (size2bin_range n); rep_lia.
+  }
+  replace 
+  (  memory_block (comp Ews) s p * memory_block Ews (s - n) (offset_val n p) *
+     memory_block Ews n p ) 
+    with ( memory_block (comp Ews) s p * (memory_block Ews n p * 
+                                          memory_block Ews (s - n) (offset_val n p)))
+    by (apply pred_ext; entailer!).
+  rewrite <- memory_block_split_offset; try rep_lia.
+  replace (n+(s-n)) with s by rep_lia.
+  rewrite memory_block_Ews_join.
+  replace s with (WORD + (s-WORD)) at 1 by lia.
+  rewrite memory_block_split_offset; try rep_lia.
+  change WORD with (sizeof (tptr tvoid)) at 1.
+  rewrite memory_block_data_at_.
+  cancel.
+  (* field_compatible *)
+  hnf.  repeat split; auto.
+  -- (* size_compatible *)
+    destruct p; try auto.
+    unfold size_compatible.
+    match goal with | HA: malloc_compatible _ _ |- _ => 
+                      unfold malloc_compatible in HA; destruct HA end.
+    change (sizeof (tptr tvoid)) with WORD; rep_lia.
+  -- (* align_compatible *)
+    destruct p; try auto.
+    unfold align_compatible.
+    eapply align_compatible_rec_by_value; try reflexivity.
+    simpl.
+    match goal with | HA: malloc_compatible _ _ |- _ => 
+                      unfold malloc_compatible in HA; destruct HA end.
+    assert (H48: (4|natural_alignment)).
+    { unfold natural_alignment; replace 8 with (2*4)%Z by lia. 
+      apply Z.divide_factor_r; auto. }
+    eapply Z.divide_trans. apply H48. auto.
+Qed.
+
+(*  This is meant to describe the extern global variables of malloc.c,
+    as they would appear as processed by CompCert and Floyd. *)
+Definition initialized_globals (gv: globals) := 
+   !! (headptr (gv malloc._bin)) &&
+   data_at Ews (tarray (tptr tvoid) BINS) (repeat nullval (Z.to_nat BINS)) (gv malloc._bin).
+
+Lemma create_mem_mgr_R: 
+  forall (gv: globals),
+  !! (headptr (gv malloc._bin)) &&
+   data_at Ews (tarray (tptr tvoid) BINS) (repeat nullval (Z.to_nat BINS)) (gv malloc._bin)
+     |-- mem_mgr_R emptyResvec gv.
+Proof.
+ intros.
+ Intros.
+ unfold mem_mgr_R.
+ Exists (repeat nullval (Z.to_nat BINS)). EExists. EExists.
+ entailer!.
+ split.
+ reflexivity.
+ repeat constructor; lia.
+  unfold mmlist'.
+  erewrite iter_sepcon_func_strong with 
+    (l := (zip3 (repeat 0%nat (Z.to_nat BINS)) (repeat nullval (Z.to_nat BINS)) (Zseq BINS)))
+    (Q := (fun it : nat * val * Z => emp)).
+  { rewrite iter_sepcon_emp'. entailer. intros. normalize. }
+  intros [[num p] sz] Hin.
+  pose proof (In_zip3 ((num,p),sz)
+                      (repeat 0%nat (Z.to_nat BINS))
+                      (repeat nullval (Z.to_nat BINS))
+                      (Zseq BINS)
+                      Hin) as [Hff [Hsf Hs]].
+  clear H H0 Hin.
+  assert (Hn: num = 0%nat) by (eapply repeat_spec; apply Hff). 
+  rewrite Hn; clear Hn Hff.
+  assert (Hp: p = nullval) by (eapply repeat_spec; apply Hsf). 
+  rewrite Hp; clear Hp Hsf.
+  assert (Hsz: 0 <= sz < BINS).
+  { assert (Hsx: 0 <= sz < BINS). 
+    apply in_Zseq; try rep_lia; try assumption. assumption. }
+  simpl. unfold mmlist.
+  apply pred_ext; entailer!.
+  pose proof (bin2size_range sz Hsz). rep_lia.
+Qed.
+(*
+Lemma create_mem_mgr: 
+  forall (gv: globals), initialized_globals gv |-- mem_mgr gv.
+Proof.  
+  intros gv. unfold mem_mgr. Exists emptyResvec. apply (create_mem_mgr_R gv).
+Qed.
+*)

--- a/progs/memmgr/malloc_shares.v
+++ b/progs/memmgr/malloc_shares.v
@@ -1,0 +1,666 @@
+Require Import VST.floyd.proofauto.
+Import Share.
+Import sepalg.
+
+(*
+
+Definition shave (sh: share) : share * share :=
+  (fst (split (glb sh Lsh)),
+   lub (snd (split (glb sh Lsh))) (glb sh Rsh)).
+
+Definition cleave: share -> share * share := slice.cleave.
+
+Lemma shave_join:
+   forall sh,  join (fst (shave sh)) (snd (shave sh)) sh.
+Proof.
+intros.
+unfold shave.
+split.
+simpl.
+-
+rewrite distrib1.
+destruct (split (glb sh Lsh)) eqn:?H.
+simpl.
+rewrite (split_disjoint _ _ _ H).
+rewrite lub_commute, lub_bot.
+rewrite <- glb_assoc.
+rewrite glb_commute.
+apply sub_glb_bot with Lsh.
+2: apply glb_Rsh_Lsh.
+exists (lub t1 (glb (comp sh) Lsh)).
+split.
+rewrite distrib2.
+rewrite <- glb_assoc.
+rewrite (glb_assoc t0).
+rewrite (distrib1 sh).
+rewrite comp2.
+rewrite lub_bot.
+rewrite (glb_commute sh).
+rewrite <- (glb_assoc t0).
+apply split_disjoint in H. rewrite H.
+rewrite (glb_commute bot), glb_bot.
+rewrite (glb_commute bot), glb_bot.
+auto.
+rewrite lub_commute.
+rewrite distrib2.
+rewrite <- (lub_commute t0).
+rewrite <- lub_assoc.
+rewrite (split_together _ _ _ H).
+rewrite distrib2.
+rewrite (glb_commute sh), <- (lub_commute Lsh), lub_absorb.
+rewrite (glb_commute (lub _ _)).
+rewrite (distrib1 Lsh).
+rewrite <- (glb_assoc Lsh Lsh).
+rewrite glb_idem.
+rewrite share_distrib2'.
+rewrite lub_idem.
+rewrite (lub_commute sh), glb_absorb.
+rewrite comp1.
+rewrite glb_top.
+rewrite glb_absorb.
+rewrite lub_assoc.
+rewrite (lub_commute (glb _ _)).
+rewrite distrib2.
+rewrite comp1.
+rewrite (glb_commute top), glb_top.
+rewrite <- lub_assoc.
+rewrite distrib1.
+rewrite glb_idem.
+rewrite lub_commute, lub_absorb.
+auto.
+-
+destruct (split (glb sh Lsh)) eqn:?H.
+simpl.
+rewrite <- lub_assoc.
+rewrite (split_together _ _ _ H).
+rewrite share_distrib2'.
+rewrite lub_Lsh_Rsh.
+rewrite glb_top.
+rewrite lub_idem.
+rewrite (lub_commute Lsh).
+rewrite glb_absorb.
+rewrite glb_absorb.
+auto.
+Qed.
+
+Lemma shave_writable:
+ forall sh,   writable_share sh -> nonempty_share (fst (shave sh)) /\ writable_share (snd (shave sh)).
+Proof.
+intros.
+unfold writable_share in H.
+destruct H.
+unfold shave.
+rewrite glb_commute in H.
+unfold writable_share.
+destruct (split (glb sh Lsh)) eqn:?H.
+simpl.
+split3.
+-
+intro.
+apply identity_share_bot in H2. subst t0.
+pose proof (split_nontrivial _ _ _ H1).
+spec H2; auto.
+rewrite H2 in H.
+apply H.
+apply bot_identity.
+-
+clear H0.
+rewrite distrib1.
+rewrite (glb_commute sh).
+rewrite <- glb_assoc.
+rewrite glb_Lsh_Rsh.
+rewrite (glb_commute bot), glb_bot.
+rewrite lub_bot.
+unfold nonempty_share, nonidentity in H|-*.
+assert (t0 <> bot /\ t1 <> bot). {
+  assert (glb sh Lsh <> bot).
+     unfold nonempty_share, nonidentity in H.
+     contradict H. rewrite H. apply bot_identity.
+   pose proof (split_nontrivial _ _ _ H1).  
+  intuition.
+}
+destruct H0.
+pose proof (split_together _ _ _ H1).
+pose proof (split_disjoint _ _ _ H1).
+rewrite glb_commute.
+clear H.
+intro.
+apply identity_share_bot in H.
+clear H1.
+assert (join t0 t1 (glb sh Lsh)) by (split; auto).
+assert (join_sub (glb sh Lsh) Lsh).
+apply leq_join_sub.
+apply glb_lower2.
+destruct H5.
+destruct (join_assoc (join_comm H1) H5) as [y [? ?]].
+assert (t1 <= Lsh).
+apply leq_join_sub; eexists; eauto.
+apply ord_spec1 in H8.
+rewrite H in H8.
+rewrite H8 in H2. apply H2; auto.
+-
+apply leq_join_sub.
+apply leq_join_sub in H0.
+apply ord_spec1 in H0.
+rewrite glb_commute.
+rewrite <- H0.
+apply lub_upper2.
+Qed.
+
+Lemma cleave_join:
+   forall sh,  join (fst (cleave sh)) (snd (cleave sh)) sh.
+Proof.
+apply slice.cleave_join.
+Qed.
+
+Lemma cleave_readable:
+  forall sh, readable_share sh -> readable_share (fst (cleave sh)) /\ readable_share (snd (cleave sh)).
+Proof.
+intros.
+unfold cleave.
+split.
+apply slice.cleave_readable1; auto.
+apply slice.cleave_readable2; auto.
+Qed.
+
+Lemma cleave_nonempty:
+  forall sh, nonempty_share sh -> nonempty_share (fst (cleave sh)) /\ nonempty_share (snd (cleave sh)).
+Proof.
+intros.
+unfold cleave.
+pose proof (slice.cleave_join sh).
+unfold slice.cleave in *.
+destruct (split (glb Lsh sh)) as [a b] eqn:H1.
+destruct (split (glb Rsh sh)) as [c d] eqn:H2.
+simpl in *.
+pose proof (split_nontrivial _ _ _ H1).  
+pose proof (split_nontrivial _ _ _ H2).
+pose proof (comp_parts comp_Lsh_Rsh sh).
+rewrite H5 in H.
+unfold nonempty_share, nonidentity in H.
+assert (~identity (glb Lsh sh) \/ ~identity (glb Rsh sh)).
+apply Classical_Prop.not_and_or.
+intros [? ?].
+apply identity_share_bot in H6.
+apply identity_share_bot in H7.
+rewrite H6,H7 in H.
+rewrite lub_idem in H.
+apply H.
+apply bot_identity.
+clear H.
+destruct H6.
+-
+assert (glb Lsh sh <> bot).
+intro. rewrite H6 in H. apply H; apply bot_identity.
+assert (a<>bot /\ b<>bot) by intuition.
+destruct H7.
+split; intro H9; apply identity_share_bot in H9; apply lub_bot_e in H9; intuition.
+-
+assert (glb Rsh sh <> bot).
+intro. rewrite H6 in H. apply H; apply bot_identity.
+assert (c<>bot /\ d<>bot) by intuition.
+destruct H7.
+split; intro H9; apply identity_share_bot in H9; apply lub_bot_e in H9; intuition.
+Qed.
+*)
+
+Lemma join_Ews:
+  join  Ews (snd (split Lsh)) Tsh.
+Proof.
+unfold Ews.
+unfold extern_retainer.
+destruct (split Lsh) as [a b] eqn:?H.
+simpl.
+split.
+rewrite glb_commute, distrib1.
+rewrite glb_commute.
+destruct (split_join _ _ _ H). 
+rewrite H0. rewrite lub_commute, lub_bot.
+clear - H1.
+pose proof (lub_upper2 a b).
+rewrite H1 in H.
+pose proof (glb_less_both H (ord_refl Rsh)).
+rewrite glb_Lsh_Rsh in H0.
+apply ord_antisym; auto.
+apply bot_correct.
+rewrite (lub_commute a).
+rewrite lub_assoc.
+destruct (split_join _ _ _ H). 
+rewrite H1.
+rewrite lub_commute.
+apply lub_Lsh_Rsh.
+Qed.
+
+Lemma comp_Ews:
+  comp(Ews) = snd(split Lsh).
+Proof.
+apply join_top_comp.
+apply join_Ews.
+Qed.
+
+(*
+
+Fixpoint nth_split_left (sh: share) (n: nat) :=
+ match n with
+ | O => sh
+ | S n' => nth_split_left (fst (split sh)) n'
+ end.
+
+Lemma nth_split_left_S:
+ forall sh n,
+  nth_split_left sh (S n) = fst (split (nth_split_left sh n)).
+Proof.
+intros.
+revert sh; induction n; intros.
+reflexivity.
+simpl in *.
+rewrite IHn.
+auto.
+Qed.
+
+Lemma leftmost_epsilon (sh: share) :
+  {n | join_sub (nth_split_left Tsh n) sh} +
+  {~ exists n, join_sub (nth_split_left Tsh n) sh}.
+  (* Andrew is quite sure this is provable. *)
+Abort.
+
+Definition augment (sh: share) := 
+  if leftmost_epsilon sh then lub sh (comp Ews) else sh.
+
+Definition leftmost_eps (sh: share) :=
+  exists n, join_sub (nth_split_left Tsh n) sh.
+
+Lemma leftmost_epsilon_Ews:  
+  leftmost_eps Ews.
+Proof.
+intros.
+unfold Ews.
+unfold extern_retainer.
+unfold Lsh.
+exists 2%nat.
+simpl.
+exists Rsh.
+unfold Rsh, Tsh. 
+split; auto.
+rewrite glb_commute.
+apply sub_glb_bot with (fst (split top)).
+exists (snd (split (fst (split top)))).
+apply split_join.
+apply surjective_pairing.
+rewrite glb_commute.
+apply glb_split.
+Qed.
+
+Axiom split_rel:
+  forall sh, split sh = (rel sh Lsh, rel sh Rsh).
+
+Axiom rel_congruence2:
+ forall x1 x2 a,
+  join_sub x1 x2 -> join_sub (rel x1 a) (rel x2 a).
+
+Lemma leftmost_epsilon_lub1:
+ forall a b n,
+    join_sub (nth_split_left Tsh n) a ->
+    join_sub (nth_split_left Tsh n) (lub a b).
+Proof.
+intros.
+eapply join_sub_trans; [apply H |].
+apply leq_join_sub.
+apply lub_upper1.
+Qed.
+
+Lemma leftmost_epsilon_lub2:
+ forall a b n,
+    join_sub (nth_split_left Tsh n) b ->
+    join_sub (nth_split_left Tsh n) (lub a b).
+intros.
+eapply join_sub_trans; [apply H |].
+apply leq_join_sub.
+apply lub_upper2.
+Qed.
+
+Lemma leftmost_epsilon_rel:
+ forall a b m n,
+    join_sub (nth_split_left Tsh m) a ->
+    join_sub (nth_split_left Tsh n) b ->
+    join_sub (nth_split_left Tsh (m+n)) (rel a b).
+Proof.
+Abort.
+
+Lemma leftmost_epsilon_glb:
+ forall a b n,
+    join_sub (nth_split_left Tsh n) a ->
+    join_sub (nth_split_left Tsh n) b ->
+    join_sub (nth_split_left Tsh n) (glb a b).
+Proof.
+intros.
+apply leq_join_sub in H.
+apply leq_join_sub in H0.
+apply leq_join_sub.
+apply glb_greatest; auto.
+Qed.
+
+Lemma leftmost_epsilon_up:
+ forall a (n m: nat),
+    (n <= m)%nat -> 
+    join_sub (nth_split_left Tsh n) a ->
+    join_sub (nth_split_left Tsh m) a.
+Proof.
+intros.
+Abort.
+
+Lemma leftmost_epsilon_Lsh:
+    join_sub (nth_split_left Tsh 1) Lsh.
+Proof.
+apply join_sub_refl.
+Qed.
+
+Lemma not_leftmost_epsilon_lub:
+  forall a b, 
+   ~ (exists n, join_sub (nth_split_left Tsh n) a) ->
+   ~ (exists n, join_sub (nth_split_left Tsh n) b) ->
+   ~ (exists n, join_sub (nth_split_left Tsh n) (lub a b)).
+Proof.
+Abort.
+
+Lemma not_leftmost_epsilon_rel1:
+  forall a b, 
+   ~ (exists n, join_sub (nth_split_left Tsh n) a) ->
+   ~ (exists n, join_sub (nth_split_left Tsh n) (rel a b)).
+Proof.
+intros.
+contradict H.
+destruct H as [n H].
+exists n.
+Abort.
+
+Lemma not_leftmost_epsilon_rel2:
+  forall a b, 
+   ~ (exists n, join_sub (nth_split_left Tsh n) b) ->
+   ~ (exists n, join_sub (nth_split_left Tsh n) (rel a b)).
+Proof.
+intros.
+contradict H.
+destruct H as [n H].
+exists n.
+Abort.
+
+Lemma not_leftmost_epsilon_glb1:
+  forall a b, 
+   ~ (exists n, join_sub (nth_split_left Tsh n) a) ->
+   ~ (exists n, join_sub (nth_split_left Tsh n) (glb a b)).
+Proof.
+intros.
+contradict H.
+destruct H as [n H].
+exists n.
+eapply join_sub_trans.
+eassumption.
+apply leq_join_sub.
+apply glb_lower1.
+Qed.
+
+Lemma not_leftmost_epsilon_glb2:
+  forall a b, 
+   ~ (exists n, join_sub (nth_split_left Tsh n) b) ->
+   ~ (exists n, join_sub (nth_split_left Tsh n) (glb a b)).
+Proof.
+intros.
+contradict H.
+destruct H as [n H].
+exists n.
+eapply join_sub_trans.
+eassumption.
+apply leq_join_sub.
+apply glb_lower2.
+Qed.
+
+Lemma not_leftmost_epsilon_Rsh:
+   ~ (exists n, join_sub (nth_split_left Tsh n) Rsh).
+Proof.
+intros [n H].
+Abort.
+
+Lemma shave_leftmost_epsilon1:
+  forall sh, leftmost_eps sh -> 
+     leftmost_eps (fst (shave sh)).
+Proof.
+intros.
+unfold shave.
+rewrite !split_rel.
+simpl.
+destruct H.
+exists ((1+x)+(1+x))%nat.
+apply leftmost_epsilon_rel.
+apply leftmost_epsilon_glb.
+eapply leftmost_epsilon_up; [ |apply H]; lia.
+eapply leftmost_epsilon_up; [ |apply leftmost_epsilon_Lsh]; lia.
+eapply leftmost_epsilon_up; [ |apply leftmost_epsilon_Lsh]; lia.
+Qed.
+
+Lemma shave_leftmost_epsilon2:
+  forall sh, ~ leftmost_eps (snd (shave sh)).
+Proof.
+intros.
+unfold shave; simpl.
+rewrite !split_rel; simpl.
+apply not_leftmost_epsilon_lub.
+apply not_leftmost_epsilon_rel2.
+apply not_leftmost_epsilon_Rsh.
+apply not_leftmost_epsilon_glb2.
+apply not_leftmost_epsilon_Rsh.
+Qed.
+
+Lemma shave_leftmost_epsilon:
+  forall sh, leftmost_eps sh -> 
+     leftmost_eps (fst (shave sh)) /\  ~ leftmost_eps (snd (shave sh)).
+Proof.
+intros.
+split.
+apply shave_leftmost_epsilon1; auto.
+apply shave_leftmost_epsilon2.
+Qed.
+
+Lemma cleave_leftmost_epsilon:
+  forall sh, leftmost_eps sh -> 
+     leftmost_eps (fst (cleave sh)) /\  ~ leftmost_eps (snd (cleave sh)).
+Proof.
+intros.
+unfold cleave, slice.cleave.
+simpl.
+rewrite !split_rel; simpl.
+split.
+-
+destruct H.
+exists (1 + x + (1 + x))%nat.
+apply leftmost_epsilon_lub1.
+apply leftmost_epsilon_rel.
+apply leftmost_epsilon_glb.
+eapply leftmost_epsilon_up;  [  | apply leftmost_epsilon_Lsh].
+lia.
+eapply leftmost_epsilon_up;  [  | apply H].
+lia.
+eapply leftmost_epsilon_up;  [  | apply leftmost_epsilon_Lsh].
+lia.
+-
+unfold leftmost_eps.
+apply not_leftmost_epsilon_lub.
+apply not_leftmost_epsilon_rel2.
+apply not_leftmost_epsilon_Rsh.
+apply not_leftmost_epsilon_rel2.
+apply not_leftmost_epsilon_Rsh.
+Qed.
+
+Lemma augment_Ews:  augment Ews = Tsh.
+Proof.
+  unfold augment.
+  destruct (leftmost_epsilon Ews).
+  rewrite comp1; auto.
+  pose leftmost_epsilon_Ews; unfold leftmost_eps in *; contradiction.
+Qed.
+
+*)
+
+Lemma nonidentity_comp_Ews:
+  nonidentity (comp Ews).
+Proof.
+  rewrite comp_Ews.
+  assert (nonidentity Lsh).
+  { replace Lsh with (fst (split top)) by auto.
+    assert (split top = (fst (split top), snd (split top))) as Htop 
+        by apply surjective_pairing.
+    pose (split_nontrivial' _ _ _ Htop).
+    pose top_share_nonidentity.
+    unfold nonidentity in *; unfold not in *; auto.
+  }
+  assert (split Lsh = (fst (split Lsh), snd (split Lsh))) as HLsh 
+      by apply surjective_pairing.
+  pose (split_nontrivial' _ _ _ HLsh). 
+  unfold nonidentity in *; unfold not in *; auto.
+Qed.
+
+(*
+
+(* Toy version of malloc_token, without large/small distinction, without 
+   the waste part of the header, and Int size rather than data type and Ptrofs. 
+   In the full development we'll have both n and s, with s>0 because small 
+   chunks are nonempty *)
+
+Definition maybe_sliver_leftmost (sh: share) :=
+  if leftmost_epsilon sh then (comp Ews) else bot.  
+
+Definition compEwsL := rel (comp Ews) Lsh.
+Definition compEwsR := rel (comp Ews) Rsh.
+
+(* The R relation *)
+Inductive tokChunk : share -> share -> Prop :=
+  | mkTokChunk: forall sh sh' a b: share, 
+    join (rel extern_retainer a) (rel Rsh b) sh ->
+    lub (rel compEwsL a) (rel compEwsR b) = sh' -> tokChunk sh sh'.
+
+Lemma tokChunk_disj:
+  forall a b, glb (rel compEwsL a) (rel compEwsR b) = bot.
+Proof.
+intros.
+apply ord_antisym.
+2: apply bot_correct.
+eapply ord_trans with (glb compEwsL compEwsR).
+apply glb_greatest.
+eapply ord_trans; [ apply glb_lower1 | apply leq_join_sub; apply rel_leq].
+eapply ord_trans; [ apply glb_lower2 | apply leq_join_sub; apply rel_leq].
+unfold compEwsL, compEwsR.
+rewrite <- rel_preserves_glb.
+rewrite glb_Lsh_Rsh.
+rewrite rel_bot1.
+apply ord_refl.
+Qed.
+
+Lemma tokChunk_Ews: tokChunk Ews (comp Ews).
+Proof.
+apply mkTokChunk with Tsh Tsh.
+rewrite !rel_top1.
+split; auto.
+unfold extern_retainer.
+rewrite split_rel; simpl.
+apply ord_antisym.
+2: apply bot_correct.
+eapply ord_trans with (glb Lsh Rsh).
+apply glb_less_both.
+apply leq_join_sub.
+apply rel_leq.
+apply ord_refl.
+rewrite glb_Lsh_Rsh.
+apply ord_refl.
+rewrite !rel_top1.
+unfold compEwsL, compEwsR.
+rewrite <- rel_preserves_lub.
+rewrite lub_Lsh_Rsh.
+rewrite !rel_top1.
+auto.
+Qed.
+
+Lemma tokChunk_bot: forall sh, tokChunk sh bot -> sh = bot.
+Proof.
+intros.
+inv H.
+assert (ET: Ews <> top). {
+ clear.
+ intro.
+ pose proof (join_Ews). rewrite H in H0.
+ apply join_top_comp in H0.
+ rewrite <- comp_bot, comp_inv in H0.
+ destruct (split Lsh) eqn:?.  simpl in *. subst t1.
+ apply split_nontrivial in Heqp.
+ apply Lsh_bot_neq; auto.
+ auto.
+}
+apply lub_bot_e in H1.
+destruct H1.
+rewrite <- (rel_bot1 compEwsR) in H1.
+apply rel_inj_l in H1. subst.
+rewrite <- (rel_bot1 compEwsL) in H.
+apply rel_inj_l in H. subst.
+rewrite !rel_bot1 in H0.
+destruct H0.
+rewrite lub_bot in H0. subst; auto.
+clear - ET; intro.
+unfold compEwsL in H.
+rewrite <- (rel_bot2 Lsh) in H.
+apply rel_inj_r in H.
+pose proof (join_Ews).
+rewrite <- comp_Ews in H0.
+rewrite H in H0.
+apply join_unit2_e in H0; auto.
+apply Lsh_bot_neq.
+clear - ET.
+unfold compEwsR.
+intro.
+rewrite <- (rel_bot2 Rsh) in H.
+apply rel_inj_r in H.
+assert (comp (comp Ews) = comp bot) by congruence.
+rewrite comp_inv in H0.
+rewrite comp_bot in H0.
+contradiction.
+clear.
+intro.
+unfold Rsh in H.
+destruct (split top) eqn:?H.
+simpl in *; subst.
+apply split_nontrivial in H0; auto.
+apply nontrivial; auto.
+Qed.
+
+
+Lemma tokChunk_fun: 
+forall sh a b,
+    join (rel extern_retainer a) (rel Rsh b) sh ->
+    a = fst(split(fst(split(glb sh extern_retainer)))) /\
+    b = snd(split(glb sh Rsh)).
+Proof.
+intros.
+inv H.
+Abort.
+
+Lemma tokChunk_functional:
+forall sh sh' sh'', tokChunk sh sh' -> tokChunk sh sh'' -> sh' = sh''.
+Proof.
+intros.
+inv H; inv H0.
+pose proof (tokChunk_fun _ _ _ H1) as [Ha Hb].
+pose proof (tokChunk_fun _ _ _ H) as [Ha0 Hb0].
+subst; reflexivity.
+Qed.
+
+Lemma tokChunk_shave: forall sh sh' sh1 sh2,
+    tokChunk sh sh' -> (sh1,sh2) = shave sh -> 
+    exists sh1' sh2', join sh1' sh2' sh' /\ tokChunk sh1 sh1' /\ tokChunk sh2 sh2'.
+Abort.
+
+Lemma tokChunk_cleave: forall sh sh' sh1 sh2,
+    tokChunk sh sh' -> (sh1,sh2) = shave sh -> 
+    exists sh1' sh2', join sh1' sh2' sh' /\ tokChunk sh1 sh1' /\ tokChunk sh2 sh2'.
+Abort.
+
+*)
+
+

--- a/progs/memmgr/mmap0.c
+++ b/progs/memmgr/mmap0.c
@@ -1,0 +1,24 @@
+#include <stddef.h>
+#include <sys/mman.h> 
+
+/* mmap0 - same as mmap except returns NULL on failure instead of MAP_FAILED.
+Because: MAP_FAILED is ((void*)-1) but the C standard disallows comparison 
+with -1.  This is enforced by Verifiable C.  So we verify the memory manager 
+against the spec of mmap0 and do not verify the body of mmap0.
+*/
+/*void* mmap0(void *addr, size_t len, int prot, int flags, int fildes, off_t off) {
+  void* p = mmap(addr,len,prot,flags,fildes,off);
+  if (p == MAP_FAILED) return NULL;
+  else return p;
+  }*/
+/*Specialization using platform-dependent values - previously hardcoded in mmap0_spec*/
+void* mmap0(void *addr, size_t len, int fildes) {
+  void* p = mmap(addr,len, 3, 4098, fildes,0);
+  if (p == MAP_FAILED) return NULL;
+  else return p;
+  }
+
+/* to convince clightgen to include these identifiers */
+int mmap0_placeholder(void) {
+  return &munmap,  &mmap0, 0;
+}

--- a/progs/memmgr/mmap0.h
+++ b/progs/memmgr/mmap0.h
@@ -1,0 +1,20 @@
+/* restricted spec for our purposes
+precond: addr == NULL 
+         prot == PROT_READ|PROT_WRITE
+         off == 0
+         flags == MAP_PRIVATE|MAP_ANONYMOUS 
+         fildes == -1 
+postcond: 
+  if ret != MAP_FAILED then ret points to page-aligned block of size len bytes 
+*/ 
+extern void *mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off);
+
+/* shim for mmap that uses null in place of MAP_FAILED */
+/*void* mmap0(void *addr, size_t len, int prot, int flags, int fildes, off_t off);*/
+void* mmap0(void *addr, size_t len, int fildes);
+
+/* restricted spec for our purposes
+precond: addr through addr+len was allocated by mmap and is a multiple of PAGESIZE
+postcond: if ret==0 then the memory was freed.
+*/ 
+extern int munmap(void *addr, size_t len);

--- a/progs/memmgr/mmap0.v
+++ b/progs/memmgr/mmap0.v
@@ -1,0 +1,439 @@
+From Coq Require Import String List ZArith.
+From compcert Require Import Coqlib Integers Floats AST Ctypes Cop Clight Clightdefs.
+Import Clightdefs.ClightNotations.
+Local Open Scope Z_scope.
+Local Open Scope string_scope.
+Local Open Scope clight_scope.
+
+Module Info.
+  Definition version := "3.10".
+  Definition build_number := "".
+  Definition build_tag := "".
+  Definition build_branch := "".
+  Definition arch := "x86".
+  Definition model := "32sse2".
+  Definition abi := "standard".
+  Definition bitsize := 32.
+  Definition big_endian := false.
+  Definition source_file := "mmap0.c".
+  Definition normalized := true.
+End Info.
+
+Definition ___builtin_ais_annot : ident := 1%positive.
+Definition ___builtin_annot : ident := 18%positive.
+Definition ___builtin_annot_intval : ident := 19%positive.
+Definition ___builtin_bswap : ident := 3%positive.
+Definition ___builtin_bswap16 : ident := 5%positive.
+Definition ___builtin_bswap32 : ident := 4%positive.
+Definition ___builtin_bswap64 : ident := 2%positive.
+Definition ___builtin_clz : ident := 6%positive.
+Definition ___builtin_clzl : ident := 7%positive.
+Definition ___builtin_clzll : ident := 8%positive.
+Definition ___builtin_ctz : ident := 9%positive.
+Definition ___builtin_ctzl : ident := 10%positive.
+Definition ___builtin_ctzll : ident := 11%positive.
+Definition ___builtin_debug : ident := 37%positive.
+Definition ___builtin_expect : ident := 26%positive.
+Definition ___builtin_fabs : ident := 12%positive.
+Definition ___builtin_fabsf : ident := 13%positive.
+Definition ___builtin_fmadd : ident := 29%positive.
+Definition ___builtin_fmax : ident := 27%positive.
+Definition ___builtin_fmin : ident := 28%positive.
+Definition ___builtin_fmsub : ident := 30%positive.
+Definition ___builtin_fnmadd : ident := 31%positive.
+Definition ___builtin_fnmsub : ident := 32%positive.
+Definition ___builtin_fsqrt : ident := 14%positive.
+Definition ___builtin_membar : ident := 20%positive.
+Definition ___builtin_memcpy_aligned : ident := 16%positive.
+Definition ___builtin_read16_reversed : ident := 33%positive.
+Definition ___builtin_read32_reversed : ident := 34%positive.
+Definition ___builtin_sel : ident := 17%positive.
+Definition ___builtin_sqrt : ident := 15%positive.
+Definition ___builtin_unreachable : ident := 25%positive.
+Definition ___builtin_va_arg : ident := 22%positive.
+Definition ___builtin_va_copy : ident := 23%positive.
+Definition ___builtin_va_end : ident := 24%positive.
+Definition ___builtin_va_start : ident := 21%positive.
+Definition ___builtin_write16_reversed : ident := 35%positive.
+Definition ___builtin_write32_reversed : ident := 36%positive.
+Definition ___compcert_i64_dtos : ident := 50%positive.
+Definition ___compcert_i64_dtou : ident := 51%positive.
+Definition ___compcert_i64_sar : ident := 62%positive.
+Definition ___compcert_i64_sdiv : ident := 56%positive.
+Definition ___compcert_i64_shl : ident := 60%positive.
+Definition ___compcert_i64_shr : ident := 61%positive.
+Definition ___compcert_i64_smod : ident := 58%positive.
+Definition ___compcert_i64_smulh : ident := 63%positive.
+Definition ___compcert_i64_stod : ident := 52%positive.
+Definition ___compcert_i64_stof : ident := 54%positive.
+Definition ___compcert_i64_udiv : ident := 57%positive.
+Definition ___compcert_i64_umod : ident := 59%positive.
+Definition ___compcert_i64_umulh : ident := 64%positive.
+Definition ___compcert_i64_utod : ident := 53%positive.
+Definition ___compcert_i64_utof : ident := 55%positive.
+Definition ___compcert_va_composite : ident := 49%positive.
+Definition ___compcert_va_float64 : ident := 48%positive.
+Definition ___compcert_va_int32 : ident := 46%positive.
+Definition ___compcert_va_int64 : ident := 47%positive.
+Definition _addr : ident := 40%positive.
+Definition _fildes : ident := 42%positive.
+Definition _len : ident := 41%positive.
+Definition _main : ident := 65%positive.
+Definition _mmap : ident := 38%positive.
+Definition _mmap0 : ident := 44%positive.
+Definition _mmap0_placeholder : ident := 45%positive.
+Definition _munmap : ident := 39%positive.
+Definition _p : ident := 43%positive.
+Definition _t'1 : ident := 66%positive.
+
+Definition f_mmap0 := {|
+  fn_return := (tptr tvoid);
+  fn_callconv := cc_default;
+  fn_params := ((_addr, (tptr tvoid)) :: (_len, tuint) :: (_fildes, tint) ::
+                nil);
+  fn_vars := nil;
+  fn_temps := ((_p, (tptr tvoid)) :: (_t'1, (tptr tvoid)) :: nil);
+  fn_body :=
+(Ssequence
+  (Ssequence
+    (Scall (Some _t'1)
+      (Evar _mmap (Tfunction
+                    (Tcons (tptr tvoid)
+                      (Tcons tuint
+                        (Tcons tint
+                          (Tcons tint (Tcons tint (Tcons tint Tnil))))))
+                    (tptr tvoid) cc_default))
+      ((Etempvar _addr (tptr tvoid)) :: (Etempvar _len tuint) ::
+       (Econst_int (Int.repr 3) tint) :: (Econst_int (Int.repr 4098) tint) ::
+       (Etempvar _fildes tint) :: (Econst_int (Int.repr 0) tint) :: nil))
+    (Sset _p (Etempvar _t'1 (tptr tvoid))))
+  (Sifthenelse (Ebinop Oeq (Etempvar _p (tptr tvoid))
+                 (Ecast (Eunop Oneg (Econst_int (Int.repr 1) tint) tint)
+                   (tptr tvoid)) tint)
+    (Sreturn (Some (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid))))
+    (Sreturn (Some (Etempvar _p (tptr tvoid))))))
+|}.
+
+Definition f_mmap0_placeholder := {|
+  fn_return := tint;
+  fn_callconv := cc_default;
+  fn_params := nil;
+  fn_vars := nil;
+  fn_temps := nil;
+  fn_body :=
+(Sreturn (Some (Econst_int (Int.repr 0) tint)))
+|}.
+
+Definition composites : list composite_definition :=
+nil.
+
+Definition global_definitions : list (ident * globdef fundef type) :=
+((___compcert_va_int32,
+   Gfun(External (EF_runtime "__compcert_va_int32"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons (tptr tvoid) Tnil) tuint cc_default)) ::
+ (___compcert_va_int64,
+   Gfun(External (EF_runtime "__compcert_va_int64"
+                   (mksignature (AST.Tint :: nil) AST.Tlong cc_default))
+     (Tcons (tptr tvoid) Tnil) tulong cc_default)) ::
+ (___compcert_va_float64,
+   Gfun(External (EF_runtime "__compcert_va_float64"
+                   (mksignature (AST.Tint :: nil) AST.Tfloat cc_default))
+     (Tcons (tptr tvoid) Tnil) tdouble cc_default)) ::
+ (___compcert_va_composite,
+   Gfun(External (EF_runtime "__compcert_va_composite"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     (tptr tvoid) cc_default)) ::
+ (___compcert_i64_dtos,
+   Gfun(External (EF_runtime "__compcert_i64_dtos"
+                   (mksignature (AST.Tfloat :: nil) AST.Tlong cc_default))
+     (Tcons tdouble Tnil) tlong cc_default)) ::
+ (___compcert_i64_dtou,
+   Gfun(External (EF_runtime "__compcert_i64_dtou"
+                   (mksignature (AST.Tfloat :: nil) AST.Tlong cc_default))
+     (Tcons tdouble Tnil) tulong cc_default)) ::
+ (___compcert_i64_stod,
+   Gfun(External (EF_runtime "__compcert_i64_stod"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons tlong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_utod,
+   Gfun(External (EF_runtime "__compcert_i64_utod"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons tulong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_stof,
+   Gfun(External (EF_runtime "__compcert_i64_stof"
+                   (mksignature (AST.Tlong :: nil) AST.Tsingle cc_default))
+     (Tcons tlong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_utof,
+   Gfun(External (EF_runtime "__compcert_i64_utof"
+                   (mksignature (AST.Tlong :: nil) AST.Tsingle cc_default))
+     (Tcons tulong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_sdiv,
+   Gfun(External (EF_runtime "__compcert_i64_sdiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_udiv,
+   Gfun(External (EF_runtime "__compcert_i64_udiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_smod,
+   Gfun(External (EF_runtime "__compcert_i64_smod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_umod,
+   Gfun(External (EF_runtime "__compcert_i64_umod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_shl,
+   Gfun(External (EF_runtime "__compcert_i64_shl"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tint Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_shr,
+   Gfun(External (EF_runtime "__compcert_i64_shr"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tint Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_sar,
+   Gfun(External (EF_runtime "__compcert_i64_sar"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tint Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_smulh,
+   Gfun(External (EF_runtime "__compcert_i64_smulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_umulh,
+   Gfun(External (EF_runtime "__compcert_i64_umulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___builtin_ais_annot,
+   Gfun(External (EF_builtin "__builtin_ais_annot"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_bswap64,
+   Gfun(External (EF_builtin "__builtin_bswap64"
+                   (mksignature (AST.Tlong :: nil) AST.Tlong cc_default))
+     (Tcons tulong Tnil) tulong cc_default)) ::
+ (___builtin_bswap,
+   Gfun(External (EF_builtin "__builtin_bswap"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap32,
+   Gfun(External (EF_builtin "__builtin_bswap32"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap16,
+   Gfun(External (EF_builtin "__builtin_bswap16"
+                   (mksignature (AST.Tint :: nil) AST.Tint16unsigned
+                     cc_default)) (Tcons tushort Tnil) tushort cc_default)) ::
+ (___builtin_clz,
+   Gfun(External (EF_builtin "__builtin_clz"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzl,
+   Gfun(External (EF_builtin "__builtin_clzl"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzll,
+   Gfun(External (EF_builtin "__builtin_clzll"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_ctz,
+   Gfun(External (EF_builtin "__builtin_ctz"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzl,
+   Gfun(External (EF_builtin "__builtin_ctzl"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzll,
+   Gfun(External (EF_builtin "__builtin_ctzll"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_fabs,
+   Gfun(External (EF_builtin "__builtin_fabs"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_fabsf,
+   Gfun(External (EF_builtin "__builtin_fabsf"
+                   (mksignature (AST.Tsingle :: nil) AST.Tsingle cc_default))
+     (Tcons tfloat Tnil) tfloat cc_default)) ::
+ (___builtin_fsqrt,
+   Gfun(External (EF_builtin "__builtin_fsqrt"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_sqrt,
+   Gfun(External (EF_builtin "__builtin_sqrt"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_memcpy_aligned,
+   Gfun(External (EF_builtin "__builtin_memcpy_aligned"
+                   (mksignature
+                     (AST.Tint :: AST.Tint :: AST.Tint :: AST.Tint :: nil)
+                     AST.Tvoid cc_default))
+     (Tcons (tptr tvoid)
+       (Tcons (tptr tvoid) (Tcons tuint (Tcons tuint Tnil)))) tvoid
+     cc_default)) ::
+ (___builtin_sel,
+   Gfun(External (EF_builtin "__builtin_sel"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tbool Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot,
+   Gfun(External (EF_builtin "__builtin_annot"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot_intval,
+   Gfun(External (EF_builtin "__builtin_annot_intval"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons (tptr tschar) (Tcons tint Tnil))
+     tint cc_default)) ::
+ (___builtin_membar,
+   Gfun(External (EF_builtin "__builtin_membar"
+                   (mksignature nil AST.Tvoid cc_default)) Tnil tvoid
+     cc_default)) ::
+ (___builtin_va_start,
+   Gfun(External (EF_builtin "__builtin_va_start"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___builtin_va_arg,
+   Gfun(External (EF_builtin "__builtin_va_arg"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_va_copy,
+   Gfun(External (EF_builtin "__builtin_va_copy"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                     cc_default))
+     (Tcons (tptr tvoid) (Tcons (tptr tvoid) Tnil)) tvoid cc_default)) ::
+ (___builtin_va_end,
+   Gfun(External (EF_builtin "__builtin_va_end"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___builtin_unreachable,
+   Gfun(External (EF_builtin "__builtin_unreachable"
+                   (mksignature nil AST.Tvoid cc_default)) Tnil tvoid
+     cc_default)) ::
+ (___builtin_expect,
+   Gfun(External (EF_builtin "__builtin_expect"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons tint (Tcons tint Tnil)) tint
+     cc_default)) ::
+ (___builtin_fmax,
+   Gfun(External (EF_builtin "__builtin_fmax"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil) AST.Tfloat
+                     cc_default)) (Tcons tdouble (Tcons tdouble Tnil))
+     tdouble cc_default)) ::
+ (___builtin_fmin,
+   Gfun(External (EF_builtin "__builtin_fmin"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil) AST.Tfloat
+                     cc_default)) (Tcons tdouble (Tcons tdouble Tnil))
+     tdouble cc_default)) ::
+ (___builtin_fmadd,
+   Gfun(External (EF_builtin "__builtin_fmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fmsub,
+   Gfun(External (EF_builtin "__builtin_fmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmadd,
+   Gfun(External (EF_builtin "__builtin_fnmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmsub,
+   Gfun(External (EF_builtin "__builtin_fnmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_read16_reversed,
+   Gfun(External (EF_builtin "__builtin_read16_reversed"
+                   (mksignature (AST.Tint :: nil) AST.Tint16unsigned
+                     cc_default)) (Tcons (tptr tushort) Tnil) tushort
+     cc_default)) ::
+ (___builtin_read32_reversed,
+   Gfun(External (EF_builtin "__builtin_read32_reversed"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons (tptr tuint) Tnil) tuint cc_default)) ::
+ (___builtin_write16_reversed,
+   Gfun(External (EF_builtin "__builtin_write16_reversed"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tushort) (Tcons tushort Tnil))
+     tvoid cc_default)) ::
+ (___builtin_write32_reversed,
+   Gfun(External (EF_builtin "__builtin_write32_reversed"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tuint) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_debug,
+   Gfun(External (EF_external "__builtin_debug"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tint Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (_mmap,
+   Gfun(External (EF_external "mmap"
+                   (mksignature
+                     (AST.Tint :: AST.Tint :: AST.Tint :: AST.Tint ::
+                      AST.Tint :: AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons (tptr tvoid)
+       (Tcons tuint (Tcons tint (Tcons tint (Tcons tint (Tcons tint Tnil))))))
+     (tptr tvoid) cc_default)) ::
+ (_munmap,
+   Gfun(External (EF_external "munmap"
+                   (mksignature (AST.Tint :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     tint cc_default)) :: (_mmap0, Gfun(Internal f_mmap0)) ::
+ (_mmap0_placeholder, Gfun(Internal f_mmap0_placeholder)) :: nil).
+
+Definition public_idents : list ident :=
+(_mmap0_placeholder :: _mmap0 :: _munmap :: _mmap :: ___builtin_debug ::
+ ___builtin_write32_reversed :: ___builtin_write16_reversed ::
+ ___builtin_read32_reversed :: ___builtin_read16_reversed ::
+ ___builtin_fnmsub :: ___builtin_fnmadd :: ___builtin_fmsub ::
+ ___builtin_fmadd :: ___builtin_fmin :: ___builtin_fmax ::
+ ___builtin_expect :: ___builtin_unreachable :: ___builtin_va_end ::
+ ___builtin_va_copy :: ___builtin_va_arg :: ___builtin_va_start ::
+ ___builtin_membar :: ___builtin_annot_intval :: ___builtin_annot ::
+ ___builtin_sel :: ___builtin_memcpy_aligned :: ___builtin_sqrt ::
+ ___builtin_fsqrt :: ___builtin_fabsf :: ___builtin_fabs ::
+ ___builtin_ctzll :: ___builtin_ctzl :: ___builtin_ctz :: ___builtin_clzll ::
+ ___builtin_clzl :: ___builtin_clz :: ___builtin_bswap16 ::
+ ___builtin_bswap32 :: ___builtin_bswap :: ___builtin_bswap64 ::
+ ___builtin_ais_annot :: ___compcert_i64_umulh :: ___compcert_i64_smulh ::
+ ___compcert_i64_sar :: ___compcert_i64_shr :: ___compcert_i64_shl ::
+ ___compcert_i64_umod :: ___compcert_i64_smod :: ___compcert_i64_udiv ::
+ ___compcert_i64_sdiv :: ___compcert_i64_utof :: ___compcert_i64_stof ::
+ ___compcert_i64_utod :: ___compcert_i64_stod :: ___compcert_i64_dtou ::
+ ___compcert_i64_dtos :: ___compcert_va_composite ::
+ ___compcert_va_float64 :: ___compcert_va_int64 :: ___compcert_va_int32 ::
+ nil).
+
+Definition prog : Clight.program := 
+  mkprogram composites global_definitions public_idents _main Logic.I.
+
+

--- a/progs/memmgr/verif_bin2size2bin.v
+++ b/progs/memmgr/verif_bin2size2bin.v
@@ -1,0 +1,27 @@
+Require Import VST.floyd.proofauto.
+Require Import malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep. (*New: to get access to the CompSpecs defined in that file*)
+Require Import VSU_malloc_definitions.
+
+Lemma body_bin2size: semax_body MF_Vprog MF_Gprog f_bin2size bin2size_spec.
+Proof. start_function. forward. 
+Qed.
+
+Lemma body_size2bin: semax_body MF_Vprog MF_Gprog f_size2bin size2bin_spec.
+Proof. start_function. 
+  forward_call (BINS-1). (*rep_lia. *)
+  forward_if.
+  - (* then *) 
+    forward. entailer!. f_equal. f_equal. unfold size2binZ; simpl. 
+    bdestruct (bin2sizeZ (BINS - 1) <? s); trivial; try lia.
+  - (* else *)
+    forward.  entailer!. f_equal. unfold size2binZ. 
+    bdestruct (bin2sizeZ (BINS - 1) <? s); try lia.
+    unfold Int.divu. do 2 rewrite Int.unsigned_repr by rep_lia. 
+    f_equal. normalize.  f_equal. rep_lia.
+Qed.
+ (*
+Definition module := 
+  [mk_body body_bin2size; mk_body body_size2bin].
+*)

--- a/progs/memmgr/verif_fill_bin.v
+++ b/progs/memmgr/verif_fill_bin.v
@@ -1,0 +1,61 @@
+Require Import VST.floyd.proofauto.
+Require Import malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+Local Open Scope logic.
+(*
+Definition Gprog : funspecs := external_specs ++ private_specs.
+*)
+
+Lemma body_fill_bin: semax_body MF_Vprog MF_Gprog f_fill_bin fill_bin_spec.
+Proof. 
+start_function. 
+forward_call b.  (*! s = bin2size(b) !*)
+set (s:=bin2sizeZ b).
+assert (WORD <= s <= bin2sizeZ(BINS-1)) by (pose proof (bin2size_range b); rep_lia).
+forward_call BIGBLOCK.  (*! *p = mmap0(BIGBLOCK ...) !*)  
+(*{ rep_lia. }*)
+Intros p.  
+if_tac in H1. (* split cases on mmap post *)
+- (* case p = nullval *)
+  forward_if. (*! if p == NULL, case true  !*)
+  forward. (*! return NULL !*)
+  Exists nullval. Exists 1. 
+  entailer!. contradiction.
+- (* case p <> nullval *)
+  assert_PROP (isptr p) by entailer!.
+  destruct p; try contradiction. 
+  rename b0 into pblk; rename i into poff. (* p as blk+ofs *)
+  assert_PROP (Ptrofs.unsigned poff + BIGBLOCK < Ptrofs.modulus) by entailer!.
+  forward_if; try contradiction. (*! if p == NULL, case false *)
+  forward_call((s,(Vptr pblk poff),nullval,0%nat,b)).  (*! t3 = list_from_block(s,p,null) *)
+  { unfold mmlist. entailer!. }
+  Intro q.
+  forward. (*! return t3 *) 
+  Exists q. Exists (chunks_from_block (size2binZ s)).
+  if_tac.
+  { (* q = null - contradiction *)
+    pose proof (chunks_from_block_pos b H).
+    assert (q<>nullval).
+    { apply (proj1 H7) in H8.
+      rewrite Nat.add_0_r in H8.
+      rewrite <- Z2Nat.inj_0 in H8.
+      apply Z2Nat.inj in H8; try rep_lia.
+      subst s.
+      rewrite bin2size2bin_id in *; try rep_lia.
+      apply chunks_from_block_nonneg.
+    }
+    contradiction.
+  }
+  entailer!.
+  assert (Hbs: 0 <= s <= bin2sizeZ(BINS-1)) by rep_lia.
+  pose proof (size2bin_range s Hbs) as Hs.
+  pose proof (chunks_from_block_pos (size2binZ s) Hs).
+  rep_lia.
+  rewrite Nat.add_0_r. (* ugh *)
+  subst s.
+  cancel.
+Qed.
+
+(*Definition module := [mk_body body_fill_bin].*)

--- a/progs/memmgr/verif_free_large.v
+++ b/progs/memmgr/verif_free_large.v
@@ -1,0 +1,26 @@
+Require Import VST.floyd.proofauto.
+Require Import malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+Local Open Scope logic.
+
+(*
+Definition Gprog : funspecs := external_specs ++ private_specs.
+*)
+Lemma body_free_large: semax_body MF_Vprog MF_Gprog f_free_large free_large_spec.
+Proof. 
+start_function. 
+forward_call( (offset_val (-(WA+WORD)) p), (s+WA+WORD) ). (*! munmap( p-(WASTE+WORD), s+WASTE+WORD ) !*)
++ entailer!. destruct p; try contradiction; simpl. normalize.
+  rewrite Ptrofs.sub_add_opp. reflexivity.
++ (* munmap pre *)
+  entailer!. 
+  sep_apply (free_large_chunk s p); try rep_lia.
+  entailer!.
+(* + rep_lia.*)
++ entailer!.   
+Qed.
+(*
+Definition module := [mk_body body_free_large].
+*)

--- a/progs/memmgr/verif_free_small.v
+++ b/progs/memmgr/verif_free_small.v
@@ -1,0 +1,140 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.msl.iter_sepcon.
+Require Import malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+Local Open Scope logic.
+(*
+Definition Gprog : funspecs := private_specs.
+*)
+Lemma body_free_small:  semax_body MF_Vprog MF_Gprog f_free_small free_small_spec.
+Proof. 
+start_function. 
+destruct H as [[Hn Hn'] [Hs Hmc]].
+forward_call s. (*! b = size2bin(s) !*)
+{ subst; pose proof (bin2size_range(size2binZ n)); pose proof (claim2 n); rep_lia. }
+set (b:=(size2binZ n)). 
+assert (Hb: b = size2binZ s) by (subst; rewrite claim3; auto).
+rewrite <- Hb.
+assert (Hb': 0 <= b < BINS) 
+  by (change b with (size2binZ n); apply claim2; split; assumption).
+rewrite (mem_mgr_split_R gv b rvec Hb'). (* to expose bins[b] in mem_mgr *)
+Intros bins idxs lens.
+forward. (*! void *q = bin[b] !*) 
+assert_PROP( (force_val (sem_cast_pointer p) = field_address (tptr tvoid) [] p) ). 
+{ entailer!. unfold field_address; normalize; if_tac; auto; contradiction. }
+forward. (*!  *((void ** )p) = q !*)
+set (q:=(Znth b bins)).
+assert_PROP (p <> nullval) by entailer!.
+apply semax_pre with 
+    (PROP ( )
+     LOCAL (temp _q q; temp _b (Vint (Int.repr b)); 
+     temp _p p; temp _s (Vptrofs (Ptrofs.repr s)); gvars gv)
+     SEP ((EX q': val, !!(malloc_compatible s p /\ p <> nullval) && 
+          data_at Tsh tuint (Vptrofs (Ptrofs.repr s)) (offset_val (- WORD) p) *
+          data_at Tsh (tptr tvoid) q' p *
+          memory_block Tsh (s - WORD) (offset_val WORD p) *
+          mmlist (bin2sizeZ b) (Znth b lens) q' nullval) ;
+     data_at Ews (tarray (tptr tvoid) BINS) bins (gv _bin);
+     iter_sepcon mmlist' (sublist 0 b (zip3 lens bins idxs)) ;
+     iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens bins idxs)) ;
+     TT)).
+{ Exists q. entailer!. }
+replace (bin2sizeZ b) with s by auto. 
+change (Znth b lens)
+  with (Nat.pred (Nat.succ (Znth b lens))).
+assert_PROP( isptr p ). 
+{ entailer!. unfold nullval in *.
+  match goal with | HA: p <> _ |- _ => simpl in HA end. (* not Archi.ptr64 *)
+  unfold is_pointer_or_null in *. simpl in *.
+  destruct p; try contradiction; simpl.  auto. 
+}
+assert (succ_pos: forall n:nat, Z.of_nat (Nat.succ n) > 0) 
+  by (intros; rewrite Nat2Z.inj_succ; rep_lia).
+rewrite <- (mmlist_unroll_nonempty s (Nat.succ (Znth b lens)) p nullval);
+  try assumption; try apply succ_pos. clear succ_pos.
+forward. (*! bin[b] = p !*)
+set (bins':=(upd_Znth b bins p)).
+set (rvec':=add_resvec rvec b 1).
+set (lens':= map Z.to_nat rvec').
+assert (Hlenrvec: Zlength rvec = BINS) 
+  by (subst lens; rewrite Zlength_map in H0; rep_lia).
+assert (Hlenrvec': Zlength rvec' = BINS)
+  by (subst rvec'; rewrite Zlength_add_resvec; rep_lia).
+apply ENTAIL_trans with 
+    (PROP ( )
+     LOCAL (temp _q q; temp _b (Vint (Int.repr b)); 
+     temp _p p; temp _s (Vptrofs (Ptrofs.repr s)); gvars gv)
+     SEP (EX bins1: list val, EX idxs1: list Z, EX lens1: list nat,  
+          !! (Zlength bins1 = BINS /\ Zlength lens1 = BINS /\ Zlength idxs1 = BINS
+             /\ lens1 = map Z.to_nat rvec'
+             /\ idxs1 = map Z.of_nat (seq 0 (Z.to_nat BINS))
+             /\ no_neg rvec') &&
+    data_at Ews (tarray (tptr tvoid) BINS) bins1 (gv _bin) * 
+    iter_sepcon mmlist' (sublist 0 b (zip3 lens1 bins1 idxs1)) *
+    mmlist (bin2sizeZ b) (Znth b lens1) (Znth b bins1) nullval *
+    iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens1 bins1 idxs1)) *
+    TT )).
+- (* first entailment *)
+  Exists bins'.  Exists idxs. Exists lens'.
+  assert_PROP(Zlength bins' = BINS /\ Zlength lens' = BINS).
+  { unfold bins'.  unfold lens'.  
+    entailer!.
+    rewrite Zlength_map. subst rvec'. rewrite Zlength_add_resvec. 
+    rewrite Zlength_map in H0. auto.
+  } 
+  replace (bin2sizeZ b) with s by auto. 
+  replace (Znth b bins') with p 
+    by (unfold bins'; rewrite upd_Znth_same; auto; rewrite H; assumption). 
+  replace (Nat.succ (Znth b lens)) with (Znth b lens').
+  2: { (* justify replacement *)
+    unfold lens'. rewrite Znth_map by rep_lia. subst rvec'.  unfold add_resvec. 
+    bdestruct(Zlength rvec =? BINS); simpl; try rep_lia.
+    bdestruct(0<=?b); simpl; try rep_lia.
+    bdestruct(b<?BINS); simpl; try rep_lia.
+    rewrite upd_Znth_same by rep_lia.  subst lens. rewrite Znth_map by rep_lia.
+    rewrite Z2Nat.inj_add; try rep_lia.
+    change (Z.to_nat 1) with 1%nat.  change Nat.succ with S. (* ugh *)  lia. 
+    unfold no_neg in *; apply Forall_Znth; try rep_lia.
+    assumption.
+  }
+  entailer!.
+  { unfold rvec'. apply add_resvec_no_neg; auto.
+    unfold no_neg in *. 
+    assert (0 <= Znth (size2binZ n) rvec).
+    apply Forall_Znth. assumption. rep_lia. lia.
+  }
+  change (upd_Znth (size2binZ n) bins p) with bins'.  entailer!.
+  (* remains to show bins' and lens' are same as originals aside from n *)
+  set (idxs:=(map Z.of_nat (seq 0 (Z.to_nat BINS)))) in *.
+  repeat rewrite sublist_zip3; try rep_lia.
+  set (lens:= map Z.to_nat rvec).
+  replace (sublist 0 (size2binZ n) lens') 
+    with (sublist 0 (size2binZ n) lens).
+  2: { unfold lens'. unfold lens.  do 2 rewrite sublist_map.
+       f_equal. unfold rvec'.  unfold add_resvec.  set (b:=(size2binZ n)). 
+       simple_if_tac''; auto.
+       rewrite sublist_upd_Znth_l; try rep_lia; reflexivity.
+  }
+  replace (sublist (size2binZ n + 1) BINS lens') 
+    with (sublist (size2binZ n + 1) BINS lens).
+  2: { unfold lens'. unfold lens.  do 2 rewrite sublist_map.
+       f_equal. unfold rvec'.  unfold add_resvec.  set (b:=(size2binZ n)). 
+       simple_if_tac''; auto.
+       rewrite sublist_upd_Znth_r; try rep_lia; reflexivity.
+  }
+  replace (sublist 0 (size2binZ n) bins') with (sublist 0 (size2binZ n) bins)
+    by (unfold bins'; rewrite sublist_upd_Znth_l; try reflexivity; try rep_lia).
+  replace (sublist (size2binZ n + 1) BINS bins')
+    with (sublist (size2binZ n + 1) BINS bins) by 
+      (unfold bins'; rewrite sublist_upd_Znth_r; try reflexivity; try rep_lia).
+  entailer!.
+- (* second entailment *)
+  subst rvec'.
+  rewrite <- (mem_mgr_split_R gv b (add_resvec rvec b 1) Hb').
+  entailer!.
+Qed.
+(*
+Definition module := [mk_body body_free_small].
+*)

--- a/progs/memmgr/verif_list_from_block.v
+++ b/progs/memmgr/verif_list_from_block.v
@@ -1,0 +1,453 @@
+Require Import VST.floyd.proofauto.
+Require Import malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+Local Open Scope logic.
+
+Lemma data_at_tuint_singleton_array_eq sh (v: val) p:
+  data_at sh (tarray tuint 1) [v] p = data_at sh tuint v p.
+Proof. apply data_at_singleton_array_eq. reflexivity. Qed.
+
+
+(* Invariant for loop 
+p, s, N, tl, tlen are fixed
+s + WORD is size of a (small) chunk (including header)
+         and we will have s = bin2sizeZ(b) for 0<=b<BINS
+p is start of the big block
+N is the number of chunks that fit following the waste prefix of size WA
+q points to the beginning of a list chunk (size field), unlike the link field
+  which points to the link field of the following chunk.
+tl to an mmlist of length tlen that is unchanged by the loop 
+*)
+
+(* TODO could use frame_SEP to avoid tl in invariant *)
+ 
+Definition list_from_inv (p:val) (s:Z) (N:Z) (tl:val) (tlen:nat) := 
+  EX j:_,
+  PROP ( N = (BIGBLOCK-WA) / (s+WORD) /\ 0 <= j < N /\
+         align_compatible (tarray tuint 1) (offset_val (WA+(j*(s+WORD))) p) (* q *)
+       )  
+(* j remains strictly smaller than N because j is the number 
+of finished chunks and the last chunk gets finished following the loop. *)
+  LOCAL( temp _q (offset_val (WA+(j*(s+WORD))) p);
+         temp _p p; 
+         temp _s (Vint (Int.repr s));
+         temp _Nblocks (Vint (Int.repr N));
+         temp _j (Vint (Int.repr j)); 
+         temp _tl tl
+) 
+(* (offset_val (WA + ... + WORD) p) accounts for waste plus M many chunks plus
+the offset for size field.  The last chunk's nxt points one word _inside_ 
+the remaining part of the big block. *)
+  SEP (memory_block Tsh WA p; (* initial waste *)
+       mmlist s (Z.to_nat j) (offset_val (WA + WORD) p) 
+                             (offset_val (WA + (j*(s+WORD)) + WORD) p); 
+       memory_block Tsh (BIGBLOCK-(WA+j*(s+WORD))) (offset_val (WA+(j*(s+WORD))) p);
+       mmlist s tlen tl nullval). 
+
+Lemma list_from_inv_remainder':
+(* The invariant says there's a memory_block at q of size (BIGBLOCK-(WA+j*(s+WORD))),
+and later we state that q+WORD is malloc_compatible for ((N-j)*(s+WORD) - WORD).  *)
+  forall N s j,
+  N = (BIGBLOCK-WA) / (s+WORD) -> 0 <= s -> 0 <= j < N -> 
+  BIGBLOCK-(WA+j*(s+WORD)) = (N-j)*(s+WORD) + (BIGBLOCK-WA) mod (s+WORD).
+Proof.
+  intros.
+  assert ((BIGBLOCK - WA) 
+          = (s+WORD) * ((BIGBLOCK - WA)/(s+WORD)) + (BIGBLOCK - WA) mod (s+WORD)) 
+    by (apply Z_div_mod_eq; rep_lia).
+  rewrite Z.sub_add_distr.
+  replace ((BIGBLOCK-WA) mod (s+WORD))%Z
+    with ((BIGBLOCK-WA) mod (s+WORD) + j*(s+WORD) - j*(s+WORD))%Z by lia.
+  assert (Hsub_cancel_r: forall p n m, n = m -> n-p = m-p)    (* klunky *) 
+    by (intros; eapply Z.sub_cancel_r; assumption).
+  replace 
+    ((N - j) * (s + WORD) + ((BIGBLOCK - WA) mod (s + WORD) + j * (s + WORD) - j * (s + WORD)))
+    with (((N - j) * (s + WORD) + ((BIGBLOCK - WA) mod (s + WORD) + j * (s + WORD)) - j * (s + WORD))) by lia.
+  apply Hsub_cancel_r.
+  replace ((N - j) * (s + WORD) + ((BIGBLOCK - WA) mod (s + WORD) + j * (s + WORD)))
+    with ( (N - j)*(s + WORD) + j*(s + WORD) + (BIGBLOCK - WA) mod (s + WORD) ) by lia.
+  replace ( (N - j)*(s + WORD) + j*(s + WORD) )%Z 
+    with ( N * (s + WORD) )%Z by lia.
+  replace (N*(s+WORD))%Z with ((s+WORD)*N)%Z by lia; subst N; auto.
+Qed.
+
+Lemma list_from_inv_remainder:
+(* consequence of list_from_inv and the loop guard (j<N-1) *)
+  forall N s j, N = (BIGBLOCK-WA) / (s+WORD) -> WORD <= s -> 0 <= j < N-1 -> 
+  WORD < BIGBLOCK - (WA + j * (s + WORD)) - (s + WORD).
+Proof.
+  intros N s j H H0 H1.
+  erewrite list_from_inv_remainder'; try apply H; try rep_lia.
+  assert (N - j >= 2) by lia.
+  assert (0 <= (BIGBLOCK - WA) mod (s + WORD)) by (apply Z_mod_lt; rep_lia).
+  assert ( (N-j)*(s+WORD) > (s+WORD) ).
+  { replace (s+WORD) with (1 * (s+WORD))%Z at 2 by lia; 
+     apply Zmult_gt_compat_r; rep_lia.  }
+  assert( (N - j) * (s + WORD) - (s + WORD)
+          <= (N - j) * (s + WORD) + (BIGBLOCK - WA) mod (s + WORD) - (s + WORD) ) as H5 by rep_lia.
+  eapply Z.lt_le_trans; try apply H5.
+  assert ((N - j) * (s + WORD) >= (s+WORD)+(s+WORD)) by nia.
+  assert ((N - j) * (s + WORD) - (s+WORD) >= (s+WORD)) by lia.
+  apply (Z.lt_le_trans _ (s+WORD) _); try rep_lia.
+Qed.
+
+
+Lemma body_list_from_block: semax_body MF_Vprog MF_Gprog f_list_from_block list_from_block_spec.
+Proof.
+start_function.
+destruct H as [Hb [Hs HmcB]].
+assert (WORD <= s <= bin2sizeZ(BINS-1))
+ by (pose proof (bin2size_range b Hb); rep_lia).
+forward. (*! Nblocks = (BIGBLOCK-WASTE) / (s+WORD) !*)
+{ (* nonzero divisor *) entailer!.
+  match goal with | HA: Int.repr _ = _  |- _  
+      => apply repr_inj_unsigned in HA; rep_lia end. }
+destruct p; try contradiction. 
+rename b0 into pblk; rename i into poff. (* p as blk+ofs *)
+assert_PROP (Ptrofs.unsigned poff + BIGBLOCK < Ptrofs.modulus) by entailer!.
+forward. (*! q = p + WASTE !*)
+forward. (*! j = 0 !*) 
+forward_while (*! while (j != Nblocks - 1) !*) 
+    (list_from_inv (Vptr pblk poff) s ((BIGBLOCK-WA) / (s+WORD)) tl tlen ).
+* (* pre implies inv *)
+  Exists 0. 
+  entailer!.
+  ** repeat (try split; try rep_lia).
+     *** apply BIGBLOCK_enough; rep_lia. 
+     *** (* alignment of q (future: make a tactic for this mess) *)
+       eapply align_compatible_rec_Tarray; try reflexivity.
+       intros. assert (Hi: i=0) by lia; subst i; simpl.
+       match goal with | |- context[(Ptrofs.unsigned ?e + 0)] =>
+         replace (Ptrofs.unsigned e + 0) with (Ptrofs.unsigned e) by lia end.
+       eapply align_compatible_rec_by_value; try reflexivity.
+       unfold align_chunk.
+       assert (Hpoff: (8 | Ptrofs.unsigned poff)) 
+         by (unfold malloc_compatible in HmcB; destruct HmcB as [Halign Hsize]; auto).
+       rewrite Mem.addressing_int64_split; auto.
+       apply Z.divide_add_r; auto.
+       replace 8 with (4*2)%Z in Hpoff by lia.
+       apply (Zdiv_prod _ 2 _); auto.  apply Z.divide_reflexive.
+     *** unfold Int.divu; normalize. 
+  ** replace BIGBLOCK with (WA + (BIGBLOCK - WA)) at 1 by rep_lia.
+     rewrite memory_block_split_repr; try rep_lia. 
+     simpl. entailer.
+* (* pre implies guard defined *)
+  entailer!.
+  set (s:=bin2sizeZ b). 
+  pose proof BIGBLOCK_enough as HB. 
+  assert (H0x: 0 <= s <= bin2sizeZ(BINS-1)) by rep_lia.
+  specialize (HB s H0x); clear H0x.
+  change (Int.signed (Int.repr 1)) with 1.
+  (*OLD proof: rewrite Int.signed_repr; rep_lia.*)
+  (*Now*) specialize (Z_div_mod (BIGBLOCK - WA) (s + WORD)); intros X.
+          destruct (Z.div_eucl (BIGBLOCK - WA) (s + WORD)) as [eu1 eu2].
+          rewrite Int.signed_repr; rep_lia.
+* (* body preserves inv *)
+  specialize (Z_div_mod (BIGBLOCK - WA) (s + WORD)); intros X.
+  remember (Z.div_eucl (BIGBLOCK - WA) (s + WORD)) as EU; destruct EU as [eu1 eu2].
+  destruct X as [X1 X2]. rep_lia.
+
+  match goal with | HA: _ /\ _ /\ _ |- _ => destruct HA as [? [? Hmc]] end.
+  match goal with | HA: ?a = ?a |- _  => clear HA end.
+  freeze [0] Fwaste. 
+  match goal with | HA: _ |- 
+        context[memory_block _ ?mm ?qq] =>set (m:=mm); set (q:=qq) end.
+  replace_in_pre
+   (memory_block Tsh m q)
+   (data_at_ Tsh (tarray tuint 1) q *
+    data_at_ Tsh (tptr tvoid) (offset_val WORD q) *
+    memory_block Tsh (s - WORD) (offset_val (WORD + WORD) q) *
+    memory_block Tsh (m - (s + WORD)) (offset_val (s + WORD) q)).
+  { set (N:=(BIGBLOCK-WA)/(s+WORD)).
+    sep_apply (memory_block_split_block s m q); 
+       try rep_lia; try entailer!; normalize; subst m.
+    ** replace (BIGBLOCK - (WA + j * (s + WORD)))
+         with (BIGBLOCK - WA - j * (s + WORD)) by lia.
+       apply BIGBLOCK_enough_j; rep_lia.
+    ** apply (malloc_compat_WORD_q N j (Vptr pblk poff)); auto; try rep_lia.
+       subst s; apply bin2size_align; auto.
+  }
+  Intros. (* flattens the SEP clause *) 
+  forward. (*! q[0] = s; !*) 
+  freeze [1; 2; 4; 5] fr1.  
+  forward. (*! *(q+WORD) = q+WORD+(s+WORD); !*)
+  forward. (*! q += s+WORD; !*)
+  forward. (*! j++; !*) 
+  { (* typecheck *) 
+    entailer!.
+    pose proof BIGBLOCK_enough. 
+    set (s:=bin2sizeZ b).
+    assert (H0x: 0 <= s <= bin2sizeZ(BINS-1)) by rep_lia.
+    match goal with | HA: forall _ : _, _ |- _ =>
+                specialize (HA s H0x) as Hrng; clear H0x end. 
+    assert (Hx: Int.min_signed <= j+1) by rep_lia.
+    subst s.
+    rewrite 2 Int.signed_repr; rep_lia.
+  }
+  (* reestablish inv *)  
+  Exists (j+1).  
+  assert (Hdist: ((j+1)*(s+WORD))%Z = j*(s+WORD) + (s+WORD))
+    by (rewrite Z.mul_add_distr_r; lia). 
+  entailer!. 
+  ** (* pure *)
+     set (s:=bin2sizeZ b).
+     assert (HRE' : j <> ((BIGBLOCK - WA) / (s + WORD) - 1)) .
+     { apply repr_neq_e. subst s. clear H3 Hdist H5.
+       (*  by (apply repr_neq_e; assumption*) rewrite X1 in *.
+       rewrite Z.mul_comm. rewrite Z.div_add_l, Zdiv_small by lia. rewrite Zplus_0_r; trivial. } 
+     assert (HRE2: j+1 < (BIGBLOCK-WA)/(s+WORD)) by (subst s; rep_lia).  
+     split. 
+     *** (* alignment of updated q *)
+       split; try rep_lia.
+       eapply align_compatible_rec_Tarray; try reflexivity.
+       intros. assert (Hi: i=0) by lia; subst i; simpl. 
+       match goal with | |- context[(Ptrofs.unsigned ?e + 0)] =>
+         replace (Ptrofs.unsigned e + 0) with (Ptrofs.unsigned e) by lia end.
+       eapply align_compatible_rec_by_value; try reflexivity.
+       unfold align_chunk.
+       assert (Hpoff: (8 | Ptrofs.unsigned poff)) 
+         by (unfold malloc_compatible in HmcB; destruct HmcB as [Halign Hsize]; auto).
+       assert (Hpoff': (4 | Ptrofs.unsigned poff)) by 
+           (replace 8 with (4*2)%Z in Hpoff by lia; apply (Zdiv_prod _ 2 _); auto).  
+       assert (HWA: (4 | WA)) by (rewrite WA_eq; apply Z.divide_reflexive).
+       assert (Hrest: (natural_alignment | (j+1)*(s+WORD)))
+         by (apply Z.divide_mul_r; subst s; apply bin2size_align; auto).
+       unfold natural_alignment in Hrest.
+       assert (Hrest' : (4 | (j + 1) * (s + WORD)))
+         by (replace 8 with (4*2)%Z in Hrest by lia; apply (Zdiv_prod _ 2 _); auto).  
+       clear Hpoff Hrest H3 (* tc_val *) (*H6*) (* 0 < 1 *).
+       assert (Hz: (4 | WA + (j + 1) * (s + WORD))) by (apply Z.divide_add_r; auto).
+       clear HWA Hpoff' Hrest'. 
+       rewrite ptrofs_add_for_alignment.
+       **** apply Z.divide_add_r; try assumption.
+            match goal with | HA: malloc_compatible _ _ |- _ => 
+                              simpl in HA; destruct HA as [Hal Hsz] end.
+            assert (H48: (4|natural_alignment)).
+            { unfold natural_alignment; replace 8 with (2*4)%Z by lia. 
+              apply Z.divide_factor_r; auto. }
+            eapply Z.divide_trans. apply H48. auto.
+       **** assert (j+1>0) by lia; assert (s+WORD>0) by rep_lia.
+            assert ((j+1)*(s+WORD) > 0) by (apply Zmult_gt_0_compat; auto).
+            rep_lia.
+       **** match goal with | HA: malloc_compatible _ _ |- _ => 
+                              simpl in HA; destruct HA as [Hal Hsz] end.
+            change Ptrofs.max_unsigned with (Ptrofs.modulus - 1).
+            assert (WA + (j + 1) * (s + WORD) <= BIGBLOCK).
+            { assert (H0s: 0 <= s) by rep_lia.
+              pose proof (BIGBLOCK_enough_j s (j+1) H0s HRE2); rep_lia.  }
+            rep_lia.
+     *** assert (H': 
+               BIGBLOCK - WA - ((BIGBLOCK-WA)/(s+WORD)) * (s + WORD) 
+               < BIGBLOCK - WA - (j + 1) * (s + WORD))
+            by (apply Z.sub_lt_mono_l; apply Z.mul_lt_mono_pos_r; rep_lia).
+         unfold offset_val.  do 3 f_equal; rep_lia.
+  ** (* spatial *)
+     thaw fr1. thaw Fwaste; cancel. (* thaw and cancel the waste *)
+    set (r:=(offset_val (WA + WORD) (Vptr pblk poff))). (* r is start of list *)
+    set (s:=bin2sizeZ b).
+    replace (offset_val (WA + j * (s + WORD) + WORD) (Vptr pblk poff)) 
+      with (offset_val WORD q) by (unfold q; normalize).
+    replace (upd_Znth 0 (default_val (tarray tuint 1) ) (Vint (Int.repr s)))
+      with [(Vint (Int.repr s))] by (unfold default_val; normalize).
+    change 4 with WORD in *. (* ugh *)
+    assert (HnxtContents: 
+    (Vptr pblk
+       (Ptrofs.add poff
+          (Ptrofs.repr (WA + j * (s + WORD) + (WORD + (s + WORD))))))
+    = (offset_val (s + WORD + WORD) q))
+      by ( simpl; f_equal; rewrite Ptrofs.add_assoc; f_equal; normalize; f_equal; rep_lia). 
+    rewrite HnxtContents; clear HnxtContents.
+    replace (Vptr pblk (Ptrofs.add poff (Ptrofs.repr (WA + j*(s+WORD) + WORD))))
+      with  (offset_val WORD q) by (unfold q; normalize). 
+    replace (offset_val (WA + j * (s + WORD) + (WORD + WORD)) (Vptr pblk poff))
+      with  (offset_val (WORD+WORD) q ) by (unfold q; normalize). 
+    set (n:=Z.to_nat j).
+    replace (Z.to_nat (j+1)) with (n+1)%nat by 
+        (unfold n; change 1%nat with (Z.to_nat 1); rewrite Z2Nat.inj_add; auto; lia). 
+    set (m':= m - (s+WORD)).
+    assert (H0s: 0 <= s) by rep_lia.
+    match goal with | HA: 0 <= j < _ |- _ => 
+               pose proof (BIGBLOCK_enough_j s j H0s (proj2 HA)) as Hsw; clear H0s end.
+    assert (Hmcq: malloc_compatible s (offset_val WORD  q)).
+    { assert (HmcqB:
+                malloc_compatible (BIGBLOCK - (WA + j*(s+WORD)) - WORD) (offset_val WORD q)).
+      { remember ((BIGBLOCK-WA)/(s+WORD)) as N. 
+        apply (malloc_compat_WORD_q N _ (Vptr pblk poff)); try auto.
+        subst N s; rep_lia.
+        rep_lia.
+        apply bin2size_align; auto.  }
+      apply (malloc_compatible_prefix s (BIGBLOCK-(WA+j*(s+WORD))-WORD)); try rep_lia; auto.  }
+    assert (Hmpos: WORD < m'). (* space remains, so we can apply mmlist_fold_last *)
+    { subst m'; subst m.
+      remember ((BIGBLOCK-WA)/(s+WORD)) as N.
+      assert (Hsp: 0 <= s) by rep_lia.
+      assert (HRE' : j <> ((BIGBLOCK - WA) / (s + WORD) - 1)).
+      { (*  by (subst N; apply repr_neq_e; assumption).*) clear H3 H1.
+         rewrite X1 in *. clear X1. subst s.
+         rewrite Z.mul_comm. rewrite Z.div_add_l, Zdiv_small by lia. rewrite Zplus_0_r. intros Nj. subst j. apply HRE; trivial. } 
+      assert (HjN: 0<=j<N-1) by (subst s; rep_lia); clear HRE HRE'.
+      apply (list_from_inv_remainder ((BIGBLOCK-WA)/(s+WORD))); rep_lia. }
+    sep_apply (mmlist_fold_last s n r q m' Hmcq Hmpos); try rep_lia.
+    { subst m'. subst m.
+      replace (BIGBLOCK - (WA + j * (s + WORD)) - (s + WORD) - WORD)
+        with (BIGBLOCK - WA - j * (s + WORD) - s - WORD - WORD) by lia.
+      assert (0 <= j*(s+WORD)) by
+    match goal with | HA: 0 <= j < _ |- _ => 
+      destruct HA; assert (0<=s+WORD) by rep_lia; apply Z.mul_nonneg_nonneg; rep_lia end.
+    entailer!.
+    assert (H': 
+        (Vptr pblk (Ptrofs.add poff (Ptrofs.repr (WA + (j+1)*(s+WORD) + WORD))))
+      = (offset_val (s+WORD+WORD) (offset_val (WA + j*(s+WORD)) (Vptr pblk poff)))).
+    { simpl. f_equal. rewrite Ptrofs.add_assoc. f_equal. normalize.
+      change (bin2sizeZ b) with s in Hdist.
+      rewrite Hdist. f_equal. rep_lia. }
+    simpl.
+    rewrite H'; clear H'.
+    unfold r (*; unfold m'; unfold m*).
+    assert (H': (offset_val (WA + WORD) (Vptr pblk poff))
+             = (Vptr pblk (Ptrofs.add poff (Ptrofs.repr (WA + WORD)))) ) by normalize.
+    simpl.
+    rewrite <- H'; clear H'.
+    unfold q.
+    entailer!.    
+
+    assert (H': (BIGBLOCK - (WA + j * (s + WORD)) - (s + WORD))
+                   = (BIGBLOCK - (WA + (j + 1) * (s + WORD))) ) by lia.
+    change (bin2sizeZ b) with s.
+    rewrite H'; clear H'.
+    replace (WA + j * (s + WORD) + (s + WORD)) with (WA + (j + 1) * (s + WORD)) by lia.
+    entailer!. }
+
+* (* after the loop *) 
+
+  set (q:= (offset_val (WA + j * (s + WORD)) (Vptr pblk poff))).
+  set (m:= (BIGBLOCK - (WA + j * (s + WORD)))).
+  replace_in_pre
+   (memory_block Tsh m q)
+   (data_at_ Tsh (tarray tuint 1) q *
+    data_at_ Tsh (tptr tvoid) (offset_val WORD q) *
+    memory_block Tsh (s - WORD) (offset_val (WORD + WORD) q) *
+    memory_block Tsh (m - (s + WORD)) (offset_val (s + WORD) q)).
+  { 
+    sep_apply (memory_block_split_block s m q); try rep_lia.
+    ** subst m. replace (BIGBLOCK - (WA + j * (s + WORD)))
+              with (BIGBLOCK - WA - j * (s + WORD)) by lia.
+       apply BIGBLOCK_enough_j; rep_lia.
+    ** subst m. 
+       set (N:=(BIGBLOCK-WA)/(s+WORD)).
+       apply (malloc_compat_WORD_q N j (Vptr pblk poff)); auto; try rep_lia.
+       subst s; apply bin2size_align; auto.
+    ** match goal with | HA: _ /\ 0 <= j < _ /\ _ |- _ => 
+                         destruct HA as [_ [_ Halign]]; normalize end.
+    ** entailer!.
+  }
+  Intros. (* flattens the SEP clause *) 
+  freeze [0;5] Fwaste. (* discard what's not needed for post *)
+  forward. (*! q[0] = s !*)
+  replace (upd_Znth 0 (default_val (tarray tuint 1) ) (Vint (Int.repr s)))
+    with [(Vint (Int.repr s))] by (unfold default_val; normalize).
+  forward. (*!  *(q+WORD) = tl !*)
+  set (r:=(offset_val (WA + WORD) (Vptr pblk poff))).   
+  set (n:=Z.to_nat j).
+  replace (offset_val (WA + j * (s + WORD) + WORD) (Vptr pblk poff)) 
+    with (offset_val WORD q) by (subst q; normalize).
+  assert (Hmc: malloc_compatible s (offset_val WORD q)).
+  { subst q.
+    rewrite offset_offset_val.
+    replace (WA + j*(s+WORD) + WORD) with (ALIGN*WORD + j*(s+WORD)) by rep_lia.
+    apply malloc_compatible_offset; try rep_lia.
+    (*+ (* TODO factor out repeated steps in following few *)
+      apply Z.add_nonneg_nonneg; try rep_lia.
+      assert (0<=s+WORD) by rep_lia; apply Z.mul_nonneg_nonneg; rep_lia. *)
+    + apply (malloc_compatible_prefix _ BIGBLOCK).
+      - split.
+        * apply Z.add_nonneg_nonneg; try rep_lia.
+        (*apply Z.add_nonneg_nonneg; try rep_lia.
+          assert (0<=s+WORD) by rep_lia; apply Z.mul_nonneg_nonneg; rep_lia.*)
+        * match goal with | HA: _ /\ _ /\ _ |- _ => 
+                        destruct HA as [H5a [[H5jlo H5jhi] H5align]]; normalize end.
+          assert (Hs0: 0<=s) by rep_lia; pose proof (BIGBLOCK_enough_j s j Hs0 H5jhi).
+          rep_lia.
+      - assumption.
+    + apply Z.divide_add_r.
+      apply WORD_ALIGN_aligned.
+      apply Z.divide_mul_r.
+      subst s.
+      apply bin2size_align; auto.  }
+  (* TODO try following using replace_in_pre *)
+  assert_PROP((offset_val WORD q) <>nullval) by entailer!.
+  set (p':=(offset_val WORD q)).
+  replace (offset_val (WORD+WORD) q) with (offset_val WORD p') 
+    by (unfold p'; normalize).
+  replace q with (offset_val (-WORD) p') 
+    by (unfold p'; normalize; simpl; normalize).
+  replace_in_pre 
+    (data_at Tsh (tarray tuint 1) [Vint (Int.repr s)] (offset_val (- WORD) p'))
+    (data_at Tsh tuint (Vint (Int.repr s)) (offset_val (- WORD) p')).
+  { entailer!. rewrite data_at_tuint_singleton_array_eq. entailer!. }
+  apply semax_pre with 
+     (PROP ( )
+     LOCAL (temp _q q; temp _p (Vptr pblk poff); temp _s (Vint (Int.repr s));
+     temp _Nblocks (Vint (Int.repr ((BIGBLOCK - WA) / (s + WORD))));
+     temp _j (Vint (Int.repr j)); temp _tl tl)
+     SEP (FRZL Fwaste; 
+          mmlist s n r p' *
+       EX tl' : val,
+       !! (malloc_compatible s p' /\ p' <> nullval) &&
+       data_at Tsh tuint (Vptrofs (Ptrofs.repr s)) (offset_val (- WORD) p') *
+       data_at Tsh (tptr tvoid) tl' p' * memory_block Tsh (s - WORD) (offset_val WORD p') *
+       mmlist s (Nat.pred (tlen + 1)) tl' nullval)).
+  Exists tl.
+  entailer!.
+  { subst p'; normalize. } 
+  replace (Nat.pred (tlen+1)) with tlen by lia; entailer!.
+  rewrite <- mmlist_unroll_nonempty; try lia.
+  sep_apply mmlist_app_null.
+  forward. (*! return p+WA+WORD *)
+  Exists r.
+  entailer!.
+  rewrite bin2size2bin_id; try rep_lia.
+  assert (Hlen: (tlen + 1 + n)%nat = (Z.to_nat (chunks_from_block b) + tlen)%nat). {
+    unfold chunks_from_block.
+    bdestruct (0<=?b); try rep_lia; simpl.
+    bdestruct (b<?BINS); try rep_lia; simpl.
+    subst n.
+    match goal with | HA: _ /\ _ /\ _ |- _ => 
+                      destruct HA as [Hja [[Hjlo Hjhi] Halign]]; normalize end.
+    assert (Hj: j = ((BIGBLOCK - WA) / (bin2sizeZ b + WORD)) - 1).
+    { (*OLD  proof: apply repr_inj_unsigned in HRE; try assumption;
+      split; try rep_lia; pose proof (BIGBLOCK_enough (bin2sizeZ b));  rep_lia.*)
+      (*NOW:*) clear Fwaste Halign Hmc PNnullval H4 PNtl Delta_specs tlen r Espec HmcB H0 H2 p' q pblk poff Hja .
+(*               pose proof (BIGBLOCK_enough (bin2sizeZ b)).*)
+               (*assert (j >= (BIGBLOCK - WA) / (bin2sizeZ b + WORD)-1). 2: rep_lia. *)
+               specialize (Z_div_mod (BIGBLOCK - WA) (bin2sizeZ b + WORD)); intros X.
+               remember (Z.div_eucl (BIGBLOCK - WA) (bin2sizeZ b + WORD) ) as EU.
+               destruct EU as [eu1 eu2].
+               destruct X. rep_lia. rewrite H0, Z.mul_comm, Z.div_add_l, Z.div_small by lia.
+               rewrite H0 in Hjhi. rewrite Z.mul_comm, Z.div_add_l, Z.div_small in Hjhi by lia.
+               exploit (BIGBLOCK_enough (bin2sizeZ b)). lia. intros BB.
+               rewrite H0, Z.mul_comm, Z.div_add_l, Z.div_small in BB by lia.
+               apply repr_inj_unsigned in HRE; try rep_lia. }
+    subst j.
+    replace (Z.to_nat ((BIGBLOCK - WA) / (bin2sizeZ b + WORD) - 1))%nat (* ugh *)
+      with (Z.to_nat ((BIGBLOCK - WA) / (bin2sizeZ b + WORD)) - (Z.to_nat 1))%nat.
+    2: { rewrite Z2Nat.inj_sub; lia. }
+    change (Z.to_nat 1) with 1%nat. 
+    rewrite Nat.add_comm. rewrite <- Nat.add_sub_swap.
+    {  (*WAS rep_lia.*) specialize (Z_div_mod (BIGBLOCK - WA) (bin2sizeZ b + WORD)); intros X.
+               remember (Z.div_eucl (BIGBLOCK - WA) (bin2sizeZ b + WORD) ) as EU.
+               destruct EU as [eu1 eu2].
+               destruct X. rep_lia.
+               rewrite H1, Z.mul_comm, Z.div_add_l, Z.div_small by lia.
+               rep_lia. } 
+    change 1%nat with (Z.to_nat 1). (* ugh *)
+    rep_lia.
+  }
+  rewrite Hlen.
+  entailer!.
+Qed.
+
+(*
+Definition module := [mk_body body_list_from_block].*)

--- a/progs/memmgr/verif_malloc_free.v
+++ b/progs/memmgr/verif_malloc_free.v
@@ -1,0 +1,96 @@
+Require Import VST.floyd.proofauto.
+Require Import malloc.
+Require Import ASI_malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+
+Lemma body_malloc i: semax_body MF_Vprog MF_Gprog f_malloc (malloc_spec_R' R_APD i).
+Proof. 
+start_function. 
+forward_call (BINS-1). (*! t'3 = bin2size(BINS-1) !*)
+try rep_lia. 
+forward_if. (*! if nbytes > t'3 !*)
+- (* case nbytes > bin2size(BINS-1) *)
+  forward_call (n, gv, rvec).  (*! t'1 = malloc_large(nbytes) !*)
+  { simpl. cancel. }
+  (*{ (* precond *) destruct H. split; try assumption. } *)
+  Intros p.
+  forward. (*! return t'1 !*) 
+  Exists p.
+  assert (guaranteed rvec n = false) by (apply large_not_guaranteed; auto).
+  destruct (guaranteed rvec n); [ discriminate |].
+  destruct (eq_dec p nullval); entailer!. simpl; cancel.
+  bdestruct (n <=? maxSmallChunk); try rep_lia.
+  simpl; cancel.
+- (* case nbytes <= bin2size(BINS-1) *)
+  forward_call(n, gv, rvec).  (*! t'2 = malloc_small(nbytes) !*)
+  { simpl; cancel. }
+  (*{ (* precond *)  destruct H. split; try rep_lia. }*)
+  Intros p.
+  forward. (*! result = t'2 !*)
+  Exists p. 
+  destruct (eq_dec p nullval); entailer.
+  simple_if_tac.  
+  + simpl; entailer!.
+  + bdestruct (n <=? maxSmallChunk); try rep_lia.
+    Intros rvec'. Exists rvec'.
+    simpl; entailer!.
+Qed.
+
+Lemma body_free i: semax_body MF_Vprog MF_Gprog f_free (free_spec_R' R_APD i).
+Proof. 
+start_function. 
+(* TODO is there a way to refer to post of free_spec_R' which I've copied here? *)
+forward_if (PROP()LOCAL()                          (*! if (p != NULL) !*)
+                SEP (if eq_dec p nullval
+                     then mem_mgr_R rvec gv
+                     else if n <=? maxSmallChunk
+                          then mem_mgr_R (add_resvec rvec (size2binZ n) 1) gv
+                          else mem_mgr_R rvec gv)). 
+- (* typecheck *) if_tac; entailer!.
+- (* case p!=NULL *)
+  apply semax_pre with 
+   (PROP ( )
+     LOCAL (temp _p p; gvars gv)
+     SEP (mem_mgr_R rvec gv;  malloc_token' Ews n p * memory_block Ews n p)).
+  { if_tac; entailer!. simpl; cancel. }
+  assert_PROP ( 0 <= n <= Ptrofs.max_unsigned - WORD ) by entailer!. 
+  sep_apply (from_malloc_token'_and_block n p); auto.
+(* future: preceding exposes not only the size but also the link pointer, though that's 
+not needed for large block. *)
+  Intros s.
+  assert_PROP( 
+     (force_val
+     (sem_add_ptr_int tuint Signed (force_val (sem_cast_pointer p))
+        (eval_unop Oneg tint (Vint (Int.repr 1)))) 
+    = field_address tuint [] (offset_val (- WORD) p))).
+  { entailer!. simpl. unfold field_address. if_tac. normalize. contradiction. }
+  forward. (*! t'2 = p[-1] !*)
+  forward. (*! s = t'2 !*) 
+  forward_call(BINS - 1). (*! t'1 = bin2size(BINS - 1) !*)
+(*  { (* precond *) rep_lia. } *)
+  deadvars!.
+  forward_if (PROP()LOCAL()               (*! if s <= t'1 !*)
+              SEP (if n <=? maxSmallChunk
+                   then mem_mgr_R (add_resvec rvec (size2binZ n) 1) gv
+                   else mem_mgr_R rvec gv)). 
+  -- (* case s <= bin2sizeZ(BINS-1) *)
+    forward_call(p,s,n,gv,rvec). (*! free_small(p,s) !*) 
+    (*{ (* preconds *) split3; try lia; try assumption. }*)
+    destruct (zle s (bin2sizeZ (BINS - 1))). 
+    + bdestruct(n <=? maxSmallChunk); try rep_lia. entailer!.
+    + rep_lia.
+  -- (* case s > bin2sizeZ(BINS-1) *)
+    bdestruct(n <=? maxSmallChunk); try rep_lia.
+    if_tac; try lia.
+    forward_call(p,s,gv,rvec). (*! free_large(p,s) !*)
+    (*{ split3; try rep_lia; auto. }*)
+    entailer.
+  -- (* joinpoint spec implies post *)
+    destruct (eq_dec p nullval); try contradiction.  entailer.
+- (* case p == NULL *) 
+  subst. simpl. forward. (*! skip !*)
+  entailer.
+- entailer.
+Qed.

--- a/progs/memmgr/verif_malloc_large.v
+++ b/progs/memmgr/verif_malloc_large.v
@@ -1,0 +1,95 @@
+Require Import VST.floyd.proofauto.
+Require Import malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+Local Open Scope logic.
+(*
+Definition Gprog : funspecs := external_specs ++ private_specs.
+*)
+Lemma body_malloc_large: semax_body MF_Vprog MF_Gprog f_malloc_large malloc_large_spec.
+Proof.
+start_function. 
+forward_call (n+WA+WORD). (*! t'1 = mmap0(nbytes+WASTE+WORD ...) !*)
+{ entailer!. }
+(*{ rep_lia. }*)
+Intros p.
+(* NOTE could split cases here; then two symbolic executions but simpler ones *)
+forward_if. (*! if (p==NULL) !*)
+- (* typecheck guard *) 
+  if_tac; entailer!.
+- (* case p == NULL *) 
+  forward. (*! return NULL  !*)
+  Exists (Vint (Int.repr 0)).
+  if_tac; entailer!. (* cases in post of mmap *)
+- (* case p <> NULL *) 
+  if_tac. (* cases in post of mmap *)
+  + (* impossible case *)
+    elimtype False. destruct p; try contradiction; simpl in *.
+  + assert_PROP (
+        (force_val
+           (sem_add_ptr_int tuint Signed
+                            (force_val
+                               (sem_cast_pointer
+                                  (force_val
+                                     (sem_add_ptr_int tschar Unsigned p
+                                                      (Vint
+                                                         (Int.sub
+                                                            (Int.mul (Ptrofs.to_int (Ptrofs.repr 4)) (Int.repr 2))
+                                                            (Ptrofs.to_int (Ptrofs.repr 4))))))))
+                            (Vint (Int.repr 0))) = field_address tuint [] (offset_val WA p)) ).
+    (* painful pointer reasoning to enable forward (p+WASTE)[0] = nbytes *)
+    { entailer!. 
+      destruct p; try contradiction; simpl.
+      normalize.
+      unfold field_address.
+      rewrite if_true.
+      { simpl.  normalize. }
+      hnf. (* drill down *) 
+      repeat split; auto.
+      - (* size compat *)
+        red. 
+        match goal with | H:size_compatible' _ _ |- _ => red in H end.
+        unfold Ptrofs.add.
+        rewrite (Ptrofs.unsigned_repr WA) by rep_lia.
+        rewrite Ptrofs.unsigned_repr by rep_lia.
+        simpl sizeof. rep_lia.
+      - (* align compat *)
+        red.
+        eapply align_compatible_rec_by_value; try reflexivity.
+        simpl in *. unfold natural_alignment in *. unfold Z.divide in *.
+        match goal with | HA: (exists z:Z, _) /\ _ |- _ => destruct HA as [Hz Hlim] end. 
+        inv Hz.
+        rewrite <- (Ptrofs.repr_unsigned i). 
+        match goal with | HA: Ptrofs.unsigned _ = _ |- _ => rewrite HA end. 
+        exists (2*x+1). change WA with 4.
+        rewrite ptrofs_add_repr. rewrite Ptrofs.unsigned_repr.
+        lia. rep_lia.
+    }
+    rewrite malloc_large_chunk; try rep_lia; try assumption.
+    Intros. (* flatten sep *)
+    forward. (*! (p+WASTE)[0] = nbytes;  !*)
+    forward. (*! return (p+WASTE+WORD);  !*)
+    (* postcond *)
+    Exists (offset_val (WA+WORD) p).
+    entailer!.
+    simpl.
+    if_tac. 
+    { elimtype False. destruct p; try contradiction; simpl in *. 
+      match goal with | HA: Vptr _ _  = nullval |- _ => inv HA end. }
+    unfold malloc_token'.
+    Exists n.
+    unfold malloc_tok.
+    if_tac. rep_lia. entailer!. 
+    { apply malloc_compatible_offset; try rep_lia; try apply WORD_ALIGN_aligned.
+      replace (n+(WA+WORD)) with (n + WA + WORD) by lia. assumption. }
+    cancel. 
+    (* split off the token's share of chunk *)
+    rewrite <- memory_block_Ews_join.
+    (* data_at_ from memory_block *)
+    replace (n - n) with 0 by lia.
+    rewrite memory_block_zero.  entailer!.
+Qed.
+(*
+Definition module := [mk_body body_malloc_large].
+*)

--- a/progs/memmgr/verif_malloc_small.v
+++ b/progs/memmgr/verif_malloc_small.v
@@ -1,0 +1,362 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.msl.iter_sepcon.
+Require Import malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+Local Open Scope logic.
+(*
+Definition Gprog : funspecs := external_specs ++ private_specs.
+*)
+Lemma body_malloc_small:  semax_body MF_Vprog MF_Gprog f_malloc_small malloc_small_spec.
+Proof. 
+start_function. 
+rewrite <- seq_assoc.  
+forward_call n. (*! t'1 = size2bin(nbytes) !*)
+(*rep_lia.*)
+forward. (*! b = t'1 !*)
+set (b:=size2binZ n).
+assert (Hprednat: forall m, m > 0 -> Nat.pred(Z.to_nat m) = Z.to_nat(Z.pred m))
+  by (intros; rewrite Z2Nat.inj_pred; reflexivity).
+assert_PROP(Zlength rvec = BINS) as Hlrvec. { 
+  unfold mem_mgr_R; Intros bins idxs lens.
+  entailer!. autorewrite with sublist in *. rep_lia.
+}
+(* Now we split cases on whether success is guaranteed. 
+   This which simplifies establishing the different cases in postcondition, 
+   but comes at the cost of two symbolic executions. *)
+destruct (guaranteed rvec n) eqn: Hguar. 
+
+* (*+ case guaranteed *) 
+assert (Hb: 0 <= b < BINS) by (apply (claim2 n); lia).
+rewrite (mem_mgr_split_R gv b rvec) by apply Hb.
+Intros bins idxs lens.
+freeze [1; 3] Otherlists.
+deadvars!.
+apply is_guaranteed in Hguar.
+assert (0 < Znth b lens)%nat. { 
+  subst b lens. autorewrite with sublist.
+  change 0%nat with (Z.to_nat 0%Z).
+  apply Z2Nat.inj_lt; rep_lia. 
+}
+assert_PROP (Znth b bins <> nullval) as Hnonnull. {
+  sep_apply (mmlist_ne_nonnull (bin2sizeZ b) (Znth b lens) (Znth b bins)).
+  entailer!.
+}
+forward. (*! p = bin[b] !*)
+forward_if( (*! if p == null *)
+     PROP()
+     LOCAL(temp _p (Znth b bins); temp _b (Vint (Int.repr b)); gvars gv)
+     SEP(FRZL Otherlists; TT; 
+         data_at Ews (tarray (tptr tvoid) BINS) bins (gv _bin);
+         mmlist (bin2sizeZ b) (Znth b lens) (Znth b bins) nullval)). 
+  + (* branch p==NULL *) contradiction.
+  + (* branch p<>NULL *)
+    forward. (*! skip *)
+    entailer!.
+  + (* after if: unroll and pop mmlist *)
+    set (p:=Znth b bins) in *. (* TODO clumsy, just to reuse old steps *)
+    set (len:=Z.of_nat(Znth b lens)) in *.
+    set (s:=bin2sizeZ b).  
+    assert_PROP (len > 0).
+    { replace (Znth b lens) with (Z.to_nat len);
+        try (subst len; rewrite nat_of_Z_eq; reflexivity).
+      sep_apply (mmlist_ne_len s len p nullval); auto. entailer!.  }
+    assert_PROP (isptr p).
+    { entailer!. unfold nullval in *.
+      match goal with | HA: p <> _ |- _ => simpl in HA end. (* not Archi.ptr64 *)
+      unfold is_pointer_or_null in *. simpl in *.
+      destruct p; try contradiction; simpl.
+      subst. contradiction. auto. }
+    replace (Znth b lens) with (Z.to_nat len); try rep_lia.
+    rewrite (mmlist_unroll_nonempty s (Z.to_nat len) p);
+      try (subst len; rewrite nat_of_Z_eq; assumption).
+    Intros q.
+    assert_PROP(force_val (sem_cast_pointer p) = field_address (tptr tvoid) [] p).
+    { entailer!. unfold field_address. if_tac. normalize. contradiction. }
+    forward. (*! q = *p !*)
+    forward. (*! bin[b]=q !*)
+    (* prepare token+chunk to return *)
+    deadvars!.
+    thaw Otherlists.  
+    sep_apply (to_malloc_token'_and_block n p q s); try rep_lia.
+    (* refold invariant *)
+    assert (Hrveclen: Zlength rvec = BINS) by
+        (subst lens; rewrite Zlength_map in H1; rep_lia). 
+    set (rvec':= add_resvec rvec b (-1)).
+    set (lens':= map Z.to_nat rvec').
+    set (bins':=(upd_Znth b bins (force_val (sem_cast_pointer q)))).
+    assert (Hlens: Nat.pred (Z.to_nat len) = (Znth b lens')).
+    { unfold lens'. 
+      unfold len.
+      rewrite nat_of_Z_eq.
+      unfold rvec'.
+      rewrite Znth_map; try (rewrite Zlength_add_resvec; rep_lia).
+      unfold add_resvec.
+      simple_if_tac' Htest.
+      -- rewrite upd_Znth_same; try rep_lia.
+         replace (Znth b lens) with (Z.to_nat(Znth b rvec))
+           by (subst lens; rewrite Znth_map; lia).
+         rewrite Hprednat. rep_lia. unfold b; lia.
+      --  bdestruct (Zlength rvec =? BINS); [ | rep_lia].
+            bdestruct (0 <=? b); [ | rep_lia].
+            bdestruct (b <? BINS); [ |rep_lia]. 
+            inv Htest.
+    } 
+    rewrite Hlens.
+    change s with (bin2sizeZ b).
+    forward. (*! return p !*) 
+    set (lens := map Z.to_nat rvec).
+    Exists p. entailer!. 
+    unfold mem_mgr_R. 
+    Exists bins'. 
+    set (idxs:= (map Z.of_nat (seq 0 (Z.to_nat BINS)))).
+    Exists idxs. 
+    Exists lens'.
+    cancel.
+    entailer!.
+    { split.
+      subst lens'. subst rvec'. rewrite Zlength_map. rewrite Zlength_add_resvec. rep_lia. 
+      apply add_resvec_no_neg; auto.
+      rep_lia.
+    }
+    (* fold mem_mgr *)
+    assert (Zlength lens = BINS) by (unfold lens; rewrite Zlength_map; rep_lia). 
+    assert (Zlength lens' = BINS) by (unfold lens'; rewrite Zlength_map; 
+                                      unfold rvec'; rewrite Zlength_add_resvec; rep_lia).
+    assert (Zlength bins' = BINS) by 
+        (replace (Zlength bins') with BINS by auto; reflexivity).
+    assert (Zlength idxs = BINS) by auto.
+    assert (Hbins': sublist 0 b bins' = sublist 0 b bins) by
+      (unfold bins'; rewrite sublist_upd_Znth_l; try reflexivity; try rep_lia).
+    assert (Hlens': sublist 0 b lens' = sublist 0 b lens). 
+    { unfold lens'; unfold lens; unfold rvec'.
+      do 2 rewrite sublist_map; f_equal.
+      unfold add_resvec.
+      simple_if_tac''; auto.
+      rewrite sublist_upd_Znth_l; try rep_lia; auto.  }      
+    assert (Hbins'': sublist (b+1) BINS bins' = sublist (b+1) BINS bins) by
+      (unfold bins'; rewrite sublist_upd_Znth_r; try reflexivity; try rep_lia).
+    assert (Hlens'': sublist (b+1) BINS lens' = sublist (b+1) BINS lens). {
+      unfold lens'. unfold lens. unfold rvec'. unfold add_resvec.
+      simple_if_tac''; auto. do 2 rewrite sublist_map; try rep_lia.
+      rewrite sublist_upd_Znth_r; auto; try rep_lia.
+      }
+    assert (Hsub:  sublist 0 b (zip3 lens bins idxs)
+                 = sublist 0 b (zip3 lens' bins' idxs)).
+    { repeat rewrite sublist_zip3; try rep_lia.
+      rewrite Hbins'. rewrite Hlens'.  reflexivity.  }
+    assert (Hsub':  sublist (b + 1) BINS (zip3 lens bins idxs)  
+                  = sublist (b + 1) BINS (zip3 lens' bins' idxs)).
+    { repeat rewrite sublist_zip3; try rep_lia.
+      rewrite Hbins''. rewrite Hlens''.  reflexivity. }
+    rewrite Hsub. rewrite Hsub'.
+    rewrite pull_right.
+    assert (Hq: q = (Znth b bins')). (* TODO clean this mess *)
+    { unfold bins'. rewrite upd_Znth_same.  
+      destruct q; auto with valid_pointer.
+      match goal with | HA: Zlength bins = _ |- _ => 
+                        auto 10  with valid_pointer; rewrite H0; assumption end.  }
+    rewrite Hq.
+    (* Annoying rewrite, but can't use replace_SEP because that's for 
+       preconditions; would have to do use it back at the last forward. *)
+    assert (Hassoc:
+        iter_sepcon mmlist' (sublist 0 b (zip3 lens' bins' idxs)) *
+        mmlist (bin2sizeZ b) (Znth b lens') (Znth b bins') nullval * TT *
+        iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens' bins' idxs))
+      = iter_sepcon mmlist' (sublist 0 b (zip3 lens' bins' idxs)) *
+        iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens' bins' idxs)) *
+        mmlist (bin2sizeZ b) (Znth b lens') (Znth b bins') nullval * TT)
+           by (apply pred_ext; entailer!).
+    sep_apply Hassoc; clear Hassoc. 
+    rewrite mem_mgr_split'; try entailer!; auto.
+
+* (*+ case not guaranteed *) 
+assert (Hb: 0 <= b < BINS) by (apply (claim2 n); lia).
+rewrite (mem_mgr_split_R gv b rvec) by apply Hb.
+Intros bins idxs lens.
+freeze [1; 3] Otherlists.
+deadvars!.
+forward. (*! p = bin[b] !*)
+(* TODO may not need post since excluding one branch *)
+forward_if( (*! if p == null *)
+    EX p:val, EX len:Z,
+     PROP(p <> nullval)
+     LOCAL(temp _p p; temp _b (Vint (Int.repr b)); gvars gv)
+     SEP(FRZL Otherlists; TT; 
+         data_at Ews (tarray (tptr tvoid) BINS) (upd_Znth b bins p) (gv _bin);
+         mmlist (bin2sizeZ b) (Z.to_nat len) p nullval)). 
+
+  + (* typecheck guard *)
+    set (lens:=map Z.to_nat rvec).
+    destruct (Znth b lens) eqn: Hblen. 
+    - (* length 0 *)
+      match goal with | HA: Znth b bins = nullval <-> _ |- _ => set (Hbn:=HA) end. 
+      (*Set Printing Implicit. -- to see the need for following step. *)
+      change Inhabitant_val with Vundef in Hbn.
+      assert (Znth b bins = nullval) by apply (proj2 Hbn Hblen).
+      change (@Znth val Vundef) with (@Znth val Inhabitant_val).
+      replace (Znth b bins) with nullval by assumption.
+      auto with valid_pointer.
+    - (* length non-zero *)
+      match goal with | HA: Znth b bins = nullval <-> _ |- _ => destruct HA end.
+      assert (Znth b bins <> nullval). {
+        assert (S n0 <> 0%nat) by congruence. 
+        change lens with (map Z.to_nat rvec) in *.
+        rewrite Hblen in *; auto.
+      }
+      change (Vint Int.zero) with nullval.
+      auto with valid_pointer.
+      apply denote_tc_test_eq_split; auto with valid_pointer.
+      sep_apply (mmlist_ne_valid_pointer (bin2sizeZ b) (S n0) (Znth b bins) nullval).
+      lia. change Inhabitant_val with Vundef; entailer!.
+  + (* branch p==NULL *) 
+    change Inhabitant_val with Vundef in *.
+    replace (Znth b bins) with nullval by assumption.
+    assert_PROP(Znth b lens = 0%nat) as Hlen0.
+   { entailer!.
+      match goal with | HA: nullval = nullval <-> _ |- _ => (apply HA; reflexivity) end.  } 
+    rewrite Hlen0.
+    rewrite mmlist_empty.
+    forward_call b. (*! p = fill_bin(b) !*) 
+    Intro r_with_l; destruct r_with_l as [root len]; simpl.
+    forward_if. (*! if p==NULL !*)
+    ++ (* typecheck guard *)
+      apply denote_tc_test_eq_split; auto with valid_pointer.
+      if_tac. entailer!.
+      sep_apply (mmlist_ne_valid_pointer (bin2sizeZ b) (Z.to_nat len) root nullval).
+      change (Z.to_nat len > 0)%nat with (0 < Z.to_nat len)%nat.
+      change 0%nat with (Z.to_nat 0). apply Z2Nat.inj_lt; rep_lia.
+      entailer!.
+    ++ (* case p==NULL after fill_bin() *) 
+      forward. (*! return null *)
+      Exists nullval. entailer!. 
+      thaw Otherlists.
+      set (idxs:= (map Z.of_nat (seq 0 (Z.to_nat BINS)))).
+      replace (data_at Ews (tarray (tptr tvoid) BINS) bins (gv _bin))
+         with (data_at Ews (tarray (tptr tvoid) BINS) bins (gv _bin) * emp) 
+         by normalize.
+      rewrite <- (mmlist_empty (bin2sizeZ b)). (* used to need: at 2. *)
+      2: solve [ pose proof (bin2size_range b); rep_lia].
+      rewrite <- Hlen0 at 1.
+      unfold mem_mgr_R. Exists bins. Exists idxs.  Exists (map Z.to_nat rvec).
+      entailer!. rewrite <-(mem_mgr_split' b); unfold b, Inhabitant_val; auto.
+      rewrite H6; cancel.
+    ++ (* case p<>NULL *)
+      if_tac. contradiction.
+      Intros.
+      forward. (*! bin[b] = p !*)
+      Exists root. Exists len.
+     entailer!. 
+    ++ pose proof (bin2size_range b); rep_lia.
+  + (* branch p!=NULL *)
+    forward. (*! skip !*)
+    Exists (Znth b bins).  
+    Exists (Z.of_nat (nth (Z.to_nat b) lens 0%nat)).
+    rewrite Nat2Z.id.  
+    match goal with | HA: Zlength bins = _ |- _ => 
+                      rewrite upd_Znth_same_val by (rewrite HA; assumption) end. 
+    entailer!.
+    rewrite <- nth_Znth; try rep_lia.
+    unfold Inhabitant_nat.
+    entailer!.
+  + (* after if: unroll and pop mmlist *)
+    Intros p len.
+    set (s:=bin2sizeZ b).  
+    assert_PROP (len > 0).
+    { sep_apply (mmlist_ne_len s len p nullval); auto. entailer!.  }
+    assert_PROP (isptr p).
+    { entailer!. clear - H6 PNp. destruct p; auto.
+      contradiction H6; simpl in *; subst; auto. }
+    rewrite (mmlist_unroll_nonempty s (Z.to_nat len) p)
+       by (rewrite Z2Nat.id; rep_lia); try assumption.
+    Intros q.
+    assert_PROP(force_val (sem_cast_pointer p) = field_address (tptr tvoid) [] p).
+    { entailer!. unfold field_address. rewrite if_true by auto. normalize. }
+    forward. (*! q = *p !*)
+    forward. (*! bin[b]=q !*)
+    (* prepare token+chunk to return *)
+    deadvars!.
+    thaw Otherlists.
+    sep_apply (to_malloc_token'_and_block n p q s).
+    (* refold invariant *)
+    rewrite upd_Znth_twice by (rewrite H0; apply Hb).
+    set (lens':=(upd_Znth b lens (Nat.pred (Z.to_nat len)))).
+    set (bins':=(upd_Znth b bins (force_val (sem_cast_pointer q)))).
+    assert (Hpredlen: Nat.pred (Z.to_nat len) = (Znth b lens')).
+    { unfold lens'. rewrite upd_Znth_same. reflexivity. 
+      match goal with | HA: Zlength lens = _ |- _ => rewrite HA end. 
+      assumption. }
+    rewrite Hpredlen. 
+    change s with (bin2sizeZ b).
+    forward. (*! return p !*)
+    Exists p. entailer!. 
+    rewrite if_false by auto.
+    bdestruct (size2binZ n <? BINS); try rep_lia.
+    set (rvec':= add_resvec rvec b (len-1)).
+    Exists rvec'.
+    assert (Heq_except: eq_except rvec' rvec (size2binZ n))
+      by (unfold rvec'; apply add_resvec_eq_except).
+    entailer!.
+    unfold mem_mgr_R.
+    set (lens:= (map Z.to_nat rvec)) in *.
+    Exists bins'. 
+    set (idxs:= (map Z.of_nat (seq 0 (Z.to_nat BINS)))).
+    Exists idxs.   
+    Exists lens'.
+    assert (Hlbins': Zlength bins' = BINS) 
+      by (subst bins'; rewrite upd_Znth_Zlength; rep_lia).
+    assert (Hllens': Zlength lens' = BINS) 
+      by (subst lens'; rewrite upd_Znth_Zlength; rep_lia). 
+    entailer!. 
+    { split.
+      -- subst lens' rvec'. rewrite Hpredlen, upd_Znth_same by rep_lia.
+         unfold add_resvec.
+         bdestruct (Zlength rvec =? BINS); [ | rep_lia].
+         bdestruct (0 <=? b); [ | rep_lia].
+         bdestruct (b <? BINS); [ |rep_lia].
+         simpl.
+         rewrite <- upd_Znth_map. subst lens. f_equal.
+         rewrite Hprednat; auto. f_equal. 
+         replace (Znth b rvec) with 0; try rep_lia.
+         symmetry.  apply small_not_guaranteed_zero; auto. 
+      -- apply add_resvec_no_neg; auto.
+         assert (0 <= Znth b rvec).
+         { apply Forall_Znth. assumption. lia. }
+         rep_lia.
+    }
+(* TODO following can be more succinct using replace, as in free_small and pre_fill *)
+    assert (Hbins': sublist 0 b bins' = sublist 0 b bins) by
+      (unfold bins'; rewrite sublist_upd_Znth_l; try reflexivity; try rep_lia).
+    assert (Hlens': sublist 0 b lens' = sublist 0 b lens) by 
+      (unfold lens'; rewrite sublist_upd_Znth_l; try reflexivity; try rep_lia).
+    assert (Hbins'': sublist (b+1) BINS bins' = sublist (b+1) BINS bins) by
+      (unfold bins'; rewrite sublist_upd_Znth_r; try reflexivity; try rep_lia).
+    assert (Hlens'': sublist (b+1) BINS lens' = sublist (b+1) BINS lens) by
+      (unfold lens'; rewrite sublist_upd_Znth_r; try reflexivity; try rep_lia).
+    assert (Hsub:  sublist 0 b (zip3 lens bins idxs)
+                 = sublist 0 b (zip3 lens' bins' idxs)).
+    { repeat rewrite sublist_zip3; try rep_lia.
+      - rewrite Hbins'. rewrite Hlens'.  reflexivity.
+      - assert (Zlength idxs = BINS) by auto. rep_lia.
+      - assert (Zlength idxs = BINS) by auto. rep_lia.
+    } 
+    assert (Hsub':  sublist (b + 1) BINS (zip3 lens bins idxs)  
+                  = sublist (b + 1) BINS (zip3 lens' bins' idxs)).
+    { repeat rewrite sublist_zip3; try rep_lia.
+      - rewrite Hbins''. rewrite Hlens''.  reflexivity.
+      - assert (Zlength idxs = BINS) by auto. rep_lia.
+      - assert (Zlength idxs = BINS) by auto. rep_lia.
+    }
+    rewrite Hsub. rewrite Hsub'.
+    rewrite pull_right.
+    assert (Hq: q = (Znth b bins')).
+    { unfold bins'. rewrite upd_Znth_same.  
+      destruct q; auto with valid_pointer. rep_lia.
+    }
+    rewrite Hq.
+    rewrite mem_mgr_split'; try entailer!; auto.
+Qed.
+(*
+Definition module := [mk_body body_malloc_small].
+*)

--- a/progs/memmgr/verif_pre_fill.v
+++ b/progs/memmgr/verif_pre_fill.v
@@ -1,0 +1,106 @@
+Require Import VST.floyd.proofauto.
+Require Import VST.msl.iter_sepcon.
+Require Import malloc.
+Require Import ASI_malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+Local Open Scope logic.
+(*
+Definition Gprog : funspecs := user_specs_R ++ private_specs.
+*)
+Lemma body_pre_fill i: semax_body MF_Vprog MF_Gprog f_pre_fill (pre_fill_spec' R_APD i).
+Proof. 
+start_function. 
+rewrite <- seq_assoc.  
+forward_call n. (*! b = size2bin(n) *)
+destruct H as [[Hn_lo Hn_hi] Hp].
+try rep_lia.
+forward.
+set (b:=size2binZ n). 
+assert (Hb: 0 <= b < BINS) by (apply size2bin_range; rep_lia).
+forward_call b. (*! t2 = bin2size(b) *)
+simpl. rewrite (mem_mgr_split_R gv b rvec) by apply Hb.
+Intros bins idxs lens.
+freeze [1; 3] Otherlists.
+deadvars!.
+try destruct H as [[Hn_lo Hn_hi] Hp].
+forward. (*! t4 = bin[b] *)
+forward_call ((bin2sizeZ b), p, (Znth b bins), (Znth b lens), b). (*! t3 = list_from_block(t2,p,t4) *)
+Intros q.
+forward. (*! bin[b] = t3 *)
+thaw Otherlists.
+
+(* fold lists into mem_mgr_R *)
+replace (size2binZ (bin2sizeZ b)) with b 
+  by (subst b; rewrite claim3; try rep_lia).
+simpl ASI_malloc.mem_mgr_R; unfold mem_mgr_R.
+set (bins':= upd_Znth b bins q).
+set (lens':= map Z.to_nat (add_resvec rvec b (chunks_from_block b))).
+assert (Hrveclen: Zlength rvec = BINS) by
+   ( subst lens; rewrite Zlength_map in H0; rep_lia). 
+Exists bins'. Exists idxs. Exists lens'.
+entailer!.
+{ split. unfold lens'. rewrite Zlength_map. rewrite Zlength_add_resvec; assumption.
+  apply add_resvec_no_neg; try assumption.
+  pose proof (chunks_from_block_nonneg (size2binZ n)).
+  assert (0 <= Znth (size2binZ n) rvec)
+    by (apply Forall_Znth; try rep_lia; try unfold no_neg in *; auto).
+  rep_lia.
+}
+set (idxs:= (map Z.of_nat (seq 0 (Z.to_nat BINS)))).
+set (lens:= (map Z.to_nat rvec)).
+assert (Zlength lens = BINS) by (unfold lens; rewrite Zlength_map; rep_lia).
+assert (Zlength idxs = BINS) by auto.
+repeat (rewrite sublist_zip3; try rep_lia).  
+replace (sublist 0 b bins) with (sublist 0 b bins') 
+  by (unfold bins'; rewrite sublist_upd_Znth_l; try reflexivity; try rep_lia).
+replace (sublist (b+1) BINS bins) with (sublist (b+1) BINS bins') 
+  by (unfold bins'; rewrite sublist_upd_Znth_r; try reflexivity; try rep_lia).
+replace (sublist 0 b lens) with (sublist 0 b lens').
+2: { unfold lens'. unfold lens.  do 2 rewrite sublist_map. f_equal.
+     unfold add_resvec. simple_if_tac''; auto.
+     rewrite sublist_upd_Znth_l; try rep_lia; reflexivity. }
+replace (sublist (b + 1) BINS lens) with (sublist (b + 1) BINS lens').
+2: { unfold lens'. unfold lens.  do 2 rewrite sublist_map. f_equal. 
+     unfold add_resvec. simple_if_tac''; auto.
+     rewrite sublist_upd_Znth_r; try rep_lia; reflexivity. }
+assert (Zlength bins' = BINS) by auto.
+assert (Zlength lens' = BINS) 
+  by (unfold lens'; rewrite Zlength_map; rewrite Zlength_add_resvec; auto).
+repeat (rewrite <- sublist_zip3; try rep_lia); try rep_lia.  
+replace (Z.to_nat (chunks_from_block b) + Znth b lens)%nat with (Znth b lens').
+2: {unfold lens'.  rewrite Znth_map.
+    unfold add_resvec. simple_if_tac' Hcond.
+    2: { assert (Zlength rvec = BINS) by auto. 
+         bdestruct(Zlength rvec =? BINS); simpl in Hcond; try contradiction.
+         bdestruct(0 <=? b); simpl in Hcond; try contradiction.
+         bdestruct(b<?BINS); simpl in Hcond; try contradiction.
+         discriminate.
+         rep_lia. 
+         destruct Hb; contradiction.
+    }
+    rewrite upd_Znth_same; try rep_lia.
+    replace (Znth b lens) with (Z.to_nat (Znth b rvec)) 
+      by (unfold lens; rewrite Znth_map; rep_lia).
+    rewrite <- Z2Nat.inj_add. f_equal. rep_lia.
+    apply chunks_from_block_nonneg.
+    apply Forall_Znth; try rep_lia; try unfold no_neg in *; auto.
+    rewrite Zlength_add_resvec; rep_lia.
+}
+replace 
+ (mmlist (bin2sizeZ b) (Znth b lens') q nullval * TT *
+  iter_sepcon mmlist' (sublist 0 b (zip3 lens' bins' idxs)) *
+  iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens' bins' idxs)) * TT)
+with 
+ (iter_sepcon mmlist' (sublist 0 b (zip3 lens' bins' idxs)) *
+  iter_sepcon mmlist' (sublist (b + 1) BINS (zip3 lens' bins' idxs)) * 
+  mmlist (bin2sizeZ b) (Znth b lens') q nullval * TT)
+by (apply pred_ext; entailer!).
+replace q with (Znth b bins').
+2: (unfold bins'; rewrite upd_Znth_same; auto; rep_lia).
+rewrite mem_mgr_split'; try entailer!; auto.
+Qed.
+(*
+Definition module := [mk_body body_pre_fill].
+*)

--- a/progs/memmgr/verif_try_pre_fill.v
+++ b/progs/memmgr/verif_try_pre_fill.v
@@ -1,0 +1,155 @@
+Require Import VST.floyd.proofauto.
+Require Import malloc.
+Require Import ASI_malloc.
+Require Import malloc_lemmas.
+Require Import malloc_sep.
+Require Import VSU_malloc_definitions.
+Local Open Scope logic.
+
+(*Definition Gprog : funspecs := try_pre_fill_spec' ::  external_specs ++ user_specs_R ++ private_specs.
+(* It's sort of a hack that try_pre_fill_spec' is included in Gprog here.
+  If we don't, and since nobody else calls this function or includes it in their own
+  Gprog, then try_pre_fill_spec' won't be in any of the Gprogs;
+ that means it won't be in the combined link_main.Gprog,
+  and then link_main.prog_correct will fail. 
+*)*)
+
+Lemma add_resvec_0: 
+  forall rvec b, 0 <= b < BINS -> Zlength rvec = BINS -> (add_resvec rvec b 0) = rvec.
+Proof.
+  intros. unfold add_resvec.
+  bdestruct(Zlength rvec =? BINS); [ | rep_lia].
+  bdestruct(0 <=? b); [ | rep_lia].
+  bdestruct(b <? BINS); [ | rep_lia].
+  simpl.
+  replace (Znth b rvec + 0) with (Znth b rvec) by lia.
+  rewrite upd_Znth_same_val; [auto | rep_lia].
+Qed.
+
+Lemma add_resvec_plus: 
+  forall rvec b n m, 0 <= b < BINS -> Zlength rvec = BINS -> 
+    (add_resvec (add_resvec rvec b n) b m) = (add_resvec rvec b (n+m)).
+Proof.
+  intros. unfold add_resvec.
+  bdestruct(Zlength rvec =? BINS); [ | rep_lia].
+  bdestruct(0 <=? b); [ | rep_lia].
+  bdestruct(b <? BINS); [ | rep_lia]; simpl.
+  rewrite upd_Znth_Zlength.
+  bdestruct(Zlength rvec =? BINS); [ | rep_lia]; simpl.
+  rewrite upd_Znth_same; try rep_lia.
+  rewrite upd_Znth_twice; try rep_lia.
+  rewrite Z.add_assoc; reflexivity. rep_lia.
+Qed.
+
+Lemma body_try_pre_fill i: semax_body MF_Vprog MF_Gprog f_try_pre_fill (try_pre_fill_spec' R_APD i).
+Proof. 
+start_function.
+destruct H as [[Hnlo Hnhi] [Hreqlo Hreqhi]].
+unfold ASI_malloc.mem_mgr_R. simpl.
+assert_PROP (Zlength rvec = BINS) as Hrvec. {
+  unfold mem_mgr_R. entailer. rewrite Zlength_map in H0. entailer!. }
+forward_call(BINS-1). (*! t1 = bin2size(BINS-1) *)
+(*rep_lia.*)
+forward_if. (*! if n > t1 *)
+(* large case *)
+{ forward. (*! return 0 *)
+  Exists 0.
+  entailer!.
+  rewrite add_resvec_0; try rep_lia.
+}
+(* small case *)
+forward_call n; try rep_lia. (*! b = size2bin(n) *)
+forward. (*! ful = 0 *)
+deadvars!.
+set (b:=size2binZ n).
+assert (Hb: 0 <= b < BINS) by (apply (size2bin_range n); rep_lia).
+forward_call b. (*! t3 = bin2size(b) *)
+forward. (*! chunks = (BIGBLOCK - WASTE) / t3 + WORD) *)
+entailer!.
+          pose proof (bin2size_range b Hb);
+          apply repr_inj_unsigned in H0; rep_lia.
+forward_while (*! while (req - ful > 0) *)
+    (EX ful:_,
+    PROP ( 0 <= ful <= Int.max_signed )
+     LOCAL (temp _n (Vptrofs (Ptrofs.repr n)); temp _req (Vptrofs (Ptrofs.repr req)); 
+            temp _b (Vint (Int.repr b)); temp _ful (Vint (Int.repr ful)); 
+            temp _chunks (Vint (Int.repr((BIGBLOCK-WA)/(bin2sizeZ b + WORD)))); 
+            gvars gv)
+     SEP (mem_mgr_R (add_resvec rvec (size2binZ n) ful) gv)).
+- (* init *)
+Exists 0.
+rewrite add_resvec_0; try rep_lia.
+entailer!.
+   f_equal.
+   unfold Int.divu.
+   f_equal.
+   pose proof (bin2size_range b Hb); rewrite !Int.unsigned_repr by rep_lia.
+   reflexivity.
+- (* typecheck guard *)
+entailer!.
+- (* body preserves *)
+forward_if. (*! if (UINT_MAX - ful < chunks) *)
+(* case overflow *)
+{ forward. (*! return ful *)
+  unfold ASI_malloc.mem_mgr_R; simpl. Exists ful.
+  entailer!.
+}
+(* continue *) 
+forward_call BIGBLOCK. (*! t3 = mmap0(BIGBLOCK) *)
+(*rep_lia.*)
+Intros p.
+forward_if. (*! if p==null *)
+-- if_tac; entailer!. 
+-- (* case p==null *)
+if_tac. forward.
+unfold ASI_malloc.mem_mgr_R; simpl. Exists ful. entailer!. contradiction.
+-- (* case p<>null *)
+forward_call (n,p,gv,(add_resvec rvec b ful)). (*! pre_fill(n,p) *)
+unfold ASI_malloc.mem_mgr_R; simpl.
+if_tac. contradiction. subst b. entailer!. 
+destruct (eq_dec p nullval). contradiction.
+{ (*split; [rep_lia|auto].*) auto. }
+unfold b.
+forward. (*! ful += chunks *)
+(* restore invar *)
+Exists (ful + chunks_from_block b); unfold b.
+entailer!.
++ unfold chunks_from_block.
+  bdestruct (0 <=? b); [ | lia].
+  bdestruct (b <? BINS); [ | lia].
+  rewrite andb_true_intro
+    by (split; [ apply Zaux.Zle_bool_true; trivial
+               | apply Zaux.Zlt_bool_true; trivial ]).
+  split; [ | trivial].
+  pose proof (bin2size_range b Hb).
+  assert (0 <= (BIGBLOCK - WA) / (bin2sizeZ b + WORD))
+        by (apply Z.div_pos; rep_lia).
+  subst b.
+  rewrite Int.signed_repr in H1.
+  * (*WAS:solve [rep_lia]. *)
+    specialize (Z_div_mod (BIGBLOCK - WA) (bin2sizeZ (size2binZ n) + WORD)); intros X.
+    destruct (Z.div_eucl (BIGBLOCK - WA) (bin2sizeZ (size2binZ n) + WORD)) as [eu1 eu2].
+    destruct X as [X1 X2]. rep_lia.
+    rewrite X1, Z.mul_comm, Z.div_add_l, Z.div_small, Zplus_0_r by lia. split. 2: rep_lia.
+    assert (0 <= eu1); rep_lia.
+  * (*WAS: split; try rep_lia. 
+    apply Zdiv_le_upper_bound; auto; rep_lia.*)
+    specialize (Z_div_mod (BIGBLOCK - WA) (bin2sizeZ (size2binZ n) + WORD)); intros X.
+    destruct (Z.div_eucl (BIGBLOCK - WA) (bin2sizeZ (size2binZ n) + WORD)) as [eu1 eu2].
+    destruct X as [X1 X2]. rep_lia. split; try rep_lia.
++ unfold ASI_malloc.mem_mgr_R; simpl.
+  entailer!.
+  rewrite add_resvec_plus.
+  subst b.
+  entailer!.
+  apply size2bin_range; rep_lia.
+  rep_lia.
+- (* after loop *) 
+forward. (*! return ful *)
+unfold ASI_malloc.mem_mgr_R; simpl.
+Exists ful.
+entailer!.
+Qed.
+(*
+Definition module := [mk_body body_try_pre_fill].
+*)


### PR DESCRIPTION
1. Create Makefile.bundled, which is to be included by clients of
  VST that want the flexibility to use either an opam/Platform
  install of VST or a local build.
2. Refactor progs/VSUpile/Makefile to use ethis.
3. Copy the Appel&Naumann malloc/free verification (from Beringer's VSU
  version of the original at github.com/PrincetonUniversity/DeepSpecDb/memmgr)
  into progs/memmgr, and make it build from the VST/Makefile as the target
  "memmgr".  Or it can build indendently (see item 1 above).