### PR TITLE
Small concurrency fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -718,7 +718,7 @@ files: _CoqProject $(FILES:.v=.vo)
 #
 # Add conclib_coqlib, conclib_sublist, and conclib_veric to the targets
 #
-simpleconc: concurrency/conclib.vo concurrency/ghosts.vo
+simpleconc: concurrency/conclib.vo concurrency/ghosts.vo atomics/verif_lock.vo
 msl:     _CoqProject $(MSL_FILES:%.v=msl/%.vo)
 sepcomp: _CoqProject $(CC_TARGET) $(SEPCOMP_FILES:%.v=sepcomp/%.vo)
 concurrency: _CoqProject $(CC_TARGET) $(SEPCOMP_FILES:%.v=sepcomp/%.vo) $(CONCUR_FILES:%.v=concurrency/%.vo)

--- a/concurrency/conclib.v
+++ b/concurrency/conclib.v
@@ -345,7 +345,8 @@ Ltac forward_spawn id arg wit :=
         instantiate (1 := fun '(a, b) => _ a) in (value of R));
         etransitivity; [|symmetry; apply PROP_into_SEP_LAMBDA]; f_equal; f_equal; f_equal;
         [ instantiate (1 := fun _ => _) in (value of Q); subst Q; f_equal; simpl; reflexivity
-        | unfold SEPx; extensionality; simpl; rewrite sepcon_emp; instantiate (1 := fun _ => _);
+        | unfold SEPx; extensionality; simpl; rewrite sepcon_emp;
+          unfold R; instantiate (1 := fun _ => _);
           reflexivity]
   ];
   forward_call [A] funspec_sub_refl (f, arg, Q, wit, R); subst Q R;

--- a/floyd/data_at_rec_lemmas.v
+++ b/floyd/data_at_rec_lemmas.v
@@ -1128,14 +1128,14 @@ Proof.
 Qed. 
 
 Lemma mapsto_share_join_values_cohere:
-  forall sh1 sh2 sh t (R:type_is_by_value t = true) b ofs,
-    sepalg.join sh1 sh2 sh -> 
+  forall sh1 sh2 (*sh*) t (R:type_is_by_value t = true) b ofs,
     type_is_volatile t = false ->
     readable_share sh1 -> readable_share sh2 -> 
   forall (v1 v2:val) (V1: ~ JMeq v1 Vundef) (V2: ~ JMeq v2 Vundef),
     mapsto sh1 t (Vptr b ofs) v1 * mapsto sh2 t (Vptr b ofs) v2 |-- !!(v1=v2).
-Proof. intros; destruct t; try discriminate R; unfold mapsto; simpl; simpl in *.
- + destruct i; destruct s; simpl; rewrite ! if_true by trivial; rewrite H0.
+Proof.
+intros; destruct t; try discriminate R; unfold mapsto; simpl; simpl in *.
+ + destruct i; destruct s; simpl; rewrite ! if_true by trivial; rewrite H.
     - eapply derives_trans.
       { apply sepcon_derives.
         + apply orp_left; [ apply derives_refl |].
@@ -1200,7 +1200,7 @@ Proof. intros; destruct t; try discriminate R; unfold mapsto; simpl; simpl in *.
           apply andp_left1. apply prop_left. intros; subst. elim V2. apply JMeq_refl. }
       normalize. rewrite derives_eq.
       apply res_predicates.address_mapsto_value_cohere.
-  + rewrite H0; clear R. rewrite ! if_true by trivial.
+  + rewrite H; clear R. rewrite ! if_true by trivial.
     - eapply derives_trans.
       { apply sepcon_derives.
         + apply orp_left; [ apply derives_refl |].
@@ -1209,7 +1209,7 @@ Proof. intros; destruct t; try discriminate R; unfold mapsto; simpl; simpl in *.
           apply andp_left1. apply prop_left. intros; subst. elim V2. apply JMeq_refl. }
       normalize. rewrite derives_eq.
       apply res_predicates.address_mapsto_value_cohere.
-  + rewrite H0; clear R. destruct f; rewrite ! if_true by trivial.
+  + rewrite H; clear R. destruct f; rewrite ! if_true by trivial.
     - eapply derives_trans.
       { apply sepcon_derives.
         + apply orp_left; [ apply derives_refl |].
@@ -1226,7 +1226,7 @@ Proof. intros; destruct t; try discriminate R; unfold mapsto; simpl; simpl in *.
           apply andp_left1. apply prop_left. intros; subst. elim V2. apply JMeq_refl. }
       normalize. rewrite derives_eq.
       apply res_predicates.address_mapsto_value_cohere.
-  + rewrite H0; clear R. rewrite ! if_true by trivial.
+  + rewrite H; clear R. rewrite ! if_true by trivial.
     - eapply derives_trans.
       { apply sepcon_derives.
         + apply orp_left; [ apply derives_refl |].
@@ -1238,18 +1238,17 @@ Proof. intros; destruct t; try discriminate R; unfold mapsto; simpl; simpl in *.
 Qed.
 
 Lemma data_at_rec_share_join_values_cohere:
-  forall sh1 sh2 sh t (R:type_is_by_value t = true) b ofs,
-    sepalg.join sh1 sh2 sh -> 
+  forall sh1 sh2 t (R:type_is_by_value t = true) b ofs,
     type_is_volatile t = false ->
     readable_share sh1 -> readable_share sh2 ->
   forall (v1 v2:reptype t) (V1: ~ JMeq v1 Vundef) (V2: ~ JMeq v2 Vundef),
     data_at_rec sh1 t v1 (Vptr b ofs) * data_at_rec sh2 t v2 (Vptr b ofs) |-- !!(v1=v2).
 Proof.
   intros.
-  revert v1 v2 ofs H0 H1 H2 R V1 V2.
+  revert v1 v2 ofs H R V1 V2.
   pattern t; type_induction t; intros; try discriminate R; simpl in R;
   rewrite !data_at_rec_eq; try solve [ normalize];
-  rewrite H0; apply (mapsto_share_join_values_cohere sh1 sh2 sh); trivial.
+  rewrite H; apply (mapsto_share_join_values_cohere sh1 sh2); trivial.
 Qed.
 
 Lemma data_at_rec_share_join:


### PR DESCRIPTION
1. Removed an unnecessary premise from data_at_rec_share_join_values_cohere
2. added atomics/verif_lock.vo to make target "simpleconc" and therefore to target "vst"
3. fixed a bug in Ltac forward_spawn