### PR TITLE
More efficient build target for coq-vst-iris package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -775,8 +775,8 @@ install: VST.config
 	for f in $(EXTRA_INSTALL_FILES); do install -m 0644 $$f "$(INSTALLDIR)/$$(dirname $$f)"; done
 
 build-iris: _CoqProject
-	$(COQC) $(COQF) $(PROGSDIR)/incr.v
-	for f in $(IRIS_INSTALL_FILES_SRC); do if [ "$${f##*.}" = "v" ]; then echo COQC $$f; $(COQC) $(COQF) $$f; fi; done
+	$(COQC) $(COQFLAGS) $(PROGSDIR)/incr.v
+	for f in $(IRIS_INSTALL_FILES_SRC); do if [ "$${f##*.}" = "v" ]; then echo COQC $$f; $(COQC) $(COQFLAGS) $$f; fi; done
 
 install-iris: VST.config
 	install -d "$(INSTALLDIR)"

--- a/Makefile
+++ b/Makefile
@@ -775,6 +775,7 @@ install: VST.config
 	for f in $(EXTRA_INSTALL_FILES); do install -m 0644 $$f "$(INSTALLDIR)/$$(dirname $$f)"; done
 
 build-iris: _CoqProject
+	$(COQC) $(COQF) $(PROGSDIR)/incr.v
 	for f in $(IRIS_INSTALL_FILES_SRC); do if [ "$${f##*.}" = "v" ]; then echo COQC $$f; $(COQC) $(COQF) $$f; fi; done
 
 install-iris: VST.config

--- a/Makefile
+++ b/Makefile
@@ -775,7 +775,7 @@ install: VST.config
 	for f in $(EXTRA_INSTALL_FILES); do install -m 0644 $$f "$(INSTALLDIR)/$$(dirname $$f)"; done
 
 build-iris: _CoqProject
-	$(MAKE) $(IRIS_INSTALL_FILES)
+	for f in $(IRIS_INSTALL_FILES_SRC); do if [ "$${f##*.}" = "v" ]; then echo COQC $$f; $(COQC) $(COQF) $$f; fi; done
 
 install-iris: VST.config
 	install -d "$(INSTALLDIR)"


### PR DESCRIPTION
Finally figured out how to avoid re-compiling the base VST files.