### PR TITLE
Adapt w.r.t. coq/coq#16904.

### DIFF
--- a/atomics/verif_kvnode_atomic_ra.v
+++ b/atomics/verif_kvnode_atomic_ra.v
@@ -907,7 +907,7 @@ Ltac lookup_spec_and_change_compspecs CS id ::=
       match goal with
        | |- mk_funspec _ _ ?t1 _ _ = mk_funspec _ _ ?t2 _ _ =>
          first [unify t1 t2
-           | elimtype False; elimtype (Witness_type_of_forward_call_does_not_match_witness_type_of_funspec
+           | exfalso; elimtype (Witness_type_of_forward_call_does_not_match_witness_type_of_funspec
       t2 t1)]
       end]
    end)

--- a/concurrency/juicy/juicy_machine.v
+++ b/concurrency/juicy/juicy_machine.v
@@ -286,7 +286,7 @@ Module Concur.
         destruct H as [sh H].
         specialize (H' (b,ofs0) ltac:(rewrite MAP'; auto)).
         destruct H' as [sh' H'].
-        elimtype False.
+        exfalso.
         clear - H ineq H'. simpl in *.
         specialize (H (ofs0-ofs)). spec H. omega.
         specialize (H' 0). spec H'. omega. replace (ofs0+0) with (ofs+(ofs0-ofs)) in H' by omega.

--- a/concurrency/juicy/semax_preservation.v
+++ b/concurrency/juicy/semax_preservation.v
@@ -458,7 +458,7 @@ Proof.
         inv J'.
         apply join_bot_bot_eq in RJ; subst.
         simpl. if_tac. auto. tauto.
-      * elimtype False; clear - RJ rsh2.  apply join_top_l in RJ. subst.
+      * exfalso; clear - RJ rsh2.  apply join_top_l in RJ. subst.
          apply shares.bot_unreadable; auto.
 
   - (* Proving alloc_cohere *)

--- a/concurrency/juicy/semax_safety_freelock.v
+++ b/concurrency/juicy/semax_safety_freelock.v
@@ -113,7 +113,7 @@ Proof.
   fixsafe safei.
   inversion safei
     as [ | ?????? bad | n0 z c m0 e args0 x at_ex Pre SafePost | ????? bad ].
-  apply (corestep_not_at_external (juicy_core_sem _)) in bad. elimtype False; subst; clear - bad atex.
+  apply (corestep_not_at_external (juicy_core_sem _)) in bad. exfalso; subst; clear - bad atex.
    simpl in bad. unfold cl_at_external in *; simpl in *. rewrite atex in bad; inv bad.
   2: inversion bad.
   subst.

--- a/concurrency/juicy/semax_safety_makelock.v
+++ b/concurrency/juicy/semax_safety_makelock.v
@@ -112,7 +112,7 @@ Proof.
   fixsafe safei.
   inversion safei
     as [ | ?????? bad | n0 z c m0 e args0 x at_ex Pre SafePost | ????? bad ].
-  apply (corestep_not_at_external (juicy_core_sem _)) in bad. elimtype False; subst; clear - bad atex.
+  apply (corestep_not_at_external (juicy_core_sem _)) in bad. exfalso; subst; clear - bad atex.
    simpl in bad. unfold cl_at_external in *; simpl in *. rewrite atex in bad; inv bad.
   2: inversion bad.
   subst.

--- a/concurrency/juicy/semax_safety_spawn.v
+++ b/concurrency/juicy/semax_safety_spawn.v
@@ -204,7 +204,7 @@ Proof.
   fixsafe safei.
   inversion safei
     as [ | ?????? bad | n0 z c m0 e args0 x at_ex Pre SafePost | ????? bad ].
-  apply (corestep_not_at_external (juicy_core_sem _)) in bad. elimtype False; subst; clear - bad atex.
+  apply (corestep_not_at_external (juicy_core_sem _)) in bad. exfalso; subst; clear - bad atex.
    simpl in bad. unfold cl_at_external in *; simpl in *. rewrite atex in bad; inv bad.
   2: inversion bad.
   subst.

--- a/examples/cont/model.v
+++ b/examples/cont/model.v
@@ -243,8 +243,8 @@ Proof.
   induction 1. intros. reflexivity.
   intros. simpl in *.
   destruct (@eq_dec adr _ i i0). subst.
-  clear - H2. destruct (boundary p'). elimtype False; omega.
- generalize (Max.le_max_l i0 n); intro. elimtype False. omega.
+  clear - H2. destruct (boundary p'). exfalso; omega.
+ generalize (Max.le_max_l i0 n); intro. exfalso. omega.
  apply IHmatch_specs.
  destruct (boundary p'); try omega.
  generalize (Max.le_max_r i0 n0);  omega.
@@ -277,7 +277,7 @@ Proof.
  intros i P w ? ?.
  hnf.
  case_eq (table_get G i); intros. eauto.
- elimtype False.
+ exfalso.
  hnf in H0.
  case_eq (make_world G h n @ i); intros.
  apply (necR_NO _ _ i H) in H2. inversion2 H0 H2.
@@ -299,7 +299,7 @@ Proof.
  unfold  initial_heap. simpl. unfold heap_get.
   rename p0 into i.
  destruct (lt_dec i (boundary p)).
- split; intro. inv H0. elimtype False.
+ split; intro. inv H0. exfalso.
  revert H0; case_eq (table_get G i); intros. destruct f as [nargs P].
  inv H1. inv H1.
  rewrite (match_specs_boundary p G i); auto; try omega.

--- a/examples/funclistmach/hoare_total.v
+++ b/examples/funclistmach/hoare_total.v
@@ -457,7 +457,7 @@ Proof.
   destruct H4 as [[[? ?] ?] ?].
   destruct H4 as [_ [? _]].
   destruct H4 as [? [? ?]].
-  destruct x. elimtype False; omega.
+  destruct x. exfalso; omega.
   assert (funptr l A lP lQ (p',(r,t'))).
   apply H5. auto.
   apply pred_nec_hereditary with (p,(r,t')); auto.
@@ -527,7 +527,7 @@ Proof.
   hnf in H12. rewrite H12 in H11. discriminate.
   eapply IHn; eauto.
   rewrite (af_level1 age_facts) in H11.
-  intro. elimtype False. omega.
+  intro. exfalso. omega.
 Qed.
 
 

--- a/examples/funclistmach3/hoare_total.v
+++ b/examples/funclistmach3/hoare_total.v
@@ -180,7 +180,7 @@ admit.
   exists (n1+n2). right.
 admit.
   clear H.
-  exists n1. left. intro. elimtype False; omega.
+  exists n1. left. intro. exfalso; omega.
   exists (n1+1). right.
   repeat intro.
   hnf in  H. spec H. omega.

--- a/examples/imp/hoare.v
+++ b/examples/imp/hoare.v
@@ -414,7 +414,7 @@ Proof.
   eapply LocalsMap.map_set_share2; eauto.
   intros.
   case_eq (LocalsMap.map_val i' r); auto; intros.
-  elimtype False.
+  exfalso.
   erewrite <- LocalsMap.map_gso_val in H8.
   3: eauto.
   rewrite H4 in H8; auto. discriminate.

--- a/examples/lam_ref/lam_ref_mach_defs.v
+++ b/examples/lam_ref/lam_ref_mach_defs.v
@@ -13,7 +13,7 @@ Require Import msl.msl_standard.
 (* Some custom tactics, maybe move into msl in base.v *)
 
 Tactic Notation "omegac" :=
-  (elimtype False; omega).
+  (exfalso; omega).
 
 Lemma IF_then_else_True:
   forall a b c : Prop, a -> (IF a then b else c) = b.

--- a/examples/lam_ref/lam_ref_type_lemmas.v
+++ b/examples/lam_ref/lam_ref_type_lemmas.v
@@ -476,7 +476,7 @@ Proof.
   intuition.
   split; auto.
 
-  elimtype False.
+  exfalso.
   simpl in H4.
   elim H4.
   destruct H as [e [He [? ?]]].

--- a/floyd/QPcomposite.v
+++ b/floyd/QPcomposite.v
@@ -222,7 +222,7 @@ set (H2 := proj1 _ _) in H0.
 clearbody H2.
 assert (ce ! i = None).
 destruct (ce ! i) eqn:?H; auto.
-elimtype False.
+exfalso.
 apply PTree.elements_correct in H1.
 assert (In i (map fst  (QP_list_helper (PTree.elements ce) H2))). {
  clear - H1; induction (PTree.elements ce) as [|[??]].

--- a/floyd/VSU.v
+++ b/floyd/VSU.v
@@ -2382,7 +2382,7 @@ revert G G_LNR Gsub; induction builtins as [|[i?]]; [ simpl; induction fs as [|[
   destruct (IHfs G); auto.
   intros.
   destruct (ident_eq i0 i). subst.
-  elimtype False. clear - H1 H4. apply delete_id_None in H1. contradiction.
+  exfalso. clear - H1 H4. apply delete_id_None in H1. contradiction.
   apply Gsub in H4. destruct H4; auto. simpl in H4. congruence.
   rename x into G1.
   rewrite H4.

--- a/floyd/VSU_addmain.v
+++ b/floyd/VSU_addmain.v
@@ -375,7 +375,7 @@ Proof.
     inv H0.
     destruct a. destruct g; simpl in *. if_tac. congruence.
     apply IHl; auto. inv H; auto.
-    if_tac. subst p0. elimtype False; clear - H0 H.
+    if_tac. subst p0. exfalso; clear - H0 H.
     inv H. apply H3; clear H3 H4. induction l; simpl in *. inv H0. destruct a. destruct g; auto.
     simpl in *. if_tac in H0; auto. apply IHl; auto. inv H; auto.
 + apply list_norepet_map_fst_filter; auto.

--- a/floyd/aggregate_pred.v
+++ b/floyd/aggregate_pred.v
@@ -414,7 +414,7 @@ Proof.
         change (if ident_eq i (name_member a1) then a1 else get_member i m)
                     with (get_member i (a1::m)) in H0.
         destruct (member_dec (get_member i (a1::m)) a0); [ | exact H0].
-        elimtype False; clear - e H2. subst a0.
+        exfalso; clear - e H2. subst a0.
         rewrite name_member_get in H2. contradiction.
 Qed.
 
@@ -511,7 +511,7 @@ Proof.
         simpl.
         change (if ident_eq i (name_member a1) then a1 else get_member i m) with (get_member i (a1::m)).
         destruct (member_dec (get_member i (a1::m)) a0).
-        elimtype False. clear - H0 H1 e. subst. apply H1. 
+        exfalso. clear - H0 H1 e. subst. apply H1. 
         rewrite name_member_get. auto.
         auto.
 Qed.
@@ -566,7 +566,7 @@ Proof.
       simpl. 
       destruct (member_dec _ _).
       change (get_member i (a1::m) = a0) in e.
-      elimtype False; clear - e H0 H1. subst. apply H1. rewrite name_member_get. auto.
+      exfalso; clear - e H0 H1. subst. apply H1. rewrite name_member_get. auto.
       f_equal.
       * unfold P'; simpl.
         rewrite if_false by (simpl; congruence).
@@ -762,7 +762,7 @@ Proof.
          specialize (H1 d0 d1).
          unfold compact_sum_inj, proj_compact_sum, list_rect in H1.
         destruct (member_dec (get_member i (a1::m)) a0).
-        elimtype False. clear - e H4. subst. rewrite name_member_get in H4. congruence.
+        exfalso. clear - e H4. subst. rewrite name_member_get in H4. congruence.
         apply (H1 H2 H3).
 Qed.
 
@@ -805,7 +805,7 @@ Proof.
       specialize (H1 i).
      change (get_member i (a0::a1::m)) with (if ident_eq i (name_member a0) then a0 else get_member i (a1::m)) in *.
       destruct (ident_eq i (name_member a0)).
-      elimtype False; clear - H0 H3 e. subst. unfold members_no_replicate in H0. apply compute_list_norepet_e in H0. inv H0.
+      exfalso; clear - H0 H3 e. subst. unfold members_no_replicate in H0. apply compute_list_norepet_e in H0. inv H0.
       apply H2. apply H3. 
       apply H1.
       right; auto.
@@ -846,7 +846,7 @@ Proof.
       contradict H1. subst; auto. 
     - change (if ident_eq i (name_member a1) then a1 else get_member i m) with (get_member i (a1::m)) in *.
        destruct (member_dec _ _).
-       elimtype False; clear - n e. subst.
+       exfalso; clear - n e. subst.
        rewrite name_member_get in *. congruence.
        destruct v.
        unfold union_pred. unfold list_rect.
@@ -890,12 +890,12 @@ Proof.
     -
        change (get_member i (a0::a1::m)) with (if ident_eq i (name_member a0) then a0 else get_member i (a1::m)) in *.
       destruct (ident_eq _ _).
-      elimtype False; clear - e H H0 H1. subst.
+      exfalso; clear - e H H0 H1. subst.
       apply compute_list_norepet_e in H. inv H. apply H4.
       destruct H0. left; auto. right; auto.
       unfold union_pred. unfold list_rect.
       destruct (member_dec _ _).
-      elimtype False.
+      exfalso.
       clear - H H0 H1 e. forget (a1::m) as m1. subst a0. 
       apply compute_list_norepet_e in H. inv H. rewrite name_member_get in H4. contradiction.
       apply (IHm a1); auto.
@@ -1027,7 +1027,7 @@ Proof.
       simpl in *.
       destruct (ident_eq _ _); [tauto |].
       destruct (member_dec _ _).
-      elimtype False; clear - e n.
+      exfalso; clear - e n.
       change (if  ident_eq i (name_member a1) then a1 else get_member i m) 
        with (get_member i (a1::m))  in e. subst. rewrite name_member_get in n. contradiction.
       apply IHm; auto.
@@ -1090,7 +1090,7 @@ Proof.
       simpl in H|-*.
       destruct (member_dec _ _).
       subst a0.
-      elimtype False; clear - j H1. subst j. rewrite name_member_get in H1. contradiction.
+      exfalso; clear - j H1. subst j. rewrite name_member_get in H1. contradiction.
       destruct v; [ tauto | ]. 
       apply IHm; auto.
 Qed.

--- a/floyd/align_compatible_dec.v
+++ b/floyd/align_compatible_dec.v
@@ -140,7 +140,7 @@ pose (D := fun x: {it: member | In it (co_members c)} =>
                 align_compatible_rec cenv_cs (type_member (proj1_sig x)) (z + FO (name_member (proj1_sig x)))).
 assert (H1: forall x, {D x} + {~ D x}). {
  subst D. intros. destruct x as [[id t0|] ?].
-2:{ elimtype False. clear - i0 PLAIN. 
+2:{ exfalso. clear - i0 PLAIN. 
    induction (co_members c) as [|[|]]; simpl in *; try discriminate; auto. destruct i0; auto. discriminate.
  }
  simpl.
@@ -167,7 +167,7 @@ destruct (Forall_dec D H1 (make_in_list (co_members c))) as [H2|H2]; clear H1; [
  intros.
  subst D. simpl.
  destruct x as [[id t0|] ?].
-2:{ elimtype False. clear - i0 PLAIN. 
+2:{ exfalso. clear - i0 PLAIN. 
    induction (co_members c) as [|[|]]; simpl in *; try discriminate; auto. destruct i0; auto. discriminate.
  }
  eapply align_compatible_rec_Tstruct_inv in H2; try eassumption.
@@ -180,7 +180,7 @@ destruct (Forall_dec D H1 (make_in_list (co_members c))) as [H2|H2]; clear H1; [
  simpl in H1. destruct (id_in_list id0 (map name_member m)) eqn:?; try discriminate.
  destruct i0. inv H. auto.
  apply id_in_list_false in Heqb.
- elimtype False. apply Heqb. apply (in_map name_member) in H. apply H.
+ exfalso. apply Heqb. apply (in_map name_member) in H. apply H.
  apply IHm. auto.
  destruct i0. inv H0. contradiction. auto.
  simpl in H1. destruct (id_in_list id0 (map name_member m)) eqn:?; try discriminate.
@@ -199,7 +199,7 @@ pose (D := fun x: {it: member | In it (co_members c)} =>
                 align_compatible_rec cenv_cs (type_member (proj1_sig x)) z).
 assert (H1: forall x, {D x} + {~ D x}). {
  subst D. intros. destruct x as [[id t0|] ?].
-2:{ elimtype False. clear - i0 PLAIN. 
+2:{ exfalso. clear - i0 PLAIN. 
    induction (co_members c) as [|[|]]; simpl in *; try discriminate; auto. destruct i0; auto. discriminate.
  }
  simpl.
@@ -222,7 +222,7 @@ destruct (Forall_dec D H1 (make_in_list (co_members c))) as [H2|H2]; clear H1; [
  intros.
  subst D. simpl.
  destruct x as [[id t0|] ?].
-2:{ elimtype False. clear - i0 PLAIN. 
+2:{ exfalso. clear - i0 PLAIN. 
    induction (co_members c) as [|[|]]; simpl in *; try discriminate; auto. destruct i0; auto. discriminate.
  }
  eapply align_compatible_rec_Tunion_inv in H2; try eassumption.
@@ -235,7 +235,7 @@ destruct (Forall_dec D H1 (make_in_list (co_members c))) as [H2|H2]; clear H1; [
  simpl in H1. destruct (id_in_list id0 (map name_member m)) eqn:?; try discriminate.
  destruct i0. inv H. auto.
  apply id_in_list_false in Heqb.
- elimtype False. apply Heqb. apply (in_map name_member) in H. apply H.
+ exfalso. apply Heqb. apply (in_map name_member) in H. apply H.
  apply IHm; auto.  
  destruct i0. inv H0. contradiction. auto.
  simpl in H1. destruct (id_in_list id0 (map name_member m)) eqn:?; try discriminate.

--- a/floyd/diagnosis.v
+++ b/floyd/diagnosis.v
@@ -65,11 +65,11 @@ Ltac ccf_SEP id0 R :=
  end.
 
 Ltac ccf2 id0 argsig retsig A Pre Post :=
- try (test_stuck; elimtype False);
+ try (test_stuck; exfalso);
  let F := fresh "F" in
  intro F;
  let x := fresh "x" in
- assert (x:A) by (elimtype False; apply F);
+ assert (x:A) by (exfalso; apply F);
  pose (xPre := Pre x); cbv beta in xPre;
  pose (xPost := Post x); cbv beta in xPost;
  repeat (match type of x with (_*_)%type =>
@@ -88,7 +88,7 @@ Ltac ccf2 id0 argsig retsig A Pre Post :=
                      (because_Precondition_not_canonical PP))
  end;
  first [test_stuck |
-  elimtype False;
+  exfalso;
   revert xPost; try rewrite no_post_exists_unit;
   repeat match goal with
   |- let _ := (EX _:_, EX _:_, _) in _ => rewrite exp_uncurry
@@ -96,7 +96,7 @@ Ltac ccf2 id0 argsig retsig A Pre Post :=
   match goal with
   | |- let _ := @exp _ _ ?B ?p in _ =>
     let w := fresh "w" in
-    assert (w:B) by (elimtype False; apply F);
+    assert (w:B) by (exfalso; apply F);
     intro xPost; clear xPost;
     pose (xPost := p w); cbv beta in xPost; revert xPost;
     repeat (match type of w with (_*_)%type =>
@@ -116,7 +116,7 @@ Ltac ccf2 id0 argsig retsig A Pre Post :=
    ccf_SEP id0 R]]
   end;
   first [test_stuck |
-   elimtype False;
+   exfalso;
    apply F]]].
 
 Ltac check_WITH_reptype id A :=
@@ -143,7 +143,7 @@ Ltac ccf1 fs :=
   end.
 
 Ltac check_canonical_funspec fs :=
-    try (test_stuck; elimtype False);
+    try (test_stuck; exfalso);
     first [ccf1 fs; [test_stuck | ] | idtac].
 
 (* Change goal to [message arg], without failing *)

--- a/floyd/field_at.v
+++ b/floyd/field_at.v
@@ -94,7 +94,7 @@ Proof.
          clear - H1 H4.
          unfold proj_compact_prod. unfold list_rect; cbv beta iota.
          destruct (member_dec (get_member i (a1 :: m)) a0).
-         elimtype False. subst a0. rewrite name_member_get in H1, H4. contradiction.
+         exfalso. subst a0. rewrite name_member_get in H1, H4. contradiction.
          reflexivity.
       rewrite H5 in H0; clear H5.
       assert (proj_compact_prod (get_member i (a1 :: m))
@@ -104,7 +104,7 @@ Proof.
          clear - H1 H4.
          unfold proj_compact_prod. unfold list_rect; cbv beta iota.
          destruct (member_dec (get_member i (a1 :: m)) a0).
-         elimtype False. subst a0. rewrite name_member_get in H1, H4. contradiction.
+         exfalso. subst a0. rewrite name_member_get in H1, H4. contradiction.
          reflexivity.
       rewrite H5 in H0; clear H5.
      apply H0; auto.

--- a/floyd/field_compat.v
+++ b/floyd/field_compat.v
@@ -1077,7 +1077,7 @@ split3.
 -
   clear - H7 NS NB.
   destruct gfs. apply I.
-  elimtype False.
+  exfalso.
   revert g H7; induction gfs; intros. destruct H7.
    unfold nested_field_type in H0. simpl in H0.
  destruct big as [ | [ | | | ] [ | ] | [ | ] | [ | ] | | | | |  ]; inv NB; contradiction.

--- a/floyd/fieldlist.v
+++ b/floyd/fieldlist.v
@@ -682,7 +682,7 @@ Proof.
   + assert (true = true) by auto; tauto.
   + destruct (id_in_list (name_member m) (map name_member m0)) eqn:HH.
     - apply id_in_list_true in HH.
-       split; intros. inv H.  destruct H. elimtype False; apply H.
+       split; intros. inv H.  destruct H. exfalso; apply H.
       apply HH.
     - apply id_in_list_false in HH.
       split; intros. split; auto. destruct H; auto.
@@ -855,7 +855,7 @@ Proof.
       pose proof Z.le_max_r (Ctypes.sizeof t0) (sizeof_union env m).
       lia.
   + simpl in *.
-    elimtype False; clear - H. destruct sz; lia.
+    exfalso; clear - H. destruct sz; lia.
 Qed.
 
 Definition in_map: forall {A B : Type} (f : A -> B) (l : list A) (x : A),

--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -795,7 +795,7 @@ Ltac lookup_spec id :=
       match goal with
        | |- mk_funspec _ _ ?t1 _ _ = mk_funspec _ _ ?t2 _ _ =>
          first [unify t1 t2
-           | elimtype False; elimtype (Witness_type_of_forward_call_does_not_match_witness_type_of_funspec
+           | exfalso; elimtype (Witness_type_of_forward_call_does_not_match_witness_type_of_funspec
       t2 t1)]
       end]
    end
@@ -1166,7 +1166,7 @@ Inductive Ridiculous: Type := .
 
 Ltac check_witness_type ts A witness :=
   (unify A (rmaps.ConstType Ridiculous); (* because [is_evar A] doesn't seem to work *)
-             elimtype False)
+             exfalso)
  ||
  let TA := constr:(functors.MixVariantFunctor._functor
      (rmaps.dependent_type_functor_rec ts A) mpred) in

--- a/floyd/funspec_old.v
+++ b/floyd/funspec_old.v
@@ -715,7 +715,7 @@ spec IHl.
 { clear IHl H4. intros.
   destruct (ident_eq i0 i). subst.
  split; intros; try contradiction.
- elimtype False; clear - H. subst Q'.
+ exfalso; clear - H. subst Q'.
  admit. (* easy *)
  specialize (H2 i0). 
  assert (In i0 (temps_of_localdef Q) <-> In i0 (temps_of_localdef Q'))
@@ -829,7 +829,7 @@ spec IHl.
 { intros. specialize (H2 i0). 
   destruct (ident_eq i i0). subst.
   split; intros; try contradiction.
-  elimtype False; clear - H. admit. (* easy *)
+  exfalso; clear - H. admit. (* easy *)
   clear - H2 n.
   split; intros. 
   assert (In i0 (temps_of_localdef Q)) by admit. (* easy *)

--- a/floyd/measure.v
+++ b/floyd/measure.v
@@ -4,13 +4,13 @@ Definition size_is (n: Z) : Prop := False.
 Lemma assert_size_is_Type (n: Z) :
   forall (A: Type), size_is n -> A.
 Proof.
-intros. elimtype False; apply H.
+intros. exfalso; apply H.
 Qed.
 
 Lemma assert_size_is_Prop (n: Z) :
   forall (A: Prop), size_is n -> A.
 Proof.
-intros. elimtype False; apply H.
+intros. exfalso; apply H.
 Qed.
 
 Opaque size_is.

--- a/floyd/semax_tactics.v
+++ b/floyd/semax_tactics.v
@@ -558,7 +558,7 @@ destruct H.
 apply IHV in H1; clear IHV.
 auto.
 clear H1.
-elimtype False.
+exfalso.
 induction G.
 inv H0.
 destruct H0.

--- a/lib/proof/spec_math.v
+++ b/lib/proof/spec_math.v
@@ -262,7 +262,7 @@ rewrite H1; clear H1.
 split.
 -
 destruct x; try destruct s; simpl in H; try discriminate; auto.
-elimtype False. clear - H0.
+exfalso. clear - H0.
 simpl in H0.
 unfold Defs.F2R in H0.
 simpl in H0.
@@ -335,7 +335,7 @@ rewrite H1.
 split; [ auto | ].
 apply generic_round_property.
 -
-elimtype False; clear - H H0 H2.
+exfalso; clear - H H0 H2.
 pose proof trunc_ff_aux t x H.
 Lra.lra.
 Defined.

--- a/mc_reify/verif_sha_bdo7.v
+++ b/mc_reify/verif_sha_bdo7.v
@@ -306,7 +306,7 @@ subst k.
 assert (k'<16)%nat by omega.
 clear H.
 do 16 (destruct k'; try reflexivity).
-elimtype False; omega.
+exfalso; omega.
 Qed.
 
 Lemma extract_from_b:
@@ -364,7 +364,7 @@ change nat_of_Z with Z.to_nat.
 rewrite Z2Nat.inj_add by omega.
 change (Z.to_nat 1) with 1%nat.
 repeat match type of H0 with
-| (64 <= _ < _)%nat => elimtype False; omega
+| (64 <= _ < _)%nat => exfalso; omega
 | (?A <= _ < _)%nat =>
  assert (H9: i=A \/ (A+1 <= i < 64)%nat) by omega;
  clear H0; destruct H9 as [H0|H0];

--- a/msl/ageable.v
+++ b/msl/ageable.v
@@ -670,7 +670,7 @@ case_eq (ageN b phi); intros.
 rename a0 into phi0.
 generalize (ageN_compose a b (a+b) phi1 _ _ H0 H1 (refl_equal _)); intro.
 rewrite H in H2; auto.
-elimtype False.
+exfalso.
 revert phi1 phi H H1 H0; induction a; intros.
 simpl in *.
 inv H0.
@@ -681,7 +681,7 @@ simpl in *.
 case_eq (age1 phi1); intros; rewrite H2 in H; try discriminate.
 rewrite H2 in H0.
 eapply IHa; eauto.
-elimtype False.
+exfalso.
 unfold ageN in *.
 revert phi1 H H0; induction a; intros.
 simpl in *. discriminate.
@@ -748,7 +748,7 @@ assert (forall m, (m <= n)%nat ->
          (exists i, F i /\ (i<m)%nat /\ ~ F (S i))).
 induction m.
 left; intros.
-elimtype False; lia.
+exfalso; lia.
 intro.
 assert (m<=n)%nat; try lia.
 destruct (IHm H2).
@@ -899,10 +899,10 @@ destruct (necR_linear H0 H1).
 clear - H2 H3.
 apply nec_refl_or_later in H3.
 destruct H3; auto.
-apply laterR_level in H0; unfold fashionR in H2; elimtype False; lia.
+apply laterR_level in H0; unfold fashionR in H2; exfalso; lia.
 apply nec_refl_or_later in H3.
 destruct H3; auto.
-apply laterR_level in H3; unfold fashionR in H2; elimtype False; lia.
+apply laterR_level in H3; unfold fashionR in H2; exfalso; lia.
 Qed.
 
 Lemma laterR_necR {A} `{agA : ageable A}:

--- a/msl/combiner_sa.v
+++ b/msl/combiner_sa.v
@@ -179,14 +179,14 @@ Proof with auto.
   eapply ijoin_eq; eauto.
   eapply join_eq; eauto.
 
-  elimtype False; clear - pa_A sa_A H1 H4 A_top_full.
+  exfalso; clear - pa_A sa_A H1 H4 A_top_full.
   destruct sh; destruct sh0; destruct sh1.
   red in H1; red in H4; simpl in H4.
   generalize (join_eq H1 H4); intro; subst x1.
   unfold midObj in *.
   tauto.
 
-  elimtype False; clear - pa_A sa_A H2 H3 A_top_full.
+  exfalso; clear - pa_A sa_A H2 H3 A_top_full.
   destruct sh;destruct sh0;destruct sh1.
   red in H3; red in H2; simpl in H2.
   generalize (join_eq H2 H3);intro;subst x1.
@@ -394,7 +394,7 @@ Proof.
   apply identity_combiner in H0.
   inversion H0.
 
-  elimtype False.
+  exfalso.
   spec H sh.
   destruct H as [sh' ?].
   destruct (join_ex_identities v) as [v0 [? ?]].

--- a/msl/cross_split.v
+++ b/msl/cross_split.v
@@ -254,12 +254,12 @@ intros [[b Hb]|].
  [assert (a=z) by (inv H; auto); subst z; clear H;
    rewrite (proof_irr Hz Ha) in X1; clear Hz; exists b; exists None;
     split; [split|]; auto
- | elimtype False; inv H];
+ | exfalso; inv H];
   [ econstructor  | ]; constructor.
 intros [[c Hc]|].
 2: intros ? ? ?; exists None; exists None; split; [split|]; econstructor; econstructor.
 intros [[z Hz]|] H Hj.
-2: elimtype False; inv H.
+2: exfalso; inv H.
 destruct (X0 a b c z) as [a' [b' [[? ?] ?]]].
 inv H. apply H3.
 inversion Hj.
@@ -315,7 +315,7 @@ Proof.
   apply join_unit2_e in H0; [ | apply None_identity]. subst z.
   exists (Some (exist nonunit _ Na), None,Some (exist nonunit _ Nb),None); repeat split; auto; constructor; auto.
 }
-  destruct z as [[z Nz] | ]; [ | elimtype False; inv H].
+  destruct z as [[z Nz] | ]; [ | exfalso; inv H].
   destruct (X0 a b c d z) as [[[[ac ad] bc] bd] [? [? [? ?]]]]; try (inv H; inv H0; auto). clear H H0.
   destruct (X ac) as [Nac | Nac ].
   apply Nac in H1. subst ad. apply Nac in H3. subst bc.
@@ -418,7 +418,7 @@ Proof.
   clear H H0.
   destruct (CrB _ _ _ _ _ H1 H2) as [[[[s p] q] r] [? [? [? ?]]]].
   exists (Some s, Some p, Some q, Some r); repeat split; try constructor; auto.
-  intros. elimtype False; inv H.
+  intros. exfalso; inv H.
   intros. assert (z = Some c) by (clear - H0; inv H0; auto).
   subst. assert (join a b c) by   (clear - H; inv H; auto).
   exists (Some a, None, Some b, None); repeat split; try constructor; auto.
@@ -427,7 +427,7 @@ Proof.
   assert (z=Some d) by (clear - H0; inv H0; auto). subst z.
   exists (None, Some a, None, Some b); repeat split; try constructor; auto.
   clear - H; inv H; auto.
-  elimtype False; inv H0; inv H.
+  exfalso; inv H0; inv H.
   destruct c as [c|]. destruct d as [d|].
   intros.
   assert (z = Some a) by (clear - H; inv H; auto). subst z.

--- a/msl/env.v
+++ b/msl/env.v
@@ -758,7 +758,7 @@ inv H.
 destruct a3; destruct H3 as [? [? ?]].  simpl in H,H1,H2; subst.
 destruct (dec_share_identity x).
 generalize (split_identity _ _ j i); intro.
-elimtype False; clear - H1.
+exfalso; clear - H1.
 revert H1; apply nonunit_nonidentity.
 apply pshare_nonunit.
 constructor; auto. constructor; auto. simpl. apply join_equiv_refl.
@@ -1085,10 +1085,10 @@ apply pshareval_join_e in H0.
 apply pshareval_join_e in H1.
 destruct a as [[[sa pa] va]|];
 destruct b as [[[sb pb] vb]|];
-destruct ab as [[[sab pab] vab]|]; try solve [elimtype False; inv H];
+destruct ab as [[[sab pab] vab]|]; try solve [exfalso; inv H];
 destruct c as [[[sc pc] vc]|];
-destruct bc as [[[sbc pbc] vbc]|]; try solve [elimtype False; inv H0];
-destruct ac as [[[sac pac] vac]|]; try solve [elimtype False; inv H1];
+destruct bc as [[[sbc pbc] vbc]|]; try solve [exfalso; inv H0];
+destruct ac as [[[sac pac] vac]|]; try solve [exfalso; inv H1];
 simpl in *;
 try (assert (Hx: join sa sb sab /\ va = vb /\ vb = vab)
      by (inv H; simpl in *; intuition;

--- a/msl/knot.v
+++ b/msl/knot.v
@@ -172,9 +172,9 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     apply extensionality; intro v.
     unfold unstratify.
     destruct (decompose_nat n (m2 + S n)) as [[r Hr]|Hr].
-    2: elimtype False; lia.
+    2: exfalso; lia.
     destruct (decompose_nat n (m1 + S n)) as [[s Hs]|Hs].
-    2: elimtype False; lia.
+    2: exfalso; lia.
     assert (m2 = r) by lia; subst r.
     assert (m1 = s) by lia; subst s.
     simpl.
@@ -209,7 +209,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     replace Hr with (refl_equal (S n)) by (apply proof_irr_nat); simpl; auto.
     destruct v; auto.
 
-    elimtype False.
+    exfalso.
     lia.
   Qed.
 
@@ -222,7 +222,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     destruct w as [nw rm]; simpl.
     destruct nw as [nw e].
     destruct (decompose_nat nw O) as [[r Hr]|?].
-    elimtype False; lia.
+    exfalso; lia.
     apply leT_bot.
 
     (* S n case *)
@@ -253,7 +253,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     assert (x = r) by lia; subst x.
     replace Hx with (refl_equal (r + S nw)) by apply proof_irr_nat.
     simpl; auto.
-    elimtype False; lia.
+    exfalso; lia.
     apply leT_bot.
   Qed.
 
@@ -302,8 +302,8 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     assert (x = r) by lia; subst x.
     replace Hx with (refl_equal (r + S m)) by apply proof_irr_nat.
     simpl; auto.
-    elimtype False; lia.
-    elimtype False; lia.
+    exfalso; lia.
+    exfalso; lia.
   Qed.
 
   Lemma unstratify_stratify3 : forall n (p:predicate) w,
@@ -314,7 +314,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     intro Hrm.
     rewrite Hrm in H; simpl in H.
     destruct (decompose_nat wn n) as [[r Hr]|?].
-    elimtype False; lia.
+    exfalso; lia.
     apply leT_bot.
   Qed.
 
@@ -375,7 +375,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     simpl.
     case (Compare_dec.le_gt_dec n (def_knot_level a)); intro.
     trivial.
-    elimtype False.
+    exfalso.
     lia.
     replace (approx n p (a,b)) with (p (a,b)).
     apply unstratify_stratify2.
@@ -387,7 +387,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     unfold approx.
     simpl.
     case (Compare_dec.le_gt_dec n (def_knot_level a)); intro.
-    elimtype False.
+    exfalso.
     lia.
     trivial.
 
@@ -404,7 +404,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     simpl.
     case (Compare_dec.le_gt_dec n (def_knot_level a)); auto.
     intro.
-    elimtype False.
+    exfalso.
     lia.
     replace (approx n p (a, b)) with (p (a, b)).
     apply unstratify_stratify1; auto.
@@ -412,7 +412,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     simpl.
     case (Compare_dec.le_gt_dec n (def_knot_level a)); auto.
     intro.
-    elimtype False.
+    exfalso.
     lia.
   Qed.
 
@@ -453,7 +453,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     unfold def_knot_level in l.
     simpl in *.
     destruct (decompose_nat x n); auto.
-    destruct s. elimtype False.
+    destruct s. exfalso.
     lia.
 
     intros.

--- a/msl/knot_full.v
+++ b/msl/knot_full.v
@@ -342,7 +342,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     case_eq (decompose_nat x n); intros.
     destruct s.
     destruct n.
-    elimtype False; lia.
+    exfalso; lia.
     assert (S x0 = x1) by lia; subst x1.
     revert H1.
     generalize e e0; revert p; rewrite e; intros.
@@ -356,7 +356,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     destruct Hs.
     simpl in H2.
     eapply H2; auto.
-    elimtype False.
+    exfalso.
     lia.
     apply T_rel_bot.
     apply T_rel_refl.
@@ -385,7 +385,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     destruct (decompose_nat x n).
     destruct s.
     simpl in H0.
-    2: simpl in *; elimtype False; lia.
+    2: simpl in *; exfalso; lia.
     clear H0.
     revert p H.
     generalize e.
@@ -449,7 +449,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     replace e with (refl_equal (m2 + S n)).
     simpl; tauto.
     apply proof_irr.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Lemma stratify_unstratify : forall n p H,
@@ -481,7 +481,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     replace e with (refl_equal (S n)) by apply proof_irr.
     simpl.
     split; auto.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Definition strat (n:nat) (p:predicate) : sinv n :=
@@ -515,7 +515,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     destruct (Compare_dec.le_gt_dec n (knot_level_def k)).
     apply T_rel_bot.
     destruct (Compare_dec.le_gt_dec n (knot_level_def k'')).
-    elimtype False.
+    exfalso.
     cut (knot_level_def k'' <= knot_level_def k).
     lia.
     replace (knot_level_def k'') with (knot_level_def k').
@@ -575,7 +575,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     unfold knot_level_def in l.
     simpl in *.
     destruct (decompose_nat x0 n); simpl.
-    destruct s; simpl; elimtype False; lia.
+    destruct s; simpl; exfalso; lia.
     auto.
     destruct x as [x Hx]; simpl.
     destruct (stratify x Hx n); simpl.
@@ -633,7 +633,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     revert k.
     induction x; simpl; intuition.
     destruct (decompose_nat 0 0); auto.
-    destruct s; elimtype False; lia.
+    destruct s; exfalso; lia.
     eapply (stratifies_unstratify_more x 0 1).
     simpl; reflexivity.
     simpl.
@@ -644,16 +644,16 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     assert (x0 = 0) by lia; subst x0.
     simpl in *.
     replace e with (refl_equal (S x)) by apply proof_irr; auto.
-    elimtype False; lia.
+    exfalso; lia.
     destruct (decompose_nat x (S x)).
     destruct s.
     assert (x0 = 0) by lia; subst x0.
     simpl in *.
     destruct (decompose_nat (S x) (S x)).
-    destruct s; elimtype False; lia.
+    destruct s; exfalso; lia.
     auto.
     destruct (decompose_nat (S x) (S x)).
-    destruct s; elimtype False; lia.
+    destruct s; exfalso; lia.
     auto.
 
     destruct (stratify (unstratify x k) (unstratify_hered x k) (S x)).
@@ -685,7 +685,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     simpl in *.
     replace e with (refl_equal (S x)) by apply proof_irr; simpl.
     tauto.
-    elimtype False; lia.
+    exfalso; lia.
     destruct (stratify (unstratify (S x) k)
       (unstratify_hered (S x) k) x).
     simpl; auto.
@@ -712,7 +712,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     simpl in *.
     replace e with (refl_equal (S x)); simpl; auto.
     apply proof_irr.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Lemma age1_eq : forall k,
@@ -816,7 +816,7 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     destruct (decompose_nat x0 x).
     destruct s.
     destruct (Compare_dec.le_gt_dec (S x) x0).
-    elimtype False; lia.
+    exfalso; lia.
     simpl.
     destruct (decompose_nat x0 x).
     destruct s.
@@ -824,11 +824,11 @@ Module KnotFull (TF':TY_FUNCTOR_FULL) : KNOT_FULL with Module TF:=TF'.
     subst x2.
     replace e0 with e by apply proof_irr.
     auto.
-    elimtype False; lia.
+    exfalso; lia.
     destruct (Compare_dec.le_gt_dec (S x) x0); auto.
     simpl.
     destruct (decompose_nat x0 x); auto.
-    destruct s. elimtype False. lia.
+    destruct s. exfalso. lia.
 
     intro.
     unfold knot_age1_def, knot_level_def.
@@ -994,7 +994,7 @@ Module KnotFull_Lemmas (K : KNOT_FULL).
     simpl.
     destruct (Compare_dec.le_gt_dec n (level k)); auto.
     destruct (Compare_dec.le_gt_dec (m+n) (level k)); auto.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Lemma approx_approx2 : forall m n,
@@ -1009,7 +1009,7 @@ Module KnotFull_Lemmas (K : KNOT_FULL).
     simpl.
     destruct (Compare_dec.le_gt_dec (m+n) (level k)); auto.
     destruct (Compare_dec.le_gt_dec n (level k)); auto.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
 

--- a/msl/knot_full_variant.v
+++ b/msl/knot_full_variant.v
@@ -371,7 +371,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     case_eq (decompose_nat x n); intros.
     destruct s.
     destruct n.
-    elimtype False; lia.
+    exfalso; lia.
     assert (S x0 = x1) by lia; subst x1.
     revert H1.
     generalize e e0; revert p; rewrite e; intros.
@@ -385,7 +385,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     destruct Hs.
     simpl in H2.
     eapply H2; auto.
-    elimtype False.
+    exfalso.
     lia.
     apply T_rel_bot.
     apply T_rel_refl.
@@ -414,7 +414,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     destruct (decompose_nat x n).
     destruct s.
     simpl in H0.
-    2: simpl in *; elimtype False; lia.
+    2: simpl in *; exfalso; lia.
     clear H0.
     revert p H.
     generalize e.
@@ -478,7 +478,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     replace e with (refl_equal (m2 + S n)).
     simpl; tauto.
     apply proof_irr.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Lemma stratify_unstratify : forall n p H,
@@ -510,7 +510,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     replace e with (refl_equal (S n)) by apply proof_irr.
     simpl.
     split; auto.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Definition strat (n:nat) (p:predicate) : sinv n :=
@@ -544,7 +544,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     destruct (Compare_dec.le_gt_dec n (knot_level_def k)).
     apply T_rel_bot.
     destruct (Compare_dec.le_gt_dec n (knot_level_def k'')).
-    elimtype False.
+    exfalso.
     cut (knot_level_def k'' <= knot_level_def k).
     lia.
     replace (knot_level_def k'') with (knot_level_def k').
@@ -604,7 +604,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     unfold knot_level_def in l.
     simpl in *.
     destruct (decompose_nat x0 n); simpl.
-    destruct s; simpl; elimtype False; lia.
+    destruct s; simpl; exfalso; lia.
     auto.
     destruct x as [x Hx]; simpl.
     destruct (stratify x Hx n); simpl.
@@ -652,7 +652,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     revert k.
     induction x; simpl; intuition.
     destruct (decompose_nat 0 0); auto.
-    destruct s; elimtype False; lia.
+    destruct s; exfalso; lia.
     eapply (stratifies_unstratify_more x 0 1).
     simpl; reflexivity.
     simpl.
@@ -663,16 +663,16 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     assert (x0 = 0) by lia; subst x0.
     simpl in *.
     replace e with (refl_equal (S x)) by apply proof_irr; auto.
-    elimtype False; lia.
+    exfalso; lia.
     destruct (decompose_nat x (S x)).
     destruct s.
     assert (x0 = 0) by lia; subst x0.
     simpl in *.
     destruct (decompose_nat (S x) (S x)).
-    destruct s; elimtype False; lia.
+    destruct s; exfalso; lia.
     auto.
     destruct (decompose_nat (S x) (S x)).
-    destruct s; elimtype False; lia.
+    destruct s; exfalso; lia.
     auto.
 
     destruct (stratify (unstratify x k) (unstratify_hered x k) (S x)).
@@ -704,7 +704,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     simpl in *.
     replace e with (refl_equal (S x)) by apply proof_irr; simpl.
     tauto.
-    elimtype False; lia.
+    exfalso; lia.
     destruct (stratify (unstratify (S x) k)
       (unstratify_hered (S x) k) x).
     simpl; auto.
@@ -731,7 +731,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     simpl in *.
     replace e with (refl_equal (S x)); simpl; auto.
     apply proof_irr.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Lemma age1_eq : forall k,
@@ -835,7 +835,7 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     destruct (decompose_nat x0 x).
     destruct s.
     destruct (Compare_dec.le_gt_dec (S x) x0).
-    elimtype False; lia.
+    exfalso; lia.
     simpl.
     destruct (decompose_nat x0 x).
     destruct s.
@@ -843,11 +843,11 @@ Module Knot_MixVariantHeredTOthRel (KI':KNOT_INPUT__MIXVARIANT_HERED_T_OTH_REL) 
     subst x2.
     replace e0 with e by apply proof_irr.
     auto.
-    elimtype False; lia.
+    exfalso; lia.
     destruct (Compare_dec.le_gt_dec (S x) x0); auto.
     simpl.
     destruct (decompose_nat x0 x); auto.
-    destruct s. elimtype False. lia.
+    destruct s. exfalso. lia.
 
     intro.
     unfold knot_age1_def, knot_level_def.
@@ -1101,7 +1101,7 @@ Proof.
     simpl.
     destruct (Compare_dec.le_gt_dec n (level k)); auto.
     destruct (Compare_dec.le_gt_dec (m+n) (level k)); auto.
-    elimtype False; lia.
+    exfalso; lia.
   + intros.
     extensionality p.
     apply pred_ext.
@@ -1111,7 +1111,7 @@ Proof.
     simpl.
     destruct (Compare_dec.le_gt_dec (m+n) (level k)); auto.
     destruct (Compare_dec.le_gt_dec n (level k)); auto.
-    elimtype False; lia.
+    exfalso; lia.
 Qed.
 
 End KnotLemmas2.

--- a/msl/knot_hered.v
+++ b/msl/knot_hered.v
@@ -261,7 +261,7 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
     case_eq (decompose_nat (S x) n); intros.
     destruct s.
     destruct n.
-    elimtype False; lia.
+    exfalso; lia.
     assert (S x1 = x0) by lia; subst x0.
     revert H0.
     unfold unstratify.
@@ -282,7 +282,7 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
 
     case_eq (decompose_nat (S x) n); intros.
     destruct s.
-    elimtype False; lia.
+    exfalso; lia.
     revert H0.
     unfold unstratify.
     rewrite H; rewrite H1; auto.
@@ -300,7 +300,7 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
     destruct (decompose_nat x n).
     destruct s.
     simpl in H0.
-    2: simpl in *; elimtype False; lia.
+    2: simpl in *; exfalso; lia.
     clear H0.
     revert p H.
     generalize e.
@@ -364,7 +364,7 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
     replace e with (refl_equal (m2 + S n)).
     simpl; tauto.
     apply proof_irr.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Lemma stratify_unstratify : forall n p H,
@@ -396,7 +396,7 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
     replace e with (refl_equal (S n)) by apply proof_irr.
     simpl.
     split; auto.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
 
@@ -533,7 +533,7 @@ Module KnotHered (TF':TY_FUNCTOR_PROP) : KNOT_HERED with Module TF:=TF'.
     simpl in *.
     replace e with (refl_equal (S x)) by apply proof_irr; simpl.
     tauto.
-    elimtype False; lia.
+    exfalso; lia.
     destruct (stratify (unstratify (S x) k)
       (unstratify_hered (S x) k) x).
     simpl; auto.

--- a/msl/knot_lemmas.v
+++ b/msl/knot_lemmas.v
@@ -66,7 +66,7 @@ Module Knot_Lemmas (K : KNOT).
     unfold approx, compose; simpl.
     destruct (Compare_dec.le_gt_dec n (level k)); auto.
     destruct (Compare_dec.le_gt_dec (m+n) (level k)); auto.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Lemma approx_approx2 : forall m n,
@@ -77,7 +77,7 @@ Module Knot_Lemmas (K : KNOT).
     unfold approx, compose; simpl.
     destruct (Compare_dec.le_gt_dec (m+n) (level k)); auto.
     destruct (Compare_dec.le_gt_dec n (level k)); auto.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   (* These are provided since sometimes it is tedious to break things out;

--- a/msl/knot_setoid.v
+++ b/msl/knot_setoid.v
@@ -387,9 +387,9 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     unfold unstratify.
     simpl.
     destruct (decompose_nat n (m2 + S n)) as [[r Hr]|Hr].
-    2: elimtype False; lia.
+    2: exfalso; lia.
     destruct (decompose_nat n (m1 + S n)) as [[s Hs]|Hs].
-    2: elimtype False; lia.
+    2: exfalso; lia.
     assert (m2 = r) by lia; subst r.
     assert (m1 = s) by lia; subst s.
     replace Hr with (refl_equal (m2 + S n)) by (apply proof_irr_nat).
@@ -417,7 +417,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     hnf; intros.
     destruct a0; destruct a'0; destruct H; simpl.
     destruct (decompose_nat n (S n)).
-    2: elimtype False; lia.
+    2: exfalso; lia.
     destruct s.
     assert (x = 0) by lia; subst x; simpl in *.
     replace e with (refl_equal (S n)) by (apply proof_irr_nat; auto); simpl.
@@ -433,7 +433,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     destruct w as [nw rm]; simpl.
     destruct nw as [nw e].
     destruct (decompose_nat nw O) as [[r Hr]|?].
-    elimtype False; lia.
+    exfalso; lia.
     apply le_T_bot.
 
     (* S n case *)
@@ -462,7 +462,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     assert (x = r) by lia; subst x.
     replace Hx with (refl_equal (r + S nw)) by apply proof_irr_nat.
     simpl; auto.
-    elimtype False; lia.
+    exfalso; lia.
     apply le_T_bot.
   Qed.
 
@@ -502,9 +502,9 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     assert (y = r) by lia; subst y.
     replace Hy with (refl_equal (r + S x)) by apply proof_irr_nat.
     simpl; auto.
-    elimtype False; lia.
+    exfalso; lia.
     simpl in *.
-    elimtype False; lia.
+    exfalso; lia.
   Qed.
 
   Lemma unstratify_stratify3 : forall n (p:predicate) w,
@@ -514,7 +514,7 @@ Module Knot (TF':TY_FUNCTOR) : KNOT with Module TF:=TF'.
     destruct w; simpl in *.
     destruct s; simpl in *.
     destruct (decompose_nat x n) as [[r Hr]|?].
-    elimtype False; lia.
+    exfalso; lia.
     apply le_T_bot.
   Qed.
 

--- a/msl/predicates_rec.v
+++ b/msl/predicates_rec.v
@@ -77,7 +77,7 @@ Section HORec.
    specialize (Hcont (fun _ => FF) (HORec' 0)).
    specialize (Hcont O).
    spec Hcont. repeat (hnf; intros). simpl in *.
-   rewrite laterR_nat in H; elimtype False; lia.
+   rewrite laterR_nat in H; exfalso; lia.
    specialize ( Hcont x).
     simpl in *. auto.
    intro x.
@@ -148,7 +148,7 @@ Proof.
     destruct (@Hcont (fun _ => FF) (HORec f) (level a)) with x a; try lia.
      rewrite H0.
     repeat (hnf; intros); split; hnf; simpl; intros.
-    simpl in H2.  apply laterR_level in H2. elimtype False; lia.
+    simpl in H2.  apply laterR_level in H2. exfalso; lia.
         simpl in H2.  apply laterR_level in H2. clear - H2. simpl in H2.  unfold natLevel in H2; lia.
      specialize (H1 _ _ (necR_refl _) (ext_refl _)). rewrite H0 in H1. simpl in H1.
      eapply H2; auto.
@@ -159,7 +159,7 @@ Proof.
     specialize (Hcont (HORec f) (fun _ => FF)).
     specialize (Hcont 0).
     spec Hcont.
-    simpl. intros. apply laterR_level in H2. simpl in H2. unfold natLevel in H2. elimtype False; lia.
+    simpl. intros. apply laterR_level in H2. simpl in H2. unfold natLevel in H2. exfalso; lia.
     specialize ( Hcont x).
     hnf in Hcont. specialize ( Hcont x'). spec Hcont. lia.
     eapply Hcont; auto.

--- a/msl/predicates_sl.v
+++ b/msl/predicates_sl.v
@@ -299,7 +299,7 @@ Proof.
   hnf in H6.
   rewrite H5 in H6; discriminate.
   clear -H1 H5.
-  elimtype False.
+  exfalso.
   revert H5; induction H1; auto.
   intros.
   unfold age in H.

--- a/msl/predicates_sl_simple.v
+++ b/msl/predicates_sl_simple.v
@@ -261,7 +261,7 @@ Proof.
   hnf in H6.
   rewrite H5 in H6; discriminate.
   clear -H1 H5.
-  elimtype False.
+  exfalso.
   revert H5; induction H1; auto.
   intros.
   unfold age in H.

--- a/msl/psepalg.v
+++ b/msl/psepalg.v
@@ -307,7 +307,7 @@ Qed.
   Proof.
     intros.
     icase a; icase b; icase c;
-    try solve [elimtype False; inv H];
+    try solve [exfalso; inv H];
     try solve [right; exists a; exists a0; exists a1; inv H; intuition].
     left; right; inv H; auto.
     left; left; inv H; auto.

--- a/msl/pshares.v
+++ b/msl/pshares.v
@@ -111,7 +111,7 @@ Proof.
 Qed.
 
 Ltac pfullshare_join :=
-  elimtype False;
+  exfalso;
   solve [ eapply pshare_join_full_false1; eauto
     | eapply pshare_join_full_false2; eauto
     | eapply pshare_join_full_false3; eauto

--- a/msl/rmaps.v
+++ b/msl/rmaps.v
@@ -176,10 +176,10 @@ Module StratModel (AV' : ADR_VAL) : STRAT_MODEL with Module AV:=AV'.
       (* saf_assoc *)
       intros a b c d e H1 H2.
       icase d. exists c. inv H1. inv H2; split; constructor.
-      icase c. 3: elimtype False; inv H2. exists b. inv H2. split; auto. icase b. constructor. constructor. inv H1.
-      icase b. 3: elimtype False; inv H1. exists (YES' PRED p1 k0 p2). split. constructor. inv H1. apply H2.
-      icase a. 3: elimtype False; inv H1. exists e. inv H1. split; auto. icase e. constructor. constructor. inv H2.
-      icase e. 3: elimtype False; inv H2. elimtype False. inv H2.
+      icase c. 3: exfalso; inv H2. exists b. inv H2. split; auto. icase b. constructor. constructor. inv H1.
+      icase b. 3: exfalso; inv H1. exists (YES' PRED p1 k0 p2). split. constructor. inv H1. apply H2.
+      icase a. 3: exfalso; inv H1. exists e. inv H1. split; auto. icase e. constructor. constructor. inv H2.
+      icase e. 3: exfalso; inv H2. exfalso. inv H2.
       destruct (@join_assoc _ _ _ p5 p3 p1 p p7) as [sh' [? ?]]. inv H1; auto. inv H2; auto.
       exists (YES' PRED sh' k p0).
       inv H1. inv H2. split; constructor; auto.
@@ -219,16 +219,16 @@ Module StratModel (AV' : ADR_VAL) : STRAT_MODEL with Module AV:=AV'.
     icase z. exists (NO' _). exists (NO' _). simpl in *. inv H. split. constructor. tauto.
     2: exists (PURE' _ k p); exists (PURE' _ k p); simpl in *; inv H; split; [constructor | tauto].
     icase x'. exists (NO' _). exists (YES' _ p k p0). split. constructor. split; auto. simpl in *; inv H. trivial.
-    2: elimtype False; inv H.
+    2: exfalso; inv H.
     icase y. exists (YES' _ p k p0). exists (NO' _). split. constructor. split; auto. simpl in *. inv H. trivial.
-    2: elimtype False; inv H.
+    2: exfalso; inv H.
     exists (YES' _ p1 k0 p0). exists (YES' _ p3 k1 p0). simpl in *. inv H. split. constructor. trivial. split; congruence.
     icase z'. exists (NO' _). exists (NO' _). simpl. icase x; inv H. split. constructor. tauto.
-    destruct x; destruct y; try (elimtype False; inv H; fail).
+    destruct x; destruct y; try (exfalso; inv H; fail).
     exists (YES' _ p1 k0 p2). exists (YES' _ p1 k0 p2). split. constructor. simpl in *. inv H. split; congruence.
     exists (NO' _). exists (YES' _ p1 k0 p2). split. constructor. simpl in *. inv H. split; congruence.
     exists (YES' _ p3 k1 p2). exists (YES' _ p k p2). simpl in *. inv H. split. constructor. trivial. split; congruence.
-    destruct x; destruct y; try (elimtype False; inv H; fail). unfold fmap in H. unfold f_res in H. unfold res_fmap in H.
+    destruct x; destruct y; try (exfalso; inv H; fail). unfold fmap in H. unfold f_res in H. unfold res_fmap in H.
     exists (PURE' _ k0 p0). exists (PURE' _ k0 p0). split. constructor. inv H. simpl. split; congruence.
   Qed.
 
@@ -553,13 +553,13 @@ Module Rmaps (AV':ADR_VAL) : RMAPS with Module AV:=AV'.
       intros a b c d e H1 H2.
       destruct d. exists c. inv H1. inv H2; split; constructor.
       2: exists (PURE k p); inv H1; inv H2; split; constructor.
-      destruct e; try (elimtype False; inv H2; fail).
+      destruct e; try (exfalso; inv H2; fail).
       destruct c. exists b. inv H2. split; auto. destruct b; try constructor. inv H1.
-      2: elimtype False; inv H2.
+      2: exfalso; inv H2.
       destruct b. exists (YES p3 k1 p4). split. constructor. inv H1. trivial.
-      2: elimtype False; inv H1.
+      2: exfalso; inv H1.
       destruct a. exists (YES p1 k0 p2). inv H1. split; trivial. constructor.
-      2: elimtype False; inv H1.
+      2: exfalso; inv H1.
       destruct (@join_assoc _ _ _ p7 p5 p3 p p1) as [sh' [? ?]].
       inv H1; auto. inv H2; auto.
       exists (YES sh' k p0). inv H1. inv H2. split; constructor; trivial.

--- a/msl/rmaps_lemmas.v
+++ b/msl/rmaps_lemmas.v
@@ -843,7 +843,7 @@ Proof.
   intros.
   case_eq (age1 m); intros.
   exists r. auto.
-  elimtype False.
+  exfalso.
   eapply age1None_levelS_absurd in H0; eauto.
 Qed.
 
@@ -872,7 +872,7 @@ Proof.
   rewrite ageN1 in H0.
   constructor 1.
   auto.
-  elimtype False.
+  exfalso.
   eapply age1None_levelS_absurd in H0; eauto.
 Qed.
 
@@ -1181,7 +1181,7 @@ assert (z=YES c k0 p0) by (inv H0; auto). clear H0; subst.
 assert (Hz: k0=k /\ p0=p) by (inv H; auto); destruct Hz; subst.
 exists (YES a k p, NO, YES b k p, NO); simpl; split; auto.
 constructor. inv H; split3; constructor; auto.
-destruct z as [|z|z].  elimtype False; inv H0.
+destruct z as [|z|z].  exfalso; inv H0.
 assert (Hx: k=k2 /\ k0=k2 /\ k1=k2 /\ p=p2 /\ p0=p2 /\ p1=p2) by  (inv H0; inv H; auto 50).
 destruct Hx as [? [? [? [? [? ?]]]]]; subst.
 assert (join c d z) by (inv H0; auto).
@@ -1226,10 +1226,10 @@ rename k2 into k; rename p2 into p.
 exists (YES (mk_lifted _ (nonidentity_nonunit n)) k p, YES (mk_lifted _ (nonidentity_nonunit n0)) k p,
        YES (mk_lifted _ (nonidentity_nonunit n1)) k p,  YES (mk_lifted _ (nonidentity_nonunit n2)) k p); split; simpl; auto.
 constructor; auto.  split3; constructor; auto.
-elimtype False; inv H0.
-elimtype False; inv H0.
-elimtype False; inv H0; inv H.
-elimtype False; inv H.
+exfalso; inv H0.
+exfalso; inv H0.
+exfalso; inv H0; inv H.
+exfalso; inv H.
 exists (PURE a p, PURE a p, PURE a p, PURE a p).
 inv H. inv H0.
 repeat split; constructor; auto.

--- a/msl/sepalg_generators.v
+++ b/msl/sepalg_generators.v
@@ -77,7 +77,7 @@ Require Import VST.msl.sepalg.
     constructor. auto with typeclass_instances.
     intros; inv H; inv H0; hnf; auto.
     repeat intro; hnf in *; subst; auto.
-    intros. icase a; icase b; icase d; try solve [elimtype False; (inv H || inv H0)].
+    intros. icase a; icase b; icase d; try solve [exfalso; (inv H || inv H0)].
     exists c; inv H0; split; constructor.
     exists true; inv H0; split; constructor.
     exists c; inv H0; split; constructor.
@@ -102,8 +102,8 @@ Require Import VST.msl.sepalg.
 
   #[global] Instance Cross_bool: Cross_alg bool.
   Proof. repeat intro.
-     icase a; icase b; try solve [elimtype False; (try inv H; inv H0)];
-    icase z; icase c; icase d; try solve [elimtype False; (try inv H; inv H0)].
+     icase a; icase b; try solve [exfalso; (try inv H; inv H0)];
+    icase z; icase c; icase d; try solve [exfalso; (try inv H; inv H0)].
      exists (true,false,false,false); repeat split; constructor.
      exists (false,true,false,false); repeat split; constructor.
      exists (false,false,true,false); repeat split; constructor.
@@ -609,8 +609,8 @@ Section sa_list.
     f_equal. eapply join_eq; eauto. eapply IHx; eauto.
 
     induction a; intros;
-    destruct b; destruct d; try (elimtype False; inv H; fail);
-    destruct c; destruct e; try (elimtype False; inv H0; fail).
+    destruct b; destruct d; try (exfalso; inv H; fail);
+    destruct c; destruct e; try (exfalso; inv H0; fail).
     exists nil. split; constructor.
     assert (join a a1 a2) by (inv H; auto).
     assert (join a2 a3 a4) by (inv H0; auto).

--- a/msl/sepalg_list.v
+++ b/msl/sepalg_list.v
@@ -505,7 +505,7 @@ unfold age in H0.
 inversion2 H H0.
 generalize (comparable_common_unit H1); intros [e1 [? ?]].
 case_eq (age1 phi'); [intros w ? | intro]; auto.
-elimtype False.
+exfalso.
 generalize (age1_join2 _ H2 H3); intros [a [b [? [? ?]]]].
 generalize (age1_join _ H0 H5); intros [c [d [? [? ?]]]].
 unfold age in H8; inversion2 H H8.

--- a/msl/tree_shares.v
+++ b/msl/tree_shares.v
@@ -924,7 +924,7 @@ Module Share <: SHARE_MODEL.
     rewrite <- IHa1_2; auto.
     intro; apply n; simpl; auto.
     intro; apply n; simpl; auto.
-    elimtype False; intuition.
+    exfalso; intuition.
   Qed.
 
   Lemma relativ_stupid1 : forall x y a,
@@ -1017,7 +1017,7 @@ Module Share <: SHARE_MODEL.
     simpl in *.
     destruct a2; simpl in *.
     destruct b; try discriminate.
-    elimtype False; clear -H H0.
+    exfalso; clear -H H0.
     revert H0.
     intros.
     apply (relativ_stupid3 _ _ _ H H0).
@@ -1733,7 +1733,7 @@ Module Share <: SHARE_MODEL.
       simpl.
       case_eq (mkCanon (split_tok2 n0 t0)); intros.
       destruct b.
-      elimtype False.
+      exfalso.
       clear - H H1.
       revert n0 H H1.
       induction t0; simpl; intros.
@@ -2207,7 +2207,7 @@ Module Share <: SHARE_MODEL.
       apply union_upper_bound.
       elim (tokenFactory_nonbot fac'2 (n0+x)); auto.
       destruct x.
-      elimtype False.
+      exfalso.
       invert_ord.
       destruct (fac_tok_classification fac'2 (n0+0)) with t0 n0
         as [? [? ?]]; auto.
@@ -2244,7 +2244,7 @@ Module Share <: SHARE_MODEL.
       apply union_upper_bound.
       elim (tokenFactory_nonbot fac'2 (S (n0+x))); auto.
       destruct x.
-      elimtype False.
+      exfalso.
       destruct (fac_tok_classification fac'2 (S (n0 + 0))) with t0 (S n0)
         as [? [? ?]]; auto.
       spec H0; [ lia |].
@@ -2257,7 +2257,7 @@ Module Share <: SHARE_MODEL.
       invert_ord; auto.
       simpl.
       destruct x.
-      elimtype False.
+      exfalso.
       destruct (fac_tok_classification fac'2 (n0 + 0)) with t0 (S n0)
         as [? [? ?]]; auto.
       elim H0; lia.
@@ -2522,7 +2522,7 @@ Proof.
   icase t0_1;icase t0_2.
   icase (bool_dec b b0).
   subst.
-  elimtype False.
+  exfalso.
   icase b0;compute in  H;compute in H0; firstorder with bool.
 Qed.
 
@@ -2583,7 +2583,7 @@ Proof.
   rewrite H0.
   apply rel_top2.
 
-  elimtype False.
+  exfalso.
   apply H.
   assert (exist (fun t0 : ShareTree => canonicalTree t0) (Leaf false) c =
                  core (exist (fun t0 : ShareTree => canonicalTree t0) (Leaf false) c)).
@@ -2706,7 +2706,7 @@ Qed.
       remember (tree_heightP (Node t2_1 t2_2)).
       icase n.
       inversion Heqn.
-      destruct (Nat.max (tree_heightP t2_1) (tree_heightP t2_2));elimtype False ;lia.
+      destruct (Nat.max (tree_heightP t2_1) (tree_heightP t2_2));exfalso ;lia.
       inversion H.
       inversion H.
       destruct (Nat.max (tree_heightP t1_1) (tree_heightP t1_2));inversion H1.
@@ -3096,7 +3096,7 @@ Proof.
     icase x2_1;icase x2_2.
     icase b;icase b0;
     simpl;
-    elimtype False; firstorder with bool.
+    exfalso; firstorder with bool.
   rewrite H1.
   simpl.
   destruct H0 as [? [? [? ?]]].
@@ -3179,7 +3179,7 @@ Qed.
     icase x1_1;icase x1_2.
     icase b;icase b0;
     simpl;
-    elimtype False; firstorder with bool.
+    exfalso; firstorder with bool.
   rewrite H1.
   simpl.
   destruct H0 as [? [? [? ?]]].
@@ -3646,7 +3646,7 @@ Qed.
     exists (Leaf b).
     compute;trivial.
     inversion H.
-    elimtype False;lia.
+    exfalso;lia.
     assert (n >= tree_heightP (Leaf b)).
       compute;lia.
     specialize ( IHn (Leaf b) H0).
@@ -3902,7 +3902,7 @@ Qed.
       remember (tree_heightP (Node t2_1 t2_2)).
       icase n.
       inversion Heqn.
-      destruct (Nat.max (tree_heightP t2_1) (tree_heightP t2_2));elimtype False ;lia.
+      destruct (Nat.max (tree_heightP t2_1) (tree_heightP t2_2));exfalso ;lia.
       inversion H.
       inversion H.
       destruct (Nat.max (tree_heightP t1_1) (tree_heightP t1_2));inversion H1.
@@ -4384,14 +4384,14 @@ Qed.
     generalize (tree_round_left_one _ _ _ _ H2);intro H3.
     destruct H3 as [b31 [b32 [H31 [H32 H33]]]];subst.
     destruct H as [_ H].
-    elimtype False;clear-H.
+    exfalso;clear-H.
     inv H.
     icase b.
 
    generalize (tree_round_left_one _ _ _ _ H1);intro H3.
    destruct H3 as [b31 [b32 [H31 [H32 H33]]]];subst.
    destruct H as [H3 H4].
-   elimtype False;clear-H3 H4 c0.
+   exfalso;clear-H3 H4 c0.
    inv H3.
    inv H4.
    generalize (mkCanon_identity _ c0);intro.
@@ -4425,7 +4425,7 @@ Qed.
 
    generalize (tree_round_left_one _ _ _ _ H0);intro H3.
    destruct H3 as [b31 [b32 [H31 [H32 H33]]]];subst.
-   elimtype False;clear -H c.
+   exfalso;clear -H c.
    destruct H as [H1 H2].
    inv H1;inv H2.
    generalize (mkCanon_identity _ c);intro.
@@ -4543,14 +4543,14 @@ Qed.
   icase x1;icase x2;unfold tree_height in *;inversion H.
   exists (exist (fun t => canonicalTree t) (Leaf b) (canonTree_Leaf _)).
   compute;split;try lia;try f_equal;try apply exist_ext;trivial.
-  elimtype False;lia.
-  elimtype False;clear -H1.
+  exfalso;lia.
+  exfalso;clear -H1.
   assert (0 = Nat.max (Nat.max (tree_heightP x1_1) (tree_heightP x1_2) + 1) 0) by lia;
   clear H1.
   generalize (Nat.max_0_r (Nat.max (tree_heightP x1_1) (tree_heightP x1_2) + 1));intro.
   rewrite H0 in H;clear H0.
   lia.
-  elimtype False;clear -H1.
+  exfalso;clear -H1.
   assert (0 = Nat.max (Nat.max (tree_heightP x1_1) (tree_heightP x1_2) + 1)
        (Nat.max (tree_heightP x2_1) (tree_heightP x2_2) + 1)) by lia;
   clear H1.
@@ -5018,14 +5018,14 @@ Qed.
     generalize (tree_round_right_one _ _ _ _ H2);intro H3.
     destruct H3 as [b31 [b32 [H31 [H32 H33]]]];subst.
     destruct H as [_ H].
-    elimtype False;clear-H.
+    exfalso;clear-H.
     inv H.
     icase b.
 
    generalize (tree_round_right_one _ _ _ _ H1);intro H3.
    destruct H3 as [b31 [b32 [H31 [H32 H33]]]];subst.
    destruct H as [H3 H4].
-   elimtype False;clear-H3 H4 c0.
+   exfalso;clear-H3 H4 c0.
    inv H3.
    inv H4.
    generalize (mkCanon_identity _ c0);intro.
@@ -5059,7 +5059,7 @@ Qed.
 
    generalize (tree_round_right_one _ _ _ _ H0);intro H3.
    destruct H3 as [b31 [b32 [H31 [H32 H33]]]];subst.
-   elimtype False;clear -H c.
+   exfalso;clear -H c.
    destruct H as [H1 H2].
    inv H1;inv H2.
    generalize (mkCanon_identity _ c);intro.
@@ -5177,14 +5177,14 @@ Qed.
   icase x1;icase x2;unfold tree_height in *;inversion H.
   exists (exist (fun t => canonicalTree t) (Leaf b0) (canonTree_Leaf _)).
   compute;split;try lia;try f_equal;try apply exist_ext;trivial.
-  elimtype False;lia.
-  elimtype False;clear -H1.
+  exfalso;lia.
+  exfalso;clear -H1.
   assert (0 = Nat.max (Nat.max (tree_heightP x1_1) (tree_heightP x1_2) + 1) 0) by lia;
   clear H1.
   generalize (Nat.max_0_r (Nat.max (tree_heightP x1_1) (tree_heightP x1_2) + 1));intro.
   rewrite H0 in H;clear H0.
   lia.
-  elimtype False;clear -H1.
+  exfalso;clear -H1.
   assert (0 = Nat.max (Nat.max (tree_heightP x1_1) (tree_heightP x1_2) + 1)
        (Nat.max (tree_heightP x2_1) (tree_heightP x2_2) + 1)) by lia;
   clear H1.
@@ -5536,7 +5536,7 @@ Qed.
     icase (mkCanon s1);
     icase (mkCanon s2).
     icase b; icase b0;simpl in *;
-    elimtype False; firstorder with bool.
+    exfalso; firstorder with bool.
   Qed.
 
   (*L30*)
@@ -5763,7 +5763,7 @@ Qed.
     simpl.
     apply f_equal;apply exist_ext.
     icase b1;icase b2;compute in c3.
-    elimtype False.
+    exfalso.
     destruct c3 as [c3 ?].
     destruct c3;
     inv H0.
@@ -5997,7 +5997,7 @@ Qed.
    intro;apply H.
    rewrite H6;apply exist_ext;trivial.
    icase b;icase b0;simpl.
-   try (elimtype False; tauto). (*useless in Coq.8.6 but required in Coq.8.6 *)
+   try (exfalso; tauto). (*useless in Coq.8.6 but required in Coq.8.6 *)
    exists (exist (fun t0 : ShareTree => canonicalTree t0)
           (Node (Leaf true) (Leaf false))
           (mkCanon_correct (Node (Leaf true) (Leaf false)))).
@@ -6006,10 +6006,10 @@ Qed.
           (Node (Leaf false) (Leaf true))
           (mkCanon_correct (Node (Leaf false) (Leaf true)))).
    split;trivial.
-   try (elimtype False; tauto). (*useless in Coq.8.6 but required in Coq.8.6 *)
-   inv H5;inv H4;elimtype False;lia.
-   inv H5;inv H4;elimtype False;lia.
-   inv H5;inv H4;elimtype False;lia.
+   try (exfalso; tauto). (*useless in Coq.8.6 but required in Coq.8.6 *)
+   inv H5;inv H4;exfalso;lia.
+   inv H5;inv H4;exfalso;lia.
+   inv H5;inv H4;exfalso;lia.
 
    generalize (canonTree_rewrite1 t1);intro H3.
    generalize (canonTree_rewrite1 t2);intro H4.
@@ -6253,7 +6253,7 @@ Qed.
     icase (bool_dec b b0);try subst b0;
     simpl;
     apply exist_ext;trivial.
-    icase b; elimtype False; firstorder with bool.
+    icase b; exfalso; firstorder with bool.
 
     f_equal;
     apply proof_irr.
@@ -6301,7 +6301,7 @@ Qed.
   rewrite H;rewrite H0.
   icase x1;icase x2.
   icase b;icase b0;
-  elimtype False; firstorder with bool.
+  exfalso; firstorder with bool.
   f_equal;apply exist_ext;
   rewrite H in H1;rewrite H0 in H1;
   icase x1;icase x2;try icase b;try icase b0;inv H1;auto.
@@ -6448,7 +6448,7 @@ Proof.
  assert (H2 := canonTree_eq_dec s12 s22).
  destruct H2 as [H2|H2].
  subst s12.
- elimtype False.
+ exfalso.
  apply H.
  rewrite<- H1 in H0.
  assert (H2 : recompose (decompose s1) = recompose (decompose s2)).
@@ -6532,17 +6532,17 @@ Proof.
   unfold countBLeafCT;simpl.
   icase s1.
   icase b.
-  elimtype False.
+  exfalso.
   apply H0.
   apply ord_antisym.
   apply H.
   apply top_correct.
   icase s2.
   icase b.
-  elimtype False.
+  exfalso.
   apply H0.
   f_equal.
-  elimtype False.
+  exfalso.
   unfold tree_height in H1.
   simpl in H1.
   lia.
@@ -6553,7 +6553,7 @@ Proof.
     apply H.
     apply bot_correct.
   inv H2.
-  elimtype False.
+  exfalso.
   unfold tree_height in H1.
   simpl in H1.
   lia.
@@ -6852,7 +6852,7 @@ Qed.
   right;unfold bot;f_equal;apply proof_irr.
   unfold tree_height in H.
   simpl in H.
-  elimtype False;lia.
+  exfalso;lia.
  Qed.
 
  (*L55*)
@@ -7031,7 +7031,7 @@ Qed.
   simpl.
   lia.
   unfold bot;f_equal;apply proof_irr.
-  elimtype False.
+  exfalso.
   destruct H as [H1 H2].
   assert (tree_height (exist (fun t : ShareTree => canonicalTree t) (Leaf b) pf1) <= 0) by (compute;lia).
   assert (tree_height (exist (fun t : ShareTree => canonicalTree t) (Leaf b0) pf2) <= 0) by (compute;lia).
@@ -7174,7 +7174,7 @@ Definition share_metric (n : nat) (s : canonTree) : nat :=
   simpl.
   icase (le_dec (tree_height s) n).
   unfold height in H;simpl in H.
-  elimtype False;lia.
+  exfalso;lia.
  Qed.
  (*L50*)
  Lemma share_metric_height_monotonic : forall s n1 n2,
@@ -7335,7 +7335,7 @@ Definition share_metric (n : nat) (s : canonTree) : nat :=
   simpl in H.
   unfold tree_height in H.
   simpl in H.
-  elimtype False.
+  exfalso.
   lia.
  Defined.
 (*D10*)
@@ -7412,7 +7412,7 @@ Definition share_metric (n : nat) (s : canonTree) : nat :=
   split;intros.
   inv H.
   destruct H.
-  elimtype False;apply n.
+  exfalso;apply n.
   rewrite<- H0.
   rewrite glb_commute.
   rewrite distrib1.

--- a/progs/list_dt.v
+++ b/progs/list_dt.v
@@ -467,13 +467,13 @@ unfold all_but_link.
 unfold add_link_back.
 unfold list_rect at 1.
 simpl @fst.
-destruct (ident_eq list_link list_link); [ | elimtype False; congruence]; intro.
+destruct (ident_eq list_link list_link); [ | exfalso; congruence]; intro.
 simpl. reflexivity.
  apply struct_pred_type_changable; auto.
  clear.
  revert v.
  simpl.
- destruct (ident_eq list_link list_link); [ | elimtype False; congruence]; intro.
+ destruct (ident_eq list_link list_link); [ | exfalso; congruence]; intro.
  simpl. reflexivity.
 * (* list link is not the first field *)
  specialize (H' H).

--- a/progs/memmgr/malloc_sep.v
+++ b/progs/memmgr/malloc_sep.v
@@ -282,10 +282,10 @@ Lemma mmlist_unroll_nonempty:
 Proof.
   intros. apply pred_ext.
   - (* LHS |-- RHS *)
-    destruct len. elimtype False; simpl in *; lia.
+    destruct len. exfalso; simpl in *; lia.
     simpl. Intros q; Exists q. entailer.
   - (* RHS |-- LHS *)
-    Intros q. destruct len. elimtype False; simpl in *; lia.
+    Intros q. destruct len. exfalso; simpl in *; lia.
     simpl. Exists q. entailer!.
 Qed.
 

--- a/progs/memmgr/verif_malloc_large.v
+++ b/progs/memmgr/verif_malloc_large.v
@@ -25,7 +25,7 @@ forward_if. (*! if (p==NULL) !*)
 - (* case p <> NULL *) 
   if_tac. (* cases in post of mmap *)
   + (* impossible case *)
-    elimtype False. destruct p; try contradiction; simpl in *.
+    exfalso. destruct p; try contradiction; simpl in *.
   + assert_PROP (
         (force_val
            (sem_add_ptr_int tuint Signed
@@ -75,7 +75,7 @@ forward_if. (*! if (p==NULL) !*)
     entailer!.
     simpl.
     if_tac. 
-    { elimtype False. destruct p; try contradiction; simpl in *. 
+    { exfalso. destruct p; try contradiction; simpl in *. 
       match goal with | HA: Vptr _ _  = nullval |- _ => inv HA end. }
     unfold malloc_token'.
     Exists n.

--- a/progs/verif_load_demo.v
+++ b/progs/verif_load_demo.v
@@ -103,7 +103,7 @@ assert_PROP (Zlength contents = n) as LEN. {
   forget (Int.unsigned (Int.shru (Int.repr tag) (Int.repr 10))) as n.
   clear - H0.
   rewrite Zlength_cons, !Zlength_map in H0.
-  destruct (zlt n 0); [elimtype False | ].
+  destruct (zlt n 0); [exfalso | ].
   rewrite Z.max_l in H0 by lia.
   pose proof (Zlength_nonneg contents).
   lia.

--- a/sepcomp/mem_lemmas.v
+++ b/sepcomp/mem_lemmas.v
@@ -187,7 +187,7 @@ split; auto.
 intros H1.
 destruct (Mem.perm_dec m b ofs k p).
 solve[f_equal; apply proof_irr].
-solve[elimtype False; auto].
+solve[exfalso; auto].
 Qed.
 
 Lemma flatinj_E: forall b b1 b2 delta (H:Mem.flat_inj b b1 = Some (b2, delta)),

--- a/sepcomp/submit/CminorgenproofSIM.v
+++ b/sepcomp/submit/CminorgenproofSIM.v
@@ -322,7 +322,7 @@ Proof. intros.
   case_eq (Int.eq_dec Int.zero Int.zero). intros ? e.
   solve[rewrite D; auto].
   intros CONTRA.
-  solve[elimtype False; auto].
+  solve[exfalso; auto].
   eapply MC_callstate with (cenv:=PTree.empty _)(cs := @nil frame); try eassumption.
   destruct INIT_MEM as [m0 [INIT_MEM [A B]]].
   assert (Genv.init_mem tprog = Some m0).

--- a/sepcomp/submit/fs_linking.v
+++ b/sepcomp/submit/fs_linking.v
@@ -61,9 +61,9 @@ Proof.
   clear - H4.
   induction bytes.
   constructor.
-  constructor. destruct a. inv H4. simpl in H1. elimtype False; auto.
+  constructor. destruct a. inv H4. simpl in H1. exfalso; auto.
   constructor.
-  inv H4. simpl in H1. elimtype False; auto.
+  inv H4. simpl in H1. exfalso; auto.
   inv H4.
   solve[eapply IHbytes; auto].
   intros [m2' [C D]].
@@ -84,9 +84,9 @@ Proof.
   clear - H4.
   induction bytes.
   constructor.
-  constructor. destruct a. inv H4. simpl in H1. elimtype False; auto.
+  constructor. destruct a. inv H4. simpl in H1. exfalso; auto.
   constructor.
-  inv H4. simpl in H1. elimtype False; auto.
+  inv H4. simpl in H1. exfalso; auto.
   solve[inv H4; auto].
 Qed.
 
@@ -411,7 +411,7 @@ simpl in H4.
 inv H4.
 simpl.
 if_tac.
-elimtype False; auto.
+exfalso; auto.
 intros H2.
 unfold Mem.loadbytes in H2.
 if_tac in H2; try congruence.

--- a/sepcomp/submit/mem_lemmas.v
+++ b/sepcomp/submit/mem_lemmas.v
@@ -134,7 +134,7 @@ split; auto.
 intros H1.
 destruct (Mem.perm_dec m b ofs k p).
 solve[f_equal; apply proof_irr].
-solve[elimtype False; auto].
+solve[exfalso; auto].
 Qed.
 
 Lemma flatinj_E: forall b b1 b2 delta (H:Mem.flat_inj b b1 = Some (b2, delta)),

--- a/sepcomp/submit_shmem/compcert_adapt/CminorgenproofEFF.v
+++ b/sepcomp/submit_shmem/compcert_adapt/CminorgenproofEFF.v
@@ -771,7 +771,7 @@ Proof. intros.
   case_eq (Int.eq_dec Int.zero Int.zero). intros ? e.
   solve[rewrite D; auto].
   intros CONTRA.
-  solve[elimtype False; auto].
+  solve[exfalso; auto].
   destruct InitMem as [m0 [INIT_MEM [A B]]].
   split.
     eapply SMC_callstate with (cenv:=PTree.empty _)(cs := @nil frame); try eassumption.

--- a/sepcomp/submit_shmem/compcert_adapt/CshmgenproofEFF.v
+++ b/sepcomp/submit_shmem/compcert_adapt/CshmgenproofEFF.v
@@ -2212,7 +2212,7 @@ Proof. intros.
     solve[rewrite D; auto].
 
     intros CONTRA.
-    solve[elimtype False; auto].
+    solve[exfalso; auto].
   assert (exists targs tres, type_of_fundef f = Tfunction targs tres).
          destruct f; simpl. eexists; eexists. reflexivity.
          eexists; eexists. reflexivity.

--- a/sepcomp/submit_shmem/compcert_adapt/RTLgenproofEFF.v
+++ b/sepcomp/submit_shmem/compcert_adapt/RTLgenproofEFF.v
@@ -81,11 +81,11 @@ Proof.
   intros until r0. repeat rewrite PTree.gsspec.
   destruct (peq id1 name); destruct (peq id2 name).
   congruence.
-  intros. inv H. elimtype False.
+  intros. inv H. exfalso.
   apply valid_fresh_absurd with r0 s1.
   apply H1. left; exists id2; auto.
   eauto with rtlg.
-  intros. inv H2. elimtype False.
+  intros. inv H2. exfalso.
   apply valid_fresh_absurd with r0 s1.
   apply H1. left; exists id1; auto.
   eauto with rtlg.
@@ -2095,7 +2095,7 @@ Proof. intros.
     solve[rewrite D; auto].
 
     intros CONTRA.
-    solve[elimtype False; auto].
+    solve[exfalso; auto].
 (*  assert (exists targs tres, type_of_fundef f = Tfunction targs tres).
          destruct f; simpl. eexists; eexists. reflexivity.
          eexists; eexists. reflexivity.

--- a/sepcomp/submit_shmem/compcert_adapt/SelectionproofEFF.v
+++ b/sepcomp/submit_shmem/compcert_adapt/SelectionproofEFF.v
@@ -2035,7 +2035,7 @@ Proof. intros.
   case_eq (Int.eq_dec Int.zero Int.zero). intros ? e.
   solve[rewrite D; auto].
   intros CONTRA.
-  solve[elimtype False; auto].
+  solve[exfalso; auto].
   destruct InitMem as [m0 [INIT_MEM [A B]]].
 destruct (core_initial_wd ge tge _ _ _ _ _ _ _  Inj
     VInj J RCH PG GDE HDomS HDomT _ (eq_refl _))

--- a/sepcomp/submit_shmem/mem_lemmas.v
+++ b/sepcomp/submit_shmem/mem_lemmas.v
@@ -134,7 +134,7 @@ split; auto.
 intros H1.
 destruct (Mem.perm_dec m b ofs k p).
 solve[f_equal; apply proof_irr].
-solve[elimtype False; auto].
+solve[exfalso; auto].
 Qed.
 
 Lemma flatinj_E: forall b b1 b2 delta (H:Mem.flat_inj b b1 = Some (b2, delta)),

--- a/sepcomp/submit_shmem/open_semantics_preservation.v
+++ b/sepcomp/submit_shmem/open_semantics_preservation.v
@@ -375,7 +375,7 @@ assert (MATCH: match_state cd j c m d tm) by (inv TRMATCH; auto).
 inv STEP. rename H6 into STEP.
 
 { (*internal step case*)
-elimtype False.
+exfalso.
 apply corestep_not_at_external in STEP.
 simpl in ATEXTSRC; rewrite STEP in ATEXTSRC; inv ATEXTSRC. }
 
@@ -427,7 +427,7 @@ set (frgnSrc' := fun b : block =>
        && REACH m' (exportedSrc nu2 (rv :: nil)) b)).
 
 assert (exists trv0, trv = Some trv0) as [trv0 ->].
-  { simpl in RVALINJ; destruct trv as [trv|]; try solve[elimtype False; auto].
+  { simpl in RVALINJ; destruct trv as [trv|]; try solve[exfalso; auto].
     solve[exists trv; auto]. }
 
 set (frgnTgt' := fun b : block =>
@@ -530,7 +530,7 @@ assert (NU2_INJ: Mem.inject (as_inj nu2) m' tm2).
     unfold mu in INCR; destruct INCR as [X _].
     rewrite as_inj_marshal in X; auto.
     intros b LOC LOCOF; case_eq (as_inj mu2 b); auto.
-    intros [b0 d0] ASINJ; elimtype False.
+    intros [b0 d0] ASINJ; exfalso.
     destruct NUMU2_SEP as [X Y].
     cut (as_inj nu b = None). intro ASINJ'.
     destruct (X _ _ _ ASINJ' ASINJ).

--- a/sepcomp/submit_shmem/trace_semantics.v
+++ b/sepcomp/submit_shmem/trace_semantics.v
@@ -219,7 +219,7 @@ case_eq (at_external sem c); auto.
 intros [[ef sig] args] AT.
 generalize (@at_external_halted_excl _ _ _ sem c).
 rewrite AT. intros [|W]; try congruence; auto.
-intros CONTRA; elimtype False; apply CONTRA.
+intros CONTRA; exfalso; apply CONTRA.
 left; exists ef, sig, args; auto.
 Qed.
 
@@ -232,7 +232,7 @@ generalize (@at_external_halted_excl _ _ _ sem c).
 rewrite AT. intros [|W]; try congruence; auto. intros AT.
 case_eq (core_semantics.halted sem c); auto.
 intros v HALT.
-intros CONTRA; elimtype False; apply CONTRA.
+intros CONTRA; exfalso; apply CONTRA.
 right; exists v; auto.
 Qed.
 

--- a/sha/verif_addlength.v
+++ b/sha/verif_addlength.v
@@ -132,7 +132,7 @@ rename H0 into H1.
      Int.unsigned (lo_part n)) by normalize.
  clear H1.
  destruct (Int.unsigned_add_either (lo_part n) (Int.repr (len*8))) as [H9|H9].
- elimtype False; rewrite H9 in H0; clear H9.
+ exfalso; rewrite H9 in H0; clear H9.
  destruct (Int.unsigned_range (Int.repr (len*8))) as [? _]; lia.
  clear H0.
  unfold Int.add in H9.

--- a/sha/verif_sha_bdo7.v
+++ b/sha/verif_sha_bdo7.v
@@ -90,7 +90,7 @@ subst k.
 assert (k'<16)%nat by lia.
 clear H.
 do 16 (destruct k'; try reflexivity).
-elimtype False; lia.
+exfalso; lia.
 Qed.
 
 Lemma extract_from_b:
@@ -138,7 +138,7 @@ rewrite !sublist_map.
 rewrite <- !map_cons, <- !map_app.
 f_equal.
 repeat match type of H0 with
-| (64 <= _ < _)%Z => elimtype False; lia
+| (64 <= _ < _)%Z => exfalso; lia
 | (?A <= _ < _)%Z =>
  assert (H9: i=A \/ (A+1 <= i < 64)%Z) by lia;
  clear H0; destruct H9 as [H0|H0];

--- a/veric/SequentialClight.v
+++ b/veric/SequentialClight.v
@@ -280,7 +280,7 @@ destruct (access_at m' loc Cur) as [[ | | | ] | ]  eqn:?H; try solve [contradict
 destruct H; discriminate.
 destruct H; discriminate.
 destruct H; discriminate.
-elimtype False; clear - r H1.
+exfalso; clear - r H1.
 unfold perm_of_sh in H1. if_tac in H1. if_tac in H1; inv H1.
 rewrite if_true in H1 by auto. inv H1.
 destruct (access_at m' loc Cur) as [[ | | | ] | ]  eqn:?H; try solve [contradiction]; try discriminate; auto.
@@ -361,7 +361,7 @@ destruct (access_at m' loc Cur). destruct p0; try contradiction.
 match goal with |- Mem.perm_order'' _ ?A =>
   destruct A; try constructor
 end.
-elimtype False.
+exfalso.
 clear - H1 r.
 unfold perm_of_sh in H1.
 if_tac in H1. if_tac in H1. inv H1; constructor.

--- a/veric/SequentialClight2.v
+++ b/veric/SequentialClight2.v
@@ -276,7 +276,7 @@ destruct (access_at m' loc Cur) as [[ | | | ] | ]  eqn:?H; try solve [contradict
 destruct H; discriminate.
 destruct H; discriminate.
 destruct H; discriminate.
-elimtype False; clear - r H1.
+exfalso; clear - r H1.
 unfold perm_of_sh in H1. if_tac in H1. if_tac in H1; inv H1.
 rewrite if_true in H1 by auto. inv H1.
 destruct (access_at m' loc Cur) as [[ | | | ] | ]  eqn:?H; try solve [contradiction]; try discriminate; auto.
@@ -357,7 +357,7 @@ destruct (access_at m' loc Cur). destruct p0; try contradiction.
 match goal with |- Mem.perm_order'' _ ?A =>
   destruct A; try constructor
 end.
-elimtype False.
+exfalso.
 clear - H1 r.
 unfold perm_of_sh in H1.
 if_tac in H1. if_tac in H1. inv H1; constructor.

--- a/veric/binop_lemmas2.v
+++ b/veric/binop_lemmas2.v
@@ -45,7 +45,7 @@ Proof.
 *
   apply eval_lvalue_any; auto.
 * destruct (eval_expr e any_environ) eqn:?; simpl in *;
-  [elimtype False; apply H0; clear;
+  [exfalso; apply H0; clear;
    try destruct u;
    destruct (typeof e) as [ | [ | | | ] [ | ] | [ | ] | [ | ] | | | | | ];
    try reflexivity
@@ -54,7 +54,7 @@ Proof.
   simpl. unfold Cop2.bool_val; simple_if_tac; reflexivity.
 *
   destruct (eval_expr e1 any_environ) eqn:?; simpl in *;
-  [ elimtype False; apply H0; clear
+  [ exfalso; apply H0; clear
   | rewrite (IHe1 _ (eq_refl _)) by congruence; auto .. ].
  {
   destruct b;
@@ -82,7 +82,7 @@ Proof.
   destruct (eval_expr e2 any_environ); reflexivity.
  }
 all:  destruct (eval_expr e2 any_environ) eqn:?; simpl in *;
-  [ elimtype False; apply H0; clear
+  [ exfalso; apply H0; clear
   | rewrite (IHe2 _ (eq_refl _)) by congruence; auto .. ];
    destruct b;
    destruct (typeof e1) as [ | [ | | | ] [ | ] | [ | ] | [ | ] | | | | | ];
@@ -110,7 +110,7 @@ all:  destruct (eval_expr e2 any_environ) eqn:?; simpl in *;
    destruct t as [ | [ | | | ] [ | ] | [ | ] | [ | ] | | | | | ];
    destruct (typeof e) as [ | [ | | | ] [ | ] | [ | ] | [ | ] | | | | | ];
   (destruct (eval_expr e any_environ) eqn:?; simpl in *;
-  [elimtype False; apply H0; clear
+  [exfalso; apply H0; clear
   | try rewrite (IHe _ (eq_refl _)) by congruence;
      auto .. ]); auto;
   try (unfold Clight_Cop2.sem_cast, Clight_Cop2.classify_cast; repeat simple_if_tac; reflexivity).

--- a/veric/compcert_rmaps.v
+++ b/veric/compcert_rmaps.v
@@ -167,10 +167,10 @@ Proof.
 Ltac glb_Rsh_tac :=
  repeat
  match goal with
- | |- Some _ = None => elimtype False
- | |- None = Some _ => elimtype False
- | |- join (Some _) _ None => elimtype False
- | |- join _ (Some _) None => elimtype False
+ | |- Some _ = None => exfalso
+ | |- None = Some _ => exfalso
+ | |- join (Some _) _ None => exfalso
+ | |- join _ (Some _) None => exfalso
  | |- join _ None _ => apply join_unit2; [ apply None_unit |]
  | |- join None _ _ => apply join_unit1; [ apply None_unit |]
  | |- Some (_,_) = Some(_,_) => do 2 f_equal; try apply exist_ext; auto
@@ -298,60 +298,60 @@ Qed.
 Proof.
 intro; intros.
 destruct a as [ra | ra sa ka pa | ka pa].
-destruct b as [rb | rb sb kb pb | kb pb]; try solve [elimtype False; inv H].
-destruct ab as [rab | rab sab kab pab | kab pab]; try solve [elimtype False; inv H].
-destruct c as [rc | rc sc kc pc | kc pc]; try solve [elimtype False; inv H0].
-destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [elimtype False; inv H0].
-destruct ac as [rac | rac sac kac pac | kac pac]; try solve [elimtype False; inv H1].
+destruct b as [rb | rb sb kb pb | kb pb]; try solve [exfalso; inv H].
+destruct ab as [rab | rab sab kab pab | kab pab]; try solve [exfalso; inv H].
+destruct c as [rc | rc sc kc pc | kc pc]; try solve [exfalso; inv H0].
+destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [exfalso; inv H0].
+destruct ac as [rac | rac sac kac pac | kac pac]; try solve [exfalso; inv H1].
 destruct (triple_join_exists_share ra rb rc rab rbc rac) as [rabc ?];
   [inv H | inv H0 | inv H1 | ] ; auto.
 assert (n5 := join_unreadable_shares j n1 n2).
 exists (NO rabc n5); constructor; auto.
-destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [elimtype False; inv H0].
-destruct ac as [rac | rac sac kac pac | kac pac]; try solve [elimtype False; inv H1].
+destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [exfalso; inv H0].
+destruct ac as [rac | rac sac kac pac | kac pac]; try solve [exfalso; inv H1].
 destruct (triple_join_exists_share ra rb rc rab rbc rac) as [rabc ?];
   [inv H | inv H0 | inv H1 | ] ; auto.
 assert (sabc := join_readable2 j sc).
 exists (YES rabc sabc kc pc); constructor; auto.
-destruct ab as [rab | rab sab kab pab | kab pab]; try solve [elimtype False; inv H].
-destruct c as [rc | rc sc kc pc | kc pc]; try solve [elimtype False; inv H0].
-destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [elimtype False; inv H0].
-destruct ac as [rac | rac sac kac pac | kac pac]; try solve [elimtype False; inv H1].
+destruct ab as [rab | rab sab kab pab | kab pab]; try solve [exfalso; inv H].
+destruct c as [rc | rc sc kc pc | kc pc]; try solve [exfalso; inv H0].
+destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [exfalso; inv H0].
+destruct ac as [rac | rac sac kac pac | kac pac]; try solve [exfalso; inv H1].
 destruct (triple_join_exists_share ra rb rc rab rbc rac) as [rabc ?];
   [inv H | inv H0 | inv H1 | ] ; auto.
 assert (sabc := join_readable1 j sab).
 exists (YES rabc sabc kab pab); constructor; auto.
-destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [elimtype False; inv H0].
-destruct ac as [rac | rac sac kac pac | kac pac]; try solve [elimtype False; inv H1].
+destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [exfalso; inv H0].
+destruct ac as [rac | rac sac kac pac | kac pac]; try solve [exfalso; inv H1].
 destruct (triple_join_exists_share ra rb rc rab rbc rac) as [rabc ?];
   [inv H | inv H0 | inv H1 | ] ; auto.
 assert (sabc := join_readable1 j sab).
 exists (YES rabc sabc kbc pbc). inv H0; inv H; inv H1; constructor; auto.
-destruct b as [rb | rb sb kb pb | kb pb]; try solve [elimtype False; inv H].
-destruct ab as [rab | rab sab kab pab | kab pab]; try solve [elimtype False; inv H].
-destruct c as [rc | rc sc kc pc | kc pc]; try solve [elimtype False; inv H0].
-destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [elimtype False; inv H0].
-destruct ac as [rac | rac sac kac pac | kac pac]; try solve [elimtype False; inv H1].
+destruct b as [rb | rb sb kb pb | kb pb]; try solve [exfalso; inv H].
+destruct ab as [rab | rab sab kab pab | kab pab]; try solve [exfalso; inv H].
+destruct c as [rc | rc sc kc pc | kc pc]; try solve [exfalso; inv H0].
+destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [exfalso; inv H0].
+destruct ac as [rac | rac sac kac pac | kac pac]; try solve [exfalso; inv H1].
 destruct (triple_join_exists_share ra rb rc rab rbc rac) as [rabc ?];
   [inv H | inv H0 | inv H1 | ] ; auto.
 assert (sabc := join_readable1 j sab).
 exists (YES rabc sabc kab pab); constructor; auto.
-destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [elimtype False; inv H0].
-destruct ac as [rac | rac sac kac pac | kac pac]; try solve [elimtype False; inv H1].
+destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [exfalso; inv H0].
+destruct ac as [rac | rac sac kac pac | kac pac]; try solve [exfalso; inv H1].
 destruct (triple_join_exists_share ra rb rc rab rbc rac) as [rabc ?];
   [inv H | inv H0 | inv H1 | ] ; auto.
 assert (sabc := join_readable1 j sab).
 exists (YES rabc sabc kac pac).  inv H; inv H0; inv H1; constructor; auto.
-destruct ab as [rab | rab sab kab pab | kab pab]; try solve [elimtype False; inv H].
-destruct c as [rc | rc sc kc pc | kc pc]; try solve [elimtype False; inv H0].
-destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [elimtype False; inv H0].
-destruct ac as [rac | rac sac kac pac | kac pac]; try solve [elimtype False; inv H1].
+destruct ab as [rab | rab sab kab pab | kab pab]; try solve [exfalso; inv H].
+destruct c as [rc | rc sc kc pc | kc pc]; try solve [exfalso; inv H0].
+destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [exfalso; inv H0].
+destruct ac as [rac | rac sac kac pac | kac pac]; try solve [exfalso; inv H1].
 destruct (triple_join_exists_share ra rb rc rab rbc rac) as [rabc ?];
   [inv H | inv H0 | inv H1 | ] ; auto.
 assert (sabc := join_readable1 j sab).
 exists (YES rabc sabc kab pab); constructor; auto.
-destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [elimtype False; inv H0].
-destruct ac as [rac | rac sac kac pac | kac pac]; try solve [elimtype False; inv H1].
+destruct bc as [rbc | rbc sbc kbc pbc | kbc pbc]; try solve [exfalso; inv H0].
+destruct ac as [rac | rac sac kac pac | kac pac]; try solve [exfalso; inv H1].
 destruct (triple_join_exists_share ra rb rc rab rbc rac) as [rabc ?];
   [inv H | inv H0 | inv H1 | ] ; auto.
 assert (sabc := join_readable1 j sab).

--- a/veric/coqlib4.v
+++ b/veric/coqlib4.v
@@ -534,7 +534,7 @@ induction n.
 intros.
 replace j with 0%nat ; try lia.
 apply X; intros.
-elimtype False; lia.
+exfalso; lia.
 intros.  apply X. intros.
 apply IHn.
 lia.

--- a/veric/expr_lemmas.v
+++ b/veric/expr_lemmas.v
@@ -708,7 +708,7 @@ induction e; simpl; intros; auto; super_unfold_lift.
   clear - CSUB IHe1 IHe2 H.
   destruct (Val.eq v1 Vundef); [ | destruct (Val.eq v2 Vundef)].
   * subst.
-   elimtype False; apply H; clear.
+   exfalso; apply H; clear.
    unfold sem_binary_operation'.
    destruct b; auto;
   destruct (typeof e1)  as [ | [ | | | ] [ | ] | [ | ] | [ | ] | | | | | ]; auto;
@@ -720,7 +720,7 @@ induction e; simpl; intros; auto; super_unfold_lift.
   try simple_if_tac; auto;
   try solve [unfold sem_cmp; simpl; simple_if_tac; auto].
  * subst.
-   elimtype False; apply H; clear.
+   exfalso; apply H; clear.
    unfold sem_binary_operation'.
    destruct b; auto;
   destruct (typeof e1)  as [ | [ | | | ] [ | ] | [ | ] | [ | ] | | | | | ]; auto;
@@ -756,7 +756,7 @@ all: try (
   clear - CSUB IHe H.
   destruct (Val.eq v Vundef).
   *
-    subst. clear IHe.  elimtype False; apply H; clear H.
+    subst. clear IHe.  exfalso; apply H; clear H.
   unfold sem_cast.
   destruct (classify_cast (typeof e) t); auto.
   * rewrite <- IHe; auto.
@@ -765,7 +765,7 @@ all: try (
   destruct (Val.eq (@eval_expr CS e rho) Vundef).
   *
   clear IHe.
-  elimtype False; apply H; clear H;
+  exfalso; apply H; clear H;
   unfold eval_field;
   destruct (typeof e); auto;
   destruct ((@cenv_cs CS) ! i0) eqn:?H; auto;

--- a/veric/expr_lemmas3.v
+++ b/veric/expr_lemmas3.v
@@ -34,7 +34,7 @@ Lemma Zle_bool_rev: forall x y, Zle_bool x y = Zge_bool y x.
 Proof.
 intros. pose proof (Zle_cases x y). pose proof (Zge_cases y x).
 destruct (Zle_bool x y); destruct (Zge_bool y x); auto;
-elimtype False; lia.
+exfalso; lia.
 Qed.
 
 (** Typechecking soundness **)

--- a/veric/expr_rel.v
+++ b/veric/expr_rel.v
@@ -302,7 +302,7 @@ match goal with |- context [decode_val ?A ?B] =>
   pose proof (decode_val_type A B);
     destruct (decode_val A B); auto; 
     try solve [inv H];
-    try solve [hnf in H; elimtype False; congruence]
+    try solve [hnf in H; exfalso; congruence]
 end];
 try solve [
   unfold decode_val; simpl;

--- a/veric/initial_world.v
+++ b/veric/initial_world.v
@@ -35,7 +35,7 @@ specialize (H loc).
 rewrite jam_true in H; auto.
 simpl in H.
 destruct (m @ loc); try destruct k;
-try solve [elimtype False; destruct H as [? [? ?]]; inv H].
+try solve [exfalso; destruct H as [? [? ?]]; inv H].
 assert (readable_share sh) by (destruct H as [? [? ?]]; auto).
 exists (m0, H1).
 simpl.
@@ -607,7 +607,7 @@ intros.
         clear H; destruct H0.
         destruct (eq_dec id a).
          subst id.
-         split; intro; try congruence. elimtype False.
+         split; intro; try congruence. exfalso.
          clear IHdl.
          assert (~In a (map fst (((p::dl)++(i,g)::nil)))).
              rewrite map_app. rewrite in_app_iff.
@@ -842,10 +842,10 @@ Proof. intros. subst.
       split; intro.
       - assert (H': b = Pos.of_nat (S (length (rev vl)))) by congruence.
         clear H; rename H' into H.
-          subst b. elimtype False; apply n; clear.
+          subst b. exfalso; apply n; clear.
           rewrite <- Zlength_rev. rewrite Zlength_correct. forget (length (rev vl)) as i.
           rewrite Zpos_Posofnat by lia. rewrite Nat2Z.inj_succ. unfold Z.succ.  lia.
-     - elimtype False.
+     - exfalso.
        assert (Z.pos b-1 >= 0) by (clear - Hb; lia).
        pose proof (Z2Nat.id _ (Z.ge_le _ _ H0)).
        clear - H1 H H2 n.
@@ -857,7 +857,7 @@ Proof. intros. subst.
            by (rewrite map_length; rewrite rev_length; auto).
        forget (map fst (rev vl)) as al.
        revert al H2 H; clear; induction j; destruct al; simpl; intros; auto. inv H; intuition.
-       elimtype False; clear - H; induction j; inv H; auto.
+       exfalso; clear - H; induction j; inv H; auto.
        f_equal. apply IHj; auto.
     + rewrite PTree.gso by auto.
       rewrite map_app.
@@ -1007,14 +1007,14 @@ rewrite alloc_globals_app.
 exists m0; split; auto.
 simpl. rewrite H0; auto.
 case_eq (Genv.alloc_globals ge m (rev vl ++ a :: nil)); intros; auto.
-elimtype False.
+exfalso.
 apply alloc_globals_app in H1.
 destruct H1 as [m' [? ?]].
 inversion2 H H1.
 simpl in H2.
 rewrite H0 in H2; inv H2.
 case_eq (Genv.alloc_globals ge m (rev vl ++ a :: nil)); intros; auto.
-elimtype False.
+exfalso.
 apply alloc_globals_app in H0.
 destruct H0 as [m' [? ?]].
 inversion2 H H0.

--- a/veric/juicy_mem.v
+++ b/veric/juicy_mem.v
@@ -333,11 +333,11 @@ exists (y',z').
 simpl.
 split; auto.
 apply (age1_joinx x y z x' y' z' H1 H2 H3 H0).
-elimtype False.
+exfalso.
 destruct (age1_join _ H0 H1) as [? [? [? [? ?]]]].
 unfold age in *.
 congruence.
-elimtype False.
+exfalso.
 destruct (age1_join _ H0 H1) as [? [? [? [? ?]]]].
 unfold age in *.
 congruence.
@@ -2044,7 +2044,7 @@ destruct (age1_juicy_mem_unpack _ _ H0).
 eexists; eauto.
 apply age1_juicy_mem_None1 in H0.
 rewrite H0 in H.
-elimtype False; inversion H.
+exfalso; inversion H.
 Qed.
 
 

--- a/veric/juicy_mem_lemmas.v
+++ b/veric/juicy_mem_lemmas.v
@@ -121,7 +121,7 @@ rewrite H1 in H0.
 inv H0. apply YES_ext; auto.
 constructor; auto.
 intros.
-elimtype False.
+exfalso.
 eapply necR_PURE in H1.
 2: constructor 1; eassumption.
 congruence.
@@ -251,7 +251,7 @@ f_equal; auto.
 specialize ( H (b, ofs)).
 cut (adr_range (b, ofs) z (b, ofs)); [intro H6|].
 destruct (adr_range_dec (b, ofs) z (b, ofs)).
-  2: elimtype False; auto.
+  2: exfalso; auto.
 simpl in H.
 cut (Z.to_nat (ofs - ofs) = O); [intro H7|].
 rewrite H7 in H.
@@ -343,7 +343,7 @@ assert (Z.to_nat (snd loc' - (ofs + 1)) = n).
   rewrite Z2Nat.id in H4; try solve [lia].
 rewrite H4.
 apply H.
-elimtype False. auto.
+exfalso. auto.
 auto.
 unfold adr_range.
 destruct loc' as (b', ofs').
@@ -376,7 +376,7 @@ specialize (H (b, ofs')).
 hnf in H.
 destruct (adr_range_dec (b, ofs) (size_chunk ch) (b, ofs')) as [H5|H5].
   2: unfold adr_range in H5.
-  2: elimtype False; apply H5; split; auto.
+  2: exfalso; apply H5; split; auto.
 destruct H as [sh [rsh H]].
 simpl in H.
 unfold access_cohere in H0.
@@ -416,7 +416,7 @@ generalize (core_load_getN ch v b ofs bl (m_phi m) (m_dry m) H3) as H7; intro.
 rewrite <- H7; auto.
 unfold core_load'.
 repeat split; auto.
-elimtype False.
+exfalso.
 apply H5.
 eapply core_load_valid; eauto.
 apply juicy_mem_access.
@@ -611,7 +611,7 @@ specialize (H (b, ofs')).
 hnf in H.
 destruct (adr_range_dec (b, ofs) (size_chunk ch) (b, ofs')) as [H5|H5].
   2: unfold adr_range in H5.
-  2: elimtype False; apply H5; split; auto.
+  2: exfalso; apply H5; split; auto.
 hnf in H.
 destruct H as [pf H].
 hnf in H.
@@ -652,7 +652,7 @@ specialize (H (b, ofs')).
 hnf in H.
 destruct (adr_range_dec (b, ofs) (size_chunk ch) (b, ofs')) as [H5|H5].
   2: unfold adr_range in H5.
-  2: elimtype False; apply H5; split; auto.
+  2: exfalso; apply H5; split; auto.
 hnf in H.
 destruct H as [pf H].
 hnf in H.
@@ -885,7 +885,7 @@ f_equal. apply proof_irr.
     constructor. apply join_unit1; auto.
     constructor. apply join_unit1; auto.
 
-    elimtype False.
+    exfalso.
     clear - H2 Hm1 H0 H6.
     assert (core (m1 @ (b0,ofs0)) = core (m_phi j @ (b0,ofs0))).
     do 2 rewrite core_resource_at.  unfold Join_rmap in *;  unfold Sep_rmap in  *; congruence.

--- a/veric/juicy_mem_ops.v
+++ b/veric/juicy_mem_ops.v
@@ -416,8 +416,8 @@ intros; inv H; split; constructor.
 intros; inv H; split; constructor.
 apply PrimcomErasure.
 apply PrimcomSafety.
-intros; elimtype False; eapply PrimexprErasure; eauto.
-intros; elimtype False; eapply PrimexprSafety; eauto.
+intros; exfalso; eapply PrimexprErasure; eauto.
+intros; exfalso; eapply PrimexprSafety; eauto.
 Qed.
 
 #[export] Existing Instance stratsem.

--- a/veric/local.v
+++ b/veric/local.v
@@ -47,13 +47,13 @@ destruct v.
 destruct (eq_nat_dec n O).
 right; intros Contra.
 destruct Contra as [n' [H H0]]. inv H.
-inv H1. elimtype False; auto.
+inv H1. exfalso; auto.
 inv H1.
 left; eexists; split; eauto.
 destruct (eq_nat_dec a 0).
 right; intros Contra; auto.
 destruct Contra as [n'' [H H0]]. inv H.
-inv H1. inv H1. elimtype False; auto.
+inv H1. inv H1. exfalso; auto.
 left; eexists; split; eauto.
 right; intros Contra.
 destruct Contra as [n' [H H0]]. inv H; inv H1.
@@ -393,7 +393,7 @@ Proof.
 intros.
 destruct k. inv H0.
 destruct s; try solve
-  [elimtype False; apply (H u k); auto
+  [exfalso; apply (H u k); auto
   |inv H0; inv H1; split; auto].
 inv H0; inv H1; split;
 destruct H8; destruct H9; congruence.

--- a/veric/rmaps.v
+++ b/veric/rmaps.v
@@ -286,42 +286,42 @@ Module StratModel (AV' : ADR_VAL) : STRAT_MODEL with Module AV:=AV'.
 *     (* saf_assoc *)
       intros a b c d e H1 H2.
       destruct d as [rd | rd sd kd pd | kd pd].
-      destruct a as [ra | | ]; try solve [elimtype False; inv H1].
-      destruct b as [rb| | ]; try solve [elimtype False; inv H1].
+      destruct a as [ra | | ]; try solve [exfalso; inv H1].
+      destruct b as [rb| | ]; try solve [exfalso; inv H1].
       assert (join ra rb rd) by (inv H1; auto).
-      destruct c as [rc | rc sc kc pc | kc pc]; try solve [elimtype False; inv H2].
-      destruct e as [re | re se ke pe | ke pe]; try solve [elimtype False; inv H2].
+      destruct c as [rc | rc sc kc pc | kc pc]; try solve [exfalso; inv H2].
+      destruct e as [re | re se ke pe | ke pe]; try solve [exfalso; inv H2].
       assert (join rd rc re) by (inv H2; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (NO' _ rf (join_unreadable_shares H3 n1 n2)); split; constructor; auto.
-      destruct e as [re | re se ke pe | ke pe]; try solve [elimtype False; inv H2].
+      destruct e as [re | re se ke pe | ke pe]; try solve [exfalso; inv H2].
       assert (join rd rc re) by (inv H2; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES' _ rf (join_readable2 H3 sc) kc pc).
       inv H2. split; constructor; auto.
-      destruct c as [rc | rc sc kc pc | kc pc]; try solve [elimtype False; inv H2].
-      destruct e as [re | re se ke pe | ke pe]; try solve [elimtype False; inv H2].
+      destruct c as [rc | rc sc kc pc | kc pc]; try solve [exfalso; inv H2].
+      destruct e as [re | re se ke pe | ke pe]; try solve [exfalso; inv H2].
       assert (H0: join rd rc re) by (inv H2; auto).
-      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [elimtype False; inv H1].
-      destruct b as [ | rb sb kb pb | ]; try solve [elimtype False; inv H1].
+      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [exfalso; inv H1].
+      destruct b as [ | rb sb kb pb | ]; try solve [exfalso; inv H1].
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES' _ rf (join_readable1 H3 sb) kd pd).  inv H1; inv H2; split; constructor; auto.
-      destruct b as [ rb | rb sb kb pb | ]; try solve [elimtype False; inv H1].
+      destruct b as [ rb | rb sb kb pb | ]; try solve [exfalso; inv H1].
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (NO' _ rf (join_unreadable_shares H3 n0 n)).  inv H1; inv H2; split; constructor; auto.
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES' _ rf (join_readable1 H3 sb) kb pb).  inv H1; inv H2; split; constructor; auto.
-      destruct e as [re | re se ke pe | ke pe]; try solve [elimtype False; inv H2].
+      destruct e as [re | re se ke pe | ke pe]; try solve [exfalso; inv H2].
       assert (H0: join rd rc re) by (inv H2; auto).
-      destruct b as [ rb | rb sb kb pb | ]; try solve [elimtype False; inv H1].
-      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [elimtype False; inv H1].
+      destruct b as [ rb | rb sb kb pb | ]; try solve [exfalso; inv H1].
+      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [exfalso; inv H1].
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES' _ rf (join_readable2 H3 sc) kc pc).  inv H1; inv H2; split; constructor; auto.
-      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [elimtype False; inv H1].
+      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [exfalso; inv H1].
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES' _ rf (join_readable1 H3 sb) kb pb).  inv H1; inv H2; split; try constructor; auto.
@@ -358,27 +358,27 @@ Module StratModel (AV' : ADR_VAL) : STRAT_MODEL with Module AV:=AV'.
       whatever... *)
    inv H; simpl; constructor; trivial.
    destruct z as [ rz | rz sz kz pz | kz pz ].
-   destruct x' as [ rx' | rx' sx' kx' px' | kx' px' ]; try solve [elimtype False; inv H].
-   destruct y as [ ry | ry sy ky py | ky py ]; try solve [elimtype False; inv H].
+   destruct x' as [ rx' | rx' sx' kx' px' | kx' px' ]; try solve [exfalso; inv H].
+   destruct y as [ ry | ry sy ky py | ky py ]; try solve [exfalso; inv H].
    exists (NO' _ rx' n0); exists (NO' _ ry n1); inv H; split; constructor; tauto.
-   destruct x' as [ rx' | rx' sx' kx' px' | kx' px' ]; try solve [elimtype False; inv H].
-   destruct y as [ ry | ry sy ky py | ky py ]; try solve [elimtype False; inv H].
+   destruct x' as [ rx' | rx' sx' kx' px' | kx' px' ]; try solve [exfalso; inv H].
+   destruct y as [ ry | ry sy ky py | ky py ]; try solve [exfalso; inv H].
    exists (NO' _ rx' n); exists (YES' _ ry sy kz pz); inv H; split; constructor; auto. simpl in *; f_equal; auto.
-   destruct y as [ ry | ry sy ky py | ky py ]; try solve [elimtype False; inv H].
+   destruct y as [ ry | ry sy ky py | ky py ]; try solve [exfalso; inv H].
    exists (YES' _ rx' sx' kx' pz); exists (NO' _ ry n); inv H; split; constructor; auto.
    exists (YES' _ rx' sx' kx' pz); exists (YES' _ ry sy ky pz); inv H; split; constructor; auto; simpl; f_equal; auto.
    exists (PURE' _ kz pz); exists (PURE' _ kz pz); simpl in *; inv H; split; [constructor | tauto].
 
-   destruct x as [ rx | rx sx kx px | kx px ]; try solve [elimtype False; inv H].
-   destruct y as [ ry | ry sy ky py | ky py ]; try solve [elimtype False; inv H].
-   destruct z' as [ rz | rz sz kz pz | kz pz ]; try solve [elimtype False; inv H].
+   destruct x as [ rx | rx sx kx px | kx px ]; try solve [exfalso; inv H].
+   destruct y as [ ry | ry sy ky py | ky py ]; try solve [exfalso; inv H].
+   destruct z' as [ rz | rz sz kz pz | kz pz ]; try solve [exfalso; inv H].
    exists (NO' _ ry n0); exists (NO' _ rz n1); inv H; split; constructor; auto.
-   destruct z' as [ rz | rz sz kz pz | kz pz ]; try solve [elimtype False; inv H].
+   destruct z' as [ rz | rz sz kz pz | kz pz ]; try solve [exfalso; inv H].
    exists (YES' _ ry sy ky py); exists (YES' _ rz sz ky py); inv H; split; constructor; auto.
-   destruct y as [ ry | ry sy ky py | ky py ]; try solve [elimtype False; inv H].
-   destruct z' as [ rz | rz sz kz pz | kz pz ]; try solve [elimtype False; inv H].
+   destruct y as [ ry | ry sy ky py | ky py ]; try solve [exfalso; inv H].
+   destruct z' as [ rz | rz sz kz pz | kz pz ]; try solve [exfalso; inv H].
    exists (NO' _ ry n); exists (YES' _ rz sz kx px); inv H; split; constructor; auto.
-   destruct z' as [ rz | rz sz kz pz | kz pz ]; try solve [elimtype False; inv H].
+   destruct z' as [ rz | rz sz kz pz | kz pz ]; try solve [exfalso; inv H].
    exists (YES' _ ry sy kx px); exists (YES' _ rz sz kx px); inv H; split; constructor; auto. simpl; f_equal; auto.
    exists (PURE' _ kx px); exists (PURE' _ kx px); inv H; split; constructor; auto.
   Qed.
@@ -1022,42 +1022,42 @@ Module Rmaps (AV':ADR_VAL): RMAPS with Module AV:=AV'.
   * (* saf_assoc *)
       intros a b c d e H1 H2.
       destruct d as [rd | rd sd kd pd | kd pd].
-      destruct a as [ra | | ]; try solve [elimtype False; inv H1].
-      destruct b as [rb| | ]; try solve [elimtype False; inv H1].
+      destruct a as [ra | | ]; try solve [exfalso; inv H1].
+      destruct b as [rb| | ]; try solve [exfalso; inv H1].
       assert (join ra rb rd) by (inv H1; auto).
-      destruct c as [rc | rc sc kc pc | kc pc]; try solve [elimtype False; inv H2].
-      destruct e as [re | re se ke pe | ke pe]; try solve [elimtype False; inv H2].
+      destruct c as [rc | rc sc kc pc | kc pc]; try solve [exfalso; inv H2].
+      destruct e as [re | re se ke pe | ke pe]; try solve [exfalso; inv H2].
       assert (join rd rc re) by (inv H2; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (NO rf (join_unreadable_shares H3 n1 n2)); split; constructor; auto.
-      destruct e as [re | re se ke pe | ke pe]; try solve [elimtype False; inv H2].
+      destruct e as [re | re se ke pe | ke pe]; try solve [exfalso; inv H2].
       assert (join rd rc re) by (inv H2; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES rf (join_readable2 H3 sc) kc pc).
       inv H2. split; constructor; auto.
-      destruct c as [rc | rc sc kc pc | kc pc]; try solve [elimtype False; inv H2].
-      destruct e as [re | re se ke pe | ke pe]; try solve [elimtype False; inv H2].
+      destruct c as [rc | rc sc kc pc | kc pc]; try solve [exfalso; inv H2].
+      destruct e as [re | re se ke pe | ke pe]; try solve [exfalso; inv H2].
       assert (H0: join rd rc re) by (inv H2; auto).
-      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [elimtype False; inv H1].
-      destruct b as [ | rb sb kb pb | ]; try solve [elimtype False; inv H1].
+      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [exfalso; inv H1].
+      destruct b as [ | rb sb kb pb | ]; try solve [exfalso; inv H1].
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES rf (join_readable1 H3 sb) kd pd).  inv H1; inv H2; split; constructor; auto.
-      destruct b as [ rb | rb sb kb pb | ]; try solve [elimtype False; inv H1].
+      destruct b as [ rb | rb sb kb pb | ]; try solve [exfalso; inv H1].
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (NO rf (join_unreadable_shares H3 n0 n)).  inv H1; inv H2; split; constructor; auto.
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES rf (join_readable1 H3 sb) kb pb).  inv H1; inv H2; split; constructor; auto.
-      destruct e as [re | re se ke pe | ke pe]; try solve [elimtype False; inv H2].
+      destruct e as [re | re se ke pe | ke pe]; try solve [exfalso; inv H2].
       assert (H0: join rd rc re) by (inv H2; auto).
-      destruct b as [ rb | rb sb kb pb | ]; try solve [elimtype False; inv H1].
-      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [elimtype False; inv H1].
+      destruct b as [ rb | rb sb kb pb | ]; try solve [exfalso; inv H1].
+      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [exfalso; inv H1].
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES rf (join_readable2 H3 sc) kc pc).  inv H1; inv H2; split; constructor; auto.
-      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [elimtype False; inv H1].
+      destruct a as [ra | ra sa ka pa | ka pa ]; try solve [exfalso; inv H1].
       assert (H: join ra rb rd) by (inv H1; auto).
       destruct (join_assoc H H0) as [rf [? ?]].
       exists (YES rf (join_readable1 H3 sb) kb pb).  inv H1; inv H2; split; try constructor; auto.

--- a/veric/rmaps_lemmas.v
+++ b/veric/rmaps_lemmas.v
@@ -579,7 +579,7 @@ Lemma YES_join_full:
 Proof.
   intros.
   inv H. eauto.
-  elimtype False; clear - RJ H0 rsh2.
+  exfalso; clear - RJ H0 rsh2.
   destruct RJ.
   destruct H0. destruct H0. destruct rsh2. subst sh sh3.
   rewrite Share.glb_commute, Share.distrib1 in H.
@@ -1087,7 +1087,7 @@ Proof.
   intros.
   case_eq (age1 m); intros.
   exists r. auto.
-  elimtype False.
+  exfalso.
   eapply age1None_levelS_absurd in H0; eauto.
 Qed.
 
@@ -1116,7 +1116,7 @@ Proof.
   rewrite ageN1 in H0.
   constructor 1.
   auto.
-  elimtype False.
+  exfalso.
   eapply age1None_levelS_absurd in H0; eauto.
 Qed.
 
@@ -1361,19 +1361,19 @@ end.
 Proof.
 intro; intros.
 destruct a as [ra | ra sa ka pa | ka pa | ma].
-destruct b as [rb | rb sb kb pb | kb pb |]; try solve [elimtype False; inv H].
-destruct z as [rz | rz sz kz pz | kz pz |]; try solve [elimtype False; inv H].
-destruct c as [rc | rc sc kc pc | kc pc |]; try solve [elimtype False; inv H0].
-destruct d as [rd | rd sd kd pd | kd pd |]; try solve [elimtype False; inv H0].
+destruct b as [rb | rb sb kb pb | kb pb |]; try solve [exfalso; inv H].
+destruct z as [rz | rz sz kz pz | kz pz |]; try solve [exfalso; inv H].
+destruct c as [rc | rc sc kc pc | kc pc |]; try solve [exfalso; inv H0].
+destruct d as [rd | rd sd kd pd | kd pd |]; try solve [exfalso; inv H0].
 assert (J1: join ra rb rz) by (inv H; auto).
 assert (J2: join rc rd rz) by (inv H0; auto).
 destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc Hd]]]].
 readable_unreadable_join_prover.
 exists (NO ac Hac,NO ad Had, NO bc Hbc, NO bd Hbd); 
   repeat split; simpl; auto; constructor; auto.
-destruct z as [rz | rz sz kz pz | kz pz |]; try solve [elimtype False; inv H].
-destruct c as [rc | rc sc kc pc | kc pc |]; try solve [elimtype False; inv H0].
-destruct d as [rd | rd sd kd pd | kd pd |]; try solve [elimtype False; inv H0].
+destruct z as [rz | rz sz kz pz | kz pz |]; try solve [exfalso; inv H].
+destruct c as [rc | rc sc kc pc | kc pc |]; try solve [exfalso; inv H0].
+destruct d as [rd | rd sd kd pd | kd pd |]; try solve [exfalso; inv H0].
 assert (J1: join ra rb rz) by (inv H; auto).
 assert (J2: join rc rd rz) by (inv H0; auto).
 destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc Hd]]]].
@@ -1381,7 +1381,7 @@ readable_unreadable_join_prover.
 exists (NO ac Hac, NO ad Had, NO bc Hbc, YES bd Hbd kb pb); inv H; inv H0;
   repeat split; simpl; auto; try constructor; auto.
 assert (J1: join ra rb rz) by (inv H; auto).
-destruct d as [rd | rd sd kd pd | kd pd |]; try solve [elimtype False; inv H0].
+destruct d as [rd | rd sd kd pd | kd pd |]; try solve [exfalso; inv H0].
 assert (J2: join rc rd rz) by (inv H0; auto).
 destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc Hd]]]].
 readable_unreadable_join_prover.
@@ -1392,17 +1392,17 @@ destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc H
 readable_unreadable_join_prover.
 exists (NO ac Hac, NO ad Had, YES bc Hbc kb pb, YES bd Hbd kd pd); inv H; inv H0;
   repeat split; simpl; auto; try constructor; auto.
-destruct b as [rb | rb sb kb pb | kb pb |]; try solve [elimtype False; inv H].
-destruct z as [rz | rz sz kz pz | kz pz |]; try solve [elimtype False; inv H].
+destruct b as [rb | rb sb kb pb | kb pb |]; try solve [exfalso; inv H].
+destruct z as [rz | rz sz kz pz | kz pz |]; try solve [exfalso; inv H].
 assert (J1: join ra rb rz) by (inv H; auto).
-destruct c as [rc | rc sc kc pc | kc pc |]; try solve [elimtype False; inv H0].
-destruct d as [rd | rd sd kd pd | kd pd |]; try solve [elimtype False; inv H0].
+destruct c as [rc | rc sc kc pc | kc pc |]; try solve [exfalso; inv H0].
+destruct d as [rd | rd sd kd pd | kd pd |]; try solve [exfalso; inv H0].
 assert (J2: join rc rd rz) by (inv H0; auto).
 destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc Hd]]]].
 readable_unreadable_join_prover.
 exists (NO ac Hac, YES ad Had kd pd, NO bc Hbc, NO bd Hbd); inv H; inv H0;
   repeat split; simpl; auto; try constructor; auto.
-destruct d as [rd | rd sd kd pd | kd pd |]; try solve [elimtype False; inv H0].
+destruct d as [rd | rd sd kd pd | kd pd |]; try solve [exfalso; inv H0].
 assert (J2: join rc rd rz) by (inv H0; auto).
 destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc Hd]]]].
 readable_unreadable_join_prover.
@@ -1413,16 +1413,16 @@ destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc H
 readable_unreadable_join_prover.
 exists (YES ac Hac kc pc, YES ad Had kd pd, NO bc Hbc, NO bd Hbd); inv H; inv H0;
   repeat split; simpl; auto; try constructor; auto.
-destruct z as [rz | rz sz kz pz | kz pz |]; try solve [elimtype False; inv H].
+destruct z as [rz | rz sz kz pz | kz pz |]; try solve [exfalso; inv H].
 assert (J1: join ra rb rz) by (inv H; auto).
-destruct c as [rc | rc sc kc pc | kc pc |]; try solve [elimtype False; inv H0].
-destruct d as [rd | rd sd kd pd | kd pd |]; try solve [elimtype False; inv H0].
+destruct c as [rc | rc sc kc pc | kc pc |]; try solve [exfalso; inv H0].
+destruct d as [rd | rd sd kd pd | kd pd |]; try solve [exfalso; inv H0].
 assert (J2: join rc rd rz) by (inv H0; auto).
 destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc Hd]]]].
 readable_unreadable_join_prover.
 exists (NO ac Hac, YES ad Had kd pd, NO bc Hbc, YES bd Hbd kd pd); inv H; inv H0;
   repeat split; simpl; auto; try constructor; auto.
-destruct d as [rd | rd sd kd pd | kd pd |]; try solve [elimtype False; inv H0].
+destruct d as [rd | rd sd kd pd | kd pd |]; try solve [exfalso; inv H0].
 assert (J2: join rc rd rz) by (inv H0; auto).
 destruct (share_cross_split _ _ _ _ _ J1 J2) as [[[[ac ad] bc] bd] [Ha [Hb [Hc Hd]]]].
 readable_unreadable_join_prover.
@@ -1456,10 +1456,10 @@ exists (YES ac Hac ka pa, YES ad Had ka pa,
 exists (PURE ka pa, PURE ka pa, PURE ka pa, PURE ka pa).
 inv H. inv H0.
 repeat split; constructor; auto.
-destruct b as [| | | mb]; try solve [elimtype False; inv H].
-destruct z as [| | | mz]; try solve [elimtype False; inv H].
-destruct c as [| | | mc]; try solve [elimtype False; inv H0].
-destruct d as [| | | md]; try solve [elimtype False; inv H0].
+destruct b as [| | | mb]; try solve [exfalso; inv H].
+destruct z as [| | | mz]; try solve [exfalso; inv H].
+destruct c as [| | | mc]; try solve [exfalso; inv H0].
+destruct d as [| | | md]; try solve [exfalso; inv H0].
 (* relies on cross-split for ghost state *)
 Qed.*)
 

--- a/veric/semax_call.v
+++ b/veric/semax_call.v
@@ -1105,7 +1105,7 @@ Proof.
     contradict H1. right; auto.
     pose proof (eqb_ident_spec (fst a) id).
     destruct (eqb_ident (fst a) id) eqn:?; auto.
-    elimtype False; apply H1. left. rewrite <- H; auto.
+    exfalso; apply H1. left. rewrite <- H; auto.
     transitivity
      (var_block Share.top a (construct_rho (filter_genv ge) ve te) *
          F vl (construct_rho (filter_genv ge) ve te)); [ | reflexivity].
@@ -1459,7 +1459,7 @@ specialize (H15 (rettype_of_type retty)).
 do 3 red in H15.
 destruct Hinline as [Hinline|Hempty].
 2:{
-elimtype False; clear - Hempty x.
+exfalso; clear - Hempty x.
 eapply Hempty. eassumption.
 }
 assert (Hty: typelist_of_type_list params = tys) by (rewrite H7, TTL3; trivial).
@@ -2110,7 +2110,7 @@ simpl exit_cont.
 apply derives_subp.
 apply assert_safe_derives; split; auto; simpl; intros.
 destruct ctl; try (apply jm_fupd_intro'; auto);
-elimtype False; clear - H; simpl in H; set (k:=ctl) in *;
+exfalso; clear - H; simpl in H; set (k:=ctl) in *;
 unfold k at 1 in H; clearbody k;
 induction ctl; try discriminate; eauto.
 Qed.

--- a/veric/semax_ext.v
+++ b/veric/semax_ext.v
@@ -292,7 +292,7 @@ Lemma add_funspecs_pre  (ext_link: Strings.String.string -> ident)
     /\ forall z, ext_compat z (m_phi m) ->
           ext_spec_pre (add_funspecs_rec ext_link Z Espec fs) ef x' ge_s tys args z m.
 Proof.
-induction fs; [intros; elimtype False; auto|]; intros ef H H1 H2 Hargsty Hpre.
+induction fs; [intros; exfalso; auto|]; intros ef H H1 H2 Hargsty Hpre.
 destruct H1 as [H1|H1].
 
 {
@@ -302,7 +302,7 @@ destruct sig; simpl.
 if_tac [e0|e0].
 intros x Hjoin Hp. exists (phi1, x). split; eauto.
 split; eauto 6.
-elimtype False; auto.
+exfalso; auto.
 }
 
 {
@@ -313,9 +313,9 @@ destruct (IHfs Hb H1 H2 Hargsty Hpre) as [x' H3].
 clear -Ha Hin H1 H3; revert x' Ha Hin H1 H3.
 destruct a; simpl; destruct f; simpl; destruct t; simpl; unfold funspec2pre; simpl.
 if_tac [e|e].
-* injection e as E; subst i; destruct fs; [solve[simpl; intros; elimtype False; auto]|].
+* injection e as E; subst i; destruct fs; [solve[simpl; intros; exfalso; auto]|].
   intros x' Ha Hb; simpl in Ha, Hb.
-  elimtype False; auto.
+  exfalso; auto.
 * intros; eexists; eauto.
 }
 Qed.
@@ -335,7 +335,7 @@ Lemma add_funspecs_pre_void  (ext_link: Strings.String.string -> ident)
     /\ forall z, ext_compat z (m_phi m) ->
           ext_spec_pre (add_funspecs_rec ext_link Z Espec fs) ef x' ge_s tys args z m.
 Proof.
-induction fs; [intros; elimtype False; auto|]; intros ef H H1 H2 Hargsty Hpre.
+induction fs; [intros; exfalso; auto|]; intros ef H H1 H2 Hargsty Hpre.
 destruct H1 as [H1|H1].
 
 {
@@ -347,7 +347,7 @@ unfold funsig2signature in e.
 simpl in e.
 split; eauto 6.
 
-elimtype False; auto.
+exfalso; auto.
 }
 
 {
@@ -358,9 +358,9 @@ destruct (IHfs Hb H1 H2 Hargsty Hpre) as [x' H3].
 clear -Ha Hin H1 H3; revert x' Ha Hin H1 H3.
 destruct a; simpl; destruct f; simpl; destruct t; simpl; unfold funspec2pre; simpl.
 if_tac [e|e].
-* injection e as E; subst i; destruct fs; [solve[simpl; intros; elimtype False; auto]|].
+* injection e as E; subst i; destruct fs; [solve[simpl; intros; exfalso; auto]|].
   intros x' Ha Hb; simpl in Ha, Hb.
-  elimtype False; auto.
+  exfalso; auto.
 * intros; eexists; eauto.
 }
 Qed.
@@ -377,7 +377,7 @@ Lemma add_funspecs_post_void (ext_link: Strings.String.string -> ident)
     /\ JMeq x (phi1', x')
     /\ Q (projT1 x') (projT2 x') (make_ext_rval (filter_genv (symb2genv ge_s)) tret ret) phi0.
 Proof.
-induction fs; [intros; elimtype False; auto|]; intros ef H H1 Hpost.
+induction fs; [intros; exfalso; auto|]; intros ef H H1 Hpost.
 destruct H1 as [H1|H1].
 
 {
@@ -387,7 +387,7 @@ if_tac [e|e].
 intros x [phi0 [phi1 [Hjoin [Hq Hnec]]]].
 exists phi0, phi1, (fst x), (snd x).
 split; auto. split; auto. destruct x; simpl in *. split; destruct s; auto.
-elimtype False; auto.
+exfalso; auto.
 }
 
 {
@@ -398,9 +398,9 @@ clear -Ha Hin H1 Hb Hpost IHfs; revert x Ha Hin H1 Hb Hpost IHfs.
 destruct a; simpl; destruct f; simpl; unfold funspec2post; simpl.
 destruct t; simpl.
 if_tac [e|e].
-* injection e as E; subst i; destruct fs; [solve[simpl; intros; elimtype False; auto]|].
+* injection e as E; subst i; destruct fs; [solve[simpl; intros; exfalso; auto]|].
   intros x' Ha Hb; simpl in Ha, Hb.
-  elimtype False; auto.
+  exfalso; auto.
 * intros. apply IHfs; auto.
 }
 Qed.
@@ -416,7 +416,7 @@ Lemma add_funspecs_post (ext_link: Strings.String.string -> ident){Z Espec tret 
     /\ JMeq x (phi1',x')
     /\ Q (projT1 x') (projT2 x') (make_ext_rval (filter_genv (symb2genv ge_s)) tret ret) phi0.
 Proof.
-induction fs; [intros; elimtype False; auto|]; intros ef H H1 Hpost.
+induction fs; [intros; exfalso; auto|]; intros ef H H1 Hpost.
 destruct H1 as [H1|H1].
 
 {
@@ -427,7 +427,7 @@ if_tac [e|e].
 intros x [phi0 [phi1 [Hjoin [Hq Hnec]]]].
 exists phi0, phi1, (fst x), (snd x).
 split; auto. split; auto. destruct x; simpl in *. split; auto.
-elimtype False; auto.
+exfalso; auto.
 }
 
 {
@@ -438,9 +438,9 @@ clear -Ha Hin H1 Hb Hpost IHfs; revert x Ha Hin H1 Hb Hpost IHfs.
 destruct a; simpl; destruct f; simpl; unfold funspec2post; simpl.
 destruct t; simpl.
 if_tac [e|e].
-* injection e as E; subst i; destruct fs; [solve[simpl; intros; elimtype False; auto]|].
+* injection e as E; subst i; destruct fs; [solve[simpl; intros; exfalso; auto]|].
   intros x' Ha Hb; simpl in Ha, Hb.
-  elimtype False; auto.
+  exfalso; auto.
 * intros. apply IHfs; auto.
 }
 Qed.

--- a/veric/semax_ext_oracle.v
+++ b/veric/semax_ext_oracle.v
@@ -213,7 +213,7 @@ Lemma add_funspecs_pre  (ext_link: Strings.String.string -> ident)
     JMeq (phi1, x) x'
     /\ ext_spec_pre (add_funspecsOracle_rec ext_link Z Espec fs) ef x' ge_s tys args z m.
 Proof.
-induction fs; [intros; elimtype False; auto|]; intros ef H H1 H2 Hpre.
+induction fs; [intros; exfalso; auto|]; intros ef H H1 H2 Hpre.
 destruct H1 as [H1|H1].
 
 {
@@ -223,7 +223,7 @@ destruct sig; simpl.
 if_tac [e0|e0].
 rewrite fst_split.
 intros x Hjoin Hp. exists (phi1,x). split; eauto.
-elimtype False; auto.
+exfalso; auto.
 }
 
 {
@@ -234,9 +234,9 @@ destruct (IHfs Hb H1 H2 Hpre) as [x' H3].
 clear -Ha Hin H1 H3; revert x' Ha Hin H1 H3.
 destruct a; simpl; destruct f; simpl; destruct f; simpl; unfold funspecOracle2pre; simpl.
 if_tac [e|e].
-* injection e as E; subst i; destruct fs; [solve[simpl; intros; elimtype False; auto]|].
+* injection e as E; subst i; destruct fs; [solve[simpl; intros; exfalso; auto]|].
   intros x' Ha Hb; simpl in Ha, Hb.
-  elimtype False; auto.
+  exfalso; auto.
 * intros; eexists; eauto.
 }
 Qed.
@@ -255,7 +255,7 @@ Lemma add_funspecs_post (ext_link: Strings.String.string -> ident)
     /\ JMeq x (phi1', x')
     /\ Q x' z (make_ext_rval (filter_genv (symb2genv ge_s)) tret ret) phi0.
 Proof.
-induction fs; [intros; elimtype False; auto|]; intros ef H H1 Hid Hpost.
+induction fs; [intros; exfalso; auto|]; intros ef H H1 Hid Hpost.
 destruct H1 as [H1|H1].
 
 {
@@ -266,7 +266,7 @@ if_tac [e0|e0].
 intros x [phi0 [phi1 [Hjoin [Hq Hnec]]]].
 exists phi0, phi1, (fst x), (snd x).
 split; auto. split; auto. destruct x; simpl in *. split; auto.
-elimtype False; auto.
+exfalso; auto.
 }
 
 {
@@ -277,9 +277,9 @@ clear -Ha Hin H1 Hb Hpost IHfs; revert x Ha Hin H1 Hb Hpost IHfs.
 destruct a; simpl; destruct f; simpl; unfold funspecOracle2post; simpl.
 destruct f; simpl.
 if_tac [e|e].
-* injection e as E; subst i; destruct fs; [solve[simpl; intros; elimtype False; auto]|].
+* injection e as E; subst i; destruct fs; [solve[simpl; intros; exfalso; auto]|].
   intros x' Ha Hb; simpl in Ha, Hb.
-  elimtype False; auto.
+  exfalso; auto.
 * intros. apply IHfs; auto.
 }
 Qed.

--- a/veric/semax_lemmas.v
+++ b/veric/semax_lemmas.v
@@ -969,7 +969,7 @@ Lemma pjoinable_emp_None {A}{JA: Join A}{PA: Perm_alg A}{SA: Sep_alg A}:
 Proof.
 intros.
 destruct w; auto.
-elimtype False.
+exfalso.
 specialize (H None (Some l)).
 spec H.
 constructor.

--- a/veric/semax_loop.v
+++ b/veric/semax_loop.v
@@ -528,7 +528,7 @@ Proof.
   rename H0 into Hora; intros.
   destruct (break_cont k) eqn: Hcont.
   { eapply jm_fupd_mono; [apply H0 | contradiction]. }
-2:{ elimtype False; clear - Hcont. revert k c Hcont; induction k; simpl; intros; try discriminate. eauto. }
+2:{ exfalso; clear - Hcont. revert k c Hcont; induction k; simpl; intros; try discriminate. eauto. }
   destruct c; eapply jm_fupd_mono; eauto; clear H0; intros; try contradiction.
 - 
   induction k; try discriminate.
@@ -694,7 +694,7 @@ destruct (continue_cont k) eqn:Hcont; try (eapply jm_fupd_mono; eauto; contradic
   eapply age_safe; try eassumption.
   eapply IHk; eauto.
 -
-  elimtype False; clear - Hcont.
+  exfalso; clear - Hcont.
   revert c o Hcont; induction k; simpl; intros; try discriminate; eauto.
 Qed.
 

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -418,7 +418,7 @@ apply inj_pair2 in H6. apply inj_pair2 in H7.
 subst.
 split; auto.
 rewrite PTree.gso in H0 by auto.
-elimtype False.
+exfalso.
 destruct H1 as [b' [? ?]].
 symmetry in H2; inv H2.
 assert (In id' (map (@fst _ _) G')).
@@ -770,7 +770,7 @@ assert (exists f, In (id, f) (prog_funct prog)). {
   forget (prog_funct prog) as g.
   clear - H1 H0.
   revert G H1 H0; induction g; destruct G; intros; simpl in *.
-  elimtype False.
+  exfalso.
   rewrite PTree.gempty in H1; inv H1.
   inv H0.
   destruct a; simpl in *; subst.
@@ -878,7 +878,7 @@ simpl in H1.
 forget (prog_funct prog) as g.
 clear - H1 H0.
 revert G H1 H0; induction g; destruct G; intros; simpl in *.
-elimtype False.
+exfalso.
 rewrite PTree.gempty in H1; inv H1.
 inv H0.
 destruct a; simpl in *; subst.
@@ -1219,7 +1219,7 @@ left; exists fspec.  inv H; auto.
 f_equal.
 destruct H as [[f [? ?]]| ?].
 destruct H. inv H. auto.
-elimtype False; clear - H3 H H6.
+exfalso; clear - H3 H H6.
 apply H3; apply in_app_iff. left; eapply match_fdecs_in; eauto.
 apply in_map_fst in H; auto.
 contradiction H3. apply in_app_iff; right.
@@ -1644,7 +1644,7 @@ destruct H5 as [H5|H5].
   destruct f; try contradiction.
  destruct H5 as [[[? [? [? Hinline]]] ?] ?].
  destruct Hinline as [Hinline|Hempty].
- 2:{ elimtype False; clear - a Hempty. eapply Hempty; eauto. }
+ 2:{ exfalso; clear - a Hempty. eapply Hempty; eauto. }
  subst c.
  simpl in H4.
  injection H; clear H; intros.

--- a/veric/semax_straight.v
+++ b/veric/semax_straight.v
@@ -1145,7 +1145,7 @@ apply TC3.
 split; [split3 | ].
 *   rewrite <- (age_jm_dry H); constructor; auto.
   destruct (sem_cast (typeof e1) t1 v2) eqn:EC.
-  2: elimtype False; clear - EC TC3;
+  2: exfalso; clear - EC TC3;
     unfold eval_cast, force_val1 in TC3; rewrite EC in TC3;
     destruct t1; try destruct f;
     try destruct (eqb_type _ _); contradiction.

--- a/veric/splice.v
+++ b/veric/splice.v
@@ -350,7 +350,7 @@ apply bot_identity.
 rewrite <- share_rel_unrel' in H.
 apply rel_nontrivial in H.
 destruct H; auto.
-elimtype False.
+exfalso.
 apply identity_share_bot in H.
 unfold Share.Rsh in H.
 destruct (Share.split Share.top) eqn:?. simpl in H. subst.

--- a/veristar/LibTactics.v
+++ b/veristar/LibTactics.v
@@ -715,7 +715,7 @@ Tactic Notation "constructors" :=
     anything else *)
 
 Tactic Notation "false_goal" :=
-  elimtype False.
+  exfalso.
 
 (** [false_post] is the underlying tactic used to prove goals
     of the form [False]. In the default implementation, it proves
@@ -4081,7 +4081,7 @@ Ltac skip_with_existential :=
 Variable skip_axiom : False.
   (* To obtain a safe development, change to [skip_axiom : True] *)
 Ltac skip_with_axiom :=
-  elimtype False; apply skip_axiom.
+  exfalso; apply skip_axiom.
 
 Tactic Notation "skip" :=
    skip_with_axiom.

--- a/veristar/redblack.v
+++ b/veristar/redblack.v
@@ -492,7 +492,7 @@ case_eq (member x t); intuition.
 clear - H0; induction t; simpl in *. inv H0.
 do_compare x t2; [constructor 1 | constructor 2 | constructor 3]; auto.
 inv H1.
-elimtype False; revert H0 H1; induction H; intros; simpl in *.
+exfalso; revert H0 H1; induction H; intros; simpl in *.
 inv H1.
 inv H2.
 rewrite H8 in H1; rewrite compare_refl in H1; inv H1.
@@ -715,7 +715,7 @@ Lemma searchtree_append_aux:
                searchtree lo hi (append(tl,tr)).
 Proof.
 induction n; intros.
-destruct tl; destruct tr; elimtype False; omega.
+destruct tl; destruct tr; exfalso; omega.
 rewrite append_equation.
 inv H0.
 eapply searchtree_expand_left; eauto.
@@ -883,7 +883,7 @@ Lemma append_shape_aux:
            (forall n, is_redblack tl Red n -> is_redblack tr Red n -> is_redblack (append (tl,tr)) Black n).
 Proof.
 induction sz; intros.
-elimtype False; omega.
+exfalso; omega.
 split; intros; rewrite append_equation.
 inv H0. hax.
 inv H2; inv H3.
@@ -1176,7 +1176,7 @@ Lemma interp_append_aux:
      (interp (append(tl,tr)) x <-> (interp tl x \/ interp tr x)).
 Proof.
 induction sz; simpl; intros.
-elimtype False; omega.
+exfalso; omega.
 rewrite append_equation.
 unfold balleft.
 intuition; jax.
@@ -1463,7 +1463,7 @@ Lemma interp_gopher: forall s k, interp (gopher s) k <-> interp s k.
   clear - H.
   revert s H; induction n; intros.
   destruct s; simpl in H. simpl; intuition.
-  elimtype False; omega.
+  exfalso; omega.
   destruct s; simpl; intuition.
   destruct (IHn s1). simpl in H; omega.
   revert H0 H1 H2; case_eq (gopher s1); intros.
@@ -1570,7 +1570,7 @@ Lemma interp_rgopher: forall s k, interp (rgopher s) k <-> interp s k.
   clear - H.
   revert s H; induction n; intros.
   destruct s; simpl in H. simpl; intuition.
-  elimtype False; omega.
+  exfalso; omega.
   destruct s; simpl; intuition.
   destruct (IHn s2). simpl in H; omega.
   revert H0 H1 H2; case_eq (rgopher s2); intros.
@@ -1710,7 +1710,7 @@ Lemma compare'_interp_aux:
   assert (interp a k). apply H2. constructor 3; auto.
   apply H0 in H16. apply H13 in H16.
   inv H16.
-  elimtype False.
+  exfalso.
   clear - e H22 H14 H6.
   destruct (interp_range _ _ _ _ H14 H6).
   simpl in H. rewrite H22 in H. rewrite e in H. apply (lt_irrefl H).
@@ -1719,7 +1719,7 @@ Lemma compare'_interp_aux:
   apply H1. apply H3. constructor 3; auto.
   apply H7 in H16.
   inv H16.
-  elimtype False; clear - H22 H6 H15 e.
+  exfalso; clear - H22 H6 H15 e.
   rewrite e in H22.
   destruct (interp_range _ _ _ _ H15 H6).
   simpl in H. rewrite H22 in H. apply (lt_irrefl H).
@@ -2041,7 +2041,7 @@ Lemma treeify_g_induc:
  (* case 1 of 11 *)
   generalize (treeify_f_length n' l0); rewrite e0; simpl; intro.
   spec H8; [ omega |].
-  elimtype False;  omega.
+  exfalso;  omega.
  (* case 2 of 11 *)
   generalize (treeify_f_length n' l0); rewrite e0; simpl; intro.
   spec H9; [omega|].
@@ -2053,7 +2053,7 @@ Lemma treeify_g_induc:
    generalize (nat_of_P_pos n'); intro.
   spec H8; [omega|].
   spec H6; [omega|].
-  elimtype False. omega.
+  exfalso. omega.
   (* case 4 of 11 *)
   subst.
    generalize (nat_of_P_pos n'); intro POS.
@@ -2061,14 +2061,14 @@ Lemma treeify_g_induc:
   eapply H0; eauto. omega. omega. apply H6. omega.
   apply H7. omega.
   (* case 5 of 11 *)
-  elimtype False; omega.
+  exfalso; omega.
   (* case 6 of 11 *)
   eapply H1; eauto.
   (* case 7 of 11 *)
   generalize (treeify_f_length n' l0); rewrite e0; simpl in *; intro.
   spec H8; [omega|].
   generalize (nat_of_P_pos n'); intro.
-  elimtype False.      generalize (nat_of_P_pos n'); intro. omega.
+  exfalso.      generalize (nat_of_P_pos n'); intro. omega.
   (* case 8 of 11 *)
   generalize (treeify_f_length n' l0); rewrite e0; simpl in *; intro.
   spec H6; [omega|]. spec H7; [omega|]. spec H9; [omega|].
@@ -2077,7 +2077,7 @@ Lemma treeify_g_induc:
   spec H6; [omega|].
   generalize (treeify_g_length n' l0); rewrite e0; simpl in *; intro.
   spec H8; [omega|].
-  elimtype False; omega.
+  exfalso; omega.
   (* case 10 of 11 *)
   generalize (treeify_g_length n' l0); rewrite e0; simpl in *; intro.
   spec H9; [omega|]. spec H6; [omega|]. spec H7; [omega|].
@@ -2176,17 +2176,17 @@ Proof.
  spec H0; [omega|].
   destruct (treeify_f n l).
   simpl in H0. destruct l0.
- simpl in H0; elimtype False; omega.
+ simpl in H0; exfalso; omega.
   destruct (treeify_f n l0); simpl; congruence.
  generalize (treeify_f_length n l); intro.
  spec H0; [omega|].
   destruct (treeify_f n l).
   simpl in H0. destruct l0.
- simpl in H0; elimtype False.
+ simpl in H0; exfalso.
   generalize (nat_of_P_pos n); intro; omega.
   destruct (treeify_g n l0); simpl; congruence.
   destruct l; simpl in H.
-  elimtype False; omega.
+  exfalso; omega.
   simpl; congruence.
 Qed.
 
@@ -2416,7 +2416,7 @@ assert (exists N, size s1 + size s2 < N).
 exists (S (size s1 + size s2)); omega.
 destruct H as [N ?].
 revert s1 s2 H; induction N; intros.
-elimtype False; omega.
+exfalso; omega.
 rewrite linear_inter_aux_equation in H2.
 simpl in H2.
 generalize(shape_rgopher s1); intro.
@@ -2587,7 +2587,7 @@ assert (exists N, size s1 + size s2 < N).
 exists (S (size s1 + size s2)); omega.
 destruct H as [N ?].
 revert s1 s2 H; induction N; intros.
-elimtype False; omega.
+exfalso; omega.
 rewrite linear_union_aux_equation in H2.
 simpl in H2.
 generalize(shape_rgopher s1); intro.
@@ -2791,7 +2791,7 @@ assert (exists N, size s1 + size s2 < N).
 exists (S (size s1 + size s2)); omega.
 destruct H as [N ?].
 revert s1 s2 H; induction N; intros.
-elimtype False; omega.
+exfalso; omega.
 rewrite linear_diff_aux_equation in H2.
 simpl in H2.
 generalize(shape_rgopher s1); intro.
@@ -2857,7 +2857,7 @@ generalize (interp_rgopher s1 x); rewrite <- Heqs1'; intro.
 generalize (interp_rgopher s2 x); rewrite <- Heqs2'; intro.
 intuition etac. left; split; auto. intro. apply H3 in H4. inv H4; intuition etac.
 destruct (interp_range _ _ _ _ H11 H0). simpl in H6. rewrite H13 in H6. apply (lt_irrefl  H6).
-inv H4. elimtype False; apply H5; apply H. constructor 1. rewrite H12; auto.
+inv H4. exfalso; apply H5; apply H. constructor 1. rewrite H12; auto.
 left; split; auto. inv H12.
 (* case t0<t1 *)
 rewrite Heqs1' in H2.
@@ -3144,7 +3144,7 @@ Lemma tree_similar_lemma':
           contradiction (lt_irrefl (lt_trans H4 l)).
        inv H16.
        destruct (interp_range _ _ _ _ H12 H16). simpl in H2.
-       elimtype False.
+       exfalso.
        destruct (H1 k') as [_ ?].
        absurd (interp (T c EE k s) k').
         intro Hx; inv Hx.  rewrite H19 in H2. contradiction (lt_irrefl  H2). inv H19.
@@ -3363,7 +3363,7 @@ Lemma filter'_spec : forall s x f,
   generalize (treeify_g_length n l); intro.
   spec H8; [omega|].
   rewrite H3 in H8.
-  destruct (snd (treeify_g n l)); [ | elimtype False; simpl in H8; clear - H8; omega].
+  destruct (snd (treeify_g n l)); [ | exfalso; simpl in H8; clear - H8; omega].
   clear; intuition etac.
 Qed.
 
@@ -3382,7 +3382,7 @@ Qed.
    Lemma choose'_spec2 : forall s, choose' s = None -> s=EE.
    Proof.
      induction s; simpl; intros; auto.
-     elimtype False. destruct s1. inv H.
+     exfalso. destruct s1. inv H.
      apply IHs1 in H. inv H.
    Qed.
 
@@ -3617,7 +3617,7 @@ Lemma lt'_strorder : StrictOrder lt'.
   rewrite compare'_equation in H, H0 |- *.
   remember (gopher a) as a'. remember (gopher b) as b'. remember (gopher c) as c'.
   destruct c'.
-  elimtype False; clear - H0; destruct b'; inv H0. destruct b'1; inv H1.
+  exfalso; clear - H0; destruct b'; inv H0. destruct b'1; inv H1.
   destruct a'; auto.
   destruct a'1.
   2: clear - H; destruct b'; inv H.
@@ -4077,7 +4077,7 @@ Proof.
   destruct (f a0); simpl in *; auto.
   apply IHel; auto.
   destruct (f a); simpl in H0; auto.
-  elimtype False; clear - H0. revert H0; induction el; simpl; intros; try discriminate.
+  exfalso; clear - H0. revert H0; induction el; simpl; intros; try discriminate.
   destruct (f a); simpl in H0; auto.
   case_eq (f a); simpl; intros.
   apply IHel; intros. eapply H0; eauto.
@@ -4225,7 +4225,7 @@ Lemma lt_compat: Proper (eq ==> eq ==> iff) lt.
             b' lob' hib' STb' b lob hib STb
             EQab EQa'b' H1;
    induction n; simpl; intros.
-   elimtype False; omega.
+   exfalso; omega.
    rewrite compare'_equation in H1; rewrite compare'_equation.
    rewrite <- (size_gopher a') in H.
    rewrite (searchtree_gopher a') in STa'.
@@ -4245,7 +4245,7 @@ Lemma lt_compat: Proper (eq ==> eq ==> iff) lt.
    destruct (gopher a'); try discriminate.
    destruct t0_1; try contradiction.
    destruct (gopher b).
-   2: elimtype False; clear - Gab; destruct (Gab t1);
+   2: exfalso; clear - Gab; destruct (Gab t1);
         absurd (interp EE t1); [intro Hx; inv Hx
                                      | apply H0; constructor 1; reflexivity].
    destruct (gopher b'); auto.
@@ -4292,7 +4292,7 @@ Lemma lt_compat: Proper (eq ==> eq ==> iff) lt.
             b' lob' hib' STb' b lob hib STb
             EQab EQa'b' H1;
    induction n; simpl; intros.
-   elimtype False; omega.
+   exfalso; omega.
    rewrite compare'_equation in H1; rewrite compare'_equation.
    rewrite <- (size_gopher a') in H.
    rewrite (searchtree_gopher a') in STa'.
@@ -4312,7 +4312,7 @@ Lemma lt_compat: Proper (eq ==> eq ==> iff) lt.
    destruct (gopher b'); try discriminate.
    destruct t0_1; try contradiction.
    destruct (gopher a).
-   2: elimtype False; clear - Gab; destruct (Gab t1);
+   2: exfalso; clear - Gab; destruct (Gab t1);
         absurd (interp EE t1); [intro Hx; inv Hx
                                      | apply H; constructor 1; reflexivity].
    destruct (gopher a'); auto.
@@ -4456,7 +4456,7 @@ Proof.
  rewrite <- is_empty_spec. unfold is_empty; simpl. destruct s; auto.
  clear s0 e.
  simpl in H.
- elimtype False; revert t0 H; induction s2; intros. inv H.
+ exfalso; revert t0 H; induction s2; intros. inv H.
  simpl in H. eapply IHs2_2; eauto.
 Qed.
 

--- a/veristar/simple_model.v
+++ b/veristar/simple_model.v
@@ -101,7 +101,7 @@ unfold env_get, env_set; intros.
 destruct v.
 destruct (Ident.eq_dec x x); auto.
 contradiction n0; auto.
-elimtype False; apply H; auto.
+exfalso; apply H; auto.
 Qed.
 
 Lemma gso_env (x y : var) (v: val) (s: env) :
@@ -131,7 +131,7 @@ Lemma env_reset2 s x z : env_set x (env_get s x) (env_set x z s) = s.
 unfold env_set, env_get; extensionality.
 destruct (Ident.eq_dec x x0); auto. subst; auto.
 destruct z; auto.
-destruct (Ident.eq_dec x x0); auto. subst; elimtype False; auto.
+destruct (Ident.eq_dec x x0); auto. subst; exfalso; auto.
 Qed.
 
 Definition heap := loc -> val.
@@ -147,7 +147,7 @@ Definition emp_at (l: loc) (h: heap) := h l = None.
 
 Lemma heap_gempty h l : identity h -> emp_at l h.
 unfold emp_at; case_eq (h l); intros ? H1; auto.
-intros H2; elimtype False.
+intros H2; exfalso.
 specialize (H2 (fun _ => None) h); rewrite <-H2 in H1; inv H1.
 intro; constructor.
 Qed.
@@ -180,7 +180,7 @@ Lemma rawnext_at1 : forall {x y h1 h2 h},
   rawnext' x y h1 -> join h1 h2 h -> emp_at x h2 /\ rawnext' x y h.
 unfold rawnext', emp_at, rawnext; intros.
 destruct H as [h' [? [? [? [? ?]]]]].
-destruct y; [ | elimtype False; apply H1; auto].
+destruct y; [ | exfalso; apply H1; auto].
 clear H1. destruct H as [h'' ?]. generalize (H x); intros.
 rewrite H3 in H1. inv H1; [ | solve [inv H8]].
 generalize (H0 x); rewrite <- H8; intro.
@@ -282,7 +282,7 @@ destruct (eq_nat_dec (e z) 0).
 subst; left; auto.
 right; exists (e z); simpl.
 destruct (e z); auto.
-elimtype False; omega.
+exfalso; omega.
 Qed.
 
 End BarebonesLogic.

--- a/veristar/variables.v
+++ b/veristar/variables.v
@@ -108,7 +108,7 @@ Ltac id_comp x y H1 H2 H3 :=
   destruct (CompSpec2Type (Ident.compare_spec x y)) as [H1|H2|H3].
 
 Lemma id2pos_inj x y : id2pos x = id2pos y -> x=y.
-introv H; id_comp x y H1 H2 H3; [auto|elimtype False; gen H2|gen H3];
+introv H; id_comp x y H1 H2 H3; [auto|exfalso; gen H2|gen H3];
 done (tapp Ilt_morphism; rewrite H; tapp Pos.lt_irrefl).
 Qed.
 


### PR DESCRIPTION
This is only a partial overlay. The CompCert and Flocq subfolders still contain calls to casetype / elimtype, but these should go away when their version is bumped. Some other uses in VST proper were also left, since they seem to correspond to a local Ltac idiom to convey error messages to the user.