### PR TITLE
Fix entanglement test in range_saturate

### DIFF
--- a/zlist/list_solver.v
+++ b/zlist/list_solver.v
@@ -1773,7 +1773,7 @@ Ltac loop2 :=
     | H2 : range_saturate_shift l2 ?s2 |- _ =>
       tryif assert (s1 + s = s2) by Zlength_solve
       then idtac
-      else idtac "Entangled: because" s1 "+" s "=" s2 "is not provable."; fail 1
+      else (idtac "Entangled: because" s1 "+" s "=" s2 "is not provable."; fail 1)
     | |- _ =>
       pose_range_saturate_shift l2 (s1 + s)
     end;
@@ -1790,7 +1790,7 @@ Ltac loop2 :=
       | H2 : range_saturate_shift l2 ?s2 |- _ =>
         tryif assert (s1 + s = s2) by Zlength_solve
         then idtac
-        else idtac "Entangled: because " s1 "+" s "=" s2 "is not provable."; fail 1
+        else (idtac "Entangled: because " s1 "+" s "=" s2 "is not provable."; fail 1)
       | |- _ =>
         pose_range_saturate_shift l2 (s1 + s)
       end;


### PR DESCRIPTION
This is UNrelated to the recent issue. https://github.com/PrincetonUniversity/VST/issues/653
This has been in my local copy for a while. I don't know why I didn't push it. The change is simple: parentheses are added to express the correct program structure. If it doesn't break anything, we can merge it.