### PR TITLE
Extend ecareful_unify and careful_unify to handle if-then-else

### DIFF
--- a/floyd/assert_lemmas.v
+++ b/floyd/assert_lemmas.v
@@ -82,6 +82,7 @@ Ltac _destruct_glob_types i Heq_gt Heq_ge t b ::=
 
 (* no "semax" in this file, just assertions. *)
 Global Transparent Int.repr.
+Global Transparent Int64.repr.
 Global Transparent Ptrofs.repr.
 
 Definition loop1x_ret_assert (Inv : environ -> mpred) (R : ret_assert) :=

--- a/floyd/client_lemmas.v
+++ b/floyd/client_lemmas.v
@@ -316,7 +316,7 @@ Proof.
  destruct (Memory.Mem.weak_valid_pointer m b (Ptrofs.unsigned i)) eqn:?;
   simpl in H; inv H.
 -
-  subst v; simpl. rewrite Int64.eq_true. reflexivity.
+  subst v; simpl. reflexivity.
 -
  destruct v; simpl in H; try solve [inv H].
  destruct (Int.eq i Int.zero) eqn:?; inv H.

--- a/floyd/seplog_tactics.v
+++ b/floyd/seplog_tactics.v
@@ -443,16 +443,26 @@ Lemma fun_equal': forall {A B} (f g : forall (x:A), B x) (y : A),
   f = g -> f y = g y.
 Proof. congruence. Qed.
 
+Lemma if_congr: forall {T: Type} (a a': bool) (b b' c c' : T),
+  a=a' -> b=b' -> c=c' -> (if a then b else c) = (if a' then b' else c').
+Proof.
+intros; subst; auto.
+Qed.
+
+
 Ltac ecareful_unify :=
   match goal with
   | |- ?X = ?X' => first [is_Type_or_type X | is_evar X | is_evar X' | constr_eq X X']; reflexivity
   | |- ?F _ = ?F' _ => first [apply fun_equal | apply fun_equal' with (f := F)]; revgoals; solve[ecareful_unify]
+  | |- (if _ then _ else _) = if _ then _ else _ => simple apply if_congr; solve[ecareful_unify]   
   end; idtac.
+
 
 Ltac careful_unify :=
   match goal with
   | |- ?X = ?X' => first [is_Type_or_type X | constr_eq X X']; reflexivity
   | |- ?F _ = ?F' _ => first [apply fun_equal | apply fun_equal' with (f := F)]; revgoals; solve[careful_unify]
+  | |- (if _ then _ else _) = if _ then _ else _ => simple apply if_congr; solve[careful_unify]   
   end; idtac.
 
 Ltac cancel :=

--- a/tweetnacl20140427/verif_crypto_core.v
+++ b/tweetnacl20140427/verif_crypto_core.v
@@ -18,10 +18,10 @@ start_function.
 assert_PROP (field_compatible (tarray tuchar 64) [] out /\ isptr out) as HH by entailer!.
 destruct HH as [FCout isptrout].
 Time forward_call (c, k, Z0, nonce, out, default_val (tarray tuchar 64), data). (*1.8*)
-(* not needed with Coq 8.17, VST 2.12 
-  unfold data_at_, field_at_. rewrite field_at_data_at.
-  rewrite field_address_offset by auto with field_compatible.
-  rewrite isptr_offset_val_zero; trivial. cancel. *)
+(* not needed with Coq 8.17, VST 2.12: *)
+try solve [unfold data_at_, field_at_; rewrite field_at_data_at;
+  rewrite field_address_offset by auto with field_compatible;
+  rewrite isptr_offset_val_zero; trivial; cancel].
 Intros ret.
 Time forward. (*1.7*)
 unfold fcore_result in H.

--- a/tweetnacl20140427/verif_ld_st.v
+++ b/tweetnacl20140427/verif_ld_st.v
@@ -233,40 +233,25 @@ forward_for_simple_bound 8 (EX i:Z,
   + entailer!. rewrite HH. 
      apply Byte.unsigned_range_2.
   + simpl; rewrite HH. forward.
-    entailer!. clear H1 H0 H. f_equal. rewrite <- (sublist_rejoin 0 i (i+1)).
-    2: lia. 2: rewrite ! Zlength_cons, Zlength_nil; lia.
-    rewrite sublist_len_1.
-    2: rewrite ! Zlength_cons, Zlength_nil; lia.
-    simpl.
-    unfold Int64.or. rewrite Int64.shl_mul_two_p, (Int64.unsigned_repr 8).
-    2: unfold Int64.max_unsigned; simpl; lia.
-    rewrite Int64.unsigned_repr. 2: apply Byte_unsigned_range_64.
+    entailer!. clear H1 H0 H. f_equal.
+    rewrite <- (sublist_rejoin 0 i (i+1)) by Zlength_solve.
+    rewrite sublist_len_1 by Zlength_solve.
+    unfold Int64.or.
+    rewrite Int64.shl_mul_two_p, (Int64.unsigned_repr 8) by rep_lia.
+    rewrite Int64.unsigned_repr by apply Byte_unsigned_range_64.
     change (two_p 8) with 256. 
-    rewrite bendian_app, bendian_singleton. simpl.
-    unfold Int64.mul.
-    rewrite (Int64.unsigned_repr 256). 2: unfold Int64.max_unsigned; simpl; lia.
-    rewrite Zplus_comm, Zmult_comm, Zlor_2powpos_add. 2: apply Byte.unsigned_range.
-    f_equal. f_equal. remember (bendian (sublist 0 i [b0; b1; b2; b3; c0; c1; c2; c3])) as q.
-    specialize (Int64.shifted_or_is_add  (Int64.repr q) Int64.zero 8).
-    change (two_p 8) with 256. rewrite Int64.unsigned_zero, Z.add_0_r.
-    intros X; rewrite <- X, Int64.or_zero; clear X.
-     2: replace Int64.zwordsize with 64 by reflexivity; lia. 2: lia.
-    rewrite Int64.shl_mul_two_p, (Int64.unsigned_repr 8).
-    2: unfold Int64.max_unsigned; simpl; lia.
-    unfold Int64.mul.
-    assert (Q: 0 <= q < 2^56).
-    { specialize (bendian_range (sublist 0 i [b0; b1; b2; b3; c0; c1; c2; c3])).             
-      rewrite Zlength_sublist, Zminus_0_r, <- Heqq. intros. 
-      assert (2^(8 * i) <= 2^56) by (apply Z.pow_le_mono_r; lia). lia.
-      lia. change (Zlength [b0; b1; b2; b3; c0; c1; c2; c3]) with 8; lia. }
-    change (2^56) with 72057594037927936 in Q.
-    change (two_p 8) with 256. change (Z.pow_pos 2 8) with 256. 
-    rewrite (Int64.unsigned_repr 256).
-    2: unfold Int64.max_unsigned; simpl; lia.
-    rewrite (Int64.unsigned_repr q).
-    2: unfold Int64.max_unsigned; simpl; lia.
-    rewrite Int64.unsigned_repr; trivial.
-    unfold Int64.max_unsigned; simpl; lia. } 
+    rewrite bendian_app, bendian_singleton.
+    simpl.
+    rewrite !Int64.Z_mod_modulus_eq.
+    f_equal.
+    rewrite Z.add_comm, Z.mul_comm, Zlor_2powpos_add by rep_lia.
+    f_equal.
+    specialize (bendian_range (sublist 0 i [b0; b1; b2; b3; c0; c1; c2; c3]));           
+      rewrite Zlength_sublist by Zlength_solve; rewrite  Zminus_0_r; intros. 
+    assert (2^(8 * i) <= 2^56) by (apply Z.pow_le_mono_r; lia).
+    rewrite (Z.mod_small (bendian _)) by rep_lia.
+    rewrite Z.mod_small by rep_lia.
+    reflexivity. } 
 forward. apply prop_right.
 clear H H0. 
 unfold bendian. simpl. 
@@ -299,7 +284,8 @@ Time forward_for_simple_bound 4 (EX i:Z,
               (sublist 0 i (map Vint (map Int.repr (map Byte.unsigned ([u0;u1;u2;u3])))) ++ 
                repeat Vundef (Z.to_nat(4-i)))
                 x))).
-{ entailer!!. }
+{ entailer!!; autorewrite with sublist; cancel.
+}
 { rename H into I.
   Time assert_PROP (field_compatible (Tarray tuchar 4 noattr) [] x /\ isptr x)
        as FC_ptrX by solve [entailer!]. (*2.3*)


### PR DESCRIPTION
closes #609 
(but only handles the case where the test-expression has type "bool", not more general if-then-else)