### PR TITLE
Make `util/make_version` more POSIX-compliant

### DIFF
--- a/util/make_version
+++ b/util/make_version
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 #usage:  util/make_version Bitsize Compcert-version
 F=veric/version.v
-builtin type -P gdate &> /dev/null
-if [ $? -eq 0 ]; then
+if command -v gdate >/dev/null; then
     DATE=gdate
 else
     DATE=date
@@ -10,7 +9,7 @@ fi
 set -e
 printf >$F 'Require Import ZArith Coq.Strings.String. Open Scope string.\n'
 printf >>$F 'Definition git_rev := "'
-if [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
+if command -v git >/dev/null && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
   git log -n 1 --pretty=format:"%H" >>$F || true
 fi
 printf >>$F '".\n'


### PR DESCRIPTION
Fixes #702

I've avoided `&>` as its not POSIX-complaint according to [stack exchange](https://unix.stackexchange.com/a/590707/45323).

I've also taken the opportunity to simplify slightly the logic that checks for `git`, relying on the return code of `command -v` rather than testing that the resulting path exists.