### PR TITLE
Pass `COQEXTRAFLAGS` through to `coqc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 # ZLIST=bundled      (default, build and use bundled zlist)
 #
 # # Choosing BITSIZE #
-# BITSIZE=32 
+# BITSIZE=32
 # BITSIZE=64
 #
 # # Choosing ARCHITECTURE #
@@ -67,8 +67,9 @@ endif
 # # User settable variables #
 COMPCERT ?= platform
 ZLIST ?= bundled
-ARCH ?= 
+ARCH ?=
 BITSIZE ?=
+COQEXTRAFLAGS ?=
 
 # # Internal variables #
 # Set to true if the bundled CompCert is used
@@ -90,7 +91,7 @@ ifeq ($(COMPCERT),platform)
     COMPCERT_EXPLICIT_PATH = false
   else ifeq ($(BITSIZE),32)
     COMPCERT_INST_DIR = $(COQLIB)/../coq-variant/compcert32/compcert
-  else 
+  else
     $(error ILLEGAL BITSIZE $(BITSIZE))
   endif
   COMPCERT_SRC_DIR = __NONE__
@@ -171,7 +172,7 @@ else
   ifeq ($(wildcard $(COMPCERT_INST_DIR)/compcert.config),)
     $(error Cannot find compcert.config in $(COMPCERT_INST_DIR))
   endif
-  
+
   include $(COMPCERT_INST_DIR)/compcert.config
 
   ifneq ($(BITSIZE),)
@@ -230,12 +231,12 @@ FLOCQ=         # this mode to use the flocq packaged with Coq or opam
 
 # ##### Configure installation folder #####
 #  1. (if present) the VST installation for reasoning about 64-bit C programs
-#     on the host  architecture will be in $(COQLIB)/user-contrib/VST, 
-#  2. (if present) the VST installation for reasoning about 32 C programs 
-#    for the 32-bit analogue of the host architecture 
+#     on the host  architecture will be in $(COQLIB)/user-contrib/VST,
+#  2. (if present) the VST installation for reasoning about 32 C programs
+#    for the 32-bit analogue of the host architecture
 #    will be in $(COQLIB)/../coq-variant/VST32/VST
 #  3. (if present) a VST installation for reasoning about C programs compiled
-#     for a _different_ architecture will be in 
+#     for a _different_ architecture will be in
 #     $(COQLIB)/../coq-variant/VST_otherarch_bitsize/VST
 #  Not all of this logic is right here in this makefile; some of it is done
 #  in the CompCert install, in choosing how to configure CompCert itself,
@@ -340,6 +341,7 @@ $(info COMPCERT_EXPLICIT_PATH=$(COMPCERT_EXPLICIT_PATH))
 $(info COMPCERT_BUILD_FROM_SRC=$(COMPCERT_BUILD_FROM_SRC))
 $(info COMPCERT_NEW=$(COMPCERT_NEW))
 $(info COQFLAGS=$(COQFLAGS))
+$(info COQEXTRAFLAGS=$(COQEXTRAFLAGS))
 $(info COMPCERT_R_FLAGS=$(COMPCERT_R_FLAGS))
 $(info =================================)
 
@@ -685,7 +687,7 @@ IRIS_INSTALL_FILES=$(sort $(IRIS_INSTALL_FILES_SRC) $(IRIS_INSTALL_FILES_VO))
 
 # This line sets COQF depending on the folder of the input file $<
 # If the folder name contains compcert, $(COMPCERT_R_FLAGS) is added, otherwise not.
-%.vo: COQF=$(if $(findstring $(COMPCERT_SRC_DIR), $(dir $<)), $(COMPCERT_R_FLAGS), $(COQFLAGS))
+%.vo: COQF=$(if $(findstring $(COMPCERT_SRC_DIR), $(dir $<)), $(COMPCERT_R_FLAGS), $(COQFLAGS)) $(COQEXTRAFLAGS)
 
 # If CompCert changes, all .vo files need to be recompiled
 %.vo: $(COMPCERT_CONFIG)
@@ -722,14 +724,14 @@ ifeq ($(BITSIZE),64)
 test: vst progs64
 	@# need this tab here to turn of special behavior of 'test' target
 test2: io
-test4: mailbox 
+test4: mailbox
 tests: test test2 test4
 all: tests
 else
 test: vst progs
 	@# need this tab here to turn of special behavior of 'test' target
 test2: io
-test3: sha hmac 
+test3: sha hmac
 test5: VSUpile
 tests: test test2 test3 test5
 all: vst files tests hmacdrbg tweetnacl aes
@@ -793,8 +795,8 @@ install: VST.config
 	for f in $(EXTRA_INSTALL_FILES); do install -m 0644 $$f "$(INSTALLDIR)/$$(dirname $$f)"; done
 
 build-iris: _CoqProject
-	$(COQC) $(COQFLAGS) $(PROGSDIR)/incr.v
-	for f in $(IRIS_INSTALL_FILES_SRC); do if [ "$${f##*.}" = "v" ]; then echo COQC $$f; $(COQC) $(COQFLAGS) $$f; fi; done
+	$(COQC) $(COQFLAGS) $(COQEXTRAFLAGS) $(PROGSDIR)/incr.v
+	for f in $(IRIS_INSTALL_FILES_SRC); do if [ "$${f##*.}" = "v" ]; then echo COQC $$f; $(COQC) $(COQFLAGS) $(COQEXTRAFLAGS) $$f; fi; done
 
 install-iris: VST.config
 	install -d "$(INSTALLDIR)"
@@ -938,7 +940,7 @@ memmgr:  floyd/proofauto.vo floyd/library.vo floyd/VSU.vo
 nothing: # need this target for the degenerate case of "make -tk */*.vo" in coq-action.yml
 
 assumptions.txt: veric/tcb.vo
-	$(COQC) $(COQFLAGS) veric/tcb.v > assumptions.txt
+	$(COQC) $(COQFLAGS) $(COQEXTRAFLAGS) veric/tcb.v > assumptions.txt
 	bash util/check_assumptions.sh
 
 # $(CC_TARGET): compcert/make
@@ -950,4 +952,3 @@ assumptions.txt: veric/tcb.vo
 # such problem, not sure exactly.  -- Andrew)
 include .depend
 -include .depend-concur
-

--- a/coq-vst-32.opam
+++ b/coq-vst-32.opam
@@ -24,13 +24,13 @@ bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
 
 build: [
-  [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32"]
+  [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32" "COQEXTRAFLAGS=-native-compiler ondemand" {coq-native:installed & coq-compcert:version<3.13~}]
 ]
 install: [
-  [make "install" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32"]
+  [make "install" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32" "COQEXTRAFLAGS=-native-compiler ondemand" {coq-native:installed & coq-compcert:version<3.13~}]
 ]
 run-test: [
-  [make "-j%{jobs}%" "test" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32"]
+  [make "-j%{jobs}%" "test" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32" "COQEXTRAFLAGS=-native-compiler ondemand" {coq-native:installed & coq-compcert:version<3.13~}]
 ]
 depends: [
   "coq" {>= "8.14" & < "8.17~"}

--- a/coq-vst.opam
+++ b/coq-vst.opam
@@ -24,13 +24,13 @@ bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
 
 build: [
-  [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
+  [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64" "COQEXTRAFLAGS=-native-compiler ondemand" {coq-native:installed & coq-compcert:version<3.13~}]
 ]
 install: [
-  [make "install" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
+  [make "install" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64" "COQEXTRAFLAGS=-native-compiler ondemand" {coq-native:installed & coq-compcert:version<3.13~}]
 ]
 run-test: [
-  [make "-j%{jobs}%" "test" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
+  [make "-j%{jobs}%" "test" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64" "COQEXTRAFLAGS=-native-compiler ondemand" {coq-native:installed & coq-compcert:version<3.13~}]
 ]
 depends: [
   "coq" {>= "8.14" & < "8.17~"}


### PR DESCRIPTION
This mimics the behavior of `coq_makefile` a bit more, and will allow the next release of VST to be compatible with coq-native even when its dependencies are not.  For example, compcert only installs .coq-native files since version 3.13, cf
https://github.com/AbsInt/CompCert/issues/476, and this change allows VST to be compatible with earlier versions of compcert even when coq-native is installed.