### PR TITLE
Update github actions artifact to version 4.1.7

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -38,7 +38,7 @@ jobs:
           - coq_version: dev
             bit_size: 32
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: coq-community/docker-coq-action@v1
@@ -78,7 +78,7 @@ jobs:
       - name: 'Create archive'
         run: tar -cpvzf archive.tgz * .depend
       - name: 'Upload archive'
-        uses: actions/upload-artifact@v4.1.7
+        uses: actions/upload-artifact@v4
         with:
           name: 'VST build artifacts ${{matrix.coq_version}} ${{matrix.bit_size}}'
           path: archive.tgz

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -38,7 +38,7 @@ jobs:
           - coq_version: dev
             bit_size: 32
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
         with:
           submodules: true
       - uses: coq-community/docker-coq-action@v1
@@ -78,7 +78,7 @@ jobs:
       - name: 'Create archive'
         run: tar -cpvzf archive.tgz * .depend
       - name: 'Upload archive'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.1.7
         with:
           name: 'VST build artifacts ${{matrix.coq_version}} ${{matrix.bit_size}}'
           path: archive.tgz

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: 'Download archive'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: 'VST build artifacts ${{matrix.coq_version}} ${{matrix.bit_size}}'


### PR DESCRIPTION
This is a variant of #793 but with some corrections that might make it actually work.