### PR TITLE
fix floyd/SeparationLogicAsLogicSoundness.v

### DIFF
--- a/floyd/SeparationLogicAsLogicSoundness.v
+++ b/floyd/SeparationLogicAsLogicSoundness.v
@@ -179,7 +179,7 @@ Proof.
   unfold MinimumLogic.CSHL_Defs.semax_body, CSHL_Defs.semax_body in H |- *.
   destruct id.
   destruct f0.
-  destruct H as [H' [H'' H]]; split3; auto. clear H' H''; intros.
+  destruct H as [H' H]; split; auto. intros.
   apply semax_sound.
   apply H.
 Qed.
@@ -229,7 +229,7 @@ Theorem semax_prog_rule :
        (Genv.find_symbol (globalenv prog) (prog_main prog) = Some b) *
        (exists m', semantics.initial_core (cl_core_sem (globalenv prog)) h
                        m q m' (Vptr b Ptrofs.zero) nil) *
-       (state_interp Mem.empty z ∗ funspec_auth ∅ ∗ has_ext z ⊢ |==> state_interp m z ∗ jsafeN OK_spec (globalenv prog) ⊤ z q ∧
+       (state_interp Mem.empty z ∗ env_auth (make_env (Genv.genv_symb (globalenv prog)), ∅) ∗ funspec_auth ∅ ∗ has_ext z ⊢ |==> state_interp m z ∗ jsafeN OK_spec (globalenv prog) ⊤ z q ∧
            (*no_locks ∧*) matchfunspecs (globalenv prog) G (*∗ funassert (nofunc_tycontext V G) (empty_environ (globalenv prog))*))
      } }%type.
 Proof.

--- a/floyd/SeparationLogicFacts.v
+++ b/floyd/SeparationLogicFacts.v
@@ -222,17 +222,16 @@ Qed.
 
 Lemma obox_left2': forall Delta i P Q,
   temp_guard Delta i ->
-  (□ local (tc_environ Delta) ∗ <affine> ⎡ allp_fun_id Delta ⎤ ∗ P ⊢ Q) ->
-   □ local (tc_environ Delta) ∗ <affine> ⎡ allp_fun_id Delta ⎤ ∗ obox Delta i P ⊢ obox Delta i Q.
+  (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢ Q) ->
+  local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ obox Delta i P) ⊢ obox Delta i Q.
 Proof.
   intros ????? [H].
   split => ?; revert H; rewrite /local /lift1 /obox /subst /env_set; monPred.unseal; intros.
-  rewrite monPred_at_intuitionistically /=.
   iIntros "(%TC & Ha & H)".
   destruct (temp_types Delta !! i) eqn: Ht; last done.
   rewrite /monpred.monPred_defs.monPred_impl_def /=.
   iIntros (x rho -> ?); iApply H; iSplit; last iSplitR "H"; last by iApply "H".
-  -   rewrite monPred_at_intuitionistically. iPureIntro; eapply tc_environ_set; eauto.
+  - iPureIntro; eapply tc_environ_set; eauto.
   - rewrite !monPred_at_affinely //.
 Qed.
 
@@ -351,8 +350,8 @@ Qed.
 
 Lemma oboxopt_left2': forall Delta i P Q,
   temp_guard_opt Delta i ->
-  (□ local (tc_environ Delta) ∗ (<affine> ⎡ allp_fun_id Delta ⎤ ∗ P) ⊢ Q) ->  
-   □ local (tc_environ Delta) ∗ (<affine> ⎡ allp_fun_id Delta ⎤ ∗ oboxopt Delta i P) ⊢ oboxopt Delta i Q.
+  (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢ Q) ->  
+  local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ oboxopt Delta i P) ⊢ oboxopt Delta i Q.
 Proof.
   intros.
   destruct i; [apply obox_left2'; auto |].
@@ -378,11 +377,11 @@ Import CSHL_Def.
 Axiom semax_conseq:
   forall `{!VSTGS OK_ty Σ} {OK_spec : ext_spec OK_ty} {CS: compspecs} E (Delta: tycontext),
   forall P' (R': ret_assert) P c (R: ret_assert),
-    (□ local (tc_environ Delta) ∗ <affine> ⎡ allp_fun_id Delta ⎤ ∗ P ⊢ (|={E}=> P')) ->
-    (□ local (tc_environ Delta) ∗ <affine> ⎡ allp_fun_id Delta ⎤ ∗ RA_normal R' ⊢ (|={E}=> RA_normal R)) ->
-    (□ local (tc_environ Delta) ∗ <affine> ⎡ allp_fun_id Delta ⎤ ∗ RA_break R' ⊢ (|={E}=> RA_break R)) ->
-    (□ local (tc_environ Delta) ∗ <affine> ⎡ allp_fun_id Delta ⎤ ∗ RA_continue R' ⊢ (|={E}=> RA_continue R)) ->
-    (forall vl, □ local (tc_environ Delta) ∗ <affine> ⎡ allp_fun_id Delta ⎤ ∗ RA_return R' vl ⊢ (RA_return R vl)) ->
+    (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢ (|={E}=> P')) ->
+    (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_normal R') ⊢ (|={E}=> RA_normal R)) ->
+    (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_break R') ⊢ (|={E}=> RA_break R)) ->
+    (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_continue R') ⊢ (|={E}=> RA_continue R)) ->
+    (forall vl, local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_return R' vl) ⊢ (|={E}=> RA_return R vl)) ->
    semax E Delta P' c R' -> semax E Delta P c R.
 
 End CLIGHT_SEPARATION_HOARE_LOGIC_COMPLETE_CONSEQUENCE.
@@ -401,11 +400,11 @@ Context `{!VSTGS OK_ty Σ} {OK_spec : ext_spec OK_ty} {CS: compspecs}.
 Lemma semax_pre_post_indexed_fupd:
   forall E (Delta: tycontext),
  forall P' (R': ret_assert) P c (R: ret_assert) ,
-    (□ local (tc_environ Delta) ∗ P ⊢ (|={E}=> P')) ->
-    (□ local (tc_environ Delta) ∗ RA_normal R' ⊢ (|={E}=> RA_normal R)) ->
-    (□ local (tc_environ Delta) ∗ RA_break R' ⊢ (|={E}=> RA_break R)) ->
-    (□ local (tc_environ Delta) ∗ RA_continue R' ⊢ (|={E}=> RA_continue R)) ->
-    (forall vl, □ local (tc_environ Delta) ∗ RA_return R' vl ⊢ (RA_return R vl)) ->
+    (local (tc_environ Delta) ∧ P ⊢ (|={E}=> P')) ->
+    (local (tc_environ Delta) ∧ RA_normal R' ⊢ (|={E}=> RA_normal R)) ->
+    (local (tc_environ Delta) ∧ RA_break R' ⊢ (|={E}=> RA_break R)) ->
+    (local (tc_environ Delta) ∧ RA_continue R' ⊢ (|={E}=> RA_continue R)) ->
+    (forall vl, local (tc_environ Delta) ∧ RA_return R' vl ⊢ (|={E}=> RA_return R vl)) ->
    semax E Delta P' c R' -> semax E Delta P c R.
 Proof.
   intros.
@@ -415,11 +414,11 @@ Qed.
 Lemma semax_pre_post_fupd:
   forall E (Delta: tycontext),
  forall P' (R': ret_assert) P c (R: ret_assert) ,
-    (□ local (tc_environ Delta) ∗ P ⊢ (|={E}=> P')) ->
-    (□ local (tc_environ Delta) ∗ RA_normal R' ⊢ (|={E}=> RA_normal R)) ->
-    (□ local (tc_environ Delta) ∗ RA_break R' ⊢ (|={E}=> RA_break R)) ->
-    (□ local (tc_environ Delta) ∗ RA_continue R' ⊢ (|={E}=> RA_continue R)) ->
-    (forall vl, □ local (tc_environ Delta) ∗ RA_return R' vl ⊢ (RA_return R vl)) ->
+    (local (tc_environ Delta) ∧ P ⊢ (|={E}=> P')) ->
+    (local (tc_environ Delta) ∧ RA_normal R' ⊢ (|={E}=> RA_normal R)) ->
+    (local (tc_environ Delta) ∧ RA_break R' ⊢ (|={E}=> RA_break R)) ->
+    (local (tc_environ Delta) ∧ RA_continue R' ⊢ (|={E}=> RA_continue R)) ->
+    (forall vl, local (tc_environ Delta) ∧ RA_return R' vl ⊢ (|={E}=> RA_return R vl)) ->
    semax E Delta P' c R' -> semax E Delta P c R.
 Proof.
   intros.
@@ -429,7 +428,7 @@ Qed.
 
 Lemma semax_pre_indexed_fupd:
  forall P' E Delta P c R,
-     (□ local (tc_environ Delta) ∗ P ⊢ (|={E}=> P')) ->
+     (local (tc_environ Delta) ∧ P ⊢ (|={E}=> P')) ->
      semax E Delta P' c R  -> semax E Delta P c R.
 Proof.
   intros; eapply semax_pre_post_indexed_fupd; eauto; try intros; by iIntros "(_ & $)".
@@ -437,18 +436,18 @@ Qed.
 
 Lemma semax_post_indexed_fupd:
  forall (R': ret_assert) E Delta (R: ret_assert) P c,
-   (□ local (tc_environ Delta) ∗ RA_normal R' ⊢ (|={E}=> RA_normal R)) ->
-   (□ local (tc_environ Delta) ∗ RA_break R' ⊢ (|={E}=> RA_break R)) ->
-   (□ local (tc_environ Delta) ∗ RA_continue R' ⊢ (|={E}=> RA_continue R)) ->
-   (forall vl, □ local (tc_environ Delta) ∗ RA_return R' vl ⊢ (RA_return R vl)) ->
-   semax E Delta P c R' -> semax E Delta P c R.
+   (local (tc_environ Delta) ∧ RA_normal R' ⊢ (|={E}=> RA_normal R)) ->
+   (local (tc_environ Delta) ∧ RA_break R' ⊢ (|={E}=> RA_break R)) ->
+   (local (tc_environ Delta) ∧ RA_continue R' ⊢ (|={E}=> RA_continue R)) ->
+   (forall vl, local (tc_environ Delta) ∧ RA_return R' vl ⊢ (|={E}=> RA_return R vl)) ->
+   semax E Delta P c R' ->  semax E Delta P c R.
 Proof.
   intros; eapply semax_pre_post_indexed_fupd; try eassumption.
   iIntros "(_ & $)". done.
 Qed.
 
 Lemma semax_post''_indexed_fupd: forall R' E Delta R P c,
-           (□ local (tc_environ Delta) ∗ R' ⊢ (|={E}=> RA_normal R)) ->
+           (local (tc_environ Delta) ∧ R' ⊢ (|={E}=> RA_normal R)) ->
       semax E Delta P c (normal_ret_assert R') ->
       semax E Delta P c R.
 Proof.
@@ -457,7 +456,7 @@ Qed.
 
 Lemma semax_pre_fupd:
  forall P' E Delta P c R,
-     (□ local (tc_environ Delta) ∗ P ⊢ (|={E}=> P')) ->
+     (local (tc_environ Delta) ∧ P ⊢ (|={E}=> P')) ->
      semax E Delta P' c R  -> semax E Delta P c R.
 Proof.
 intros; eapply semax_pre_post_fupd; eauto; intros; by iIntros "(_ & $)".
@@ -468,7 +467,7 @@ Lemma semax_post_fupd:
    (local (tc_environ Delta) ∧ RA_normal R' ⊢ (|={E}=> RA_normal R)) ->
    (local (tc_environ Delta) ∧ RA_break R' ⊢ (|={E}=> RA_break R)) ->
    (local (tc_environ Delta) ∧ RA_continue R' ⊢ (|={E}=> RA_continue R)) ->
-   (forall vl, local (tc_environ Delta) ∧ RA_return R' vl ⊢ (RA_return R vl)) ->
+   (forall vl, local (tc_environ Delta) ∧ RA_return R' vl ⊢ (|={E}=> RA_return R vl)) ->
    semax E Delta P c R' ->  semax E Delta P c R.
 Proof.
   intros; eapply semax_pre_post_fupd; try eassumption.
@@ -554,6 +553,7 @@ Lemma semax_pre_post : forall `{!VSTGS OK_ty Σ} {OK_spec : ext_spec OK_ty} {CS:
    semax E Delta P' c R' -> semax E Delta P c R.
 Proof.
   intros; eapply semax_pre_post_fupd, H4; rewrite ?H ?H0 ?H1 ?H2; auto.
+  intros. rewrite H3. apply fupd_intro.
 Qed.
 
 End GenConseq.
@@ -741,7 +741,7 @@ Proof.
   + apply derives_fupd_refl.
   + apply derives_fupd_refl.
   + apply derives_fupd_refl.
-  + intros; rewrite bi.and_elim_r //.
+  + intros; apply derives_fupd_refl.
 Qed.
 
 End GenIExtrFacts.
@@ -1174,7 +1174,7 @@ Axiom semax_call_forward: forall `{!VSTGS OK_ty Σ} {OK_spec : ext_spec OK_ty} {
           (▷ (F ∗ assert_of (fun rho => P x (ge_of rho, eval_exprlist argsig bl rho))))))
          (Scall ret a bl)
          (normal_ret_assert
-            (∃ old:val, assert_of (substopt ret (`old) F) ∗ maybe_retval (assert_of (Q x)) retsig ret)).
+            (∃ old:val, assert_of (substopt ret (`old) F) ∗ maybe_retval (Q x) retsig ret)).
 
 End CLIGHT_SEPARATION_HOARE_LOGIC_CALL_FORWARD.
 
@@ -1195,7 +1195,7 @@ Axiom semax_call_backward: forall `{!VSTGS OK_ty Σ} {OK_spec : ext_spec OK_ty} 
              tc_fn_return Delta ret retsig⌝ ∧
           ((*▷*)((tc_expr Delta a) ∧ (tc_exprlist Delta argsig bl)))  ∧
          assert_of (`(func_ptr (mk_funspec  (argsig,retsig) cc A Ef P Q)) (eval_expr a)) ∗
-          ▷(assert_of (fun rho => (P x (ge_of rho, eval_exprlist argsig bl rho))) ∗ oboxopt Delta ret (maybe_retval (assert_of (Q x)) retsig ret -∗ R)))
+          ▷(assert_of (fun rho => (P x (ge_of rho, eval_exprlist argsig bl rho))) ∗ oboxopt Delta ret (maybe_retval (Q x) retsig ret -∗ R)))
          (Scall ret a bl)
          (normal_ret_assert R).
 
@@ -1237,7 +1237,7 @@ Theorem semax_call_backward: forall `{!VSTGS OK_ty Σ} {OK_spec : ext_spec OK_ty
              tc_fn_return Delta ret retsig⌝ ∧
           ((*▷*)((tc_expr Delta a) ∧ (tc_exprlist Delta argsig bl)))  ∧
          assert_of (`(func_ptr (mk_funspec (argsig,retsig) cc A Ef P Q)) (eval_expr a)) ∗
-          ▷(assert_of (fun rho => P x (ge_of rho, eval_exprlist argsig bl rho)) ∗ oboxopt Delta ret (maybe_retval (assert_of (Q x)) retsig ret -∗ R)))
+          ▷(assert_of (fun rho => P x (ge_of rho, eval_exprlist argsig bl rho)) ∗ oboxopt Delta ret (maybe_retval (Q x) retsig ret -∗ R)))
          (Scall ret a bl)
          (normal_ret_assert R).
 Proof.
@@ -1333,7 +1333,7 @@ Theorem semax_call_forward: forall `{!VSTGS OK_ty Σ} {OK_spec : ext_spec OK_ty}
           (▷ (F ∗ assert_of (fun rho => P x (ge_of rho, eval_exprlist argsig bl rho))))))
          (Scall ret a bl)
          (normal_ret_assert
-            (∃ old:val, assert_of (substopt ret (`old) F) ∗ maybe_retval (assert_of (Q x)) retsig ret)).
+            (∃ old:val, assert_of (substopt ret (`old) F) ∗ maybe_retval (Q x) retsig ret)).
 Proof.
   intros.
   eapply semax_pre; [| apply semax_call_backward].

--- a/veric/SeparationLogic.v
+++ b/veric/SeparationLogic.v
@@ -525,18 +525,14 @@ Axiom semax_skip:
    forall E Delta (P : assert), semax E Delta P Sskip (normal_ret_assert P).
 
 Axiom semax_conseq:
- forall E Delta P' (R': ret_assert) P c (R: ret_assert) ,
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ P) ⊢
-                   (|={E}=> P') ) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_normal R') ⊢
-                   (|={E}=> RA_normal R)) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_break R') ⊢
-                   (|={E}=> RA_break R)) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_continue R') ⊢
-                   (|={E}=> RA_continue R)) ->
-   (forall vl, □ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_return R' vl) ⊢
-                   (|={E}=> RA_return R vl)) ->
-   semax E Delta P' c R' ->  semax E Delta P c R.
+  forall E Delta (P' : assert) (R': ret_assert) (P:assert) c (R: ret_assert),
+  (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢ (|={E}=> P')) ->
+  (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_normal R') ⊢ (|={E}=> RA_normal R)) ->
+  (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_break R') ⊢ (|={E}=> RA_break R)) ->
+  (local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_continue R') ⊢ (|={E}=> RA_continue R)) ->
+  (forall vl, local (tc_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_return R' vl) ⊢ (|={E}=> RA_return R vl)) ->
+  semax E Delta P' c R' -> semax E Delta P c R.
+
 
 Axiom semax_Slabel:
      forall E Delta (P:assert) (c:statement) (Q:ret_assert) l,
@@ -714,12 +710,12 @@ Axiom semax_extract_later_prop:
            semax E Delta ((▷ ⌜PP⌝) ∧ P) c Q.
 
 Axiom semax_adapt_frame: forall E Delta c (P P': assert) (Q Q' : ret_assert)
-   (H: local (typecheck_environ Delta) ∧ (allp_fun_id Delta ∗ P) ⊢
+   (H: local (typecheck_environ Delta) ∧ <affine> allp_fun_id Delta ∗ P ⊢
                    ∃ F: assert, (⌜closed_wrt_modvars c F⌝ ∧ |={E}=> (P' ∗ F) ∧
-                         ⌜local (tc_environ Delta) ∧ allp_fun_id Delta ∗ RA_normal (frame_ret_assert Q' F) ⊢ |={E}=> RA_normal Q⌝ ∧
-                         ⌜local (tc_environ Delta) ∧ allp_fun_id Delta ∗ RA_break (frame_ret_assert Q' F) ⊢ |={E}=> RA_break Q⌝ ∧
-                         ⌜local (tc_environ Delta) ∧ allp_fun_id Delta ∗ RA_continue (frame_ret_assert Q' F) ⊢ |={E}=> RA_continue Q⌝ ∧
-                         ⌜forall vl, local (tc_environ Delta) ∧ allp_fun_id Delta ∗ RA_return (frame_ret_assert Q' F) vl ⊢ RA_return Q vl⌝))
+                         ⌜local (tc_environ Delta) ∧ <affine> allp_fun_id Delta ∗ RA_normal (frame_ret_assert Q' F) ⊢ |={E}=> RA_normal Q⌝ ∧
+                         ⌜local (tc_environ Delta) ∧ <affine> allp_fun_id Delta ∗ RA_break (frame_ret_assert Q' F) ⊢ |={E}=> RA_break Q⌝ ∧
+                         ⌜local (tc_environ Delta) ∧ <affine> allp_fun_id Delta ∗ RA_continue (frame_ret_assert Q' F) ⊢ |={E}=> RA_continue Q⌝ ∧
+                         ⌜forall vl, local (tc_environ Delta) ∧ <affine> allp_fun_id Delta ∗ RA_return (frame_ret_assert Q' F) vl ⊢ |={E}=> RA_return Q vl⌝))
    (SEM: semax E Delta P' c Q'),
    semax E Delta P c Q.
 
@@ -729,7 +725,7 @@ Axiom semax_adapt: forall E Delta c (P P': assert) (Q Q' : ret_assert)
                         ⌜RA_normal Q' ⊢ |={E}=> RA_normal Q⌝ ∧
                         ⌜RA_break Q' ⊢ |={E}=> RA_break Q⌝ ∧
                         ⌜RA_continue Q' ⊢ |={E}=> RA_continue Q⌝ ∧
-                        ⌜forall vl, RA_return Q' vl ⊢ RA_return Q vl⌝))
+                        ⌜forall vl, RA_return Q' vl ⊢ |={E}=> RA_return Q vl⌝))
    (SEM: semax E Delta P' c Q'),
    semax E Delta P c Q.
 

--- a/veric/semax_conseq.v
+++ b/veric/semax_conseq.v
@@ -96,15 +96,15 @@ Qed.
 
 Lemma semax'_conseq {CS: compspecs}:
  forall E Delta P' (R': ret_assert) (P: assert) c (R: ret_assert),
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ P) ⊢
+   (local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢
                    (|={E}=> P')) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_normal R') ⊢
+   (local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_normal R') ⊢
                    (|={E}=> RA_normal R)) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_break R') ⊢
+   (local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_break R') ⊢
                    (|={E}=> RA_break R)) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_continue R') ⊢
+   (local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_continue R') ⊢
                    (|={E}=> RA_continue R)) ->
-   (forall vl, □ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_return R' vl) ⊢
+   (forall vl, local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_return R' vl) ⊢
                    (|={E}=> RA_return R vl)) ->
    semax' OK_spec E Delta P' c R' ⊢ semax' OK_spec E Delta P c R.
 Proof.
@@ -116,7 +116,7 @@ Proof.
   assert (typecheck_environ Delta rho) by (by eapply typecheck_environ_sub).
   eapply monPred_in_entails in H; rewrite monPred_at_fupd in H.
   iMod (H with "[P]").
-  { rewrite !monPred_at_sep monPred_at_affinely monPred_at_intuitionistically /=; iFrame "P".
+  { rewrite monPred_at_and monPred_at_sep monPred_at_affinely /=; iFrame "P".
     iSplit; iIntros "!>"; auto. }
   rewrite -wp_conseq; first by iApply ("H" with "[%] [$] [$] [//] [$] [$]").
   all: destruct R, R'; simpl in *.
@@ -125,53 +125,49 @@ Proof.
     iDestruct (funassert_allp_fun_id_sub' with "E F") as "(#? & ? & ?)"; [done..|].
     eapply monPred_in_entails in H0; rewrite monPred_at_fupd in H0.
     iMod (H0 with "[R]") as "$"; last by iFrame.
-    rewrite !monPred_at_sep monPred_at_affinely monPred_at_intuitionistically /=; iFrame.
+    rewrite monPred_at_and monPred_at_sep monPred_at_affinely /=; iFrame.
     iSplit; iIntros "!>"; auto.
   - iIntros "((%rho' & R & (% & %) & E) & F)".
     assert (typecheck_environ Delta rho') by (by eapply typecheck_environ_sub).
     iDestruct (funassert_allp_fun_id_sub' with "E F") as "(#? & ? & ?)"; [done..|].
     eapply monPred_in_entails in H1; rewrite monPred_at_fupd in H1.
     iMod (H1 with "[R]") as "$"; last by iFrame.
-    rewrite !monPred_at_sep monPred_at_affinely monPred_at_intuitionistically /=; iFrame.
+    rewrite monPred_at_and monPred_at_sep monPred_at_affinely /=; iFrame.
     iSplit; iIntros "!>"; auto.
   - iIntros "((%rho' & R & (% & %) & E) & F)".
     assert (typecheck_environ Delta rho') by (by eapply typecheck_environ_sub).
     iDestruct (funassert_allp_fun_id_sub' with "E F") as "(#? & ? & ?)"; [done..|].
     eapply monPred_in_entails in H2; rewrite monPred_at_fupd in H2.
     iMod (H2 with "[R]") as "$"; last by iFrame.
-    rewrite !monPred_at_sep monPred_at_affinely monPred_at_intuitionistically /=; iFrame.
+    rewrite monPred_at_and monPred_at_sep monPred_at_affinely /=; iFrame.
     iSplit; iIntros "!>"; auto.
   - intros; iIntros "((%rho' & R & (% & %) & E) & F)".
     assert (typecheck_environ Delta rho') by (by eapply typecheck_environ_sub).
     iDestruct (funassert_allp_fun_id_sub' with "E F") as "(#? & ? & ?)"; [done..|].
     eapply monPred_in_entails in H3; rewrite monPred_at_fupd in H3.
     iMod (H3 with "[R]") as "$"; last by iFrame.
-    rewrite !monPred_at_sep monPred_at_affinely monPred_at_intuitionistically /=; iFrame.
+    rewrite monPred_at_and monPred_at_sep monPred_at_affinely /=; iFrame.
     iSplit; iIntros "!>"; auto.
 Qed.
 
+
 Lemma semax_conseq {CS: compspecs}:
- forall E Delta P' (R': ret_assert) P c (R: ret_assert) ,
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ P) ⊢
-                   (|={E}=> P') ) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_normal R') ⊢
-                   (|={E}=> RA_normal R)) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_break R') ⊢
-                   (|={E}=> RA_break R)) ->
-   (□ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_continue R') ⊢
-                   (|={E}=> RA_continue R)) ->
-   (forall vl, □ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ RA_return R' vl) ⊢
-                   (|={E}=> RA_return R vl)) ->
-   semax OK_spec E Delta P' c R' ->  semax OK_spec E Delta P c R.
+  forall E Delta (P' : assert) (R': ret_assert) (P:assert) c (R: ret_assert),
+  (local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢ (|={E}=> P')) ->
+  (local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_normal R') ⊢ (|={E}=> RA_normal R)) ->
+  (local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_break R') ⊢ (|={E}=> RA_break R)) ->
+  (local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_continue R') ⊢ (|={E}=> RA_continue R)) ->
+  (forall vl, local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ RA_return R' vl) ⊢ (|={E}=> RA_return R vl)) ->
+  semax OK_spec E Delta P' c R' -> semax OK_spec E Delta P c R.
 Proof.
   intros.
-  eapply bi.bi_emp_valid_mono, H4; apply semax'_conseq; auto.
+  eapply bi.bi_emp_valid_mono, H4; apply semax'_conseq; done.
 Qed.
 
 (* Part 2: Deriving simpler and older version of consequence rules from semax_conseq. *)
 Lemma semax'_post_fupd:
  forall {CS: compspecs} (R': ret_assert) E Delta (R: ret_assert) P c,
-   (forall ek vl, □ local (typecheck_environ Delta) ∗
+   (forall ek vl, local (typecheck_environ Delta) ∧
                 proj_ret_assert R' ek vl
          ⊢ |={E}=> proj_ret_assert R ek vl) ->
    semax' OK_spec E Delta P c R' ⊢ semax' OK_spec E Delta P c R.
@@ -193,7 +189,7 @@ Qed.
 
 Lemma semax'_post:
  forall {CS: compspecs} (R': ret_assert) E Delta (R: ret_assert) P c,
-   (forall ek vl, □ local (typecheck_environ Delta) ∗
+   (forall ek vl, local (typecheck_environ Delta) ∧
                 proj_ret_assert R' ek vl
          ⊢ proj_ret_assert R ek vl) ->
    semax' OK_spec E Delta P c R' ⊢ semax' OK_spec E Delta P c R.
@@ -205,7 +201,7 @@ Qed.
 
 Lemma semax'_pre_fupd:
  forall {CS: compspecs} (P' : assert) E Delta R (P : assert) c,
-  (□ local (typecheck_environ Delta) ∗ P ⊢ |={E}=> P') -> 
+  (local (typecheck_environ Delta) ∧ P ⊢ |={E}=> P') -> 
   semax' OK_spec E Delta P' c R ⊢ semax' OK_spec E Delta P c R.
 Proof.
 intros.
@@ -215,7 +211,7 @@ Qed.
 
 Lemma semax'_pre:
  forall {CS: compspecs} (P': assert) E Delta R (P: assert) c,
-  (□ local (typecheck_environ Delta) ∗ P ⊢ P') ->
+  (local (typecheck_environ Delta) ∧ P ⊢ P') ->
   semax' OK_spec E Delta P' c R ⊢ semax' OK_spec E Delta P c R.
 Proof.
 intros; apply semax'_pre_fupd.
@@ -225,9 +221,9 @@ Qed.
 Lemma semax'_pre_post_fupd:
  forall
       {CS: compspecs} (P' : assert) (R': ret_assert) E Delta (R: ret_assert) (P: assert) c,
-   (□ local (typecheck_environ Delta) ∗ P ⊢ |={E}=> P') ->
-   (forall ek vl, □ local (typecheck_environ Delta)
-                       ∗  proj_ret_assert R ek vl
+   (local (typecheck_environ Delta) ∧ P ⊢ |={E}=> P') ->
+   (forall ek vl, local (typecheck_environ Delta)
+                       ∧  proj_ret_assert R ek vl
                     ⊢ |={E}=> proj_ret_assert R' ek vl) ->
    semax' OK_spec E Delta P' c R ⊢ semax' OK_spec E Delta P c R'.
 Proof.
@@ -239,9 +235,9 @@ Qed.
 Lemma semax'_pre_post:
  forall
       {CS: compspecs} (P': assert) (R': ret_assert) E Delta (R: ret_assert) (P: assert) c,
-   (□ local (typecheck_environ Delta) ∗ P ⊢ P') ->
-   (forall ek vl, □ local (typecheck_environ Delta)
-                       ∗  proj_ret_assert R ek vl
+   (local (typecheck_environ Delta) ∧ P ⊢ P') ->
+   (forall ek vl, local (typecheck_environ Delta)
+                       ∧  proj_ret_assert R ek vl
                     ⊢ proj_ret_assert R' ek vl) ->
    semax' OK_spec E Delta P' c R ⊢ semax' OK_spec E Delta P c R'.
 Proof.
@@ -252,8 +248,8 @@ Qed.
 
 Lemma semax_post'_fupd {CS: compspecs}:
  forall (R': ret_assert) E Delta (R: ret_assert) P c,
-   (forall ek vl, □ local (typecheck_environ Delta)
-                      ∗  proj_ret_assert R' ek vl
+   (forall ek vl, local (typecheck_environ Delta)
+                      ∧  proj_ret_assert R' ek vl
                         ⊢ |={E}=> proj_ret_assert R ek vl) ->
    semax OK_spec E Delta P c R' ->  semax OK_spec E Delta P c R.
 Proof.
@@ -264,14 +260,14 @@ Qed.
 
 Lemma semax_post_fupd {CS: compspecs}:
  forall (R': ret_assert) E Delta (R: ret_assert) P c,
-   (□ local (typecheck_environ Delta)
-                      ∗  RA_normal R' ⊢ |={E}=> RA_normal R) ->
-   (□ local (typecheck_environ Delta)
-                      ∗ RA_break R' ⊢ |={E}=> RA_break R) ->
-   (□ local (typecheck_environ Delta)
-                      ∗ RA_continue R' ⊢ |={E}=> RA_continue R) ->
-   (forall vl, □ local (typecheck_environ Delta)
-                      ∗ RA_return R' vl ⊢ |={E}=> RA_return R vl) ->
+   (local (typecheck_environ Delta)
+                      ∧  RA_normal R' ⊢ |={E}=> RA_normal R) ->
+   (local (typecheck_environ Delta)
+                      ∧ RA_break R' ⊢ |={E}=> RA_break R) ->
+   (local (typecheck_environ Delta)
+                      ∧ RA_continue R' ⊢ |={E}=> RA_continue R) ->
+   (forall vl, local (typecheck_environ Delta)
+                      ∧ RA_return R' vl ⊢ |={E}=> RA_return R vl) ->
    semax OK_spec E Delta P c R' ->  semax OK_spec E Delta P c R.
 Proof.
 unfold semax.
@@ -283,8 +279,8 @@ Qed.
 
 Lemma semax_post' {CS: compspecs}:
  forall (R': ret_assert) E Delta (R: ret_assert) P c,
-   (forall ek vl, □ local (typecheck_environ Delta)
-                      ∗  proj_ret_assert R' ek vl
+   (forall ek vl, local (typecheck_environ Delta)
+                      ∧  proj_ret_assert R' ek vl
                         ⊢ proj_ret_assert R ek vl) ->
    semax OK_spec E Delta P c R' ->  semax OK_spec E Delta P c R.
 Proof.
@@ -295,14 +291,14 @@ Qed.
 
 Lemma semax_post {CS: compspecs}:
  forall (R': ret_assert) E Delta (R: ret_assert) P c,
-   (□ local (typecheck_environ Delta)
-                      ∗  RA_normal R' ⊢ RA_normal R) ->
-   (□ local (typecheck_environ Delta)
-                      ∗ RA_break R' ⊢ RA_break R) ->
-   (□ local (typecheck_environ Delta)
-                      ∗ RA_continue R' ⊢ RA_continue R) ->
-   (forall vl, □ local (typecheck_environ Delta)
-                      ∗ RA_return R' vl ⊢ RA_return R vl) ->
+   (local (typecheck_environ Delta)
+                      ∧  RA_normal R' ⊢ RA_normal R) ->
+   (local (typecheck_environ Delta)
+                      ∧ RA_break R' ⊢ RA_break R) ->
+   (local (typecheck_environ Delta)
+                      ∧ RA_continue R' ⊢ RA_continue R) ->
+   (forall vl, local (typecheck_environ Delta)
+                      ∧ RA_return R' vl ⊢ RA_return R vl) ->
    semax OK_spec E Delta P c R' ->  semax OK_spec E Delta P c R.
 Proof.
 unfold semax.
@@ -314,7 +310,7 @@ Qed.
 
 Lemma semax_pre_fupd {CS: compspecs} :
  forall P' E Delta P c R,
-   (□ local (typecheck_environ Delta) ∗ P ⊢ |={E}=> P') ->
+   (local (typecheck_environ Delta) ∧ P ⊢ |={E}=> P') ->
      semax OK_spec E Delta P' c R  -> semax OK_spec E Delta P c R.
 Proof.
 unfold semax.
@@ -324,7 +320,7 @@ Qed.
 
 Lemma semax_pre {CS: compspecs} :
  forall P' E Delta P c R,
-   (□ local (typecheck_environ Delta) ∗ P ⊢ P') ->
+   (local (typecheck_environ Delta) ∧ P ⊢ P') ->
      semax OK_spec E Delta P' c R  -> semax OK_spec E Delta P c R.
 Proof.
 unfold semax.
@@ -334,15 +330,15 @@ Qed.
 
 Lemma semax_pre_post_fupd {CS: compspecs}:
  forall P' (R': ret_assert) E Delta P c (R: ret_assert) ,
-   (□ local (typecheck_environ Delta) ∗ P ⊢ |={E}=> P') ->
-   (□ local (typecheck_environ Delta)
-                      ∗  RA_normal R' ⊢ |={E}=> RA_normal R) ->
-   (□ local (typecheck_environ Delta)
-                      ∗ RA_break R' ⊢ |={E}=> RA_break R) ->
-   (□ local (typecheck_environ Delta)
-                      ∗ RA_continue R' ⊢ |={E}=> RA_continue R) ->
-   (forall vl, □ local (typecheck_environ Delta)
-                      ∗ RA_return R' vl ⊢ |={E}=> RA_return R vl) ->
+   (local (typecheck_environ Delta) ∧ P ⊢ |={E}=> P') ->
+   (local (typecheck_environ Delta)
+                      ∧  RA_normal R' ⊢ |={E}=> RA_normal R) ->
+   (local (typecheck_environ Delta)
+                      ∧ RA_break R' ⊢ |={E}=> RA_break R) ->
+   (local (typecheck_environ Delta)
+                      ∧ RA_continue R' ⊢ |={E}=> RA_continue R) ->
+   (forall vl, local (typecheck_environ Delta)
+                      ∧ RA_return R' vl ⊢ |={E}=> RA_return R vl) ->
    semax OK_spec E Delta P' c R' ->  semax OK_spec E Delta P c R.
 Proof.
 intros.
@@ -352,15 +348,15 @@ Qed.
 
 Lemma semax_pre_post {CS: compspecs}:
  forall P' (R': ret_assert) E Delta P c (R: ret_assert) ,
-   (□ local (typecheck_environ Delta) ∗ P ⊢ P') ->
-   (□ local (typecheck_environ Delta)
-                      ∗  RA_normal R' ⊢ RA_normal R) ->
-   (□ local (typecheck_environ Delta)
-                      ∗ RA_break R' ⊢ RA_break R) ->
-   (□ local (typecheck_environ Delta)
-                      ∗ RA_continue R' ⊢ RA_continue R) ->
-   (forall vl, □ local (typecheck_environ Delta)
-                      ∗ RA_return R' vl ⊢ RA_return R vl) ->
+   (local (typecheck_environ Delta) ∧ P ⊢ P') ->
+   (local (typecheck_environ Delta)
+                      ∧  RA_normal R' ⊢ RA_normal R) ->
+   (local (typecheck_environ Delta)
+                      ∧ RA_break R' ⊢ RA_break R) ->
+   (local (typecheck_environ Delta)
+                      ∧ RA_continue R' ⊢ RA_continue R) ->
+   (forall vl, local (typecheck_environ Delta)
+                      ∧ RA_return R' vl ⊢ RA_return R vl) ->
    semax OK_spec E Delta P' c R' ->  semax OK_spec E Delta P c R.
 Proof.
 intros.
@@ -399,12 +395,12 @@ Proof.
 Qed.
 
 Lemma semax_adapt_frame {cs} E Delta c (P P': assert) (Q Q' : ret_assert)
-   (H: □ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ P) ⊢
+   (H: local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢
                    ∃ F: mpred, (|={E}=> (P' ∗ ⎡F⎤) ∧
-                         ⌜□ local (tc_environ Delta) ∗ <affine> allp_fun_id Delta ∗ RA_normal (frame_ret_assert Q' ⎡F⎤) ⊢ |={E}=> RA_normal Q⌝ ∧
-                         ⌜□ local (tc_environ Delta) ∗ <affine> allp_fun_id Delta ∗ RA_break (frame_ret_assert Q' ⎡F⎤) ⊢ |={E}=> RA_break Q⌝ ∧
-                         ⌜□ local (tc_environ Delta) ∗ <affine> allp_fun_id Delta ∗ RA_continue (frame_ret_assert Q' ⎡F⎤) ⊢ |={E}=> RA_continue Q⌝ ∧
-                         ⌜forall vl, □ local (tc_environ Delta) ∗ <affine> allp_fun_id Delta ∗ RA_return (frame_ret_assert Q' ⎡F⎤) vl ⊢ |={E}=> RA_return Q vl⌝))
+                         ⌜local (tc_environ Delta) ∧ <affine> allp_fun_id Delta ∗ RA_normal (frame_ret_assert Q' ⎡F⎤) ⊢ |={E}=> RA_normal Q⌝ ∧
+                         ⌜local (tc_environ Delta) ∧ <affine> allp_fun_id Delta ∗ RA_break (frame_ret_assert Q' ⎡F⎤) ⊢ |={E}=> RA_break Q⌝ ∧
+                         ⌜local (tc_environ Delta) ∧ <affine> allp_fun_id Delta ∗ RA_continue (frame_ret_assert Q' ⎡F⎤) ⊢ |={E}=> RA_continue Q⌝ ∧
+                         ⌜forall vl, local (tc_environ Delta) ∧ <affine> allp_fun_id Delta ∗ RA_return (frame_ret_assert Q' ⎡F⎤) vl ⊢ |={E}=> RA_return Q vl⌝))
    (SEM: semax(CS := cs) OK_spec E Delta P' c Q'):
    semax OK_spec E Delta P c Q.
 Proof.
@@ -419,7 +415,7 @@ Proof.
 Qed.
 
 Lemma semax_adapt_frame' {cs} E Delta c (P P': assert) (Q Q' : ret_assert)
-   (H: □ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ P) ⊢
+   (H: local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢
                    ∃ F: mpred, (|={E}=> (P' ∗ ⎡F⎤) ∧
                          ⌜RA_normal (frame_ret_assert Q' ⎡F⎤) ⊢ |={E}=> RA_normal Q⌝ ∧
                          ⌜RA_break (frame_ret_assert Q' ⎡F⎤) ⊢ |={E}=> RA_break Q⌝ ∧
@@ -439,7 +435,7 @@ Proof.
 Qed.
 
 Lemma semax_adapt {cs} E Delta c (P P': assert) (Q Q' : ret_assert)
-   (H: □ local (typecheck_environ Delta) ∗ (<affine> allp_fun_id Delta ∗ P) ⊢
+   (H: local (typecheck_environ Delta) ∧ (<affine> allp_fun_id Delta ∗ P) ⊢
                    (|={E}=> P' ∧
                         ⌜RA_normal Q' ⊢ |={E}=> RA_normal Q⌝ ∧
                         ⌜RA_break Q' ⊢ |={E}=> RA_break Q⌝ ∧

--- a/veric/semax_prog.v
+++ b/veric/semax_prog.v
@@ -1588,7 +1588,7 @@ Proof.
               (FR ∗ Q x1 ret) ⊢ (Q' x ret)⌝ ∧
       ((stackframe_of f ∗ ⎡FR⎤ ∗ assert_of (fun tau => P x1 (ge_of tau, vals))) ∧
             local (fun tau => map (λ i, lookup i (te_of tau)) (map fst (fn_params f)) = map Some vals /\ tc_vals (map snd (fn_params f)) vals))).
- - split => rho. unfold local; monPred.unseal; rewrite /bind_ret monPred_at_intuitionistically monPred_at_affinely /=.
+ - split => rho. unfold local; monPred.unseal; rewrite /bind_ret  monPred_at_affinely /=.
    iIntros "(%TC & #OM & (%vals & (%MAP & %VUNDEF) & HP') & M2)".
    specialize (Sub (ge_of rho, vals)). iMod (Sub with "[$HP']") as "Sub". {
      iPureIntro; split; trivial.
@@ -1637,12 +1637,12 @@ Proof.
     + eapply semax_pre_post_fupd.
       6: rewrite /semax -semax_mask_mono //; apply SB3.
       all: clear SB2; intros; simpl; try iIntros "(_ & ([] & ?) & _)".
-      * split => rho; unfold local; monPred.unseal; rewrite monPred_at_intuitionistically; iIntros "(%TC & (N1 & (? & N2)) & (%VALS & %TCVals)) !>"; iFrame.
+      * split => rho; unfold local; monPred.unseal; iIntros "(%TC & (N1 & (? & N2)) & (%VALS & %TCVals)) !>"; iFrame.
         iPureIntro; repeat (split; trivial).
         apply (tc_vals_Vundef TCVals).
       * split => rho; rewrite /bind_ret; monPred.unseal; destruct (fn_return f); try iIntros "(_ & ([] & _) & _)".
         rewrite /= -QPOST; iIntros "(? & (? & ?) & ?)"; iFrame; done.
-      * split => rho; rewrite /local /bind_ret; monPred.unseal; rewrite monPred_at_intuitionistically; iIntros "(% & (Q & $) & ?)".
+      * split => rho; rewrite /local /bind_ret; monPred.unseal; iIntros "(% & (Q & $) & ?)".
         destruct vl; simpl.
         -- rewrite -QPOST.
            iDestruct "Q" as "($ & $)"; iFrame; done.


### PR DESCRIPTION
Trying to fix the return case in semax_extract_exists in SeparationLogicAsLogic.v. semax_return may not have the proper fupd.