### PR TITLE
Add some lemmas to array.v

### DIFF
--- a/RefinedVST.md
+++ b/RefinedVST.md
@@ -21,6 +21,7 @@ sudo apt-get install libmpfr-dev # Implicit Cerberus dependency.
 opam repo add coq-released "https://coq.inria.fr/opam/released"
 opam repo add iris-dev "https://gitlab.mpi-sws.org/iris/opam.git"
 opam update
+opam pin yojson 2.2.2 # 3.0.0 removed a feature that our version of cerberus-lib depends on, have to use older versions (or update cerberus-lib)
 opam pin add -n -y cerberus-lib "git+https://github.com/rems-project/cerberus.git#6e3e8be7a3f75b1f1cb0704dca8ef3945be0e413"
 ```
 

--- a/refinedVST/typing/array.v
+++ b/refinedVST/typing/array.v
@@ -674,14 +674,10 @@ Section array.
                                      ((l arr_ofs{elm_cty, length tys - i}ₗ i) @ &own (array_ptr elm_cty l i $ length tys)))
     ⊢ typed_bin_op ge l ⎡l ◁ₗ{β} array elm_cty tys⎤ v ⎡v ◁ᵥₐₗ|ofs_cty| i @ int ofs_cty⎤ Oadd (tptr elm_cty) ofs_cty (tptr elm_cty) T.
   Proof.
-    iIntros "( % & % & HT)".
+    iIntros "( % & % & HT) (% & Hl) Hv" (Φ) "HΦ".
+    iDestruct (ty_own_val_int_in_range with "Hv") as "%".
     unfold int; simpl_type.
-    iIntros "(% & Hl) (% & % & %)" (Φ) "HΦ".
-    apply val_to_Z_in_range in H4 as ?.
-    2: {
-      (* TODO ty_own_val_int_in_range*)
-      admit.
-    }
+    iDestruct "Hv" as "(% & % & %)".
     rewrite !Z.add_0_l.
     iApply wp_binop_sc.
     {
@@ -689,16 +685,16 @@ Section array.
       match goal with | |- ?x = _ =>
       instantiate (1:=adr2val (l.1, l.2 + expr.sizeof elm_cty * i)) end.
       rewrite /sem_add; destruct ofs_cty; try done; simpl.
-      - destruct i0, v, s eqn:Hs; try done; rewrite /val_to_Z /= in H4; inversion H4;
+      - destruct i0, v, s eqn:Hs; try done; rewrite /val_to_Z /= in H5; inv H5;
         rewrite /= /adr2val /expr.sizeof /Ptrofs.of_ints ptrofs_mul_repr ptrofs_add_repr //=.
-        + repeat f_equal. apply Int.signed_eq_unsigned. inv H5. simpl in *. rep_lia.
-        + repeat f_equal. apply Int.signed_eq_unsigned. inv H5. simpl in *. rep_lia.
-        + repeat f_equal. apply Int.signed_eq_unsigned. inv H5. simpl in *. rep_lia.
+        + repeat f_equal. apply Int.signed_eq_unsigned. inv H2. simpl in *. rep_lia.
+        + repeat f_equal. apply Int.signed_eq_unsigned. inv H2. simpl in *. rep_lia.
+        + repeat f_equal. apply Int.signed_eq_unsigned. inv H2. simpl in *. rep_lia.
       - simpl. destruct v; try done. rewrite /= /adr2val /expr.sizeof /Ptrofs.of_ints ptrofs_mul_repr ptrofs_add_repr //=.
-        destruct s; inv H4; try done.
-        repeat f_equal. rewrite Int64.unsigned_signed //. rewrite /Int64.lt /=. if_tac ; try rep_lia. inv H5.
-        simpl in *. rewrite -H7 in H4, H0.
-        rewrite Int64.signed_zero in H2.
+        destruct s; inv H5; try done.
+        repeat f_equal. rewrite Int64.unsigned_signed //. rewrite /Int64.lt /=. if_tac ; try rep_lia. inv H2.
+        simpl in *. rewrite -H7 in H5, H0.
+        rewrite Int64.signed_zero in H3.
         rep_lia.
     }
     iSplit => //.
@@ -712,7 +708,7 @@ Section array.
     rewrite /ty_own_val_at /ty_own_val /=.
     iSplit => //. iSplit => //. iSplit => //.
     iPureIntro. eapply has_layout_loc_array_ofs; try done. simpl. done.
-  Admitted.
+  Qed.
   Definition type_bin_op_offset_array_inst := [instance type_bin_op_offset_array].
   Global Existing Instance type_bin_op_offset_array_inst.
 
@@ -747,7 +743,7 @@ Section array.
     iSplit => //. iSplit => //. iSplit => //.
     iPureIntro.
     eapply has_layout_loc_array_ofs in H4; try done.
-  Admitted.
+  Qed.
   Definition type_bin_op_offset_array_ptr_inst := [instance type_bin_op_offset_array_ptr].
   Global Existing Instance type_bin_op_offset_array_ptr_inst.
 
@@ -782,7 +778,7 @@ Section array.
     iSplit => //. iSplit => //. iSplit => //.
     iPureIntro.
     eapply has_layout_loc_array_ofs in H4; try done.
-  Admitted.
+  Qed.
   Definition type_bin_op_neg_offset_array_ptr_inst := [instance type_bin_op_neg_offset_array_ptr].
   Global Existing Instance type_bin_op_neg_offset_array_ptr_inst.
 

--- a/refinedVST/typing/automation.v
+++ b/refinedVST/typing/automation.v
@@ -483,7 +483,7 @@ Local Open Scope clight_scope.
     iIntros.
     simpl.
     repeat liRStep.
-    
+  Abort.
 
 End automation_tests.
 

--- a/refinedVST/typing/automation.v
+++ b/refinedVST/typing/automation.v
@@ -4,7 +4,7 @@ From lithium Require Import hooks normalize.
 From VST.lithium Require Export all.
 From VST.typing Require Export type.
 From VST.typing.automation Require Export proof_state (* solvers simplification loc_eq. *).
-From VST.typing Require Import programs (* function *) singleton (* own *) (* struct *) (* bytes *) int.
+From VST.typing Require Import programs (* function *) singleton array (* struct *) (* bytes *) own int.
 Set Default Proof Using "Type".
 Set Nested Proofs Allowed.
 (** * Defining extensions *)
@@ -366,11 +366,11 @@ Ltac split_blocks Pfull Ps :=
   repeat (iApply tac_split_big_sepM; [reflexivity|]; iIntros "?"); iIntros "_".
 *)
 
-
+Import env.
 Section automation_tests.
   Context `{!typeG OK_ty Σ} {cs : compspecs}.
   
-  Import env.
+
 
   Goal forall Espec ge f (_x:ident) (x:val),
   temp _x x
@@ -385,10 +385,10 @@ Section automation_tests.
     liShow; try done.
   Qed.
 
-  Goal forall Espec ge f (_x:ident) b  (l:address) ty,
+  Goal forall Espec ge f (_x:ident) b (l:address) ty,
   TCDone (ty_has_op_type ty tint MCNone) ->
   ⊢ lvar _x tint b -∗
-    ⎡ ty_own ty Own (b, Ptrofs.unsigned Ptrofs.zero) ⎤ -∗
+    ⎡ (b, Ptrofs.unsigned Ptrofs.zero) ◁ₗ ty ⎤ -∗
     typed_stmt Espec ge (Sassign (Evar _x tint) (Econst_int (Int.repr 1) tint)) f
                (λ v t, ⎡ (b, Ptrofs.unsigned Ptrofs.zero) ◁ₗ Int.signed (Int.repr 1) @ int tint ⎤ ∗ True).
   Proof.
@@ -422,6 +422,69 @@ Section automation_tests.
   liRStep.
   done.
 Qed.
+
+End automation_tests.
+
+Section automation_tests.
+Import Clightdefs.ClightNotations.
+Local Open Scope Z_scope.
+Local Open Scope string_scope.
+Local Open Scope clight_scope.
+
+  Definition _ar : ident := $"ar".
+  Definition _i : ident := $"i".
+  Definition _j : ident := $"j".
+  Definition _k : ident := $"k".
+  Definition _main : ident := $"main".
+  Definition _permute : ident := $"permute".
+  Definition _t'1 : ident := 128%positive.
+
+  Definition f_permute := {|
+    fn_return := tvoid;
+    fn_callconv := cc_default;
+    fn_params := ((_ar, (tptr tint)) :: (_i, tint) :: (_j, tint) :: nil);
+    fn_vars := nil;
+    fn_temps := ((_k, tint) :: (_t'1, tint) :: nil);
+    fn_body :=
+  (Ssequence
+    (Sset _k
+      (Ederef
+        (Ebinop Oadd (Etempvar _ar (tptr tint)) (Etempvar _i tint) (tptr tint))
+        tint))
+    (Ssequence
+      (Ssequence
+        (Sset _t'1
+          (Ederef
+            (Ebinop Oadd (Etempvar _ar (tptr tint)) (Etempvar _j tint)
+              (tptr tint)) tint))
+        (Sassign
+          (Ederef
+            (Ebinop Oadd (Etempvar _ar (tptr tint)) (Etempvar _i tint)
+              (tptr tint)) tint) (Etempvar _t'1 tint)))
+      (Sassign
+        (Ederef
+          (Ebinop Oadd (Etempvar _ar (tptr tint)) (Etempvar _j tint)
+            (tptr tint)) tint) (Etempvar _k tint))))
+  |}.
+
+  Context `{!typeG OK_ty Σ} {cs : compspecs}.
+  Goal forall Espec ge ar_b i_b j_b (i j: nat) (k t'1: val) (elts:list Z) v1 v2 f,
+    ⊢ lvar _ar (tptr tint) ar_b -∗
+      lvar _i tint i_b -∗
+      ⎡(i_b, 0)↦|tint| (Vint (Int.repr i))⎤ -∗
+      lvar _j tint j_b -∗
+      ⎡(j_b, 0)↦|tint| (Vint (Int.repr j))⎤ -∗
+      temp _k k -∗
+      temp _t'1 t'1 -∗
+      ⎡(ar_b, 0) ◁ₗ (array tint (elts `at_type` int tint)) ⎤-∗
+      <affine> ⌜elts !! i = Some v1⌝ ∗ <affine> ⌜elts !! j = Some v2⌝ ∗ <affine> ⌜i ≠ j⌝ -∗
+    typed_stmt Espec ge (fn_body f_permute) f (λ _ _, ⎡((ar_b, 0) ◁ₗ (array tint (<[j:=v1]>(<[i:=v2]>elts) `at_type` int tint)))⎤).
+  Proof.
+    iIntros.
+    simpl.
+    repeat liRStep.
+    
+
 End automation_tests.
 
 From VST.typing Require Import automation_test.

--- a/refinedVST/typing/programs.v
+++ b/refinedVST/typing/programs.v
@@ -574,11 +574,6 @@ Section proper.
     l ◁ₗ{β} ty2 ∗ T ⊢ simplify_goal (l◁ₗ{β} ty1) T.
   Proof. rewrite Heq. iIntros "$". Qed.
 
-  (* Global Instance ty_own_val_le cty: Proper ((⊑)  ==> eq ==> (⊢)) (ty_own_val_at cty).
-  Proof. intros ?? EQ ??->. apply EQ. Qed.
-  Global Instance ty_own_val_proper cty: Proper ((≡) ==> eq ==> (≡)) (ty_own_val_at cty).
-  Proof. intros ?? EQ ??->. apply EQ. Qed. *)
-
   Lemma simplify_hyp_val_eq cty ty1 ty2 (Heq : ty1 ≡@{type} ty2) v T:
     (v ◁ᵥ|cty| ty2 -∗ T) ⊢ simplify_hyp (v ◁ᵥ|cty| ty1) T.
   Proof. iIntros "HT ?". rewrite Heq. by iApply "HT". Qed.

--- a/refinedVST/typing/programs.v
+++ b/refinedVST/typing/programs.v
@@ -183,7 +183,8 @@ Section judgements.
   (*** statements *)
 (*  Definition typed_stmt_post_cond (fn : function) (ls : list address) (R : val → type → iProp Σ) (v : val) : iProp Σ :=
     (∃ ty, v ◁ᵥ ty ∗ ([∗ list] l;v ∈ ls;(fn.(f_args) ++ fn.(f_local_vars)), l ↦|v.2|) ∗ R v ty)%I. *)
-  Context (OK_spec : ext_spec OK_ty) (ge : genv).
+  Context (OK_spec : ext_spec OK_ty) (ge_genv : Genv.t Clight.fundef Ctypes.type).
+  #[local] Definition ge := (Build_genv ge_genv cenv_cs).
 
   (* Possibly we will want break-types, continue-types, etc. For now, using option to distinguish between
      fallthrough (normal) type and return type. *)
@@ -564,7 +565,7 @@ Arguments learnable_data {_ _} _.
 (*Arguments learnalign_learn {_ _ _ _ _} _.*)
 
 Section proper.
-  Context `{!typeG OK_ty Σ} {cs : compspecs} (ge: genv).
+  Context `{!typeG OK_ty Σ} {cs : compspecs} (ge : Genv.t Clight.fundef Ctypes.type).
 
   Lemma simplify_hyp_place_eq ty1 ty2 (Heq : ty1 ≡@{type} ty2) l β T:
     (l ◁ₗ{β} ty2 -∗ T) ⊢ simplify_hyp (l◁ₗ{β} ty1) T.

--- a/refinedVST/typing/type.v
+++ b/refinedVST/typing/type.v
@@ -749,6 +749,9 @@ Ltac simpl_type :=
         | |- context C [ty_own_val (?x @ {| rty := ?f |} )] =>
             let G := context C [let '({| ty_own_val := y |} ) := (f x) in y ] in
             change G
+        | |- context C [ty_own_val_at ?cty (?x @ {| rty := ?f |} )] =>
+            let G := context C [let '({| ty_own_val := y |} ) := (f x) in y cty ] in
+            change G
      end; simpl.
 
 Ltac unfold_type_equiv :=


### PR DESCRIPTION
Add necessary lemmas in array.v.
Fixed an issue where there were 2 sources of composite env in typed_ definitions.