### PR TITLE
Adapt to rocq-prover/rocq#20809 (use evar created by `evar` tactic instead of hard-coded name in `unfold_post`)

### DIFF
--- a/floyd/forward.v
+++ b/floyd/forward.v
@@ -926,10 +926,16 @@ end.
 Ltac cancel_for_forward_call := cancel_for_evar_frame.
 Ltac default_cancel_for_forward_call := cancel_for_evar_frame.
 
+(* Work-around to obtain the evar that was created by the `evar` tactic.
+   See PR #834. *)
+Ltac evar_value x := (eval unfold x in x).
+
 Ltac unfold_post := match goal with |- ?Post = _ => let A := fresh "A" in let B := fresh "B" in first
-  [evar (A : Type); evar (B : A -> environ -> mpred); unify Post (@exp _ _ ?A ?B);
+  [evar (A : Type); evar (B : A -> environ -> mpred); let A_evar := (evar_value A) in let B_evar := (evar_value B) in
+     unify Post (@exp _ _ A_evar B_evar);
      change Post with (@exp _ _ A B); subst A B |
-   evar (A : list Prop); evar (B : environ -> mpred); unify Post (PROPx ?A ?B);
+   evar (A : list Prop); evar (B : environ -> mpred); let A_evar := (evar_value A) in let B_evar := (evar_value B) in
+     unify Post (PROPx A_evar B_evar);
      change Post with (PROPx A B); subst A B | idtac] end.
 
 


### PR DESCRIPTION
This PR fixes a bug that is triggered by rocq-prover/rocq#20809, which adds automatically generated names to some evars.

Evars created by `evar A` and `evar B` in `unfold_post` cannot be referenced as `?A` and `?B` if some evars named `A` and `B` already existed before the call, since `evar` gives a fresh name to the created evar ([source](https://rocq-prover.org/doc/master/refman/proof-engine/tactics.html#rocq:tacn.evar)).