### PR TITLE
Allow coq-vst-zlist to be version dev

### DIFF
--- a/coq-vst.opam
+++ b/coq-vst.opam
@@ -37,7 +37,7 @@ depends: [
   "coq-core" { >= "9.0" }
   "coq-stdlib" { >= "9.0" }
   "coq-compcert" {>= "3.15" & < "3.17~"}
-  "coq-vst-zlist" {= "2.13"}
+  "coq-vst-zlist" {= "2.13" | = "dev"}
   "coq-flocq" {>= "4.2.0" & < "5~"}
 ]
 tags: [


### PR DESCRIPTION
Otherwise there's no way to pin to the repo version of VST