### PR TITLE
fix builddep: align dependency versions

### DIFF
--- a/builddep/coq-vst-on-iris-builddep.opam
+++ b/builddep/coq-vst-on-iris-builddep.opam
@@ -25,8 +25,10 @@ bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
 
 depends: [
-  "coq" {>= "8.14" & < "8.17~"}
+  "coq" {>= "8.19" & < "8.21~"}
   "coq-compcert" {>= "3.11"}
   "coq-vst-zlist" {>= "2.11"}
   "coq-flocq" {>= "4.1.0"}
+  "coq-iris"
+  "coq-vst-ora" {= "1.0"}
 ]


### PR DESCRIPTION
Updates `builddep/coq-vst-on-iris-builddep.opam` so the declared
dependencies match what the build actually requires:

- Bump `coq` to `>= 8.19 & < 8.21~` to agree with the Makefile.
- Add `coq-iris` (required).
- Add `coq-vst-ora` pinned to `= 1.0` (1.1 does not currently work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)