### PR TITLE
Accept dev versions of coq, coq-compcert and coq-flocq in coq-vst.opam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -919,14 +919,14 @@ floyd/floyd.coq: floyd/proofauto.vo
 # missing dependency edges.
 ifeq ($(COMPCERT_NEW),true)
 	# DEPENDENCIES VARIANT COMPCERT_NEW
-	$(COQDEP) $(DEPFLAGS) >.depend-tmp 2>.depend-stderr `find $(filter $(wildcard *), $(DIRS) concurrency/common concurrency/compiler concurrency/juicy concurrency/util paco concurrency/sc_drf) -name "*.v"` || { cat .depend-stderr; rm -f .depend-tmp .depend-stderr; exit 1; }
+	ulimit -S -n `ulimit -H -n` 2>/dev/null || true; $(COQDEP) $(DEPFLAGS) >.depend-tmp 2>.depend-stderr `find $(filter $(wildcard *), $(DIRS) concurrency/common concurrency/compiler concurrency/juicy concurrency/util paco concurrency/sc_drf) -name "*.v"` || { cat .depend-stderr; rm -f .depend-tmp .depend-stderr; exit 1; }
 	@grep -v 'Warning:.*found in the loadpath' .depend-stderr || true
 	@rm -f .depend-stderr
 	@echo "" >>.depend-tmp
 	@mv .depend-tmp .depend
 else
 	# DEPENDENCIES DEFAULT
-	$(COQDEP) $(DEPFLAGS) >.depend-tmp 2>.depend-stderr `find $(filter $(wildcard *), $(DIRS)) -name "*.v"` || { cat .depend-stderr; rm -f .depend-tmp .depend-stderr; exit 1; }
+	ulimit -S -n `ulimit -H -n` 2>/dev/null || true; $(COQDEP) $(DEPFLAGS) >.depend-tmp 2>.depend-stderr `find $(filter $(wildcard *), $(DIRS)) -name "*.v"` || { cat .depend-stderr; rm -f .depend-tmp .depend-stderr; exit 1; }
 	@grep -v 'Warning:.*found in the loadpath' .depend-stderr || true
 	@rm -f .depend-stderr
 	@mv .depend-tmp .depend

--- a/Makefile
+++ b/Makefile
@@ -913,13 +913,23 @@ floyd/floyd.coq: floyd/proofauto.vo
 
 .depend depend:
 	@echo 'coqdep ... >.depend'
+# The dependency file is written to a temporary file first and moved in
+# place only when coqdep succeeds: a partial .depend (e.g. after coqdep
+# is killed) would otherwise silently poison parallel builds with
+# missing dependency edges.
 ifeq ($(COMPCERT_NEW),true)
 	# DEPENDENCIES VARIANT COMPCERT_NEW
-	$(COQDEP) $(DEPFLAGS) 2>&1 >.depend `find $(filter $(wildcard *), $(DIRS) concurrency/common concurrency/compiler concurrency/juicy concurrency/util paco concurrency/sc_drf) -name "*.v"` | grep -v 'Warning:.*found in the loadpath' || true
-	@echo "" >>.depend
+	$(COQDEP) $(DEPFLAGS) >.depend-tmp 2>.depend-stderr `find $(filter $(wildcard *), $(DIRS) concurrency/common concurrency/compiler concurrency/juicy concurrency/util paco concurrency/sc_drf) -name "*.v"` || { cat .depend-stderr; rm -f .depend-tmp .depend-stderr; exit 1; }
+	@grep -v 'Warning:.*found in the loadpath' .depend-stderr || true
+	@rm -f .depend-stderr
+	@echo "" >>.depend-tmp
+	@mv .depend-tmp .depend
 else
 	# DEPENDENCIES DEFAULT
-	$(COQDEP) $(DEPFLAGS) 2>&1 >.depend `find $(filter $(wildcard *), $(DIRS)) -name "*.v"` | grep -v 'Warning:.*found in the loadpath' || true
+	$(COQDEP) $(DEPFLAGS) >.depend-tmp 2>.depend-stderr `find $(filter $(wildcard *), $(DIRS)) -name "*.v"` || { cat .depend-stderr; rm -f .depend-tmp .depend-stderr; exit 1; }
+	@grep -v 'Warning:.*found in the loadpath' .depend-stderr || true
+	@rm -f .depend-stderr
+	@mv .depend-tmp .depend
 endif
 ifeq ($(COMPCERT_BUILD_FROM_SRC),true)
 	# DEPENDENCIES TO BUILD COMPCERT FROM SOURCE

--- a/coq-vst.opam
+++ b/coq-vst.opam
@@ -33,12 +33,12 @@ run-test: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.19" & < "9.2~"}
+  "coq" {(>= "8.19" & < "9.2~") | = "dev"}
   "coq-core" { >= "9.0" }
   "coq-stdlib" { >= "9.0" }
-  "coq-compcert" {>= "3.15" & < "3.17~"}
+  "coq-compcert" {(>= "3.15" & < "3.17~") | = "dev"}
   "coq-vst-zlist" {= "2.13" | = "dev"}
-  "coq-flocq" {>= "4.2.0" & < "5~"}
+  "coq-flocq" {(>= "4.2.0" & < "5~") | = "dev"}
 ]
 tags: [
   "category:Computer Science/Semantics and Compilation/Semantics"


### PR DESCRIPTION
Allows installing a pin to this branch on a switch tracking Rocq master