### PR TITLE
Accept dev versions of coq, coq-compcert and coq-flocq in coq-vst.opam

### DIFF
--- a/coq-vst.opam
+++ b/coq-vst.opam
@@ -34,8 +34,8 @@ run-test: [
 depends: [
   "ocaml"
   "coq" {(>= "8.19" & < "9.2~") | = "dev"}
-  "coq-core" { >= "9.0" }
-  "coq-stdlib" { >= "9.0" }
+  ("coq-core" {(>= "9.0") | = "dev"} | "rocq-core" {(>= "9.0") | = "dev"})
+  ("coq-stdlib" {(>= "9.0") | = "dev"} | "rocq-stdlib" {(>= "9.0") | = "dev"})
   "coq-compcert" {(>= "3.15" & < "3.17~") | = "dev"}
   "coq-vst-zlist" {= "2.13" | = "dev"}
   "coq-flocq" {(>= "4.2.0" & < "5~") | = "dev"}

--- a/coq-vst.opam
+++ b/coq-vst.opam
@@ -33,12 +33,12 @@ run-test: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.19" & < "9.2~"}
+  "coq" {(>= "8.19" & < "9.2~") | = "dev"}
   "coq-core" { >= "9.0" }
   "coq-stdlib" { >= "9.0" }
-  "coq-compcert" {>= "3.15" & < "3.17~"}
+  "coq-compcert" {(>= "3.15" & < "3.17~") | = "dev"}
   "coq-vst-zlist" {= "2.13" | = "dev"}
-  "coq-flocq" {>= "4.2.0" & < "5~"}
+  "coq-flocq" {(>= "4.2.0" & < "5~") | = "dev"}
 ]
 tags: [
   "category:Computer Science/Semantics and Compilation/Semantics"


### PR DESCRIPTION
Allows installing a pin to this branch on a switch tracking Rocq master.

Wordsmithed by Codex.
