### PR TITLE
Make .depend generation atomic and fail on coqdep errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -913,13 +913,27 @@ floyd/floyd.coq: floyd/proofauto.vo
 
 .depend depend:
 	@echo 'coqdep ... >.depend'
+# coqdep's dependency output is written to a temporary file and moved
+# into place only if coqdep succeeds: a partial .depend (e.g. after
+# coqdep is killed) would otherwise silently poison parallel builds with
+# missing dependency edges.  coqdep's stderr is still filtered live
+# through grep; its real exit status is recovered through the pipe via a
+# status file (this recipe runs under POSIX sh, which lacks pipefail).
 ifeq ($(COMPCERT_NEW),true)
 	# DEPENDENCIES VARIANT COMPCERT_NEW
-	$(COQDEP) $(DEPFLAGS) 2>&1 >.depend `find $(filter $(wildcard *), $(DIRS) concurrency/common concurrency/compiler concurrency/juicy concurrency/util paco concurrency/sc_drf) -name "*.v"` | grep -v 'Warning:.*found in the loadpath' || true
-	@echo "" >>.depend
+	@{ $(COQDEP) $(DEPFLAGS) `find $(filter $(wildcard *), $(DIRS) concurrency/common concurrency/compiler concurrency/juicy concurrency/util paco concurrency/sc_drf) -name "*.v"` 2>&1 >.depend-tmp; echo $$? >.depend-status; } | \
+	   grep -v 'Warning:.*found in the loadpath' || true; \
+	st=`cat .depend-status`; rm -f .depend-status; \
+	[ "$$st" = 0 ] || { rm -f .depend-tmp; exit 1; }; \
+	echo "" >>.depend-tmp; \
+	mv .depend-tmp .depend
 else
 	# DEPENDENCIES DEFAULT
-	$(COQDEP) $(DEPFLAGS) 2>&1 >.depend `find $(filter $(wildcard *), $(DIRS)) -name "*.v"` | grep -v 'Warning:.*found in the loadpath' || true
+	@{ $(COQDEP) $(DEPFLAGS) `find $(filter $(wildcard *), $(DIRS)) -name "*.v"` 2>&1 >.depend-tmp; echo $$? >.depend-status; } | \
+	   grep -v 'Warning:.*found in the loadpath' || true; \
+	st=`cat .depend-status`; rm -f .depend-status; \
+	[ "$$st" = 0 ] || { rm -f .depend-tmp; exit 1; }; \
+	mv .depend-tmp .depend
 endif
 ifeq ($(COMPCERT_BUILD_FROM_SRC),true)
 	# DEPENDENCIES TO BUILD COMPCERT FROM SOURCE

--- a/Makefile
+++ b/Makefile
@@ -921,7 +921,8 @@ floyd/floyd.coq: floyd/proofauto.vo
 # status file (this recipe runs under POSIX sh, which lacks pipefail).
 ifeq ($(COMPCERT_NEW),true)
 	# DEPENDENCIES VARIANT COMPCERT_NEW
-	@{ $(COQDEP) $(DEPFLAGS) `find $(filter $(wildcard *), $(DIRS) concurrency/common concurrency/compiler concurrency/juicy concurrency/util paco concurrency/sc_drf) -name "*.v"` 2>&1 >.depend-tmp; echo $$? >.depend-status; } | \
+	@ulimit -S -n `ulimit -H -n` 2>/dev/null || true; \
+	{ $(COQDEP) $(DEPFLAGS) `find $(filter $(wildcard *), $(DIRS) concurrency/common concurrency/compiler concurrency/juicy concurrency/util paco concurrency/sc_drf) -name "*.v"` 2>&1 >.depend-tmp; echo $$? >.depend-status; } | \
 	   grep -v 'Warning:.*found in the loadpath' || true; \
 	st=`cat .depend-status`; rm -f .depend-status; \
 	[ "$$st" = 0 ] || { rm -f .depend-tmp; exit 1; }; \
@@ -929,7 +930,8 @@ ifeq ($(COMPCERT_NEW),true)
 	mv .depend-tmp .depend
 else
 	# DEPENDENCIES DEFAULT
-	@{ $(COQDEP) $(DEPFLAGS) `find $(filter $(wildcard *), $(DIRS)) -name "*.v"` 2>&1 >.depend-tmp; echo $$? >.depend-status; } | \
+	@ulimit -S -n `ulimit -H -n` 2>/dev/null || true; \
+	{ $(COQDEP) $(DEPFLAGS) `find $(filter $(wildcard *), $(DIRS)) -name "*.v"` 2>&1 >.depend-tmp; echo $$? >.depend-status; } | \
 	   grep -v 'Warning:.*found in the loadpath' || true; \
 	st=`cat .depend-status`; rm -f .depend-status; \
 	[ "$$st" = 0 ] || { rm -f .depend-tmp; exit 1; }; \


### PR DESCRIPTION
Adjustments authored by Fable to make the `coqdep` step more robust, at the cost of readability.

Wordsmithed by Codex.
